### PR TITLE
Ensure add_default_playlist indicates success

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -126,7 +126,7 @@ class PlaylistManager:
 
     def add_default_playlist(self):
         """Add a default playlist to the manager, called when no playlists exist."""
-        return self.playlists.append(
+        self.playlists.append(
             Playlist(
                 "Default",
                 PlaylistManager.DEFAULT_PLAYLIST_START,
@@ -134,6 +134,7 @@ class PlaylistManager:
                 [],
             )
         )
+        return True
 
     def find_plugin(self, plugin_id, instance):
         """Searches playlists to find a plugin with the given ID and instance."""

--- a/tests/unit/test_model_more.py
+++ b/tests/unit/test_model_more.py
@@ -53,3 +53,11 @@ def test_refresh_info_helpers():
     d = ri.to_dict()
     ri2 = RefreshInfo.from_dict(d)
     assert ri2.plugin_id == "ai_text"
+
+
+def test_add_default_playlist_returns_true_and_grows_list():
+    pm = PlaylistManager([])
+    before = len(pm.playlists)
+    result = pm.add_default_playlist()
+    assert result is True
+    assert len(pm.playlists) == before + 1


### PR DESCRIPTION
## Summary
- Return `True` after appending the default playlist
- Test that adding default playlist returns `True` and grows playlist list

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c38e72362c832086109d3c24efe826