### PR TITLE
fix: scope wizard nav ids per step to remove duplicates (JTN-314)

### DIFF
--- a/src/static/scripts/progressive_disclosure.js
+++ b/src/static/scripts/progressive_disclosure.js
@@ -249,16 +249,20 @@ class ProgressiveDisclosure {
         const steps = container.querySelectorAll('.wizard-step');
         let currentStep = 0;
 
-        // Show first step
-        if (steps.length > 0) {
-            steps[0].classList.add('active');
-        }
+        // Do not inject navigation into an empty wizard container — this would
+        // produce orphaned wizardPrev/wizardNext elements (duplicate-id risk).
+        if (steps.length === 0) return;
 
-        // Create navigation
+        // Show first step
+        steps[0].classList.add('active');
+
+        // Create navigation — use data attributes instead of ids so multiple
+        // wizards on one page (or a hidden placeholder alongside a real one)
+        // never produce duplicate id attributes in the document.
         const navigation = document.createElement('div');
         navigation.className = 'wizard-navigation';
         navigation.innerHTML = `
-            <button type="button" class="action-button is-secondary" id="wizardPrev" disabled>
+            <button type="button" class="action-button is-secondary" data-wizard-prev disabled>
                 Previous
             </button>
             <div class="wizard-progress">
@@ -269,7 +273,7 @@ class ProgressiveDisclosure {
                     ).join('')}
                 </div>
             </div>
-            <button type="button" class="action-button" id="wizardNext">
+            <button type="button" class="action-button" data-wizard-next>
                 Next
             </button>
         `;
@@ -277,8 +281,8 @@ class ProgressiveDisclosure {
         container.appendChild(navigation);
 
         // Navigation event handlers
-        const prevBtn = navigation.querySelector('#wizardPrev');
-        const nextBtn = navigation.querySelector('#wizardNext');
+        const prevBtn = navigation.querySelector('[data-wizard-prev]');
+        const nextBtn = navigation.querySelector('[data-wizard-next]');
         const stepText = navigation.querySelector('.wizard-step-text');
         const stepDots = navigation.querySelectorAll('.wizard-step-dot');
 

--- a/tests/static/test_no_duplicate_wizard_ids.py
+++ b/tests/static/test_no_duplicate_wizard_ids.py
@@ -1,0 +1,115 @@
+# pyright: reportMissingImports=false
+"""Regression test for JTN-314: wizard nav buttons must not use DOM ids.
+
+The initializeWizard() method in progressive_disclosure.js previously injected
+buttons with id="wizardPrev" and id="wizardNext".  Because the plugin.html
+template always includes a hidden .setup-wizard placeholder, those ids appeared
+in the rendered HTML of every plugin settings page — producing 136 duplicate-id
+findings in the 2026-04-06 dogfood audit.
+
+Fix: buttons now use data-wizard-prev / data-wizard-next attributes instead of
+ids, and an early-return guard prevents any navigation from being injected into
+an empty wizard container.
+"""
+
+import re
+from pathlib import Path
+
+# Plugin ids that can be rendered without external API credentials
+_RENDERABLE_PLUGINS = [
+    "clock",
+    "calendar",
+    "weather",
+    "ai_image",
+    "rss",
+    "countdown",
+    "year_progress",
+]
+
+_JS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "static"
+    / "scripts"
+    / "progressive_disclosure.js"
+)
+
+
+# ---------------------------------------------------------------------------
+# Static JS source checks
+# ---------------------------------------------------------------------------
+
+
+def test_wizard_buttons_use_data_attributes_not_ids():
+    """progressive_disclosure.js must not emit id="wizardPrev" or id="wizardNext"."""
+    source = _JS_PATH.read_text(encoding="utf-8")
+    assert 'id="wizardPrev"' not in source, (
+        'progressive_disclosure.js still uses id="wizardPrev" — '
+        "switch to data-wizard-prev attribute"
+    )
+    assert 'id="wizardNext"' not in source, (
+        'progressive_disclosure.js still uses id="wizardNext" — '
+        "switch to data-wizard-next attribute"
+    )
+
+
+def test_wizard_js_queries_data_attributes():
+    """JS must query wizard buttons via [data-wizard-prev]/[data-wizard-next]."""
+    source = _JS_PATH.read_text(encoding="utf-8")
+    assert (
+        "[data-wizard-prev]" in source
+    ), "progressive_disclosure.js must use querySelector('[data-wizard-prev]')"
+    assert (
+        "[data-wizard-next]" in source
+    ), "progressive_disclosure.js must use querySelector('[data-wizard-next]')"
+
+
+def test_wizard_empty_container_guard_present():
+    """initializeWizard must return early when there are no wizard steps."""
+    source = _JS_PATH.read_text(encoding="utf-8")
+    # Expect a guard like: if (steps.length === 0) return;
+    assert re.search(
+        r"steps\.length\s*===\s*0.*return", source, re.DOTALL
+    ), "initializeWizard should have an early-return guard for empty step lists"
+
+
+# ---------------------------------------------------------------------------
+# Rendered HTML checks — no id="wizardPrev" or id="wizardNext" in page HTML
+# ---------------------------------------------------------------------------
+
+
+def _find_duplicate_ids(html: str) -> list[str]:
+    """Return a list of id values that appear more than once in the HTML."""
+    ids = re.findall(r'\bid="([^"]+)"', html)
+    seen: dict[str, int] = {}
+    for id_val in ids:
+        seen[id_val] = seen.get(id_val, 0) + 1
+    return [id_val for id_val, count in seen.items() if count > 1]
+
+
+def test_plugin_pages_have_no_wizard_id_attributes(client):
+    """Rendered plugin pages must not contain id='wizardPrev' or id='wizardNext'."""
+    for plugin_id in _RENDERABLE_PLUGINS:
+        resp = client.get(f"/plugin/{plugin_id}")
+        if resp.status_code != 200:
+            continue
+        html = resp.get_data(as_text=True)
+        assert (
+            'id="wizardPrev"' not in html
+        ), f'/plugin/{plugin_id} HTML contains id="wizardPrev" (JTN-314)'
+        assert (
+            'id="wizardNext"' not in html
+        ), f'/plugin/{plugin_id} HTML contains id="wizardNext" (JTN-314)'
+
+
+def test_plugin_pages_have_no_duplicate_ids(client):
+    """Rendered plugin pages must not contain any duplicate id attributes."""
+    for plugin_id in _RENDERABLE_PLUGINS:
+        resp = client.get(f"/plugin/{plugin_id}")
+        if resp.status_code != 200:
+            continue
+        html = resp.get_data(as_text=True)
+        dupes = _find_duplicate_ids(html)
+        assert (
+            dupes == []
+        ), f"/plugin/{plugin_id} has duplicate id attribute(s): {dupes}"


### PR DESCRIPTION
## Summary

- Replaces `id="wizardPrev"` / `id="wizardNext"` with `data-wizard-prev` / `data-wizard-next` attributes in `initializeWizard()` — eliminates the source of duplicate DOM ids across plugin settings pages
- Adds an early-return guard so navigation is never injected into an empty `.setup-wizard` placeholder (the hidden placeholder in `plugin.html` was the root cause of 136 duplicate-id findings in the 2026-04-06 dogfood audit)
- Updates the two `navigation.querySelector` calls to use `[data-wizard-prev]` / `[data-wizard-next]` attribute selectors
- Adds 5 regression tests in `tests/static/test_no_duplicate_wizard_ids.py` covering JS source checks and rendered HTML checks for 7 plugin pages

## Root cause

`plugin.html` always includes `<div class="setup-wizard" hidden>` as a placeholder. When `ProgressiveDisclosure.init()` ran, `setupWizard()` found this empty container and called `initializeWizard()`, which unconditionally appended navigation buttons with `id="wizardPrev"` and `id="wizardNext"`. Those ids appeared in every rendered plugin page — 136 flagged pages in the audit.

## Test plan

- [ ] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/static/test_no_duplicate_wizard_ids.py -v` — all 5 new tests pass
- [ ] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no -q` — 2403 passed
- [ ] `scripts/lint.sh` — all checks pass (mypy advisory only, pre-existing)

Fixes: JTN-314

🤖 Generated with [Claude Code](https://claude.com/claude-code)