### PR TITLE
Prevent zero-height resize and streamline ratio calc

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -118,6 +118,11 @@ def resize_image(image, desired_size, image_settings=None):
     desired_width, desired_height = desired_size
     desired_width, desired_height = int(desired_width), int(desired_height)
 
+    if img_height == 0:
+        raise ValueError("Image height must be non-zero")
+    if desired_height == 0:
+        raise ValueError("Desired height must be non-zero")
+
     img_ratio = img_width / img_height
     desired_ratio = desired_width / desired_height
 
@@ -128,7 +133,6 @@ def resize_image(image, desired_size, image_settings=None):
     x_offset, y_offset = 0, 0
     new_width, new_height = img_width, img_height
     # Step 1: Determine crop dimensions
-    desired_ratio = desired_width / desired_height
     if img_ratio > desired_ratio:
         # Image is wider than desired aspect ratio
         new_width = int(img_height * desired_ratio)

--- a/tests/unit/test_image_utils.py
+++ b/tests/unit/test_image_utils.py
@@ -175,3 +175,17 @@ def test_take_screenshot_general_exception(monkeypatch):
     # But we can test that the function returns an image when mocked
     result = image_utils.take_screenshot("http://example.com", (80, 60))
     assert isinstance(result, Image.Image)
+
+
+def test_resize_image_zero_img_height():
+    """resize_image should fail when source image height is zero."""
+    img = Image.new("RGB", (10, 0), "white")
+    with pytest.raises(ValueError):
+        image_utils.resize_image(img, (5, 5))
+
+
+def test_resize_image_zero_desired_height():
+    """resize_image should fail when desired height is zero."""
+    img = Image.new("RGB", (10, 10), "white")
+    with pytest.raises(ValueError):
+        image_utils.resize_image(img, (5, 0))


### PR DESCRIPTION
## Summary
- avoid divide-by-zero in `resize_image` by validating image and desired heights
- compute desired ratio once instead of twice
- add tests for zero dimensions

## Testing
- `pytest tests/unit/test_image_utils.py tests/unit/test_image_utils_edge.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4d7409b588320b6f4acb55e81fa47