### PR TITLE
Handle unknown orientations in change_orientation

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -100,6 +100,8 @@ def change_orientation(image, orientation, inverted=False):
         angle = 0
     elif orientation == "vertical":
         angle = 90
+    else:
+        raise ValueError(f"Unknown orientation: {orientation}")
 
     if inverted:
         angle = (angle + 180) % 360

--- a/tests/unit/test_image_utils.py
+++ b/tests/unit/test_image_utils.py
@@ -60,6 +60,12 @@ def test_change_orientation():
     assert out_v.size[0] != img.size[0] or out_v.size[1] != img.size[1]
 
 
+def test_change_orientation_invalid():
+    img = Image.new("RGB", (10, 10), "white")
+    with pytest.raises(ValueError):
+        image_utils.change_orientation(img, "diagonal")
+
+
 def test_resize_image_and_keep_width():
     img = Image.new("RGB", (200, 100), "white")
     out = image_utils.resize_image(img, (100, 100))


### PR DESCRIPTION
## Summary
- raise `ValueError` for unsupported orientations
- test `change_orientation` rejects invalid orientation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c252917d6c8320a2c83a39854bdd78