### PR TITLE
Add progress tracking and surface step metrics

### DIFF
--- a/src/plugins/unsplash/unsplash.py
+++ b/src/plugins/unsplash/unsplash.py
@@ -1,13 +1,14 @@
 import logging
 import random
 
-import requests
+import requests  # type: ignore[import-untyped]
 from PIL import Image
 from PIL.Image import Resampling
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from utils.http_utils import http_get
 from utils.image_utils import process_image_from_bytes
+from utils.progress import record_step
 
 LANCZOS = Resampling.LANCZOS
 
@@ -19,6 +20,7 @@ def grab_image(image_url, dimensions, timeout_ms=40000):
     try:
         response = http_get(image_url, timeout=timeout_ms / 1000)
         response.raise_for_status()
+
         def _resize(im: Image.Image):
             return im.resize(dimensions, LANCZOS)
 
@@ -75,6 +77,7 @@ class Unsplash(BasePlugin):
                 image_url = random.choice(results)["urls"]["full"]
             else:
                 image_url = data["urls"]["full"]
+            record_step("api")
         except requests.exceptions.RequestException as e:
             logger.error(f"Error fetching image from Unsplash API: {e}")
             raise RuntimeError(
@@ -93,6 +96,7 @@ class Unsplash(BasePlugin):
         logger.info(f"Grabbing image from: {image_url}")
 
         image = grab_image(image_url, dimensions, timeout_ms=40000)
+        record_step("image")
 
         if not image:
             raise RuntimeError("Failed to load image, please check logs.")

--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -133,6 +133,15 @@
             if (response.ok && result && result.success) {
                 if (result && result.metrics){
                     const m = result.metrics;
+                    if (Array.isArray(m.steps) && m.steps.length){
+                        let pct = 60;
+                        const inc = 30 / m.steps.length;
+                        for (const [name, ms] of m.steps){
+                            pct += inc;
+                            setStep(`${name} ${ms} ms`, pct);
+                            await new Promise(r => setTimeout(r, 50));
+                        }
+                    }
                     const text = `Request ${m.request_ms ?? '-'} ms • Generate ${m.generate_ms ?? '-'} ms • Preprocess ${m.preprocess_ms ?? '-'} ms • Display ${m.display_ms ?? '-'} ms`;
                     if (progressText) progressText.textContent = text;
                 }

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -105,6 +105,15 @@
                     // Show metrics if present
                     if (result && result.metrics) {
                         const m = result.metrics;
+                        if (Array.isArray(m.steps) && m.steps.length) {
+                            let pct = 60;
+                            const inc = 30 / m.steps.length;
+                            for (const [name, ms] of m.steps) {
+                                pct += inc;
+                                setStep(`${name} ${ms} ms`, pct);
+                                await new Promise(r => setTimeout(r, 50));
+                            }
+                        }
                         const text = `Request ${m.request_ms} ms • Generate ${m.generate_ms ?? '-'} ms • Preprocess ${m.preprocess_ms ?? '-'} ms • Display ${m.display_ms ?? '-'} ms`;
                         if (progressText) progressText.textContent = text;
                     }

--- a/src/utils/progress.py
+++ b/src/utils/progress.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from threading import local
+from time import perf_counter
+
+_thread_local = local()
+
+
+@dataclass
+class ProgressTracker:
+    """Track named steps and their elapsed time in milliseconds."""
+
+    steps: list[tuple[str, int]] = field(default_factory=list)
+    _start: float = field(default_factory=perf_counter)
+    _last: float = field(init=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        self._last = self._start
+
+    def step(self, name: str) -> None:
+        now = perf_counter()
+        elapsed_ms = int((now - self._last) * 1000)
+        self.steps.append((name, elapsed_ms))
+        self._last = now
+
+    def get_steps(self) -> list[tuple[str, int]]:
+        return list(self.steps)
+
+
+@contextmanager
+def track_progress() -> Iterator[ProgressTracker]:
+    """Context manager to expose a tracker via thread-local storage."""
+
+    tracker = ProgressTracker()
+    _thread_local.tracker = tracker
+    try:
+        yield tracker
+    finally:
+        _thread_local.tracker = None
+
+
+def record_step(name: str) -> None:
+    """Record a progress step if a tracker is active."""
+
+    tracker: ProgressTracker | None = getattr(_thread_local, "tracker", None)
+    if tracker:
+        tracker.step(name)


### PR DESCRIPTION
## Summary
- introduce a thread-local progress tracker for recording step timings
- instrument weather and Unsplash plugins to log API/parse/render milestones
- expose step metrics through refresh task and plugin routes and display them in UI progress bars

## Testing
- `pre-commit run --files src/utils/progress.py src/plugins/unsplash/unsplash.py src/plugins/weather/weather.py src/refresh_task.py src/blueprints/plugin.py src/templates/plugin.html src/static/scripts/playlist.js` (with `SKIP=gitleaks`)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b9061c5c8320af349e88179b6a38