### PR TITLE
Use module logger in plugin registry and test missing directory logging

### DIFF
--- a/src/plugins/plugin_registry.py
+++ b/src/plugins/plugin_registry.py
@@ -46,7 +46,7 @@ def _load_single_plugin_instance(plugin_config):
         _LAST_HOT_RELOAD = {"plugin_id": plugin_id, "reloaded": reloaded}
         return instance
     except ImportError as e:
-        logging.error(f"Failed to import plugin module {module_name}: {e}")
+        logger.error(f"Failed to import plugin module {module_name}: {e}")
         raise
 
 
@@ -55,19 +55,19 @@ def load_plugins(plugins_config):
     for plugin in plugins_config:
         plugin_id = plugin.get("id")
         if plugin.get("disabled", False):
-            logging.info(f"Plugin {plugin_id} is disabled, skipping.")
+            logger.info(f"Plugin {plugin_id} is disabled, skipping.")
             continue
 
         plugin_dir = plugins_module_path / plugin_id
         if not plugin_dir.is_dir():
-            logging.error(
+            logger.error(
                 f"Could not find plugin directory {plugin_dir} for '{plugin_id}', skipping."
             )
             continue
 
         module_path = plugin_dir / f"{plugin_id}.py"
         if not module_path.is_file():
-            logging.error(
+            logger.error(
                 f"Could not find module path {module_path} for '{plugin_id}', skipping."
             )
             continue

--- a/tests/unit/test_plugin_registry_errors.py
+++ b/tests/unit/test_plugin_registry_errors.py
@@ -1,4 +1,6 @@
 # pyright: reportMissingImports=false
+import logging
+
 from plugins.plugin_registry import PLUGIN_CLASSES, get_plugin_instance, load_plugins
 
 
@@ -16,6 +18,22 @@ def test_load_plugins_skips_disabled_and_missing_paths(monkeypatch, tmp_path):
 
     assert "nonexistent" not in PLUGIN_CLASSES
     assert "skipme" not in PLUGIN_CLASSES
+
+
+def test_load_plugins_logs_error_for_missing_dir(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("SRC_DIR", str(tmp_path))
+    (tmp_path / "plugins").mkdir(parents=True, exist_ok=True)
+
+    PLUGIN_CLASSES.clear()
+    plugins = [{"id": "missing", "class": "X"}]
+    with caplog.at_level(logging.ERROR, logger="plugins.plugin_registry"):
+        load_plugins(plugins)
+
+    assert any(
+        record.name == "plugins.plugin_registry"
+            and "Could not find plugin directory" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_get_plugin_instance_raises_for_unregistered():


### PR DESCRIPTION
## Summary
- switch plugin registry to use module logger for all log calls
- add unit test ensuring missing plugin directories log an error

## Testing
- `pytest tests/unit/test_plugin_registry_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68c38e6bdb5c8320bd9eb1c7622e13e9