### PR TITLE
refactor: centralize current time helper

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -6,18 +6,22 @@ from datetime import datetime
 main_bp = Blueprint("main", __name__)
 
 
+def _current_dt(device_config):
+    try:
+        from utils.time_utils import now_device_tz
+
+        return now_device_tz(device_config)
+    except Exception:
+        return datetime.utcnow()
+
+
 @main_bp.route("/")
 def main_page():
     device_config = current_app.config["DEVICE_CONFIG"]
     # Compute a non-mutating next-up preview for SSR convenience
     playlist_manager = device_config.get_playlist_manager()
     latest_refresh = device_config.get_refresh_info()
-    try:
-        from utils.time_utils import now_device_tz
-
-        current_dt = now_device_tz(device_config)
-    except Exception:
-        current_dt = datetime.utcnow()
+    current_dt = _current_dt(device_config)
 
     next_up = {}
     try:
@@ -68,12 +72,7 @@ def refresh_info():
 def next_up():
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
-    try:
-        from utils.time_utils import now_device_tz
-
-        current_dt = now_device_tz(device_config)
-    except Exception:
-        current_dt = datetime.utcnow()
+    current_dt = _current_dt(device_config)
 
     try:
         playlist = playlist_manager.determine_active_playlist(current_dt)
@@ -101,12 +100,7 @@ def display_next():
     playlist_manager = device_config.get_playlist_manager()
 
     # Determine current time
-    try:
-        from utils.time_utils import now_device_tz
-
-        current_dt = now_device_tz(device_config)
-    except Exception:
-        current_dt = datetime.utcnow()
+    current_dt = _current_dt(device_config)
 
     # Pick next eligible and commit index change
     playlist = playlist_manager.determine_active_playlist(current_dt)

--- a/tests/unit/test_main_current_dt.py
+++ b/tests/unit/test_main_current_dt.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from blueprints.main import _current_dt
+
+
+def test_current_dt_returns_now_device_tz(monkeypatch):
+    sentinel = datetime(2020, 1, 1)
+
+    def fake(device_config):
+        return sentinel
+
+    monkeypatch.setattr("utils.time_utils.now_device_tz", fake, raising=True)
+
+    assert _current_dt(object()) is sentinel
+
+
+def test_current_dt_falls_back_to_utc(monkeypatch):
+    def boom(device_config):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("utils.time_utils.now_device_tz", boom, raising=True)
+
+    result = _current_dt(object())
+    assert isinstance(result, datetime)
+    assert result.tzinfo is None
+    assert abs((result - datetime.utcnow()).total_seconds()) < 5


### PR DESCRIPTION
## Summary
- add `_current_dt` helper with UTC fallback
- use helper in main blueprint routes to avoid duplicated logic
- add tests for helper

## Testing
- `pytest tests/unit/test_main_current_dt.py tests/integration/test_main_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2543077588320b1f4a4ddc6cdb510