### PR TITLE
fix: swap collapsible section arrow icon direction (JTN-244)

### DIFF
--- a/src/static/scripts/ui_helpers.js
+++ b/src/static/scripts/ui_helpers.js
@@ -8,7 +8,7 @@
     button.setAttribute("aria-expanded", String(!isOpen));
     content.classList.toggle("is-open", !isOpen);
     content.removeAttribute("hidden");
-    if (icon) icon.textContent = isOpen ? "▲" : "▼";
+    if (icon) icon.textContent = isOpen ? "▼" : "▲";
     const sectionId = button.closest('.collapsible')?.id;
     if (sectionId) {
       savePref('collapsible_', sectionId, !isOpen);

--- a/tests/static/test_collapsible_icon_direction.py
+++ b/tests/static/test_collapsible_icon_direction.py
@@ -1,0 +1,34 @@
+"""Tests for collapsible section arrow icon direction logic.
+
+JTN-244: The toggle function must show ▼ when closing and ▲ when opening,
+reflecting the *new* (post-toggle) state, not the old state.
+"""
+
+
+def test_ui_helpers_script_exists(client):
+    resp = client.get("/static/scripts/ui_helpers.js")
+    assert resp.status_code == 200
+
+
+def test_toggle_collapsible_icon_reflects_post_toggle_state(client):
+    """JTN-244: Icon ternary must use the inverted isOpen value.
+
+    Before the fix, ``isOpen ? "▲" : "▼"`` used the pre-toggle state, so the
+    arrow was backwards. The correct logic is ``isOpen ? "▼" : "▲"``:
+    - when the section *was* open (isOpen=true) we are closing it → show ▼
+    - when the section *was* closed (isOpen=false) we are opening it → show ▲
+    """
+    resp = client.get("/static/scripts/ui_helpers.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    # The correct (fixed) ternary must be present
+    assert 'isOpen ? "▼" : "▲"' in js
+
+    # The inverted (buggy) ternary must NOT appear in toggleCollapsible
+    # (restoreCollapsibles and setCollapsibles use the same icon chars differently,
+    # so we narrow the check to the toggle function body)
+    toggle_start = js.find("function toggleCollapsible(")
+    toggle_end = js.find("\n  }", toggle_start)
+    toggle_body = js[toggle_start:toggle_end]
+    assert 'isOpen ? "▲" : "▼"' not in toggle_body


### PR DESCRIPTION
## Summary
- Collapsible section arrow icon showed inverted direction after toggle
- Swapped the ternary so icon reflects the current state, not the previous state

## Test plan
- [x] Verified icon logic matches post-toggle state
- [x] Added regression test in `tests/static/test_collapsible_icon_direction.py`
- [x] All 2149 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)