### PR TITLE
Verify preview route in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
           curl -fsS ${SERVER_URL}/settings >/dev/null
           curl -fsS ${SERVER_URL}/playlist >/dev/null
           curl -sS -o /dev/null -w "%{http_code}\n" ${SERVER_URL}/preview | tee preview_code.txt
+          grep -q '^200$' preview_code.txt || { echo "Preview route did not return 200" >&2; kill $SERVER_PID 2>/dev/null || true; exit 1; }
           curl -fsS ${SERVER_URL}/plugin/clock >/dev/null
           curl -fsS ${SERVER_URL}/images/clock/faces/digital.png >/dev/null
           curl -fsS "${SERVER_URL}/download-logs?hours=2" >/dev/null


### PR DESCRIPTION
## Summary
- ensure preview route responds with 200 in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c399e8d5a8832094da908ec779cc51