### PR TITLE
fix: configure gitleaks action with token

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -22,5 +22,5 @@ jobs:
           fetch-depth: 0
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
-        with:
-          args: detect --no-banner --redact --source .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- remove invalid args usage in gitleaks workflow
- supply required GITHUB_TOKEN to gitleaks action

## Testing
- `pre-commit run --files .github/workflows/gitleaks.yml` *(fails: URLError 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c390cc10e08320a36efc924ce18963