### PR TITLE
Add timezone utility tests

### DIFF
--- a/tests/unit/test_time_utils_timezone.py
+++ b/tests/unit/test_time_utils_timezone.py
@@ -1,0 +1,30 @@
+import pytz
+
+from utils.time_utils import get_timezone, now_in_timezone
+
+
+def test_get_timezone_valid():
+    tz = get_timezone("US/Eastern")
+    assert tz == pytz.timezone("US/Eastern")
+
+
+def test_get_timezone_invalid():
+    tz = get_timezone("Invalid/Zone")
+    assert tz == pytz.UTC
+
+
+def test_get_timezone_none():
+    tz = get_timezone(None)
+    assert tz == pytz.UTC
+
+
+def test_now_in_timezone_returns_aware_datetime():
+    dt = now_in_timezone("US/Eastern")
+    assert dt.tzinfo is not None
+    assert dt.tzinfo.zone == "US/Eastern"
+
+
+def test_now_in_timezone_default_utc():
+    dt = now_in_timezone()
+    assert dt.tzinfo is not None
+    assert dt.tzinfo.zone == "UTC"


### PR DESCRIPTION
## Summary
- add tests for get_timezone with valid, invalid, and none inputs
- ensure now_in_timezone returns timezone-aware datetimes

## Testing
- `pre-commit run --files tests/unit/test_time_utils_timezone.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `pytest tests/unit/test_time_utils_timezone.py`


------
https://chatgpt.com/codex/tasks/task_e_68c39c3e67588320b8b29ad1f96e31c0