### PR TITLE
tests: import datetime in clock tests

### DIFF
--- a/tests/plugins/test_clock.py
+++ b/tests/plugins/test_clock.py
@@ -1,6 +1,6 @@
 # pyright: reportMissingImports=false
-import math
 from datetime import datetime
+import math
 
 import pytest
 from PIL import Image


### PR DESCRIPTION
## Summary
- import datetime at top of clock tests

## Testing
- `pre-commit run --files tests/plugins/test_clock.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest tests/plugins/test_clock.py`


------
https://chatgpt.com/codex/tasks/task_e_68c38e89f0fc8320a710d87387b0da4c