### PR TITLE
Ensure image folder plugin has logging import and initialization test

### DIFF
--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -1,4 +1,4 @@
-import logging
+import logging  # Needed for module-level logger
 import os
 import random
 

--- a/tests/plugins/test_image_folder.py
+++ b/tests/plugins/test_image_folder.py
@@ -112,3 +112,13 @@ def test_generate_image_errors(tmp_path, device_config_dev):
         assert False
     except RuntimeError as e:
         assert "No image files found" in str(e)
+
+
+def test_image_folder_initializes_without_name_error():
+    """Plugin should be importable and instantiable without NameError."""
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder(
+        {"id": "image_folder", "class": "ImageFolder", "name": "Image Folder"}
+    )
+    assert plugin is not None


### PR DESCRIPTION
## Summary
- clarify logging import in image folder plugin module
- add test confirming the image folder plugin can be imported and instantiated without NameError

## Testing
- `pytest tests/plugins/test_image_folder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2526e056c83208488f55bd62b4977