### PR TITLE
Insert SVG title after opening tag and test

### DIFF
--- a/src/utils/icon_utils.py
+++ b/src/utils/icon_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 from markupsafe import Markup
 
 
@@ -21,9 +22,11 @@ def render_icon(name: str, class_name: str = "icon-image", title: str | None = N
             if "<svg" in svg and "class=" not in svg.split("<svg", 1)[1].split(">", 1)[0]:
                 svg = svg.replace("<svg", f"<svg {cls_attr}", 1)
             # title
-            if title:
-                if "<title>" not in svg:
-                    svg = svg.replace("<svg", "<svg", 1).replace(">", f"><title>{title}</title>", 1)
+            if title and "<title>" not in svg:
+                match = re.search(r"<svg\b[^>]*>", svg, flags=re.IGNORECASE)
+                if match:
+                    pos = match.end()
+                    svg = svg[:pos] + f"<title>{title}</title>" + svg[pos:]
             return Markup(svg)
     except Exception:
         # On any failure, fall through to class-based fallback

--- a/tests/unit/test_icon_utils.py
+++ b/tests/unit/test_icon_utils.py
@@ -1,0 +1,36 @@
+import builtins
+import io
+import re
+from utils import icon_utils
+
+
+def _setup_svg(monkeypatch, svg_content):
+    monkeypatch.setattr(icon_utils.os.path, "isfile", lambda path: True)
+
+    def fake_open(*args, **kwargs):
+        return io.StringIO(svg_content)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+def test_title_injected_with_xml_declaration(monkeypatch):
+    svg_content = (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        "<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+    )
+    _setup_svg(monkeypatch, svg_content)
+    result = icon_utils.render_icon("test", title="MyIcon")
+    assert "<title>MyIcon</title>" in result
+    assert re.search(r"<svg[^>]*><title>MyIcon</title>", str(result))
+
+
+def test_title_injected_with_doctype(monkeypatch):
+    svg_content = (
+        "<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' "
+        "'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>\n"
+        "<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+    )
+    _setup_svg(monkeypatch, svg_content)
+    result = icon_utils.render_icon("test", title="DocIcon")
+    assert "<title>DocIcon</title>" in result
+    assert re.search(r"<svg[^>]*><title>DocIcon</title>", str(result))


### PR DESCRIPTION
## Summary
- ensure render_icon inserts <title> element immediately after the opening <svg> tag
- add unit tests for SVGs with XML declaration or DOCTYPE

## Testing
- `pre-commit run --files src/utils/icon_utils.py tests/unit/test_icon_utils.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `SKIP=gitleaks pre-commit run --files src/utils/icon_utils.py tests/unit/test_icon_utils.py`
- `pytest tests/unit/test_icon_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c252759e9c83208ee98a4b943d33bf