### PR TITLE
Add conditional exit to lint script

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -53,3 +53,9 @@ fi
 # Add your post-run actions here - they will execute regardless of lint failures
 
 
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_EXIT -ne 0 ]; then
+    exit 1
+fi
+
+exit 0
+


### PR DESCRIPTION
## Summary
- Ensure lint script exits non-zero when Ruff, Black, or mypy fail

## Testing
- `bash scripts/lint.sh` *(fails: lint errors reported)*

------
https://chatgpt.com/codex/tasks/task_e_68c399e3cbc083209858f2eb88df6cee