### PR TITLE
Handle network errors when resolving local IP

### DIFF
--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -66,7 +66,7 @@ from config import Config
 from display.display_manager import DisplayManager
 from plugins.plugin_registry import load_plugins, pop_hot_reload_info
 from refresh_task import RefreshTask
-from utils.app_utils import generate_startup_image
+from utils.app_utils import generate_startup_image, get_ip_address
 from utils.http_utils import APIError, json_error, wants_json, json_internal_error
 
 logger = logging.getLogger(__name__)
@@ -379,16 +379,9 @@ if __name__ == "__main__":
 
         # Get local IP address for display (only in dev mode when running on non-Pi)
         if DEV_MODE:
-            import socket
-
-            try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.connect(("8.8.8.8", 80))
-                local_ip = s.getsockname()[0]
-                s.close()
+            local_ip = get_ip_address()
+            if local_ip:
                 logger.info(f"Serving on http://{local_ip}:{PORT}")
-            except OSError:
-                pass  # Ignore if we can't get the IP
 
         serve(app, host="0.0.0.0", port=PORT, threads=1)
     finally:

--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -44,10 +44,12 @@ def resolve_path(file_path):
 
 
 def get_ip_address():
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.connect(("8.8.8.8", 80))
-        ip_address = s.getsockname()[0]
-    return ip_address
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return None
 
 
 def get_wifi_name():

--- a/tests/unit/test_app_utils.py
+++ b/tests/unit/test_app_utils.py
@@ -199,6 +199,28 @@ def test_get_ip_address(monkeypatch):
     assert result == "192.168.1.100"
 
 
+def test_get_ip_address_failure(monkeypatch):
+    """get_ip_address returns None when socket operations fail."""
+    import socket
+
+    class MockSocket:
+        AF_INET = socket.AF_INET
+        SOCK_DGRAM = socket.SOCK_DGRAM
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def connect(self, *args, **kwargs):
+            raise OSError("boom")
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **kw: MockSocket())
+    result = app_utils.get_ip_address()
+    assert result is None
+
+
 def test_get_font_valid(monkeypatch, tmp_path):
     """Test get_font with valid font family."""
     from PIL import ImageFont


### PR DESCRIPTION
## Summary
- catch OSError in `get_ip_address` and return `None`
- log serving URL only when IP detected
- test IP lookup failure path

## Testing
- `pytest tests/unit/test_app_utils.py`
- `pytest tests/unit/test_inkypi.py tests/unit/test_inkypi_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2541b9504832098aeabe923d034ea