### PR TITLE
Use shutil.which for browser detection

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
 from io import BytesIO
@@ -255,11 +256,7 @@ def take_screenshot(target, dimensions, timeout_ms=None):
 
         command = None
         for browser in browsers:
-            if os.path.exists(browser) or (
-                browser in ["chromium", "chromium-headless-shell", "google-chrome"]
-                and subprocess.run(["which", browser], capture_output=True).returncode
-                == 0
-            ):
+            if os.path.exists(browser) or shutil.which(browser):
                 command = [
                     browser,
                     "--headless",

--- a/tests/unit/test_take_screenshot.py
+++ b/tests/unit/test_take_screenshot.py
@@ -173,6 +173,10 @@ def test_take_screenshot_browser_fallback_to_chromium(monkeypatch):
     monkeypatch.setattr("utils.image_utils.subprocess.run", fake_run)
     monkeypatch.setattr("utils.image_utils.os.path.exists", mock_exists)
     monkeypatch.setattr("utils.image_utils.os.remove", lambda p: None)
+    monkeypatch.setattr(
+        "utils.image_utils.shutil.which",
+        lambda b: b if b in ["chromium", "chromium-headless-shell", "google-chrome"] else None,
+    )
 
     class _Ctx:
         def __init__(self, size=(10, 6)):
@@ -202,14 +206,8 @@ def test_take_screenshot_no_browser_available(monkeypatch):
 
     image_utils = importlib.reload(image_utils)
 
-    def fake_which(cmd):
-        return False
-
     monkeypatch.setattr("utils.image_utils.os.path.exists", lambda p: False)
-    monkeypatch.setattr(
-        "utils.image_utils.subprocess.run",
-        lambda cmd, **kwargs: type("Result", (), {"returncode": 1})(),
-    )
+    monkeypatch.setattr("utils.image_utils.shutil.which", lambda b: None)
 
     out = image_utils.take_screenshot("http://example.com", (8, 4))
     assert out is None


### PR DESCRIPTION
## Summary
- rely on `shutil.which` instead of spawning `which` via subprocess when discovering browsers
- adjust tests to mock `shutil.which` and stabilize history test

## Testing
- `pre-commit run --files src/utils/image_utils.py` *(fails: URLError: Tunnel connection failed: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2546929408320a79d8d48bb1d4b01