### PR TITLE
fix: wire Edit Refresh Settings button on playlist page (JTN-185, JTN-151)

### DIFF
--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -651,6 +651,23 @@
                 openDeleteInstanceModal(t.getAttribute('data-playlist'), t.getAttribute('data-plugin-id'), t.getAttribute('data-instance'));
             });
         });
+        document.querySelectorAll('.refresh-settings-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const t = e.currentTarget;
+                let refreshSettings = {};
+                try {
+                    refreshSettings = JSON.parse(t.getAttribute('data-refresh') || '{}');
+                } catch (_err) {
+                    refreshSettings = {};
+                }
+                openRefreshModal(
+                    t.getAttribute('data-playlist'),
+                    t.getAttribute('data-plugin-id'),
+                    t.getAttribute('data-instance'),
+                    refreshSettings
+                );
+            });
+        });
         document.querySelectorAll('.plugin-display-btn').forEach(btn => {
             btn.addEventListener('click', (e) => {
                 const t = e.currentTarget;

--- a/tests/static/test_playlist_refresh_btn.py
+++ b/tests/static/test_playlist_refresh_btn.py
@@ -1,0 +1,61 @@
+"""Tests that the Edit Refresh Settings button is properly wired up."""
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PLAYLIST_JS = ROOT / "src" / "static" / "scripts" / "playlist.js"
+PLAYLIST_HTML = ROOT / "src" / "templates" / "playlist.html"
+
+
+class TestRefreshSettingsBtnListener:
+    """Verify playlist.js registers a click listener for .refresh-settings-btn."""
+
+    def test_js_has_refresh_settings_btn_listener(self):
+        js_text = PLAYLIST_JS.read_text()
+        assert (
+            ".refresh-settings-btn" in js_text
+        ), "playlist.js must bind a click listener on .refresh-settings-btn"
+
+    def test_js_calls_open_refresh_modal(self):
+        js_text = PLAYLIST_JS.read_text()
+        # The listener block should call openRefreshModal
+        assert (
+            "openRefreshModal" in js_text
+        ), "playlist.js must call openRefreshModal from the refresh-settings-btn listener"
+
+    def test_js_parses_data_refresh_attribute(self):
+        js_text = PLAYLIST_JS.read_text()
+        assert (
+            "data-refresh" in js_text
+        ), "playlist.js must read the data-refresh attribute"
+
+
+class TestRefreshSettingsBtnTemplate:
+    """Verify playlist.html has the button with required data attributes."""
+
+    def test_html_has_refresh_settings_btn(self):
+        html_text = PLAYLIST_HTML.read_text()
+        assert (
+            "refresh-settings-btn" in html_text
+        ), "playlist.html must contain a .refresh-settings-btn element"
+
+    def test_html_btn_has_required_data_attributes(self):
+        html_text = PLAYLIST_HTML.read_text()
+        for attr in (
+            "data-playlist",
+            "data-plugin-id",
+            "data-instance",
+            "data-refresh",
+        ):
+            assert re.search(
+                rf'class="[^"]*refresh-settings-btn[^"]*"[^>]*{attr}=',
+                html_text,
+                re.DOTALL,
+            ), f"refresh-settings-btn must have {attr} attribute"
+
+    def test_html_has_refresh_modal(self):
+        html_text = PLAYLIST_HTML.read_text()
+        assert (
+            "refreshSettingsModal" in html_text
+        ), "playlist.html must contain the refreshSettingsModal markup"

--- a/tests/static/test_playlist_refresh_btn.py
+++ b/tests/static/test_playlist_refresh_btn.py
@@ -47,9 +47,9 @@ class TestRefreshSettingsBtnTemplate:
             html_text,
             re.DOTALL,
         )
-        assert btn_pattern, (
-            "playlist.html must contain a button with refresh-settings-btn class"
-        )
+        assert (
+            btn_pattern
+        ), "playlist.html must contain a button with refresh-settings-btn class"
         btn_match = btn_pattern.group(0)
         for attr in (
             "data-playlist",
@@ -57,9 +57,7 @@ class TestRefreshSettingsBtnTemplate:
             "data-instance",
             "data-refresh",
         ):
-            assert attr in btn_match, (
-                f"refresh-settings-btn must have {attr} attribute"
-            )
+            assert attr in btn_match, f"refresh-settings-btn must have {attr} attribute"
 
     def test_html_has_refresh_modal(self):
         html_text = PLAYLIST_HTML.read_text()

--- a/tests/static/test_playlist_refresh_btn.py
+++ b/tests/static/test_playlist_refresh_btn.py
@@ -42,17 +42,24 @@ class TestRefreshSettingsBtnTemplate:
 
     def test_html_btn_has_required_data_attributes(self):
         html_text = PLAYLIST_HTML.read_text()
+        btn_pattern = re.search(
+            r'<button[^>]*class="[^"]*refresh-settings-btn[^"]*"[^>]*>',
+            html_text,
+            re.DOTALL,
+        )
+        assert btn_pattern, (
+            "playlist.html must contain a button with refresh-settings-btn class"
+        )
+        btn_match = btn_pattern.group(0)
         for attr in (
             "data-playlist",
             "data-plugin-id",
             "data-instance",
             "data-refresh",
         ):
-            assert re.search(
-                rf'class="[^"]*refresh-settings-btn[^"]*"[^>]*{attr}=',
-                html_text,
-                re.DOTALL,
-            ), f"refresh-settings-btn must have {attr} attribute"
+            assert attr in btn_match, (
+                f"refresh-settings-btn must have {attr} attribute"
+            )
 
     def test_html_has_refresh_modal(self):
         html_text = PLAYLIST_HTML.read_text()


### PR DESCRIPTION
## Summary
- Wire the missing click handler for `.refresh-settings-btn` on the playlist page — the modal functions existed but the button was never connected
- Completes the remaining dead-end action from JTN-151 (partially fixed in PR #128)

## Changes
- `src/static/scripts/playlist.js` — add event listener in `init()` binding `.refresh-settings-btn` → `openRefreshModal()`
- `tests/static/test_playlist_refresh_btn.py` — 6 tests verifying listener wiring and template markup

## Test plan
- [ ] All existing tests pass (2033 passing)
- [ ] New tests verify button listener and template attributes
- [ ] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to refresh plugin settings for individual playlist items via a dedicated settings button.

* **Tests**
  * Added test coverage validating the refresh settings functionality and its integration with the playlist interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->