### PR TITLE
Handle missing fonts in startup image

### DIFF
--- a/tests/unit/test_app_utils.py
+++ b/tests/unit/test_app_utils.py
@@ -246,6 +246,12 @@ def test_get_font_invalid_family():
     assert result is None
 
 
+def test_get_font_strict_raises():
+    """get_font should raise when strict mode is enabled."""
+    with pytest.raises(ValueError):
+        app_utils.get_font("InvalidFont", 24, strict=True)
+
+
 def test_get_font_invalid_weight(monkeypatch, tmp_path):
     """Test get_font with invalid weight for valid family."""
     from PIL import ImageFont


### PR DESCRIPTION
## Summary
- allow get_font to optionally raise when fonts missing
- fallback to default fonts in generate_startup_image
- test strict mode for get_font

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4d6f334948320a597e58fcd76f4a6