### PR TITLE
Fix shellcheck lint warnings in scripts

### DIFF
--- a/install/inkypi
+++ b/install/inkypi
@@ -5,11 +5,12 @@
 PROGRAM_PATH=/usr/local/inkypi
 VENV_PATH="$PROGRAM_PATH/venv_inkypi"
 
+# shellcheck source=/dev/null
 source "$VENV_PATH/bin/activate"
 
 export PROJECT_DIR="$PROGRAM_PATH"
 export SRC_DIR="$PROGRAM_PATH/src"
 
-python -u "$(realpath $PROGRAM_PATH/src/inkypi.py)"
+python -u "$(realpath "$PROGRAM_PATH/src/inkypi.py")"
 
 deactivate

--- a/install/install.sh
+++ b/install/install.sh
@@ -20,7 +20,6 @@ set -euo pipefail
 bold=$(tput bold 2>/dev/null || true)
 normal=$(tput sgr0 2>/dev/null || true)
 red=$(tput setaf 1 2>/dev/null || true)
-green=$(tput setaf 2 2>/dev/null || true)
 
 SOURCE=${BASH_SOURCE[0]}
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -152,22 +151,22 @@ enable_interfaces(){
 show_loader() {
   local pid=$!
   local delay=0.1
-  local spinstr='|/-\'
+  local spinstr="|/-\\"
   if [[ -z "$pid" ]]; then
     printf "%s [\e[32m\xE2\x9C\x94\e[0m]\n" "$1"
     return
   fi
-  printf "$1 [${spinstr:0:1}] "
-  while ps a | awk '{print $1}' | grep -q "${pid}"; do
+  printf "%s [%s] " "$1" "${spinstr:0:1}"
+  while ps -p "$pid" > /dev/null 2>&1; do
     local temp=${spinstr#?}
-    printf "\r$1 [${temp:0:1}] "
-    spinstr=${temp}${spinstr%"${temp}"}
-    sleep ${delay}
+    printf "\r%s [%s] " "$1" "${temp:0:1}"
+    spinstr=${temp}${spinstr%"$temp"}
+    sleep "$delay"
   done
-  if [[ $? -eq 0 ]]; then
-    printf "\r$1 [\e[32m\xE2\x9C\x94\e[0m]\n"
+  if wait "$pid"; then
+    printf "\r%s [\e[32m\xE2\x9C\x94\e[0m]\n" "$1"
   else
-    printf "\r$1 [\e[31m\xE2\x9C\x98\e[0m]\n"
+    printf "\r%s [\e[31m\xE2\x9C\x98\e[0m]\n" "$1"
   fi
 }
 
@@ -227,10 +226,10 @@ create_venv(){
     echo_header "Upgrading pip and core build tools (pip/setuptools/wheel)"
     $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel --retries 10 --timeout 60 --no-cache-dir
     echo_header "Installing python dependencies"
-    $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE --retries 10 --timeout 60 --no-cache-dir
+    $VENV_PATH/bin/python -m pip install -r "$PIP_REQUIREMENTS_FILE" --retries 10 --timeout 60 --no-cache-dir
   else
     $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel --retries 10 --timeout 60 --no-cache-dir > /dev/null 2>&1
-    $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE -qq --retries 10 --timeout 60 --no-cache-dir > pip_install.log 2>&1 &
+    $VENV_PATH/bin/python -m pip install -r "$PIP_REQUIREMENTS_FILE" -qq --retries 10 --timeout 60 --no-cache-dir > pip_install.log 2>&1 &
     show_loader "\tInstalling python dependencies. "
   fi
 
@@ -238,9 +237,9 @@ create_venv(){
   if [[ -n "$WS_TYPE" ]]; then
     echo "Adding additional dependencies for waveshare to the python virtual environment. "
     if [[ "$VERBOSE" -eq 1 ]]; then
-      $VENV_PATH/bin/python -m pip install -r $WS_REQUIREMENTS_FILE --retries 10 --timeout 60 --no-cache-dir
+      $VENV_PATH/bin/python -m pip install -r "$WS_REQUIREMENTS_FILE" --retries 10 --timeout 60 --no-cache-dir
     else
-      $VENV_PATH/bin/python -m pip install -r $WS_REQUIREMENTS_FILE --retries 10 --timeout 60 --no-cache-dir > ws_pip_install.log 2>&1 &
+      $VENV_PATH/bin/python -m pip install -r "$WS_REQUIREMENTS_FILE" --retries 10 --timeout 60 --no-cache-dir > ws_pip_install.log 2>&1 &
       show_loader "\tInstalling additional Waveshare python dependencies. "
     fi
   fi
@@ -261,7 +260,7 @@ install_app_service() {
 
 install_executable() {
   echo "Adding executable to ${BINPATH}/$APPNAME"
-  cp $SCRIPT_DIR/inkypi $BINPATH/
+  cp "$SCRIPT_DIR"/inkypi "$BINPATH/"
   sudo chmod +x $BINPATH/$APPNAME
 }
 
@@ -345,9 +344,9 @@ copy_project() {
 }
 
 # Get Raspberry Pi hostname
-get_hostname() {
-  echo "$(hostname)"
-}
+  get_hostname() {
+    hostname
+  }
 
 # Get Raspberry Pi IP address
 get_ip_address() {
@@ -364,7 +363,7 @@ ask_for_reboot() {
   echo_header "[•] After your Pi is rebooted, you can access the web UI by going to $(echo_blue "'$hostname.local'") or $(echo_blue "'$ip_address'") in your browser."
   echo_header "[•] If you encounter any issues or have suggestions, please submit them here: https://github.com/fatihak/InkyPi/issues"
 
-  read -p "Would you like to restart your Raspberry Pi now? [Y/N] " userInput
+    read -r -p "Would you like to restart your Raspberry Pi now? [Y/N] " userInput
   userInput="${userInput^^}"
 
   if [[ "${userInput,,}" == "y" ]]; then

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -4,12 +4,10 @@
 bold=$(tput bold)
 normal=$(tput sgr0)
 red=$(tput setaf 1)
-green=$(tput setaf 2)
 
 APPNAME="inkypi"
 INSTALL_PATH="/usr/local/$APPNAME"
 BINPATH="/usr/local/bin"
-VENV_PATH="$INSTALL_PATH/venv_$APPNAME"
 SERVICE_FILE="/etc/systemd/system/$APPNAME.service"
 CONFIG_DIR="$INSTALL_PATH/src/config"
 

--- a/install/update.sh
+++ b/install/update.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # Formatting stuff
-bold=$(tput bold)
-normal=$(tput sgr0)
-green=$(tput setaf 2)
-red=$(tput setaf 1)
+
 
 SOURCE=${BASH_SOURCE[0]}
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -58,6 +55,7 @@ if [ ! -d "$VENV_PATH" ]; then
 fi
 
 # Activate the virtual environment
+# shellcheck source=/dev/null
 source "$VENV_PATH/bin/activate"
 
 # Upgrade pip
@@ -74,7 +72,7 @@ else
 fi
 
 echo "Updating executable in ${BINPATH}/$APPNAME"
-cp $SCRIPT_DIR/inkypi $BINPATH/
+cp "$SCRIPT_DIR"/inkypi "$BINPATH/"
 sudo chmod +x $BINPATH/$APPNAME
 
 echo "Restarting $APPNAME service."

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,7 +3,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
-cd "${REPO_ROOT}"
+cd "${REPO_ROOT}" || exit
 
 source scripts/venv.sh
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
-cd "${REPO_ROOT}"
+cd "${REPO_ROOT}" || exit
 
 source scripts/venv.sh
 

--- a/scripts/venv.sh
+++ b/scripts/venv.sh
@@ -6,24 +6,21 @@ SRC_DIR="src"
 
 if [ ! -d "$VENV_DIR" ]; then
     echo "Creating virtual environment in $VENV_DIR..."
-    python3 -m venv $VENV_DIR
-
-    if [ $? -ne 0 ]; then
+    if ! python3 -m venv "$VENV_DIR"; then
         echo "Failed to create virtual environment. Ensure python3 is installed."
         exit 1
     fi
 fi
 
 echo "Activating virtual environment..."
-source $VENV_DIR/bin/activate
-
-if [ $? -ne 0 ]; then
+# shellcheck source=/dev/null
+if ! source "$VENV_DIR/bin/activate"; then
     echo "Failed to activate virtual environment."
     exit 1
 fi
 
 python -m pip install --upgrade pip
-python -m pip install --no-cache-dir -r $REQUIREMENTS_FILE
+python -m pip install --no-cache-dir -r "$REQUIREMENTS_FILE"
 
 export PYTHONPATH="$SRC_DIR${PYTHONPATH:+:$PYTHONPATH}"
 export SRC_DIR=$SRC_DIR


### PR DESCRIPTION
## Summary
- Clean up unused variables and unsafe patterns in install scripts
- Improve spinner helper and quote file paths to satisfy shellcheck
- Harden helper scripts with safe `cd` usage and venv activation checks

## Testing
- `shellcheck install/install.sh install/uninstall.sh install/update.sh scripts/format.sh scripts/lint.sh scripts/venv.sh install/inkypi`
- `scripts/lint.sh` *(fails: would reformat files, ruff & mypy issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c39272a99c832089823e414798dcfc