### PR TITLE
Use subprocess for shutdown with error handling

### DIFF
--- a/tests/integration/test_settings_extra.py
+++ b/tests/integration/test_settings_extra.py
@@ -24,11 +24,15 @@ def test_save_settings_zero_interval_rejected(client):
 
 def test_shutdown_reboot_path(client, monkeypatch):
     calls = {"cmd": None}
-    monkeypatch.setattr("os.system", lambda cmd: calls.update(cmd=cmd))
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
 
     resp = client.post("/shutdown", json={"reboot": True})
     assert resp.status_code == 200
-    assert "reboot" in (calls["cmd"] or "")
+    assert calls["cmd"] and "reboot" in calls["cmd"]
 
 
 def test_download_logs_has_attachment_header(client, monkeypatch):

--- a/tests/integration/test_settings_more.py
+++ b/tests/integration/test_settings_more.py
@@ -3,12 +3,17 @@
 
 def test_shutdown_route_logs_and_returns_json(client, monkeypatch):
     calls = {"cmd": None}
-    monkeypatch.setattr("os.system", lambda cmd: calls.update(cmd=cmd))
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
 
     resp = client.post("/shutdown", json={"reboot": False})
     assert resp.status_code == 200
     assert resp.json.get("success") is True
-    assert isinstance(calls["cmd"], str)
+    assert isinstance(calls["cmd"], list)
+    assert "shutdown" in calls["cmd"]
 
 
 def test_download_logs_dev_mode_message(client, monkeypatch):
@@ -210,12 +215,16 @@ def test_shutdown_route_reboot(client, monkeypatch):
     import blueprints.settings as settings_mod
 
     calls = {"cmd": None}
-    monkeypatch.setattr(settings_mod.os, "system", lambda cmd: calls.update(cmd=cmd))
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr(settings_mod.subprocess, "run", fake_run)
 
     resp = client.post("/shutdown", json={"reboot": True})
     assert resp.status_code == 200
-    assert isinstance(calls["cmd"], str)
-    assert "reboot" in calls["cmd"]  # type: ignore[unreachable]
+    assert isinstance(calls["cmd"], list)
+    assert "reboot" in calls["cmd"]
 
 
 def test_download_logs_with_parameters(client, monkeypatch):


### PR DESCRIPTION
## Summary
- Replace `os.system` with `subprocess.run` in shutdown route and handle failures
- Mention authentication/CSRF in shutdown docstring
- Update tests to mock `subprocess.run` and stabilize history ordering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c25423fea88320aeb1eda65d27c349