### PR TITLE
chore: update CI workflow for stable Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: install/requirements-dev.txt
       - name: Install dev dependencies
         run: |
           python -m pip install -U pip wheel
           pip install -r install/requirements-dev.txt
-      - name: Ruff + Black
+      - name: Lint and type-check
         run: scripts/lint.sh
-      - name: Type check (mypy)
-        run: mypy src
 
   shellcheck:
     name: Shell script validation
@@ -70,6 +68,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.11', '3.12', '3.13' ]
+        include:
+          - python-version: '3.13'
+            allow-failure: true
+    continue-on-error: ${{ matrix.allow-failure == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- use Python 3.12 for lint job
- remove redundant mypy step
- allow failures for Python 3.13 test matrix

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `act -j lint` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68c38e78d52483208e0476cb3a71b0a1