### PR TITLE
Remove duplicate imports from inkypi module

### DIFF
--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -49,8 +49,6 @@ import warnings
 warnings.filterwarnings("ignore", message=".*Busy Wait: Held high.*")
 
 import argparse
-import logging
-import os
 import secrets
 
 from flask import Flask, request, g


### PR DESCRIPTION
## Summary
- Remove redundant `logging` and `os` imports from secondary block in `src/inkypi.py`
- Rely on top-level import block for logging and environment modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c25496ca70832093ab2780e5951ac3