### PR TITLE
feat: add SSRF and path-traversal input validation (JTN-96)

### DIFF
--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -13,9 +13,15 @@ from plugins.base_plugin.settings_schema import (
     section,
     widget,
 )
+from utils.app_utils import resolve_path
 from utils.image_utils import pad_image_blur
+from utils.security_utils import validate_file_path
 
 logger = logging.getLogger(__name__)
+
+
+def _get_upload_dir():
+    return resolve_path(os.path.join("static", "images", "saved"))
 
 
 def _resolve_background_color(
@@ -83,12 +89,20 @@ class ImageUpload(BasePlugin):
     def open_image(self, img_index: int, image_locations: list) -> Image:
         if not image_locations:
             raise RuntimeError("No images provided.")
+
+        image_path = image_locations[img_index]
+        try:
+            image_path = validate_file_path(image_path, _get_upload_dir())
+        except ValueError:
+            logger.error("Image path outside allowed directory: %s", image_path)
+            raise RuntimeError("Invalid image file path.") from None
+
         # Open the image using Pillow
         try:
-            with Image.open(image_locations[img_index]) as img:
+            with Image.open(image_path) as img:
                 image = img.copy()
         except (OSError, ValueError) as e:
-            logger.error(f"Failed to read image file: {str(e)}")
+            logger.error("Failed to read image file: %s", e)
             raise RuntimeError("Failed to read image file.") from e
         return image
 
@@ -137,9 +151,18 @@ class ImageUpload(BasePlugin):
             return
 
         for image_path in image_locations:
-            if os.path.exists(image_path):
+            try:
+                safe_path = validate_file_path(image_path, _get_upload_dir())
+            except ValueError:
+                logger.warning(
+                    "Skipping cleanup of path outside upload dir: %s", image_path
+                )
+                continue
+            if os.path.exists(safe_path):
                 try:
-                    os.remove(image_path)
-                    logger.info(f"Deleted uploaded image: {image_path}")
+                    os.remove(safe_path)
+                    logger.info("Deleted uploaded image: %s", safe_path)
                 except OSError as e:
-                    logger.warning(f"Failed to delete uploaded image {image_path}: {e}")
+                    logger.warning(
+                        "Failed to delete uploaded image %s: %s", safe_path, e
+                    )

--- a/src/plugins/screenshot/screenshot.py
+++ b/src/plugins/screenshot/screenshot.py
@@ -3,6 +3,7 @@ import logging
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import callout, field, schema, section
 from utils.image_utils import take_screenshot
+from utils.security_utils import validate_url
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,11 @@ class Screenshot(BasePlugin):
         url = settings.get("url")
         if not url:
             raise RuntimeError("URL is required.")
+
+        try:
+            validate_url(url)
+        except ValueError as e:
+            raise RuntimeError(f"Invalid URL: {e}") from e
 
         dimensions = self.get_oriented_dimensions(device_config)
 

--- a/src/utils/security_utils.py
+++ b/src/utils/security_utils.py
@@ -1,0 +1,110 @@
+"""Input validation utilities for URL and file-path security."""
+
+import ipaddress
+import os
+import socket
+import urllib.parse
+
+
+def validate_url(url: str) -> str:
+    """Validate that a URL uses an allowed scheme and does not resolve to a private IP.
+
+    Parameters
+    ----------
+    url:
+        The URL string to validate.
+
+    Returns
+    -------
+    str
+        The original *url* if validation passes.
+
+    Raises
+    ------
+    ValueError
+        If the URL is empty, uses a disallowed scheme, targets localhost,
+        or resolves to a private/reserved IP address.
+    """
+    if not url:
+        raise ValueError("URL must not be empty")
+
+    parsed = urllib.parse.urlparse(url)
+
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("URL scheme must be http or https")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL must include a hostname")
+
+    if hostname.lower() == "localhost":
+        raise ValueError("URL must not target localhost")
+
+    # Reject bare IP addresses that are private/loopback/etc. before DNS
+    try:
+        addr = ipaddress.ip_address(hostname)
+        _reject_private_ip(addr, hostname)
+    except ValueError:
+        # hostname is not a literal IP — fall through to DNS resolution
+        pass
+
+    # Resolve hostname and check all resulting IPs
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError("Cannot resolve hostname") from exc
+
+    for info in addr_infos:
+        ip_str = info[4][0]
+        addr = ipaddress.ip_address(ip_str)
+        _reject_private_ip(addr, hostname)
+
+    return url
+
+
+def _reject_private_ip(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address, hostname: str
+) -> None:
+    """Raise ValueError if *addr* is private, loopback, link-local, reserved, or multicast."""
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+    ):
+        raise ValueError(
+            "URL must not resolve to a private, loopback, link-local, reserved, or multicast address"
+        )
+
+
+def validate_file_path(file_path: str, allowed_directory: str) -> str:
+    """Ensure *file_path* resolves to a location inside *allowed_directory*.
+
+    Parameters
+    ----------
+    file_path:
+        The file path to validate.
+    allowed_directory:
+        The directory the path must reside within.
+
+    Returns
+    -------
+    str
+        The resolved (real) path if it is inside the allowed directory.
+
+    Raises
+    ------
+    ValueError
+        If the resolved path escapes the allowed directory.
+    """
+    real_path = os.path.realpath(file_path)
+    real_allowed = os.path.realpath(allowed_directory)
+    try:
+        common = os.path.commonpath([real_allowed, real_path])
+    except ValueError as exc:
+        # On Windows, paths on different drives raise ValueError
+        raise ValueError("Path is outside the allowed directory") from exc
+    if common != real_allowed:
+        raise ValueError("Path is outside the allowed directory")
+    return real_path

--- a/tests/plugins/test_image_upload.py
+++ b/tests/plugins/test_image_upload.py
@@ -1,8 +1,20 @@
 # pyright: reportMissingImports=false
+import tempfile
 from io import BytesIO
 
 import pytest
 from PIL import Image
+
+import plugins.image_upload.image_upload as _image_upload_mod
+
+
+@pytest.fixture(autouse=True)
+def _patch_upload_dir(monkeypatch):
+    """Point _get_upload_dir to the system temp directory so that tests using
+    tempfile.NamedTemporaryFile pass path validation."""
+    monkeypatch.setattr(
+        _image_upload_mod, "_get_upload_dir", lambda: tempfile.gettempdir()
+    )
 
 
 def build_upload(name: str, content: bytes, content_type: str = "image/png"):
@@ -61,6 +73,11 @@ def test_image_upload_success(client, monkeypatch, device_config_dev, tmp_path):
 
     # Intercept handle_request_files to feed our upload through the real validator
     import utils.app_utils as app_utils
+
+    # Re-patch _get_upload_dir to match the actual upload path used by
+    # handle_request_files so that path validation accepts saved files.
+    real_upload_dir = app_utils.resolve_path("static/images/saved")
+    monkeypatch.setattr(_image_upload_mod, "_get_upload_dir", lambda: real_upload_dir)
 
     def fake_handle_request_files(request_files, form_data=None):
         if form_data is None:
@@ -190,21 +207,25 @@ def test_image_upload_open_image_no_images():
         plugin.open_image(0, [])
 
 
-def test_image_upload_open_image_invalid_file(monkeypatch):
+def test_image_upload_open_image_invalid_file(monkeypatch, tmp_path):
     from PIL import Image
 
     from plugins.image_upload.image_upload import ImageUpload
 
     plugin = ImageUpload({"id": "image_upload"})
 
-    # Mock Image.open to raise exception (upstream uses Image.open directly)
+    # Use a path inside the allowed dir so path validation passes,
+    # then mock Image.open to raise an exception
+    monkeypatch.setattr(_image_upload_mod, "_get_upload_dir", lambda: str(tmp_path))
+    fake_path = str(tmp_path / "missing.png")
+
     def mock_open(path):
         raise OSError("File not found")
 
     monkeypatch.setattr(Image, "open", mock_open)
 
     with pytest.raises(RuntimeError, match="Failed to read image file"):
-        plugin.open_image(0, ["/fake/path.png"])
+        plugin.open_image(0, [fake_path])
 
 
 def test_image_upload_generate_image_index_out_of_range(monkeypatch, device_config_dev):

--- a/tests/plugins/test_screenshot.py
+++ b/tests/plugins/test_screenshot.py
@@ -1,5 +1,19 @@
+import socket
+
+import pytest
+
+
 def test_screenshot_success(monkeypatch, device_config_dev):
     from plugins.screenshot.screenshot import Screenshot
+
+    # Mock DNS resolution to return a public IP so validate_url passes
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ],
+    )
 
     # Success is covered by autouse fixture replacing take_screenshot
     img = Screenshot({"id": "screenshot"}).generate_image(
@@ -11,6 +25,15 @@ def test_screenshot_success(monkeypatch, device_config_dev):
 
 def test_screenshot_failure(monkeypatch, device_config_dev):
     from plugins.screenshot.screenshot import Screenshot
+
+    # Mock DNS resolution to return a public IP so validate_url passes
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ],
+    )
 
     # Force take_screenshot to return None at the import location used by plugin
     monkeypatch.setattr(
@@ -26,3 +49,41 @@ def test_screenshot_failure(monkeypatch, device_config_dev):
         assert False, "Expected failure when screenshot cannot be taken"
     except RuntimeError:
         pass
+
+
+def test_screenshot_rejects_file_url(device_config_dev):
+    """Screenshot plugin must reject file:// URLs."""
+    from plugins.screenshot.screenshot import Screenshot
+
+    plugin = Screenshot({"id": "screenshot"})
+    with pytest.raises(RuntimeError, match="Invalid URL"):
+        plugin.generate_image({"url": "file:///etc/passwd"}, device_config_dev)
+
+
+def test_screenshot_rejects_localhost(device_config_dev):
+    """Screenshot plugin must reject localhost URLs."""
+    from plugins.screenshot.screenshot import Screenshot
+
+    plugin = Screenshot({"id": "screenshot"})
+    with pytest.raises(RuntimeError, match="Invalid URL"):
+        plugin.generate_image({"url": "http://localhost:8080"}, device_config_dev)
+
+
+def test_screenshot_rejects_metadata_endpoint(monkeypatch, device_config_dev):
+    """Screenshot plugin must reject cloud metadata endpoints."""
+    from plugins.screenshot.screenshot import Screenshot
+
+    # 169.254.169.254 is link-local — mock DNS so it resolves to that IP
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))
+        ],
+    )
+
+    plugin = Screenshot({"id": "screenshot"})
+    with pytest.raises(RuntimeError, match="Invalid URL"):
+        plugin.generate_image(
+            {"url": "http://169.254.169.254/latest/meta-data/"}, device_config_dev
+        )

--- a/tests/unit/test_image_upload_unit.py
+++ b/tests/unit/test_image_upload_unit.py
@@ -25,6 +25,12 @@ def make_png_file(path, size=(10, 10), color=(255, 0, 0)):
     img.save(path, format="PNG")
 
 
+@pytest.fixture(autouse=True)
+def _patch_upload_dir(tmp_path, monkeypatch):
+    """Point _get_upload_dir to tmp_path so path validation accepts test images."""
+    monkeypatch.setattr(image_upload_mod, "_get_upload_dir", lambda: str(tmp_path))
+
+
 def test_open_image_success(tmp_path):
     p = tmp_path / "img.png"
     make_png_file(p)
@@ -39,10 +45,12 @@ def test_open_image_no_images():
         u.open_image(0, [])
 
 
-def test_open_image_bad_path():
+def test_open_image_bad_path(tmp_path):
     u = image_upload_mod.ImageUpload({"id": "image_upload"})
+    # Path inside tmp_path (allowed dir) but does not exist — triggers OSError in Image.open
+    bad = str(tmp_path / "nonexistent.png")
     with pytest.raises(RuntimeError):
-        u.open_image(0, ["/non/existent/path.png"])
+        u.open_image(0, [bad])
 
 
 def test_generate_image_no_images():
@@ -101,3 +109,49 @@ def test_generate_image_padImage_true(tmp_path):
     out = u.generate_image(settings, device)
     # When padding, upstream uses ImageOps.pad() which pads to exact device dimensions
     assert out.size == device.get_resolution()
+
+
+# ---------------------------------------------------------------------------
+# Path traversal / security tests
+# ---------------------------------------------------------------------------
+
+
+def test_open_image_rejects_path_traversal(tmp_path, monkeypatch):
+    """open_image must reject paths that escape the upload directory."""
+    # _get_upload_dir is already patched to tmp_path by autouse fixture
+    u = image_upload_mod.ImageUpload({"id": "image_upload"})
+    malicious = str(tmp_path / ".." / ".." / "etc" / "passwd")
+    with pytest.raises(RuntimeError, match="Invalid image file path"):
+        u.open_image(0, [malicious])
+
+
+def test_open_image_rejects_absolute_outside(tmp_path, monkeypatch):
+    """open_image must reject absolute paths outside the upload directory."""
+    u = image_upload_mod.ImageUpload({"id": "image_upload"})
+    with pytest.raises(RuntimeError, match="Invalid image file path"):
+        u.open_image(0, ["/etc/passwd"])
+
+
+def test_cleanup_skips_invalid_paths(tmp_path, monkeypatch):
+    """cleanup must silently skip paths outside the upload directory."""
+    # Create a file inside the allowed dir to verify it gets cleaned up
+    safe_file = tmp_path / "safe.png"
+    make_png_file(safe_file)
+
+    settings = {
+        "imageFiles[]": ["/etc/passwd", str(safe_file)],
+    }
+    u = image_upload_mod.ImageUpload({"id": "image_upload"})
+    # Should not raise — the invalid path is skipped, the safe path is deleted
+    u.cleanup(settings)
+    assert not safe_file.exists(), "Safe file should have been deleted"
+
+
+def test_cleanup_skips_traversal_paths(tmp_path, monkeypatch):
+    """cleanup must skip traversal paths without raising."""
+    settings = {
+        "imageFiles[]": [str(tmp_path / ".." / ".." / "etc" / "passwd")],
+    }
+    u = image_upload_mod.ImageUpload({"id": "image_upload"})
+    # Must not raise
+    u.cleanup(settings)

--- a/tests/unit/test_security_utils.py
+++ b/tests/unit/test_security_utils.py
@@ -1,0 +1,235 @@
+# pyright: reportMissingImports=false
+"""Tests for utils.security_utils — URL and file-path validation."""
+
+import socket
+
+import pytest
+
+from utils.security_utils import validate_file_path, validate_url
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_getaddrinfo_public(host, port, *args, **kwargs):
+    """Return a fake getaddrinfo result pointing to a public IP."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+
+def _mock_getaddrinfo_private(host, port, *args, **kwargs):
+    """Return a fake getaddrinfo result pointing to a private IP."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 0))]
+
+
+def _mock_getaddrinfo_loopback(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+
+
+def _mock_getaddrinfo_link_local(host, port, *args, **kwargs):
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))]
+
+
+def _mock_getaddrinfo_fail(host, port, *args, **kwargs):
+    raise socket.gaierror("Name resolution failed")
+
+
+# ---------------------------------------------------------------------------
+# URL validation — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlAccepted:
+    def test_http_url_passes(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_public)
+        assert validate_url("http://example.com") == "http://example.com"
+
+    def test_https_url_passes(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_public)
+        assert validate_url("https://example.com/page") == "https://example.com/page"
+
+    def test_url_with_port_passes(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_public)
+        assert (
+            validate_url("http://example.com:8080/path")
+            == "http://example.com:8080/path"
+        )
+
+    def test_url_with_query_passes(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_public)
+        url = "https://example.com/search?q=test&page=1"
+        assert validate_url(url) == url
+
+
+# ---------------------------------------------------------------------------
+# URL validation — scheme rejection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlSchemeRejected:
+    def test_file_scheme_rejected(self):
+        with pytest.raises(ValueError, match="scheme must be http or https"):
+            validate_url("file:///etc/passwd")
+
+    def test_javascript_scheme_rejected(self):
+        with pytest.raises(ValueError, match="scheme must be http or https"):
+            validate_url("javascript:alert(1)")
+
+    def test_data_scheme_rejected(self):
+        with pytest.raises(ValueError, match="scheme must be http or https"):
+            validate_url("data:text/html,<h1>hi</h1>")
+
+    def test_ftp_scheme_rejected(self):
+        with pytest.raises(ValueError, match="scheme must be http or https"):
+            validate_url("ftp://files.example.com/readme.txt")
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_url("")
+
+
+# ---------------------------------------------------------------------------
+# URL validation — hostname checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlHostname:
+    def test_no_hostname_rejected(self):
+        with pytest.raises(ValueError, match="must include a hostname"):
+            validate_url("http://")
+
+    def test_localhost_rejected(self):
+        with pytest.raises(ValueError, match="must not target localhost"):
+            validate_url("http://localhost:8080")
+
+    def test_localhost_case_insensitive(self):
+        with pytest.raises(ValueError, match="must not target localhost"):
+            validate_url("http://LOCALHOST/path")
+
+
+# ---------------------------------------------------------------------------
+# URL validation — IP address checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlIpRejected:
+    def test_loopback_ipv4_rejected(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_loopback)
+        with pytest.raises(
+            ValueError, match="private.*loopback.*link-local.*reserved.*multicast"
+        ):
+            validate_url("http://127.0.0.1")
+
+    def test_ipv6_loopback_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 0, 0, 0))
+            ],
+        )
+        with pytest.raises(ValueError):
+            validate_url("http://[::1]")
+
+    def test_private_10x_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 0))
+            ],
+        )
+        with pytest.raises(ValueError):
+            validate_url("http://10.0.0.1")
+
+    def test_private_172_16_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.16.0.1", 0))
+            ],
+        )
+        with pytest.raises(ValueError):
+            validate_url("http://172.16.0.1")
+
+    def test_private_192_168_rejected(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_private)
+        with pytest.raises(ValueError):
+            validate_url("http://192.168.1.1")
+
+    def test_link_local_rejected(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_link_local)
+        with pytest.raises(ValueError):
+            validate_url("http://169.254.169.254/latest/meta-data/")
+
+
+# ---------------------------------------------------------------------------
+# URL validation — DNS resolution
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlDns:
+    def test_dns_resolving_to_private_rejected(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_private)
+        with pytest.raises(ValueError):
+            validate_url("http://evil.example.com")
+
+    def test_unresolvable_host_rejected(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _mock_getaddrinfo_fail)
+        with pytest.raises(ValueError, match="Cannot resolve hostname"):
+            validate_url("http://nonexistent.invalid")
+
+
+# ---------------------------------------------------------------------------
+# File path validation — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFilePathAccepted:
+    def test_valid_path_within_directory(self, tmp_path):
+        allowed = tmp_path / "uploads"
+        allowed.mkdir()
+        target = allowed / "image.png"
+        target.touch()
+        result = validate_file_path(str(target), str(allowed))
+        assert result == str(target.resolve())
+
+    def test_nested_subdirectory(self, tmp_path):
+        allowed = tmp_path / "uploads"
+        sub = allowed / "sub" / "deep"
+        sub.mkdir(parents=True)
+        target = sub / "file.txt"
+        target.touch()
+        result = validate_file_path(str(target), str(allowed))
+        assert result == str(target.resolve())
+
+
+# ---------------------------------------------------------------------------
+# File path validation — rejection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFilePathRejected:
+    def test_traversal_rejected(self, tmp_path):
+        allowed = tmp_path / "uploads"
+        allowed.mkdir()
+        malicious = str(allowed / ".." / ".." / "etc" / "passwd")
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            validate_file_path(malicious, str(allowed))
+
+    def test_absolute_path_outside_rejected(self, tmp_path):
+        allowed = tmp_path / "uploads"
+        allowed.mkdir()
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            validate_file_path("/etc/passwd", str(allowed))
+
+    def test_symlink_escaping_rejected(self, tmp_path):
+        allowed = tmp_path / "uploads"
+        allowed.mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("secret")
+        link = allowed / "escape.txt"
+        link.symlink_to(outside)
+        with pytest.raises(ValueError, match="outside the allowed directory"):
+            validate_file_path(str(link), str(allowed))


### PR DESCRIPTION
## Summary
- Add URL validation to the Screenshot plugin to block SSRF attacks — only `http://` and `https://` schemes allowed, private/loopback/link-local/reserved IPs rejected via DNS resolution check
- Add file path validation to the Image Upload plugin to prevent path traversal — all paths verified to resolve within `static/images/saved/` using `os.path.realpath()`
- New shared `src/utils/security_utils.py` module with reusable `validate_url()` and `validate_file_path()` functions

## Changes
- **New:** `src/utils/security_utils.py` — shared validation utilities
- **Modified:** `src/plugins/screenshot/screenshot.py` — URL validation before `take_screenshot()`
- **Modified:** `src/plugins/image_upload/image_upload.py` — path validation in `open_image()` and `cleanup()`
- **New:** `tests/unit/test_security_utils.py` — 25 unit tests for both validators
- **Modified:** `tests/plugins/test_screenshot.py` — 3 SSRF rejection integration tests
- **Modified:** `tests/unit/test_image_upload_unit.py` — 4 path traversal tests

## Test plan
- [x] All existing tests pass (1983 total)
- [x] New tests cover scheme rejection, IP blocking, DNS resolution, path traversal, symlink escape
- [x] Linting passes (ruff + black)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads now validate file paths to prevent directory traversal attacks, ensuring uploaded files remain within the allowed directory.
  * Screenshot generation now validates URLs before processing, rejecting localhost addresses, file:// protocol, private network IP ranges, and cloud metadata endpoints.
  * Improved error messages and logging for rejected invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->