### PR TITLE
test: ensure CSP header enforced when report-only disabled

### DIFF
--- a/tests/unit/test_health_csp.py
+++ b/tests/unit/test_health_csp.py
@@ -8,3 +8,12 @@ def test_csp_report_only_header(client, monkeypatch):
     assert ro or csp
 
 
+
+def test_csp_header_enforced_when_report_only_disabled(client, monkeypatch):
+    # Disable report-only mode to enforce CSP header
+    monkeypatch.setenv("INKYPI_CSP_REPORT_ONLY", "0")
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Content-Security-Policy" in resp.headers
+    assert "Content-Security-Policy-Report-Only" not in resp.headers
+


### PR DESCRIPTION
## Summary
- test CSP header presence when report-only mode disabled

## Testing
- `SKIP=gitleaks pre-commit run --files tests/unit/test_health_csp.py`
- `pytest tests/unit/test_health_csp.py`


------
https://chatgpt.com/codex/tasks/task_e_68c399fc2e1483209b8bd1f5cb281d26