### PR TITLE
Safely insert SVG titles with XML parsing

### DIFF
--- a/src/utils/icon_utils.py
+++ b/src/utils/icon_utils.py
@@ -1,4 +1,5 @@
 import os
+import xml.etree.ElementTree as ET
 from markupsafe import Markup
 
 
@@ -15,15 +16,26 @@ def render_icon(name: str, class_name: str = "icon-image", title: str | None = N
         if os.path.isfile(svg_path):
             with open(svg_path, "r", encoding="utf-8") as f:
                 svg = f.read()
-            # inject class and title if missing
-            # naive injection: add class attribute to first <svg ...>
-            cls_attr = f'class="{class_name}"'
-            if "<svg" in svg and "class=" not in svg.split("<svg", 1)[1].split(">", 1)[0]:
-                svg = svg.replace("<svg", f"<svg {cls_attr}", 1)
-            # title
+
+            try:
+                root = ET.fromstring(svg)
+            except ET.ParseError:
+                # If the SVG cannot be parsed, fall through to the fallback below
+                raise
+
+            if "class" not in root.attrib:
+                root.set("class", class_name)
+
             if title:
-                if "<title>" not in svg:
-                    svg = svg.replace("<svg", "<svg", 1).replace(">", f"><title>{title}</title>", 1)
+                has_title = any(child.tag.split("}", 1)[-1] == "title" for child in root)
+                if not has_title:
+                    ns = root.tag.split("}", 1)[0].strip("{") if root.tag.startswith("{") else None
+                    title_tag = f"{{{ns}}}title" if ns else "title"
+                    title_elem = ET.Element(title_tag)
+                    title_elem.text = title
+                    root.insert(0, title_elem)
+
+            svg = ET.tostring(root, encoding="unicode")
             return Markup(svg)
     except Exception:
         # On any failure, fall through to class-based fallback

--- a/tests/unit/test_icon_utils.py
+++ b/tests/unit/test_icon_utils.py
@@ -1,0 +1,49 @@
+import io
+import xml.etree.ElementTree as ET
+
+from src.utils.icon_utils import render_icon
+
+
+def setup_svg(monkeypatch, svg_content: str, name: str):
+    from src.utils import icon_utils
+    def fake_isfile(path: str) -> bool:
+        return path.endswith(f"{name}.svg")
+    def fake_open(path: str, mode: str = "r", encoding: str | None = None):
+        return io.StringIO(svg_content)
+    monkeypatch.setattr(icon_utils.os.path, "isfile", fake_isfile)
+    import builtins
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+def test_render_icon_adds_attrs(monkeypatch):
+    svg = "<svg width='24' height='24'></svg>"
+    setup_svg(monkeypatch, svg, "test")
+    result = render_icon("test", class_name="cls", title="Hello")
+    root = ET.fromstring(str(result))
+    assert root.attrib["class"] == "cls"
+    assert root.attrib["width"] == "24"
+    assert root.attrib["height"] == "24"
+    title = root.find("title")
+    assert title is not None and title.text == "Hello"
+
+
+def test_render_icon_preserves_existing_title(monkeypatch):
+    svg = "<svg class='existing'><title>Old</title></svg>"
+    setup_svg(monkeypatch, svg, "existing")
+    result = render_icon("existing", class_name="new", title="New")
+    root = ET.fromstring(str(result))
+    # class should remain unchanged
+    assert root.attrib["class"] == "existing"
+    # title should not be replaced
+    title = root.find("title")
+    assert title is not None and title.text == "Old"
+
+
+def test_render_icon_no_attributes(monkeypatch):
+    svg = "<svg></svg>"
+    setup_svg(monkeypatch, svg, "plain")
+    result = render_icon("plain", class_name="cls", title="Hi")
+    root = ET.fromstring(str(result))
+    assert root.attrib["class"] == "cls"
+    title = root.find("title")
+    assert title is not None and title.text == "Hi"


### PR DESCRIPTION
## Summary
- parse SVG icons with `xml.etree.ElementTree` and insert `<title>` elements while preserving existing attributes
- add tests for icons with and without existing attributes or titles

## Testing
- `pytest tests/unit/test_icon_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c252ee60908320832449f524b164b9