### PR TITLE
Skip virtualenv in CI linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           python -m pip install -U pip wheel
           pip install -r install/requirements-dev.txt
       - name: Lint and type-check
+        env:
+          CI: true
         run: scripts/lint.sh
 
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ pre-commit install               # install hooks
 pre-commit run --files <paths>   # run checks on the given files
 ```
 
+- Linting: `scripts/lint.sh` uses a local `.venv` automatically. When `CI` or
+  `VIRTUAL_ENV` is set, it assumes dependencies are already installed and skips
+  creating the virtual environment.
+
 - Hot reload for plugins: When `INKYPI_ENV=dev` or `--dev`, plugin code is reloaded on each request, so changes to `plugins/<id>/<id>.py` take effect immediately.
 - Plugin validator: Validate plugin folders quickly.
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,7 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
 cd "${REPO_ROOT}" || exit
 
-source scripts/venv.sh
+# Use existing environment in CI or when a virtualenv is active
+if [[ -z "${CI:-}" && -z "${VIRTUAL_ENV:-}" ]]; then
+    # shellcheck source=scripts/venv.sh
+    source scripts/venv.sh
+fi
 
 # Track failures
 RUFF_EXIT=0


### PR DESCRIPTION
## Summary
- Avoid sourcing scripts/venv.sh in lint.sh when running in CI or an existing venv
- Explicitly mark lint job to use existing environment
- Document lint.sh virtualenv behavior in README

## Testing
- `scripts/lint.sh` (fails: Ruff/Black/Mypy issues)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4d32574f08320b087824ae3f6ffa6