### PR TITLE
Ignore egg-info directories and remove stray metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 wheels/
 share/python-wheels/
 *.egg-info/
+*.egg-info
 .installed.cfg
 *.egg
 MANIFEST


### PR DESCRIPTION
## Summary
- remove stray `UNKNOWN.egg-info` folder and ensure egg-info artifacts are ignored

## Testing
- `pre-commit run --files .gitignore` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c38eba9aa0832086ee62608adcb0b0