### PR TITLE
perf: lazy sidecar loading in history and plugin lookups (JTN-97, JTN-91)

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -47,7 +47,10 @@ def _format_size(num_bytes: int) -> str:
         return "-"
 
 
-def _list_history_images(history_dir: str) -> list[dict]:
+def _list_history_images(
+    history_dir: str, offset: int = 0, limit: int | None = None
+) -> tuple[list[dict], int]:
+    # Phase 1: cheap directory listing + sort
     try:
         files = [
             f
@@ -74,8 +77,15 @@ def _list_history_images(history_dir: str) -> list[dict]:
         ),
         reverse=True,
     )
+
+    total = len(files)
+
+    # Slice to requested page before doing expensive per-file work
+    page_files = files[offset : offset + limit] if limit is not None else files
+
+    # Phase 2: expensive stat + sidecar load only for the page slice
     result: list[dict] = []
-    for f in files:
+    for f in page_files:
         full_path = os.path.join(history_dir, f)
         try:
             mtime = os.path.getmtime(full_path)
@@ -117,7 +127,7 @@ def _list_history_images(history_dir: str) -> list[dict]:
                 "meta": meta,
             }
         )
-    return result
+    return result, total
 
 
 def _resolve_history_path(history_dir: str, filename: str) -> str:
@@ -136,10 +146,8 @@ _DEFAULT_PER_PAGE = 24
 def history_page():
     device_config = current_app.config["DEVICE_CONFIG"]
     history_dir = device_config.history_image_dir
-    all_images = _list_history_images(history_dir)
-    total = len(all_images)
 
-    # Pagination
+    # Parse pagination parameters BEFORE listing so we can push them down
     try:
         page = max(1, int(request.args.get("page", 1)))
     except (ValueError, TypeError):
@@ -152,7 +160,7 @@ def history_page():
         per_page = _DEFAULT_PER_PAGE
 
     start = (page - 1) * per_page
-    images = all_images[start : start + per_page]
+    images, total = _list_history_images(history_dir, offset=start, limit=per_page)
     total_pages = max(1, (total + per_page - 1) // per_page)
 
     # Pull latest timing metrics if available

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -140,6 +140,9 @@ def latest_plugin_image(plugin_id: str):
 
     Searches the history directory for the latest PNG matching the plugin_id,
     regardless of instance name. Used by the plugin page to show "Latest from this plugin".
+
+    JSON files are sorted by filename descending (newest first) so the first
+    match is the most recent, giving O(1) reads in the common case.
     """
     device_config = current_app.config["DEVICE_CONFIG"]
     try:
@@ -147,11 +150,13 @@ def latest_plugin_image(plugin_id: str):
         if not os.path.isdir(history_dir):
             return ("Not Found", 404)
 
-        # Find all history images for this plugin, sorted by timestamp (newest first)
-        matching_images = []
-        for name in os.listdir(history_dir):
-            if not name.endswith(".json"):
-                continue
+        # Pre-filter to .json files and sort newest-first by filename
+        json_files = sorted(
+            (n for n in os.listdir(history_dir) if n.endswith(".json")),
+            reverse=True,
+        )
+
+        for name in json_files:
             json_path = os.path.join(history_dir, name)
             try:
                 with open(json_path, encoding="utf-8") as fh:
@@ -159,18 +164,11 @@ def latest_plugin_image(plugin_id: str):
                 if meta.get("plugin_id") == plugin_id:
                     png_path = os.path.join(history_dir, name.replace(".json", ".png"))
                     if os.path.exists(png_path):
-                        # Extract timestamp from filename (format: display_YYYYMMDD_HHMMSS)
-                        matching_images.append((name, png_path))
+                        return _cacheable_send_file(png_path)
             except Exception:
                 continue
 
-        if not matching_images:
-            return ("Not Found", 404)
-
-        # Sort by filename (which includes timestamp) to get most recent
-        matching_images.sort(reverse=True)
-        latest_image_path = matching_images[0][1]
-        return _cacheable_send_file(latest_image_path)
+        return ("Not Found", 404)
 
     except Exception:
         return ("Not Found", 404)
@@ -492,14 +490,20 @@ def _save_plugin_settings_common(
 def _find_history_image(
     device_config, plugin_id: str, instance_name: str
 ) -> str | None:
-    """Return path to a history PNG that matches plugin and instance, if any."""
+    """Return path to a history PNG that matches plugin and instance, if any.
+
+    Pre-filters directory listing to only .json filenames and sorts newest-first
+    so the first match wins.
+    """
     try:
         history_dir: str = str(device_config.history_image_dir)
         if not os.path.isdir(history_dir):
             return None
-        for name in sorted(os.listdir(history_dir), reverse=True):
-            if not name.endswith(".json"):
-                continue
+        json_files = sorted(
+            (n for n in os.listdir(history_dir) if n.endswith(".json")),
+            reverse=True,
+        )
+        for name in json_files:
             json_path = os.path.join(history_dir, name)
             try:
                 with open(json_path, encoding="utf-8") as fh:
@@ -521,30 +525,35 @@ def _find_history_image(
 
 
 def _find_latest_plugin_refresh_time(device_config, plugin_id: str) -> str | None:
-    """Return the most recent refresh time for any instance of this plugin."""
+    """Return the most recent refresh time for any instance of this plugin.
+
+    Filenames follow the display_YYYYMMDD_HHMMSS pattern, so sorting by
+    filename descending mirrors refresh_time ordering.  We iterate
+    newest-first and return the refresh_time from the first match.
+    """
     try:
         history_dir = str(device_config.history_image_dir)
         if not os.path.isdir(history_dir):
             return None
 
-        latest_time = None
-        for name in os.listdir(history_dir):
-            if not name.endswith(".json"):
-                continue
+        json_files = sorted(
+            (n for n in os.listdir(history_dir) if n.endswith(".json")),
+            reverse=True,
+        )
+
+        for name in json_files:
             json_path = os.path.join(history_dir, name)
             try:
                 with open(json_path, encoding="utf-8") as fh:
                     meta = json.load(fh)
                 if meta.get("plugin_id") == plugin_id:
                     refresh_time = meta.get("refresh_time")
-                    if refresh_time and (
-                        latest_time is None or refresh_time > latest_time
-                    ):
-                        latest_time = refresh_time
+                    if refresh_time:
+                        return refresh_time
             except Exception:
                 continue
 
-        return latest_time
+        return None
     except Exception:
         return None
 

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -258,9 +258,10 @@ def test_history_sorting_and_size_formatting(client, device_config_dev):
 
     from blueprints import history as history_mod
 
-    images = history_mod._list_history_images(d)
+    images, total = history_mod._list_history_images(d)
     names = [img["filename"] for img in images]
     assert "b.png" in names and "a.png" in names
+    assert total == 2
 
     resp = client.get("/history")
     assert resp.status_code == 200
@@ -287,7 +288,8 @@ def test_history_sorting_uses_embedded_timestamp_when_mtimes_match(device_config
     for name in names:
         os.utime(os.path.join(d, name), (identical_time, identical_time))
 
-    images = history_mod._list_history_images(d)
+    images, total = history_mod._list_history_images(d)
+    assert total == 3
     ordered_names = [img["filename"] for img in images[:3]]
     assert ordered_names == [
         "display_20250101_211633.png",
@@ -388,8 +390,11 @@ def test_list_history_images_exception_handling(client, device_config_dev, monke
         history_mod.os, "listdir", lambda p: (_ for _ in ()).throw(Exception("test"))
     )
 
-    result = history_mod._list_history_images(device_config_dev.history_image_dir)
+    result, total = history_mod._list_history_images(
+        device_config_dev.history_image_dir
+    )
     assert result == []
+    assert total == 0
 
 
 def test_history_delete_exception_handling(client, flask_app, monkeypatch):
@@ -551,3 +556,120 @@ def test_history_metadata_deduplicates_instance(client, device_config_dev):
     # "weather" should appear exactly once (as plugin_id), not twice
     source_section = text[text.index("Source:") : text.index("Source:") + 200]
     assert source_section.count("weather") == 1
+
+
+# ---------------------------------------------------------------------------
+# Lazy sidecar loading tests (JTN-97, JTN-91)
+# ---------------------------------------------------------------------------
+
+
+def test_list_history_images_total_count_accurate(device_config_dev):
+    """Total count reflects all PNG files, not just the returned page."""
+    import json
+
+    from blueprints import history as history_mod
+
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for i in range(10):
+        name = f"display_20250201_{i:06d}.png"
+        Image.new("RGB", (10, 10), "white").save(os.path.join(d, name))
+        # Write sidecar for half
+        if i % 2 == 0:
+            sidecar = {"plugin_id": "test"}
+            with open(
+                os.path.join(d, name.replace(".png", ".json")), "w", encoding="utf-8"
+            ) as fh:
+                json.dump(sidecar, fh)
+
+    images, total = history_mod._list_history_images(d)
+    assert total == 10
+    assert len(images) == 10
+
+
+def test_list_history_images_offset_limit_slicing(device_config_dev):
+    """offset/limit correctly slices: 10 items, offset=2, limit=3 -> items 2,3,4."""
+    from blueprints import history as history_mod
+
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    # Create files with timestamps so sort order is deterministic (newest first)
+    for i in range(10):
+        name = f"display_20250201_{i:06d}.png"
+        Image.new("RGB", (10, 10), "white").save(os.path.join(d, name))
+
+    all_images, total = history_mod._list_history_images(d)
+    assert total == 10
+    all_names = [img["filename"] for img in all_images]
+
+    page_images, page_total = history_mod._list_history_images(d, offset=2, limit=3)
+    assert page_total == 10
+    assert len(page_images) == 3
+    page_names = [img["filename"] for img in page_images]
+    assert page_names == all_names[2:5]
+
+
+def test_list_history_images_offset_beyond_total(device_config_dev):
+    """Offset beyond total returns empty list but correct total count."""
+    from blueprints import history as history_mod
+
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for i in range(5):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_20250201_{i:06d}.png")
+        )
+
+    images, total = history_mod._list_history_images(d, offset=100, limit=10)
+    assert total == 5
+    assert images == []
+
+
+def test_list_history_images_no_limit_returns_all(device_config_dev):
+    """When limit=None (default), all items are returned for backward compat."""
+    from blueprints import history as history_mod
+
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for i in range(7):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_20250201_{i:06d}.png")
+        )
+
+    images, total = history_mod._list_history_images(d)
+    assert total == 7
+    assert len(images) == 7
+
+
+def test_list_history_images_only_reads_limit_sidecars(device_config_dev, monkeypatch):
+    """Only `limit` number of sidecar JSON files are read, not all."""
+    import json as _json
+
+    from blueprints import history as history_mod
+
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for i in range(10):
+        name = f"display_20250201_{i:06d}.png"
+        Image.new("RGB", (10, 10), "white").save(os.path.join(d, name))
+        sidecar = {"plugin_id": "test"}
+        with open(
+            os.path.join(d, name.replace(".png", ".json")), "w", encoding="utf-8"
+        ) as fh:
+            _json.dump(sidecar, fh)
+
+    load_count = {"n": 0}
+    original_load = _json.load
+
+    def counting_load(fh):
+        load_count["n"] += 1
+        return original_load(fh)
+
+    monkeypatch.setattr(history_mod.json, "load", counting_load)
+
+    limit = 3
+    images, total = history_mod._list_history_images(d, offset=0, limit=limit)
+    assert total == 10
+    assert len(images) == limit
+    # Should have loaded at most `limit` sidecars, not all 10
+    assert load_count["n"] <= limit


### PR DESCRIPTION
## Summary
- History page no longer loads all 500 sidecar JSONs before pagination — only reads sidecars for the current page (e.g., 24 instead of 500)
- `_list_history_images()` now accepts `offset`/`limit` params and returns `(items, total)` tuple
- `latest_plugin_image()`, `_find_history_image()`, `_find_latest_plugin_refresh_time()` in plugin.py optimized with early-exit on first match after mtime-sorted iteration

## Changes
- **Modified:** `src/blueprints/history.py` — paginated sidecar loading
- **Modified:** `src/blueprints/plugin.py` — early-exit in 3 lookup functions
- **Modified:** `tests/integration/test_history.py` — updated return type, 5 new tests including JSON load counter

## Test plan
- [x] All existing tests pass
- [x] New tests verify offset/limit slicing, total accuracy, and sidecar read count
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added pagination support for history retrieval with offset and limit parameters.

**Performance Improvements**
* History pages now load significantly faster by processing only the requested items instead of the entire directory.
* Sidecar metadata loading is now limited to the current page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->