### PR TITLE
Raise error for unsupported image orientations

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -95,11 +95,17 @@ def get_image(image_url, timeout_seconds: float = 10.0):
     return img
 
 
-def change_orientation(image, orientation, inverted=False):
+def change_orientation(image, orientation, inverted: bool = False):
+    """Rotate an image based on the given orientation.
+
+    Raises a :class:`ValueError` if an unsupported orientation is provided.
+    """
     if orientation == "horizontal":
         angle = 0
     elif orientation == "vertical":
         angle = 90
+    else:
+        raise ValueError(f"Unsupported orientation: {orientation}")
 
     if inverted:
         angle = (angle + 180) % 360

--- a/tests/unit/test_image_utils_more.py
+++ b/tests/unit/test_image_utils_more.py
@@ -1,4 +1,5 @@
 # pyright: reportMissingImports=false
+import pytest
 from PIL import Image
 
 from utils.image_utils import apply_image_enhancement, change_orientation
@@ -15,3 +16,9 @@ def test_change_orientation_inverted_flag():
     out = change_orientation(img, "horizontal", inverted=True)
     # 180-degree rotate keeps size swapped if expand=1, but horizontal keeps angle=180
     assert out.size == (20, 10)
+
+
+def test_change_orientation_unknown_orientation():
+    img = Image.new("RGB", (10, 10), "white")
+    with pytest.raises(ValueError):
+        change_orientation(img, "diagonal")


### PR DESCRIPTION
## Summary
- raise ValueError for unknown orientations in `change_orientation`
- test behavior with unsupported orientation values

## Testing
- `pre-commit run --files src/utils/image_utils.py tests/unit/test_image_utils_more.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest` *(fails: tests/integration/test_history.py::test_history_sorting_and_size_formatting - assert (10387 != -1 and 9336 != -1 and 10387 < 9336))*
- `pytest tests/unit/test_image_utils_more.py::test_change_orientation_unknown_orientation -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2527af09483209dca6f73a91956f4