### PR TITLE
Verify preview endpoint in CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,11 @@ jobs:
           curl -fsS ${SERVER_URL}/settings >/dev/null
           curl -fsS ${SERVER_URL}/playlist >/dev/null
           curl -sS -o /dev/null -w "%{http_code}\n" ${SERVER_URL}/preview | tee preview_code.txt
-          grep -q '^200$' preview_code.txt || { echo "Preview route did not return 200" >&2; kill $SERVER_PID 2>/dev/null || true; exit 1; }
+          if ! grep -q '^200$' preview_code.txt; then
+            echo "Preview route did not return 200" >&2
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
           curl -fsS ${SERVER_URL}/plugin/clock >/dev/null
           curl -fsS ${SERVER_URL}/images/clock/faces/digital.png >/dev/null
           curl -fsS "${SERVER_URL}/download-logs?hours=2" >/dev/null


### PR DESCRIPTION
## Summary
- ensure smoke test validates preview route response

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: line length and other lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c39c3941d88320969be689d8bbfc18