### PR TITLE
test: ensure newspaper plugin initializes

### DIFF
--- a/src/plugins/newspaper/newspaper.py
+++ b/src/plugins/newspaper/newspaper.py
@@ -31,7 +31,7 @@ class Newspaper(BasePlugin):
             image_url = FREEDOM_FORUM_URL.format(date.day, newspaper_slug)
             image = get_image(image_url)
             if image:
-                logging.info(
+                logger.info(
                     f"Found {newspaper_slug} front cover for {date.strftime('%Y-%m-%d')}"
                 )
                 break

--- a/tests/plugins/test_newspaper.py
+++ b/tests/plugins/test_newspaper.py
@@ -1,8 +1,18 @@
 from PIL import Image
+from plugins.newspaper.constants import NEWSPAPERS
 
 
 def _png_image(size=(600, 800), color="white"):
     return Image.new("RGB", size, color)
+
+
+def test_newspaper_initialization():
+    from plugins.newspaper.newspaper import Newspaper
+
+    plugin = Newspaper({"id": "newspaper"})
+    template = plugin.generate_settings_template()
+
+    assert template["newspapers"] == sorted(NEWSPAPERS, key=lambda n: n["name"])
 
 
 def test_newspaper_success_with_expand_height(monkeypatch, device_config_dev):


### PR DESCRIPTION
## Summary
- use module logger in newspaper plugin and ensure logging imported
- add tests to cover plugin initialization and settings generation

## Testing
- `pytest tests/plugins/test_newspaper.py`
- `pre-commit run --files src/plugins/newspaper/newspaper.py tests/plugins/test_newspaper.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68c2526ac8ec8320b23803fab4a8cae0