### PR TITLE
Ensure socket is closed in connectivity check

### DIFF
--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -62,10 +62,15 @@ def is_connected():
     """Check if the Raspberry Pi has an internet connection."""
     try:
         # Try to connect to Google's public DNS server
-        socket.create_connection(("8.8.8.8", 53), timeout=2)
-        return True
+        conn = socket.create_connection(("8.8.8.8", 53), timeout=2)
     except OSError:
         return False
+    else:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return True
 
 
 def get_font(font_name, font_size=50, font_weight="normal"):


### PR DESCRIPTION
## Summary
- close socket after connectivity check in `is_connected`

## Testing
- `pytest tests/unit/test_app_utils.py::test_is_connected_true_false -vv`
- `pytest` *(fails: tests/integration/test_history.py::test_history_sorting_and_size_formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68c254a2ceb483208c89b85c5c0c3398