### PR TITLE
feat: serve WebP-encoded images for accepting clients (JTN-302)

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -3,7 +3,6 @@ import logging
 import os
 import shutil
 from datetime import UTC, datetime
-from pathlib import Path
 
 from flask import (
     Blueprint,
@@ -267,15 +266,11 @@ def history_image(filename: str):
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
     try:
-        resolved = _resolve_history_path(history_dir, filename)
+        _resolve_history_path(history_dir, filename)
     except ValueError:
         return json_error(_ERR_INVALID_FILENAME, status=400)
     if filename.lower().endswith(".png"):
-        return maybe_serve_webp(
-            Path(resolved),
-            request.headers.get("Accept"),
-            safe_root=history_dir,
-        )
+        return maybe_serve_webp(history_dir, filename, request.headers.get("Accept"))
     return send_from_directory(history_dir, filename)
 
 

--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 from datetime import UTC, datetime
+from pathlib import Path
 
 from flask import (
     Blueprint,
@@ -15,6 +16,7 @@ from flask import (
 from werkzeug.exceptions import BadRequest
 
 from utils.http_utils import json_error, json_internal_error, json_success
+from utils.image_serving import maybe_serve_webp
 from utils.time_utils import get_timezone, now_device_tz
 
 logger = logging.getLogger(__name__)
@@ -265,9 +267,11 @@ def history_image(filename: str):
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
     try:
-        _resolve_history_path(history_dir, filename)
+        resolved = _resolve_history_path(history_dir, filename)
     except ValueError:
         return json_error(_ERR_INVALID_FILENAME, status=400)
+    if filename.lower().endswith(".png"):
+        return maybe_serve_webp(Path(resolved), request.headers.get("Accept"))
     return send_from_directory(history_dir, filename)
 
 

--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -271,7 +271,11 @@ def history_image(filename: str):
     except ValueError:
         return json_error(_ERR_INVALID_FILENAME, status=400)
     if filename.lower().endswith(".png"):
-        return maybe_serve_webp(Path(resolved), request.headers.get("Accept"))
+        return maybe_serve_webp(
+            Path(resolved),
+            request.headers.get("Accept"),
+            safe_root=history_dir,
+        )
     return send_from_directory(history_dir, filename)
 
 

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -3,7 +3,6 @@ import math
 import os
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from pathlib import Path
 from uuid import uuid4
 
 from flask import (
@@ -94,12 +93,11 @@ def preview_image():
         path = device_config.current_image_file
     if not os.path.exists(path):
         return ("Preview not available", 404)
-    # Both candidate paths come from device_config (trusted JSON), so the
-    # parent directory of whichever one we picked is a safe containment root.
-    safe_root = os.path.dirname(os.path.abspath(path))
-    return maybe_serve_webp(
-        Path(path), request.headers.get("Accept"), safe_root=safe_root
-    )
+    # Both candidate paths come from device_config (trusted JSON).
+    abs_path = os.path.abspath(path)
+    safe_root = os.path.dirname(abs_path)
+    filename = os.path.basename(abs_path)
+    return maybe_serve_webp(safe_root, filename, request.headers.get("Accept"))
 
 
 @main_bp.route("/api/current_image", methods=["GET"])

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -94,7 +94,12 @@ def preview_image():
         path = device_config.current_image_file
     if not os.path.exists(path):
         return ("Preview not available", 404)
-    return maybe_serve_webp(Path(path), request.headers.get("Accept"))
+    # Both candidate paths come from device_config (trusted JSON), so the
+    # parent directory of whichever one we picked is a safe containment root.
+    safe_root = os.path.dirname(os.path.abspath(path))
+    return maybe_serve_webp(
+        Path(path), request.headers.get("Accept"), safe_root=safe_root
+    )
 
 
 @main_bp.route("/api/current_image", methods=["GET"])

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -3,6 +3,7 @@ import math
 import os
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
+from pathlib import Path
 from uuid import uuid4
 
 from flask import (
@@ -16,6 +17,7 @@ from flask import (
 )
 
 from utils.http_utils import json_error
+from utils.image_serving import maybe_serve_webp
 from utils.rate_limiter import CooldownLimiter
 
 logger = logging.getLogger(__name__)
@@ -92,7 +94,7 @@ def preview_image():
         path = device_config.current_image_file
     if not os.path.exists(path):
         return ("Preview not available", 404)
-    return send_file(path, mimetype="image/png", conditional=True)
+    return maybe_serve_webp(Path(path), request.headers.get("Accept"))
 
 
 @main_bp.route("/api/current_image", methods=["GET"])

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -47,7 +47,12 @@ def _encode_webp(
 # ---------------------------------------------------------------------------
 
 
-def maybe_serve_webp(image_path: Path, accept_header: str | None) -> Response:
+def maybe_serve_webp(
+    image_path: Path,
+    accept_header: str | None,
+    *,
+    safe_root: Path | str,
+) -> Response:
     """Return a WebP response if the client accepts it, otherwise the original PNG.
 
     Parameters
@@ -56,29 +61,53 @@ def maybe_serve_webp(image_path: Path, accept_header: str | None) -> Response:
         Absolute path to the PNG file on disk.
     accept_header:
         Value of the ``Accept`` request header (may be *None*).
+    safe_root:
+        Trusted directory the resolved *image_path* must live within. The
+        function re-validates containment using ``realpath`` and raises
+        :class:`ValueError` if the path escapes — defense in depth on top of
+        any caller-side validation.
 
     Returns
     -------
     flask.Response
         Either a WebP response (``Content-Type: image/webp``) with an ETag, or
         the result of ``flask.send_file`` for the original PNG.
+
+    Raises
+    ------
+    ValueError
+        If *image_path* is not contained within *safe_root* after symlink
+        resolution.
     """
-    path_str = str(image_path)
+    safe_path = _validate_under_root(image_path, safe_root)
 
     if not _client_accepts_webp(accept_header):
-        return send_file(path_str, mimetype="image/png", conditional=True)
+        return send_file(safe_path, mimetype="image/png", conditional=True)
 
-    stat = os.stat(path_str)
+    stat = os.stat(safe_path)
     mtime = int(stat.st_mtime)
     size = stat.st_size
 
-    webp_bytes = _encode_webp(path_str, mtime, size)
+    webp_bytes = _encode_webp(safe_path, mtime, size)
 
-    etag = _make_etag(path_str, mtime)
+    etag = _make_etag(safe_path, mtime)
     response = Response(webp_bytes, mimetype="image/webp")
     response.headers["ETag"] = etag
     response.headers["Cache-Control"] = "no-cache"
     return response
+
+
+def _validate_under_root(image_path: Path, safe_root: Path | str) -> str:
+    """Resolve *image_path* and assert it lives under *safe_root*.
+
+    Returns the resolved absolute path string. This is the sanitization
+    boundary that downstream filesystem calls rely on.
+    """
+    root = os.path.realpath(str(safe_root))
+    candidate = os.path.realpath(str(image_path))
+    if os.path.commonpath([root, candidate]) != root:
+        raise ValueError("image_path escapes safe_root")
+    return candidate
 
 
 # ---------------------------------------------------------------------------

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -1,0 +1,99 @@
+"""WebP on-the-fly encoding for image-serving routes.
+
+Browsers that send ``Accept: image/webp`` receive a WebP-encoded version of
+the PNG file.  The encoded bytes are cached in-process (keyed on path, mtime,
+and file size) so repeated requests within a server lifetime are essentially
+free.  Browsers that do not advertise WebP support receive the original PNG via
+a standard ``flask.send_file`` call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from flask import Response, send_file
+from PIL import Image
+
+# ---------------------------------------------------------------------------
+# Internal cache
+# ---------------------------------------------------------------------------
+
+_WEBP_QUALITY = 85
+_WEBP_METHOD = 4
+_CACHE_MAX = 32  # maximum number of distinct (path, mtime, size) entries
+
+
+@lru_cache(maxsize=_CACHE_MAX)
+def _encode_webp(
+    path: str, mtime: int, size: int
+) -> bytes:  # noqa: ARG001 (size is cache key)
+    """Return WebP-encoded bytes for *path*.
+
+    The *mtime* and *size* parameters are only used as cache-key components;
+    they ensure the cache is invalidated automatically when the file changes.
+    """
+    with Image.open(path) as img:
+        buf = io.BytesIO()
+        img.save(buf, format="WEBP", quality=_WEBP_QUALITY, method=_WEBP_METHOD)
+        return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Public helper
+# ---------------------------------------------------------------------------
+
+
+def maybe_serve_webp(image_path: Path, accept_header: str | None) -> Response:
+    """Return a WebP response if the client accepts it, otherwise the original PNG.
+
+    Parameters
+    ----------
+    image_path:
+        Absolute path to the PNG file on disk.
+    accept_header:
+        Value of the ``Accept`` request header (may be *None*).
+
+    Returns
+    -------
+    flask.Response
+        Either a WebP response (``Content-Type: image/webp``) with an ETag, or
+        the result of ``flask.send_file`` for the original PNG.
+    """
+    path_str = str(image_path)
+
+    if not _client_accepts_webp(accept_header):
+        return send_file(path_str, mimetype="image/png", conditional=True)
+
+    stat = os.stat(path_str)
+    mtime = int(stat.st_mtime)
+    size = stat.st_size
+
+    webp_bytes = _encode_webp(path_str, mtime, size)
+
+    etag = _make_etag(path_str, mtime)
+    response = Response(webp_bytes, mimetype="image/webp")
+    response.headers["ETag"] = etag
+    response.headers["Cache-Control"] = "no-cache"
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _client_accepts_webp(accept_header: str | None) -> bool:
+    """Return *True* when *accept_header* explicitly lists ``image/webp``."""
+    if not accept_header:
+        return False
+    return "image/webp" in accept_header
+
+
+def _make_etag(path: str, mtime: int) -> str:
+    """Produce a stable ETag string from *path*, *mtime*, and the literal ``"webp"``."""
+    raw = f"{path}:{mtime}:webp"
+    return hashlib.sha1(raw.encode()).hexdigest()  # noqa: S324 — not security-sensitive

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -15,8 +15,9 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
-from flask import Response, send_file
+from flask import Response, send_from_directory
 from PIL import Image
+from werkzeug.exceptions import NotFound
 
 # ---------------------------------------------------------------------------
 # Internal cache
@@ -48,41 +49,49 @@ def _encode_webp(
 
 
 def maybe_serve_webp(
-    image_path: Path,
-    accept_header: str | None,
-    *,
     safe_root: Path | str,
+    filename: str,
+    accept_header: str | None,
 ) -> Response:
     """Return a WebP response if the client accepts it, otherwise the original PNG.
 
     Parameters
     ----------
-    image_path:
-        Absolute path to the PNG file on disk.
+    safe_root:
+        Trusted directory the file lives in. Must be a path the application
+        controls (not user-supplied).
+    filename:
+        Name of the PNG file inside *safe_root*. May contain user-controlled
+        data; sanitization is delegated to ``flask.send_from_directory`` which
+        rejects path-traversal attempts.
     accept_header:
         Value of the ``Accept`` request header (may be *None*).
-    safe_root:
-        Trusted directory the resolved *image_path* must live within. The
-        function re-validates containment using ``realpath`` and raises
-        :class:`ValueError` if the path escapes — defense in depth on top of
-        any caller-side validation.
 
     Returns
     -------
     flask.Response
         Either a WebP response (``Content-Type: image/webp``) with an ETag, or
-        the result of ``flask.send_file`` for the original PNG.
+        the result of ``flask.send_from_directory`` for the original PNG.
 
     Raises
     ------
-    ValueError
-        If *image_path* is not contained within *safe_root* after symlink
-        resolution.
+    werkzeug.exceptions.NotFound
+        If the resolved file does not exist or escapes *safe_root*.
     """
-    safe_path = _validate_under_root(image_path, safe_root)
+    root_str = str(safe_root)
 
     if not _client_accepts_webp(accept_header):
-        return send_file(safe_path, mimetype="image/png", conditional=True)
+        # send_from_directory performs path-traversal validation internally;
+        # this is the recognized sanitization sink.
+        return send_from_directory(root_str, filename, mimetype="image/png")
+
+    # For the WebP path we still need an absolute filesystem path. Re-use
+    # send_from_directory's validation by calling it once to resolve, then
+    # falling back to a direct read of the same validated path. The simplest
+    # way is to reconstruct the path via safe_join semantics: any traversal
+    # attempt on filename would have already raised in the PNG branch above
+    # for unfetched callers, but we re-validate here defensively.
+    safe_path = _safe_join(root_str, filename)
 
     stat = os.stat(safe_path)
     mtime = int(stat.st_mtime)
@@ -97,16 +106,19 @@ def maybe_serve_webp(
     return response
 
 
-def _validate_under_root(image_path: Path, safe_root: Path | str) -> str:
-    """Resolve *image_path* and assert it lives under *safe_root*.
+def _safe_join(root: str, filename: str) -> str:
+    """Resolve *filename* under *root* with path-traversal protection.
 
-    Returns the resolved absolute path string. This is the sanitization
-    boundary that downstream filesystem calls rely on.
+    Returns an absolute filesystem path. Raises :class:`NotFound` if the
+    resolved path escapes *root* or does not exist — mirroring the behavior of
+    ``send_from_directory`` so callers see consistent error semantics.
     """
-    root = os.path.realpath(str(safe_root))
-    candidate = os.path.realpath(str(image_path))
-    if os.path.commonpath([root, candidate]) != root:
-        raise ValueError("image_path escapes safe_root")
+    base = os.path.realpath(root)
+    candidate = os.path.realpath(os.path.join(base, filename))
+    if os.path.commonpath([base, candidate]) != base:
+        raise NotFound()
+    if not os.path.isfile(candidate):
+        raise NotFound()
     return candidate
 
 

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -96,4 +96,6 @@ def _client_accepts_webp(accept_header: str | None) -> bool:
 def _make_etag(path: str, mtime: int) -> str:
     """Produce a stable ETag string from *path*, *mtime*, and the literal ``"webp"``."""
     raw = f"{path}:{mtime}:webp"
-    return hashlib.sha1(raw.encode()).hexdigest()  # noqa: S324 — not security-sensitive
+    # sha256 used purely for cache-key fingerprinting (not security-sensitive),
+    # but we use it instead of sha1 to keep SonarCloud quiet (rule S4790).
+    return hashlib.sha256(raw.encode()).hexdigest()[:40]

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from flask import Response, send_from_directory
 from PIL import Image
 from werkzeug.exceptions import NotFound
+from werkzeug.utils import safe_join
 
 # ---------------------------------------------------------------------------
 # Internal cache
@@ -109,17 +110,14 @@ def maybe_serve_webp(
 def _safe_join(root: str, filename: str) -> str:
     """Resolve *filename* under *root* with path-traversal protection.
 
-    Returns an absolute filesystem path. Raises :class:`NotFound` if the
-    resolved path escapes *root* or does not exist — mirroring the behavior of
-    ``send_from_directory`` so callers see consistent error semantics.
+    Wraps :func:`werkzeug.utils.safe_join`, which is the Flask-recommended
+    sanitizer for joining a trusted base directory with an untrusted filename.
+    Raises :class:`NotFound` if traversal is attempted or the file is missing.
     """
-    base = os.path.realpath(root)
-    candidate = os.path.realpath(os.path.join(base, filename))
-    if os.path.commonpath([base, candidate]) != base:
+    joined = safe_join(root, filename)
+    if joined is None or not os.path.isfile(joined):
         raise NotFound()
-    if not os.path.isfile(candidate):
-        raise NotFound()
-    return candidate
+    return joined
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_serving.py
+++ b/tests/test_image_serving.py
@@ -35,7 +35,7 @@ def test_webp_returned_when_header_present(tmp_path):
     png = _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, "image/webp,*/*;q=0.8")
+        resp = maybe_serve_webp(png, "image/webp,*/*;q=0.8", safe_root=tmp_path)
 
     assert resp.content_type == "image/webp"
     # Verify the bytes are valid WebP (RIFF….WEBP header)
@@ -53,7 +53,7 @@ def test_png_returned_when_header_absent(tmp_path):
     png = _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, None)
+        resp = maybe_serve_webp(png, None, safe_root=tmp_path)
 
     assert resp.content_type == "image/png"
 
@@ -67,7 +67,7 @@ def test_png_returned_when_header_no_webp(tmp_path):
     png = _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, "image/png,*/*")
+        resp = maybe_serve_webp(png, "image/png,*/*", safe_root=tmp_path)
 
     assert resp.content_type == "image/png"
 
@@ -81,7 +81,7 @@ def test_etag_present_for_webp_response(tmp_path):
     png = _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, "image/webp")
+        resp = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
 
     assert "ETag" in resp.headers
     assert resp.headers["ETag"]  # non-empty
@@ -98,7 +98,7 @@ def test_etag_changes_when_mtime_changes(tmp_path):
 
     # First response
     with app.test_request_context("/"):
-        resp1 = maybe_serve_webp(png, "image/webp")
+        resp1 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
     etag1 = resp1.headers["ETag"]
 
     # Overwrite the file with a new image (different mtime)
@@ -113,7 +113,7 @@ def test_etag_changes_when_mtime_changes(tmp_path):
     _encode_webp.cache_clear()
 
     with app.test_request_context("/"):
-        resp2 = maybe_serve_webp(png, "image/webp")
+        resp2 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
     etag2 = resp2.headers["ETag"]
 
     assert etag1 != etag2
@@ -131,9 +131,9 @@ def test_cache_returns_same_bytes_on_repeated_call(tmp_path):
     _encode_webp.cache_clear()
 
     with app.test_request_context("/"):
-        resp1 = maybe_serve_webp(png, "image/webp")
+        resp1 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
     with app.test_request_context("/"):
-        resp2 = maybe_serve_webp(png, "image/webp")
+        resp2 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
 
     assert resp1.get_data() == resp2.get_data()
     # Cache should have exactly 1 entry (second call was a hit)

--- a/tests/test_image_serving.py
+++ b/tests/test_image_serving.py
@@ -1,0 +1,142 @@
+"""Tests for utils.image_serving — WebP on-the-fly encoding helper."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from PIL import Image
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_png(tmp_path: Path, name: str = "test.png") -> Path:
+    """Write a small PNG file and return its path."""
+    p = tmp_path / name
+    img = Image.new("RGB", (4, 4), color=(10, 20, 30))
+    img.save(p, format="PNG")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_webp_returned_when_header_present(tmp_path):
+    """Client sending Accept: image/webp receives WebP bytes."""
+    from flask import Flask
+
+    from utils.image_serving import maybe_serve_webp
+
+    png = _make_png(tmp_path)
+    app = Flask(__name__)
+    with app.test_request_context("/"):
+        resp = maybe_serve_webp(png, "image/webp,*/*;q=0.8")
+
+    assert resp.content_type == "image/webp"
+    # Verify the bytes are valid WebP (RIFF….WEBP header)
+    data = resp.get_data()
+    assert data[:4] == b"RIFF"
+    assert data[8:12] == b"WEBP"
+
+
+def test_png_returned_when_header_absent(tmp_path):
+    """Client without Accept: image/webp gets the original PNG."""
+    from flask import Flask
+
+    from utils.image_serving import maybe_serve_webp
+
+    png = _make_png(tmp_path)
+    app = Flask(__name__)
+    with app.test_request_context("/"):
+        resp = maybe_serve_webp(png, None)
+
+    assert resp.content_type == "image/png"
+
+
+def test_png_returned_when_header_no_webp(tmp_path):
+    """Client sending only image/png in Accept header gets PNG."""
+    from flask import Flask
+
+    from utils.image_serving import maybe_serve_webp
+
+    png = _make_png(tmp_path)
+    app = Flask(__name__)
+    with app.test_request_context("/"):
+        resp = maybe_serve_webp(png, "image/png,*/*")
+
+    assert resp.content_type == "image/png"
+
+
+def test_etag_present_for_webp_response(tmp_path):
+    """WebP response includes an ETag header."""
+    from flask import Flask
+
+    from utils.image_serving import maybe_serve_webp
+
+    png = _make_png(tmp_path)
+    app = Flask(__name__)
+    with app.test_request_context("/"):
+        resp = maybe_serve_webp(png, "image/webp")
+
+    assert "ETag" in resp.headers
+    assert resp.headers["ETag"]  # non-empty
+
+
+def test_etag_changes_when_mtime_changes(tmp_path):
+    """ETag must differ after the file is updated (mtime changes)."""
+    from flask import Flask
+
+    from utils.image_serving import _encode_webp, maybe_serve_webp
+
+    png = _make_png(tmp_path)
+    app = Flask(__name__)
+
+    # First response
+    with app.test_request_context("/"):
+        resp1 = maybe_serve_webp(png, "image/webp")
+    etag1 = resp1.headers["ETag"]
+
+    # Overwrite the file with a new image (different mtime)
+    time.sleep(0.01)  # ensure mtime differs on fast filesystems
+    img2 = Image.new("RGB", (4, 4), color=(50, 60, 70))
+    img2.save(png, format="PNG")
+    # Touch mtime explicitly to guarantee change
+    new_mtime = int(os.path.getmtime(str(png))) + 1
+    os.utime(str(png), (new_mtime, new_mtime))
+
+    # Clear the lru_cache so the new file is re-encoded
+    _encode_webp.cache_clear()
+
+    with app.test_request_context("/"):
+        resp2 = maybe_serve_webp(png, "image/webp")
+    etag2 = resp2.headers["ETag"]
+
+    assert etag1 != etag2
+
+
+def test_cache_returns_same_bytes_on_repeated_call(tmp_path):
+    """Repeated calls with same mtime hit lru_cache (same object returned)."""
+    from flask import Flask
+
+    from utils.image_serving import _encode_webp, maybe_serve_webp
+
+    png = _make_png(tmp_path)
+    app = Flask(__name__)
+
+    _encode_webp.cache_clear()
+
+    with app.test_request_context("/"):
+        resp1 = maybe_serve_webp(png, "image/webp")
+    with app.test_request_context("/"):
+        resp2 = maybe_serve_webp(png, "image/webp")
+
+    assert resp1.get_data() == resp2.get_data()
+    # Cache should have exactly 1 entry (second call was a hit)
+    info = _encode_webp.cache_info()
+    assert info.currsize == 1
+    assert info.hits >= 1

--- a/tests/test_image_serving.py
+++ b/tests/test_image_serving.py
@@ -32,10 +32,10 @@ def test_webp_returned_when_header_present(tmp_path):
 
     from utils.image_serving import maybe_serve_webp
 
-    png = _make_png(tmp_path)
+    _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, "image/webp,*/*;q=0.8", safe_root=tmp_path)
+        resp = maybe_serve_webp(tmp_path, "test.png", "image/webp,*/*;q=0.8")
 
     assert resp.content_type == "image/webp"
     # Verify the bytes are valid WebP (RIFF….WEBP header)
@@ -50,12 +50,12 @@ def test_png_returned_when_header_absent(tmp_path):
 
     from utils.image_serving import maybe_serve_webp
 
-    png = _make_png(tmp_path)
+    _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, None, safe_root=tmp_path)
+        resp = maybe_serve_webp(tmp_path, "test.png", None)
 
-    assert resp.content_type == "image/png"
+    assert resp.mimetype == "image/png"
 
 
 def test_png_returned_when_header_no_webp(tmp_path):
@@ -64,12 +64,12 @@ def test_png_returned_when_header_no_webp(tmp_path):
 
     from utils.image_serving import maybe_serve_webp
 
-    png = _make_png(tmp_path)
+    _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, "image/png,*/*", safe_root=tmp_path)
+        resp = maybe_serve_webp(tmp_path, "test.png", "image/png,*/*")
 
-    assert resp.content_type == "image/png"
+    assert resp.mimetype == "image/png"
 
 
 def test_etag_present_for_webp_response(tmp_path):
@@ -78,10 +78,10 @@ def test_etag_present_for_webp_response(tmp_path):
 
     from utils.image_serving import maybe_serve_webp
 
-    png = _make_png(tmp_path)
+    _make_png(tmp_path)
     app = Flask(__name__)
     with app.test_request_context("/"):
-        resp = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
+        resp = maybe_serve_webp(tmp_path, "test.png", "image/webp")
 
     assert "ETag" in resp.headers
     assert resp.headers["ETag"]  # non-empty
@@ -98,7 +98,7 @@ def test_etag_changes_when_mtime_changes(tmp_path):
 
     # First response
     with app.test_request_context("/"):
-        resp1 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
+        resp1 = maybe_serve_webp(tmp_path, "test.png", "image/webp")
     etag1 = resp1.headers["ETag"]
 
     # Overwrite the file with a new image (different mtime)
@@ -113,7 +113,7 @@ def test_etag_changes_when_mtime_changes(tmp_path):
     _encode_webp.cache_clear()
 
     with app.test_request_context("/"):
-        resp2 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
+        resp2 = maybe_serve_webp(tmp_path, "test.png", "image/webp")
     etag2 = resp2.headers["ETag"]
 
     assert etag1 != etag2
@@ -125,18 +125,46 @@ def test_cache_returns_same_bytes_on_repeated_call(tmp_path):
 
     from utils.image_serving import _encode_webp, maybe_serve_webp
 
-    png = _make_png(tmp_path)
+    _make_png(tmp_path)
     app = Flask(__name__)
 
     _encode_webp.cache_clear()
 
     with app.test_request_context("/"):
-        resp1 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
+        resp1 = maybe_serve_webp(tmp_path, "test.png", "image/webp")
     with app.test_request_context("/"):
-        resp2 = maybe_serve_webp(png, "image/webp", safe_root=tmp_path)
+        resp2 = maybe_serve_webp(tmp_path, "test.png", "image/webp")
 
     assert resp1.get_data() == resp2.get_data()
     # Cache should have exactly 1 entry (second call was a hit)
     info = _encode_webp.cache_info()
     assert info.currsize == 1
     assert info.hits >= 1
+
+
+def test_path_traversal_rejected(tmp_path):
+    """Filename containing '..' must not escape safe_root."""
+    from flask import Flask
+    from werkzeug.exceptions import NotFound
+
+    from utils.image_serving import maybe_serve_webp
+
+    # Create a file outside the safe_root
+    outside = tmp_path.parent / "outside.png"
+    img = Image.new("RGB", (4, 4), color=(0, 0, 0))
+    img.save(outside, format="PNG")
+    try:
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        app = Flask(__name__)
+        with app.test_request_context("/"):
+            try:
+                maybe_serve_webp(nested, "../../outside.png", "image/webp")
+            except NotFound:
+                return
+            raise AssertionError("Expected NotFound for path traversal attempt")
+    finally:
+        try:
+            outside.unlink()
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## Summary

- Adds `src/utils/image_serving.py` with a `maybe_serve_webp()` helper that inspects the `Accept` header and returns a WebP-encoded copy of a PNG when the client supports it, falling back to the original PNG otherwise.
- Pillow encodes with `quality=85, method=4`; encoded bytes are cached via `lru_cache` keyed on `(path, mtime, size)` so repeated requests within a server lifetime are free.
- WebP responses include an `ETag` derived from `sha1(path:mtime:webp)` to support caching.
- Wired into `/preview` (main blueprint) and `/history/image/<filename>` (history blueprint) — non-PNG history files still go through `send_from_directory` unchanged.
- PNG is always served when the client does not advertise `image/webp`.

## Changes

- `src/utils/image_serving.py` — new helper module
- `src/blueprints/main.py` — wrap `/preview` with `maybe_serve_webp`
- `src/blueprints/history.py` — wrap `/history/image/<filename>` for `.png` files
- `tests/test_image_serving.py` — 6 tests covering: webp returned when header present, png fallback (absent header, no-webp header), ETag present, ETag changes on mtime change, cache hit on repeated call

## Test plan

- [ ] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/test_image_serving.py -q` — 6 passed
- [ ] Full suite `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no -q` — 2404 passed
- [ ] `scripts/lint.sh` — ruff + black both pass
- [ ] Manual: open `/preview` in a WebP-capable browser (Chrome/Firefox) with DevTools → Network → confirm `Content-Type: image/webp` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images (including previews and history images) are now served as WebP when the browser supports it, falling back to PNG otherwise for faster load and reduced bandwidth.
* **Tests**
  * Added tests covering format negotiation, caching behavior, ETag changes on updates, and protection against path traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->