### PR TITLE
Remove unused datetime import

### DIFF
--- a/src/display/display_manager.py
+++ b/src/display/display_manager.py
@@ -1,7 +1,6 @@
 import fnmatch
 import logging
 import os
-from datetime import datetime
 
 from display.abstract_display import AbstractDisplay
 from display.mock_display import MockDisplay


### PR DESCRIPTION
## Summary
- remove unused datetime import in display_manager

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c252bad5cc8320af7dedd6c79f38c0