### PR TITLE
Handle wrap-around playlist times

### DIFF
--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -184,3 +184,17 @@ def test_plugin_instance_should_refresh_interval_and_scheduled():
 def test_get_time_range_minutes():
     p = Playlist("Morning", "06:00", "09:30")
     assert p.get_time_range_minutes() == 210
+
+
+def test_playlist_wraparound_is_active():
+    p = Playlist("Late Night", "23:00", "02:00")
+    assert p.is_active("23:30") is True
+    assert p.is_active("00:30") is True
+    assert p.is_active("01:59") is True
+    assert p.is_active("22:59") is False
+    assert p.is_active("02:00") is False
+
+
+def test_get_time_range_minutes_wraparound():
+    p = Playlist("Late Night", "23:00", "02:00")
+    assert p.get_time_range_minutes() == 180


### PR DESCRIPTION
## Summary
- allow playlists spanning midnight to be considered active
- compute playlist durations correctly when intervals wrap around
- test playlist activity and duration for a 23:00–02:00 range

## Testing
- `ruff check src/model.py tests/unit/test_model.py`
- `black src/model.py tests/unit/test_model.py`
- `pytest tests/unit/test_model.py::test_playlist_wraparound_is_active tests/unit/test_model.py::test_get_time_range_minutes_wraparound -q`
- `pytest tests/unit/test_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c38e8cb85483209363702c1767d8e3