### PR TITLE
Avoid blocking during system stats logging

### DIFF
--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -323,7 +323,8 @@ class RefreshTask:
             return
 
         metrics = {
-            "cpu_percent": psutil.cpu_percent(interval=1),
+            # interval=None ensures a non-blocking snapshot of CPU usage
+            "cpu_percent": psutil.cpu_percent(interval=None),
             "memory_percent": psutil.virtual_memory().percent,
             "disk_percent": psutil.disk_usage("/").percent,
             "load_avg_1_5_15": os.getloadavg(),


### PR DESCRIPTION
## Summary
- prevent `psutil.cpu_percent` from stalling refresh loop by using non-blocking interval
- test `log_system_stats` to ensure non-blocking behavior with patched `psutil`

## Testing
- `python - <<'PY'
from config import Config
from refresh_task import RefreshTask
from display.display_manager import DisplayManager
from time import perf_counter

cfg = Config()
cfg.update_value("log_system_stats", True)

dm = DisplayManager(cfg)
rt = RefreshTask(cfg, dm)
start = perf_counter()
rt.log_system_stats()
elapsed = perf_counter() - start
print(f"log_system_stats took {elapsed:.3f}s")
PY`
- `SKIP=gitleaks pre-commit run --files src/refresh_task.py tests/integration/test_refresh_task.py`
- `pytest tests/integration/test_refresh_task.py::test_refresh_task_system_stats_logging -q`

------
https://chatgpt.com/codex/tasks/task_e_68c38e68a6a08320a9154d116ecfee2f