### PR TITLE
fix: add server-side required field validation for plugin save (JTN-187, JTN-186)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -28,6 +28,39 @@ plugin_bp = Blueprint("plugin", __name__)
 PLUGINS_DIR = resolve_path("plugins")
 
 
+def _validate_required_fields(plugin, form_data):
+    """Validate required fields from plugin schema against form data.
+
+    Returns an error message string if any required fields are empty/missing,
+    or None if validation passes.
+    """
+    if not hasattr(plugin, "build_settings_schema"):
+        return None
+    try:
+        schema = plugin.build_settings_schema()
+    except Exception:
+        return None
+
+    missing = []
+
+    def _check_items(items):
+        for item in items:
+            kind = item.get("kind", "")
+            if kind == "row":
+                _check_items(item.get("items", []))
+            elif kind == "field":
+                name = item.get("name", "")
+                if item.get("required") and not str(form_data.get(name, "")).strip():
+                    missing.append(item.get("label", name))
+
+    for section in schema.get("sections", []):
+        _check_items(section.get("items", []))
+
+    if missing:
+        return f"Required fields missing: {', '.join(missing)}"
+    return None
+
+
 def _sanitize_log(value: str) -> str:
     """Strip control characters from user input before logging to prevent log injection."""
     return value.replace("\n", "").replace("\r", "").replace("\x00", "")[:200]
@@ -270,6 +303,17 @@ def update_plugin_instance(instance_name: str):
                 status=404,
             )
 
+        # Validate required fields defined in the plugin schema
+        plugin_config = device_config.get_plugin(plugin_id)
+        if plugin_config:
+            try:
+                plugin = get_plugin_instance(plugin_config)
+                validation_error = _validate_required_fields(plugin, plugin_settings)
+                if validation_error:
+                    return json_error(validation_error, status=400)
+            except Exception:
+                logger.debug("Could not validate plugin schema for %s", plugin_id)
+
         plugin_instance.settings = plugin_settings
         device_config.write_config()
     except APIError as e:
@@ -451,6 +495,15 @@ def _save_plugin_settings_common(
             f"Plugin '{_sanitize_response_value(plugin_id)}' not found",
             status=404,
         )
+
+    # Validate required fields defined in the plugin schema
+    try:
+        plugin = get_plugin_instance(plugin_config)
+        validation_error = _validate_required_fields(plugin, plugin_settings)
+        if validation_error:
+            return json_error(validation_error, status=400)
+    except Exception:
+        logger.debug("Could not validate plugin schema for %s", plugin_id)
 
     default_playlist_name = "Default"
     playlist = playlist_manager.get_playlist(default_playlist_name)

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -342,8 +342,8 @@
         toggle.title = "Toggle visibility";
         input.parentElement.insertBefore(toggle, input.nextSibling);
       });
-      var addBtn = document.getElementById("addApiKeyBtn");
-      var saveBtn = document.getElementById("saveApiKeysBtn");
+      const addBtn = document.getElementById("addApiKeyBtn");
+      const saveBtn = document.getElementById("saveApiKeysBtn");
       if (addBtn) {
         addBtn.addEventListener("click", () => addRow());
       } else if (config.mode === "generic") {

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -342,8 +342,18 @@
         toggle.title = "Toggle visibility";
         input.parentElement.insertBefore(toggle, input.nextSibling);
       });
-      document.getElementById("addApiKeyBtn")?.addEventListener("click", () => addRow());
-      document.getElementById("saveApiKeysBtn")?.addEventListener("click", saveKeys);
+      var addBtn = document.getElementById("addApiKeyBtn");
+      var saveBtn = document.getElementById("saveApiKeysBtn");
+      if (addBtn) {
+        addBtn.addEventListener("click", () => addRow());
+      } else if (config.mode === "generic") {
+        console.warn("api_keys_page: #addApiKeyBtn not found in DOM");
+      }
+      if (saveBtn) {
+        saveBtn.addEventListener("click", saveKeys);
+      } else {
+        console.warn("api_keys_page: #saveApiKeysBtn not found in DOM");
+      }
       document.addEventListener("click", (event) => {
         const actionEl = event.target.closest("[data-api-action]");
         if (!actionEl) return;

--- a/tests/integration/test_api_json_errors.py
+++ b/tests/integration/test_api_json_errors.py
@@ -34,6 +34,9 @@ def test_save_plugin_settings_error_json(client, flask_app, monkeypatch):
 
     monkeypatch.setattr(dc, "update_value", boom_update_value, raising=True)
 
-    resp = client.post("/save_plugin_settings", data={"plugin_id": "ai_text"})
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "ai_text", "textPrompt": "Hello"},
+    )
     assert resp.status_code == 500
     assert "error" in resp.get_json()

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -222,7 +222,10 @@ def test_save_plugin_settings_exception_handling(client, flask_app, monkeypatch)
         lambda *args, **kwargs: (_ for _ in ()).throw(Exception("test")),
     )
 
-    resp = client.post("/save_plugin_settings", data={"plugin_id": "ai_text"})
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "ai_text", "textPrompt": "Hello"},
+    )
     assert resp.status_code == 500
     assert "An internal error occurred" in resp.get_json().get("error", "")
 

--- a/tests/integration/test_plugin_validation.py
+++ b/tests/integration/test_plugin_validation.py
@@ -1,0 +1,107 @@
+# pyright: reportMissingImports=false
+"""Tests for server-side plugin settings validation (JTN-187)."""
+
+
+def test_save_rejects_missing_required_fields(client):
+    """Saving plugin settings with empty required fields should return 400."""
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_folder", "folder_path": ""},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Required" in data.get("error", "")
+    assert "Folder Path" in data.get("error", "")
+
+
+def test_save_accepts_valid_required_fields(client):
+    """Saving with all required fields filled should not return 400."""
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_folder", "folder_path": "/tmp/test-images"},
+    )
+    assert resp.status_code != 400
+
+
+def test_save_rejects_whitespace_only_required_fields(client):
+    """Whitespace-only values should be treated as empty for required fields."""
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_folder", "folder_path": "   "},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Required" in data.get("error", "")
+
+
+def test_save_alias_rejects_missing_required_fields(client):
+    """The alias save route also validates required fields."""
+    resp = client.post(
+        "/plugin/image_folder/save",
+        data={"folder_path": ""},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Required" in data.get("error", "")
+
+
+def test_save_skips_validation_for_plugin_without_schema(client):
+    """Plugins that do not define build_settings_schema should not fail validation."""
+    # clock plugin exists but we just verify it does not 400 due to missing schema
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "clock"},
+    )
+    # Should succeed (200) — not a validation error
+    assert resp.status_code == 200
+
+
+def test_update_instance_rejects_missing_required_fields(client, device_config_dev):
+    """Updating an existing plugin instance validates required fields."""
+    # Create an instance first via save
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default")
+    playlist = pm.get_playlist("Default")
+    playlist.add_plugin(
+        {
+            "plugin_id": "image_folder",
+            "name": "test_instance",
+            "plugin_settings": {"folder_path": "/tmp/existing"},
+            "refresh": {"interval": 300},
+        }
+    )
+    device_config_dev.write_config()
+
+    resp = client.put(
+        "/update_plugin_instance/test_instance",
+        data={"plugin_id": "image_folder", "folder_path": ""},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Required" in data.get("error", "")
+
+
+def test_update_instance_accepts_valid_required_fields(client, device_config_dev):
+    """Updating an existing instance with valid required fields should succeed."""
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default")
+    playlist = pm.get_playlist("Default")
+    playlist.add_plugin(
+        {
+            "plugin_id": "image_folder",
+            "name": "valid_instance",
+            "plugin_settings": {"folder_path": "/tmp/old"},
+            "refresh": {"interval": 300},
+        }
+    )
+    device_config_dev.write_config()
+
+    resp = client.put(
+        "/update_plugin_instance/valid_instance",
+        data={"plugin_id": "image_folder", "folder_path": "/tmp/new-path"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get("success") is True


### PR DESCRIPTION
## Summary
- Add server-side validation that checks required fields in plugin schemas before saving — returns 400 with descriptive error if required fields are empty
- Investigate API Keys add buttons: listeners ARE correctly wired; added defensive console.warn guards for missing DOM elements

## Changes
- `src/blueprints/plugin.py` — add `_validate_required_fields()` helper, integrate into save and update routes
- `src/static/scripts/api_keys_page.js` — add defensive console.warn if DOM elements missing during init
- `tests/integration/test_plugin_validation.py` — 7 tests covering validation rejection, acceptance, whitespace, alias routes, schema-less plugins
- Updated 2 existing tests to pass the new validation (provide required fields)

## Test plan
- [ ] All existing tests pass (2052 passing)
- [ ] Saving plugin with empty required field returns 400
- [ ] Saving plugin with valid required fields succeeds
- [ ] Schema-less plugins bypass validation gracefully
- [ ] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)