### PR TITLE
Constrain pytz dependency to current release

### DIFF
--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -5,7 +5,7 @@ types-requests==2.32.0.20241016
 urllib3==2.5.0
 werkzeug==3.1.3
 pillow==11.0.0
-pytz==2025.2
+pytz>=2024.1,<2025.0
 types-pytz==2024.2.0.20241221
 openai==1.58.1
 numpy==2.2.1

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -5,7 +5,7 @@ requests==2.32.4
 urllib3==2.5.0
 werkzeug==3.1.3
 pillow==11.0.0
-pytz==2025.2
+pytz>=2024.1,<2025.0
 openai==1.58.1
 numpy==2.2.1
 icalendar==6.3.1


### PR DESCRIPTION
## Summary
- constrain pytz to 2024 releases in install and dev requirements

## Testing
- `pip install --upgrade -r install/requirements.txt`
- `pip install --upgrade -r install/requirements-dev.txt`
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68c38ef41d4083208e58c6a2ea06c720