### PR TITLE
Respect None default in get_config

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -50,7 +50,10 @@ def _list_history_images(history_dir: str) -> list[dict]:
         except Exception:
             return 0.0
 
-    files.sort(key=lambda f: _safe_mtime(os.path.join(history_dir, f)), reverse=True)
+    files.sort(
+        key=lambda f: (_safe_mtime(os.path.join(history_dir, f)), f),
+        reverse=True,
+    )
     result: list[dict] = []
     for f in files:
         full_path = os.path.join(history_dir, f)

--- a/src/config.py
+++ b/src/config.py
@@ -181,9 +181,10 @@ class Config:
             json.dump(self.config, outfile, indent=4)
 
     def get_config(self, key=None, default=None):
-        if default is None:
-            default = {}
-        """Gets the value of a specific configuration key or returns the entire config if none provided."""
+        """Gets the value of a specific configuration key or returns the entire config if none provided.
+
+        If the key is absent and no default is supplied, ``None`` is returned.
+        """
         if key is not None:
             return self.config.get(key, default)
         return self.config
@@ -283,14 +284,16 @@ class Config:
 
     def load_playlist_manager(self):
         """Loads the playlist manager object from the config."""
-        playlist_manager = PlaylistManager.from_dict(self.get_config("playlist_config"))
+        playlist_manager = PlaylistManager.from_dict(
+            self.get_config("playlist_config", {})
+        )
         if not playlist_manager.playlists:
             playlist_manager.add_default_playlist()
         return playlist_manager
 
     def load_refresh_info(self):
         """Loads the refresh information from the config."""
-        return RefreshInfo.from_dict(self.get_config("refresh_info"))
+        return RefreshInfo.from_dict(self.get_config("refresh_info", {}))
 
     def get_playlist_manager(self):
         """Returns the playlist manager."""


### PR DESCRIPTION
## Summary
- stop `Config.get_config` from replacing `None` defaults with `{}`
- update internal callers to provide `{}` when required
- ensure history images sort deterministically even when timestamps tie

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2528726948320865ea8f598c9d7b7