### PR TITLE
refactor: add main entry point

### DIFF
--- a/tests/unit/test_inkypi.py
+++ b/tests/unit/test_inkypi.py
@@ -24,8 +24,9 @@ def _reload_inkypi(monkeypatch, argv=None, env=None):
         del sys.modules["inkypi"]
 
     import inkypi  # noqa: F401
-
-    return importlib.reload(sys.modules["inkypi"])
+    mod = importlib.reload(sys.modules["inkypi"])
+    mod.main(argv[1:])
+    return mod
 
 
 def test_inkypi_dev_mode_and_blueprints(monkeypatch):

--- a/tests/unit/test_inkypi_extra.py
+++ b/tests/unit/test_inkypi_extra.py
@@ -31,8 +31,9 @@ def _reload_inkypi(monkeypatch, argv=None, env=None):
         del sys.modules["inkypi"]
 
     import inkypi  # noqa: F401
-
-    return importlib.reload(sys.modules["inkypi"])
+    mod = importlib.reload(sys.modules["inkypi"])
+    mod.main(argv[1:])
+    return mod
 
 
 def test_create_app_before_request_starts_refresh(monkeypatch):

--- a/tests/unit/test_inkypi_handlers_json.py
+++ b/tests/unit/test_inkypi_handlers_json.py
@@ -33,8 +33,9 @@ def _reload_inkypi(monkeypatch, argv=None, env=None):
         del sys.modules["inkypi"]
 
     import inkypi  # noqa: F401
-
-    return importlib.reload(sys.modules["inkypi"])
+    mod = importlib.reload(sys.modules["inkypi"])
+    mod.main(argv[1:])
+    return mod
 
 
 def _register_test_routes(app):

--- a/tests/unit/test_main_function.py
+++ b/tests/unit/test_main_function.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from tests.unit.test_secret_key import _write_min_device_config
+
+
+def test_import_does_not_parse(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["inkypi.py", "--dev"])
+    sys.modules.pop("inkypi", None)
+    import inkypi
+    assert inkypi.args is None
+    assert inkypi.app is None
+
+
+def test_main_invocation(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "device.json"
+    _write_min_device_config(cfg_path)
+    monkeypatch.setenv("INKYPI_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["inkypi.py", "--web-only"])
+    sys.modules.pop("inkypi", None)
+    inkypi = importlib.import_module("inkypi")
+    inkypi.main(["--web-only"])
+    assert inkypi.args.web_only is True
+    assert inkypi.app is not None

--- a/tests/unit/test_secret_key.py
+++ b/tests/unit/test_secret_key.py
@@ -52,6 +52,7 @@ def test_secret_key_dev_persisted(tmp_path, monkeypatch):
     # Force fresh import with current env
     sys.modules.pop("inkypi", None)
     inkypi = importlib.import_module("inkypi")
+    inkypi.main([])
 
     # SECRET_KEY should be generated and persisted in .env under PROJECT_DIR
     secret = inkypi.app.secret_key
@@ -87,6 +88,7 @@ def test_secret_key_prod_ephemeral(tmp_path, monkeypatch):
     # Fresh import
     sys.modules.pop("inkypi", None)
     inkypi = importlib.import_module("inkypi")
+    inkypi.main([])
 
     # Verify we're actually in production mode
     assert not inkypi.DEV_MODE, f"DEV_MODE should be False but is {inkypi.DEV_MODE}"
@@ -129,8 +131,9 @@ def _reload_inkypi(monkeypatch, argv=None, env=None):
         del sys.modules["inkypi"]
 
     import inkypi  # noqa: F401
-
-    return importlib.reload(sys.modules["inkypi"])
+    mod = importlib.reload(sys.modules["inkypi"])
+    mod.main(argv[1:])
+    return mod
 
 
 def test_secret_key_from_env(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `main()` to handle CLI parsing and setup
- call `main()` in module entrypoint
- update tests to import module without side effects and check `main`

## Testing
- `pytest`
- `pre-commit run --files tests/unit/test_main_function.py` *(failed: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68c399ac51a48320a53a4e7f66e2f74d