### PR TITLE
fix: playlist modal defaults and context-aware preview text (JTN-188, JTN-189)

### DIFF
--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -430,8 +430,8 @@
         document.getElementById("modalTitle").textContent = "New Playlist";
         document.getElementById("playlist_name").value = "";
         document.getElementById("editingPlaylistName").value = "";
-        document.getElementById("start_time").value = "00:00";
-        document.getElementById("end_time").value = "24:00";
+        document.getElementById("start_time").value = "09:00";
+        document.getElementById("end_time").value = "17:00";
         const cycleInput = document.getElementById('cycle_minutes');
         if (cycleInput) cycleInput.value = "";
         if (modal) modal.dataset.mode = "create";

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -270,9 +270,13 @@
             <div class="form-help workflow-help">
                 <div id="update-now-help" class="sr-only">Generate and display image immediately with current settings</div>
                 <div id="save-settings-help" class="sr-only">Save settings for future use without generating image</div>
+                {% if plugin_instance %}
                 <div id="update-instance-help" class="sr-only">Update and save this plugin instance configuration</div>
+                <p>Use <strong>Update Instance</strong> to save and refresh the displayed image.</p>
+                {% else %}
                 <div id="add-playlist-help" class="sr-only">Add this plugin to an automated playlist</div>
                 <p>Saving does not schedule recurrence. Use <strong>Add to Playlist</strong> to have this plugin run automatically.</p>
+                {% endif %}
             </div>
         </div>
         </aside>

--- a/tests/static/test_playlist_preview_ux.py
+++ b/tests/static/test_playlist_preview_ux.py
@@ -1,22 +1,35 @@
 """Tests for playlist modal defaults and preview helper text (JTN-188, JTN-189)."""
 
+import re
 from pathlib import Path
 
 
-def test_playlist_modal_no_all_day_default():
-    """openCreateModal should not default to 00:00-24:00 (overlaps Default)."""
+def test_playlist_modal_defaults_to_non_overlapping_range():
+    """openCreateModal should default to 09:00-17:00, not 00:00-24:00."""
     js = Path("src/static/scripts/playlist.js").read_text()
-    # Find the openCreateModal function and verify it doesn't use 00:00/24:00
-    # The defaults should be something like 09:00-17:00
-    assert (
-        '"00:00"' not in js or "openCreateModal" not in js.split('"00:00"')[0][-200:]
-    ), "openCreateModal should not default start_time to 00:00"
+    # Find openCreateModal function body
+    match = re.search(
+        r"function\s+openCreateModal\s*\(\)\s*\{(.*?)\n\s*\}", js, re.DOTALL
+    )
+    assert match, "openCreateModal function not found"
+    body = match.group(1)
+    assert '"09:00"' in body, "start_time should default to 09:00"
+    assert '"17:00"' in body, "end_time should default to 17:00"
+    assert '"00:00"' not in body, "start_time should not default to 00:00"
+    assert '"24:00"' not in body, "end_time should not default to 24:00"
 
 
 def test_preview_helper_text_is_conditional():
-    """plugin.html helper text must be context-aware (draft vs instance)."""
+    """The workflow-help region must be context-aware (draft vs instance)."""
     html = Path("src/templates/plugin.html").read_text()
-    # The helper text should be wrapped in {% if plugin_instance %}
-    assert "{% if plugin_instance %}" in html
-    assert "Update Instance" in html
-    assert "Add to Playlist" in html
+    # Find the workflow-help section specifically
+    match = re.search(
+        r'class="form-help workflow-help">(.*?)</div>\s*</div>', html, re.DOTALL
+    )
+    assert match, "workflow-help section not found"
+    help_section = match.group(1)
+    assert (
+        "{% if plugin_instance %}" in help_section
+    ), "workflow-help must use conditional rendering for plugin_instance"
+    assert "Update Instance" in help_section
+    assert "Add to Playlist" in help_section

--- a/tests/static/test_playlist_preview_ux.py
+++ b/tests/static/test_playlist_preview_ux.py
@@ -1,0 +1,22 @@
+"""Tests for playlist modal defaults and preview helper text (JTN-188, JTN-189)."""
+
+from pathlib import Path
+
+
+def test_playlist_modal_no_all_day_default():
+    """openCreateModal should not default to 00:00-24:00 (overlaps Default)."""
+    js = Path("src/static/scripts/playlist.js").read_text()
+    # Find the openCreateModal function and verify it doesn't use 00:00/24:00
+    # The defaults should be something like 09:00-17:00
+    assert (
+        '"00:00"' not in js or "openCreateModal" not in js.split('"00:00"')[0][-200:]
+    ), "openCreateModal should not default start_time to 00:00"
+
+
+def test_preview_helper_text_is_conditional():
+    """plugin.html helper text must be context-aware (draft vs instance)."""
+    html = Path("src/templates/plugin.html").read_text()
+    # The helper text should be wrapped in {% if plugin_instance %}
+    assert "{% if plugin_instance %}" in html
+    assert "Update Instance" in html
+    assert "Add to Playlist" in html


### PR DESCRIPTION
## Summary
- Change New Playlist modal time defaults from 00:00-24:00 to 09:00-17:00 so they don't overlap the Default playlist
- Make Preview & Apply helper text context-aware: draft pages reference "Add to Playlist", instance pages reference "Update Instance"

## Changes
- `src/static/scripts/playlist.js` — update `openCreateModal()` defaults
- `src/templates/plugin.html` — conditional Jinja2 for helper text and sr-only descriptions
- `tests/static/test_playlist_preview_ux.py` — 2 tests

## Test plan
- [ ] All existing tests pass (2047 passing)
- [ ] New playlist modal opens with 09:00-17:00 defaults
- [ ] Draft plugin pages show "Add to Playlist" helper text
- [ ] Instance plugin pages show "Update Instance" helper text
- [ ] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted default start and end times when creating new playlists from an all-day window to 9:00 AM–5:00 PM.

* **Documentation**
  * Help guidance now displays context-sensitive information, providing specific instructions based on your current action—whether you're creating a new playlist or updating an existing one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->