### PR TITLE
Unify refresh actions under execute method

### DIFF
--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -338,11 +338,15 @@ class RefreshTask:
 
 
 class RefreshAction:
-    """Base class for a refresh action. Subclasses should override the methods below."""
+    """Base class for a refresh action.
 
-    def refresh(self, plugin, device_config, current_dt):
-        """Perform a refresh operation and return the updated image."""
-        raise NotImplementedError("Subclasses must implement the refresh method.")
+    Subclasses must implement :meth:`execute` to perform the refresh operation
+    and return the resulting image.
+    """
+
+    def execute(self, plugin, device_config, current_dt):
+        """Execute the refresh operation and return the updated image."""
+        raise NotImplementedError("Subclasses must implement the execute method.")
 
     def get_refresh_info(self):
         """Return refresh metadata as a dictionary."""

--- a/tests/integration/test_refresh_task.py
+++ b/tests/integration/test_refresh_task.py
@@ -267,7 +267,7 @@ def test_refresh_action_base_class():
 
     # Test that NotImplementedError is raised for abstract methods
     try:
-        action.refresh(None, None, None)
+        action.execute(None, None, None)
         assert False, "Should have raised NotImplementedError"
     except NotImplementedError:
         pass

--- a/tests/unit/test_refresh_task_execute.py
+++ b/tests/unit/test_refresh_task_execute.py
@@ -1,0 +1,103 @@
+from PIL import Image
+
+
+def _dummy_plugin(device_config):
+    class DummyPlugin:
+        config = {"image_settings": []}
+
+        def generate_image(self, settings, cfg):
+            return Image.new("RGB", cfg.get_resolution(), "white")
+
+    return DummyPlugin()
+
+
+def test_manual_refresh_uses_execute(device_config_dev, monkeypatch):
+    """Ensure ManualRefresh is executed via the unified execute method."""
+    from display.display_manager import DisplayManager
+    from refresh_task import ManualRefresh, RefreshTask
+
+    dm = DisplayManager(device_config_dev)
+    task = RefreshTask(device_config_dev, dm)
+
+    # Stub plugin retrieval
+    dummy_cfg = {"id": "dummy", "class": "Dummy"}
+    monkeypatch.setattr(device_config_dev, "get_plugin", lambda pid: dummy_cfg)
+    monkeypatch.setattr(
+        "refresh_task.get_plugin_instance",
+        lambda cfg: _dummy_plugin(device_config_dev),
+        raising=True,
+    )
+
+    refresh = ManualRefresh("dummy", {})
+    called = {"val": False}
+
+    def fake_execute(self, plugin, device_config, current_dt):
+        called["val"] = True
+        return Image.new("RGB", device_config.get_resolution(), "white")
+
+    monkeypatch.setattr(refresh, "execute", fake_execute.__get__(refresh, ManualRefresh))
+
+    try:
+        task.start()
+        task.manual_update(refresh)
+        assert called["val"]
+    finally:
+        task.stop()
+
+
+def test_playlist_refresh_uses_execute(device_config_dev, monkeypatch):
+    """Ensure PlaylistRefresh is executed via the unified execute method."""
+    from display.display_manager import DisplayManager
+    from refresh_task import PlaylistRefresh, RefreshTask
+
+    dm = DisplayManager(device_config_dev)
+    task = RefreshTask(device_config_dev, dm)
+
+    # Avoid waiting during the loop
+    monkeypatch.setattr(task.condition, "wait", lambda timeout=None: None)
+
+    # Stub plugin config and instance
+    dummy_cfg = {"id": "dummy", "class": "Dummy"}
+    monkeypatch.setattr(device_config_dev, "get_plugin", lambda pid: dummy_cfg)
+    monkeypatch.setattr(
+        "refresh_task.get_plugin_instance",
+        lambda cfg: _dummy_plugin(device_config_dev),
+        raising=True,
+    )
+
+    class FakePluginInstance:
+        plugin_id = "dummy"
+        name = "inst"
+        settings = {}
+
+        def get_image_path(self):
+            return "dummy.png"
+
+        def should_refresh(self, dt):
+            return True
+
+    fake_plugin_instance = FakePluginInstance()
+    fake_playlist = type("PL", (), {"name": "pl"})()
+
+    def fake_determine(self, pm, latest_refresh, current_dt):
+        if not getattr(self, "_done", False):
+            self._done = True
+            return fake_playlist, fake_plugin_instance
+        return None, None
+
+    monkeypatch.setattr(task, "_determine_next_plugin", fake_determine.__get__(task, RefreshTask))
+
+    called = {"val": False}
+
+    def fake_execute(self, plugin, device_config, current_dt):
+        called["val"] = True
+        task.running = False
+        return Image.new("RGB", device_config.get_resolution(), "white")
+
+    monkeypatch.setattr(PlaylistRefresh, "execute", fake_execute, raising=True)
+
+    task.start()
+    task.thread.join(timeout=1)
+    assert called["val"]
+    task.stop()
+


### PR DESCRIPTION
## Summary
- Rename `RefreshAction.refresh` to `execute` and update documentation
- Ensure all refresh paths call `execute`
- Add tests confirming manual and playlist refreshes use the unified method

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c38e5c001883209558420b20c4e231