### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/plugins/image_url/image_url.py
+++ b/src/plugins/image_url/image_url.py
@@ -1,13 +1,11 @@
 import logging
-from io import BytesIO
 
-import requests
 from PIL import Image
 from PIL.Image import Resampling
 
 from plugins.base_plugin.base_plugin import BasePlugin
-from utils.image_utils import process_image_from_bytes
 from utils.http_utils import http_get
+from utils.image_utils import process_image_from_bytes
 
 LANCZOS = Resampling.LANCZOS
 

--- a/src/plugins/unsplash/unsplash.py
+++ b/src/plugins/unsplash/unsplash.py
@@ -1,14 +1,13 @@
 import logging
 import random
-from io import BytesIO
 
 import requests
 from PIL import Image
 from PIL.Image import Resampling
 
 from plugins.base_plugin.base_plugin import BasePlugin
-from utils.image_utils import process_image_from_bytes
 from utils.http_utils import http_get
+from utils.image_utils import process_image_from_bytes
 
 LANCZOS = Resampling.LANCZOS
 

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -4,13 +4,10 @@ import threading
 from datetime import datetime
 from time import perf_counter
 
-import pytz
-from PIL import Image
-
 from model import PlaylistManager, RefreshInfo
-from utils.time_utils import now_device_tz
 from plugins.plugin_registry import get_plugin_instance
 from utils.image_utils import compute_image_hash, load_image_from_path
+from utils.time_utils import now_device_tz
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- drop unused imports from image_url, unsplash, and refresh_task modules
- run ruff to sort and clean import blocks

## Testing
- `ruff check --fix src/plugins/image_url/image_url.py src/plugins/unsplash/unsplash.py src/refresh_task.py`
- `ruff check .` *(fails: Found 133 errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c253f271d483208fa5871388d9c9e4