### PR TITLE
Handle missing getloadavg in system stats logging

### DIFF
--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -336,13 +336,17 @@ class RefreshTask:
             "cpu_percent": psutil.cpu_percent(interval=None),
             "memory_percent": psutil.virtual_memory().percent,
             "disk_percent": psutil.disk_usage("/").percent,
-            "load_avg_1_5_15": os.getloadavg(),
             "swap_percent": psutil.swap_memory().percent,
             "net_io": {
                 "bytes_sent": psutil.net_io_counters().bytes_sent,
                 "bytes_recv": psutil.net_io_counters().bytes_recv,
             },
         }
+
+        try:
+            metrics["load_avg_1_5_15"] = os.getloadavg()
+        except (OSError, AttributeError):
+            metrics["load_avg_1_5_15"] = None
 
         logger.info(f"System Stats: {metrics}")
 


### PR DESCRIPTION
## Summary
- handle environments without os.getloadavg by catching OSError/AttributeError and setting load average metric to None
- test system stats logging when os.getloadavg is unavailable

## Testing
- `pytest tests/integration/test_refresh_task.py::test_refresh_task_system_stats_logging tests/integration/test_refresh_task.py::test_refresh_task_system_stats_logging_no_getloadavg -vv`
- `pre-commit run --files src/refresh_task.py tests/integration/test_refresh_task.py` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d73a378c8320ae0db583720af2e7