### PR TITLE
Harden shutdown route with subprocess and error handling

### DIFF
--- a/tests/integration/test_settings_extra.py
+++ b/tests/integration/test_settings_extra.py
@@ -24,11 +24,11 @@ def test_save_settings_zero_interval_rejected(client):
 
 def test_shutdown_reboot_path(client, monkeypatch):
     calls = {"cmd": None}
-    monkeypatch.setattr("os.system", lambda cmd: calls.update(cmd=cmd))
+    monkeypatch.setattr("subprocess.run", lambda cmd, check: calls.update(cmd=cmd))
 
     resp = client.post("/shutdown", json={"reboot": True})
     assert resp.status_code == 200
-    assert "reboot" in (calls["cmd"] or "")
+    assert "reboot" in (calls["cmd"] or [])
 
 
 def test_download_logs_has_attachment_header(client, monkeypatch):

--- a/tests/integration/test_settings_more.py
+++ b/tests/integration/test_settings_more.py
@@ -3,12 +3,14 @@
 
 def test_shutdown_route_logs_and_returns_json(client, monkeypatch):
     calls = {"cmd": None}
-    monkeypatch.setattr("os.system", lambda cmd: calls.update(cmd=cmd))
+    monkeypatch.setattr(
+        "subprocess.run", lambda cmd, check: calls.update(cmd=cmd)
+    )
 
     resp = client.post("/shutdown", json={"reboot": False})
     assert resp.status_code == 200
     assert resp.json.get("success") is True
-    assert isinstance(calls["cmd"], str)
+    assert isinstance(calls["cmd"], list)
 
 
 def test_download_logs_dev_mode_message(client, monkeypatch):
@@ -265,12 +267,14 @@ def test_shutdown_route_reboot(client, monkeypatch):
     import blueprints.settings as settings_mod
 
     calls = {"cmd": None}
-    monkeypatch.setattr(settings_mod.os, "system", lambda cmd: calls.update(cmd=cmd))
+    monkeypatch.setattr(
+        settings_mod.subprocess, "run", lambda cmd, check: calls.update(cmd=cmd)
+    )
 
     resp = client.post("/shutdown", json={"reboot": True})
     assert resp.status_code == 200
-    assert isinstance(calls["cmd"], str)
-    assert "reboot" in calls["cmd"]  # type: ignore[unreachable]
+    assert isinstance(calls["cmd"], list)
+    assert "reboot" in calls["cmd"]
 
 
 def test_download_logs_with_parameters(client, monkeypatch):


### PR DESCRIPTION
## Summary
- replace os.system with subprocess.run in settings shutdown route
- handle subprocess errors and note security considerations
- adjust tests to monkeypatch subprocess.run

## Testing
- `pre-commit run --files src/blueprints/settings.py tests/integration/test_settings_more.py tests/integration/test_settings_extra.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest` *(fails: tests/unit/test_weather_plugin.py::test_open_meteo_moon_phase_fetch_failure)*
- `pytest tests/integration/test_settings_more.py::test_shutdown_route_logs_and_returns_json tests/integration/test_settings_more.py::test_shutdown_route_reboot tests/integration/test_settings_extra.py::test_shutdown_reboot_path`


------
https://chatgpt.com/codex/tasks/task_e_68c38c80e5408320aa281faefa7f9905