### PR TITLE
Fix typos and quote consistency in AbstractDisplay

### DIFF
--- a/src/display/abstract_display.py
+++ b/src/display/abstract_display.py
@@ -2,7 +2,7 @@ class AbstractDisplay:
     """
     Abstract base class for all display devices.
 
-    This class defines methods taht subclasses are required to implement for
+    This class defines methods that subclasses are required to implement for
     initialization and to display images on a screen.
 
     These implementations will be device specific.
@@ -29,7 +29,7 @@ class AbstractDisplay:
             NotImplementedError: If not implemented in a subclass.
         """
         raise NotImplementedError(
-            "Method 'initialize_display(...) must be provided in a subclass."
+            "Method 'initialize_display(...)' must be provided in a subclass."
         )
 
     def display_image(self, image, image_settings=None):
@@ -45,5 +45,5 @@ class AbstractDisplay:
             NotImplementedError: If not implemented in a subclass.
         """
         raise NotImplementedError(
-            "Method 'display_image(...) must be provided in a subclass."
+            "Method 'display_image(...)' must be provided in a subclass."
         )


### PR DESCRIPTION
## Summary
- Correct typo in `AbstractDisplay` docstring
- Close quotes in `initialize_display` and `display_image` NotImplementedError messages

## Testing
- `pytest` (fails: 54 failed, 535 passed, 8 skipped, 18 errors in 15.83s)

------
https://chatgpt.com/codex/tasks/task_e_68c254a7b3bc8320950120658abe3cca