### PR TITLE
fix: lazy-load history images to fix Playwright timeout (JTN-316)

### DIFF
--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block title %}InkyPi - History{% endblock %}
 {% block head %}
-    <script src="{{ url_for('static', filename='scripts/lightbox.js') }}"></script>
-    <script src="{{ url_for('static', filename='scripts/history_page.js') }}"></script>
+    <script src="{{ url_for('static', filename='scripts/lightbox.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='scripts/history_page.js') }}" defer></script>
 {% endblock %}
 {% block body %}
     <main id="main-content" role="main" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
@@ -92,7 +92,7 @@
             <div class="history-card">
                 <a class="history-thumb" href="{{ url_for('history.history_image', filename=img.filename) }}" aria-label="Preview {{ img.filename }}">
                     <div class="img-skeleton" aria-hidden="true"></div>
-                    <img class="history-image" src="{{ url_for('history.history_image', filename=img.filename) }}" alt="{{ img.filename }}" loading="lazy">
+                    <img class="history-image" src="{{ url_for('history.history_image', filename=img.filename) }}" alt="{{ img.filename }}" loading="lazy" decoding="async">
                 </a>
                 <div class="history-card-body">
                     <div class="history-meta">

--- a/tests/unit/test_history_lazy_loading.py
+++ b/tests/unit/test_history_lazy_loading.py
@@ -1,0 +1,84 @@
+# pyright: reportMissingImports=false
+"""
+Tests that /history images are lazy-loaded to prevent Playwright timeout (JTN-316).
+
+Verifies that:
+- Every <img> on /history has loading="lazy"
+- Every <img> on /history has decoding="async"
+- The page-level scripts use defer to avoid blocking HTML parsing
+"""
+
+import os
+import re
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _html(client, path: str) -> str:
+    resp = client.get(path)
+    assert resp.status_code == 200, f"Expected 200 for {path}, got {resp.status_code}"
+    return resp.get_data(as_text=True)
+
+
+def _get_img_tags(html: str) -> list[str]:
+    """Return all <img ...> tag strings from HTML."""
+    return re.findall(r"<img\b[^>]*>", html, flags=re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_history_page_all_imgs_have_loading_lazy(client, device_config_dev, tmp_path):
+    """Every <img> rendered on /history must carry loading="lazy"."""
+    # Create a few dummy history images so the grid renders
+    history_dir = device_config_dev.history_image_dir
+    for name in ("display_20240101_120000.png", "display_20240102_130000.png"):
+        open(os.path.join(history_dir, name), "w").close()
+
+    html = _html(client, "/history")
+    imgs = _get_img_tags(html)
+    assert imgs, "Expected at least one <img> tag on /history with dummy images"
+    for tag in imgs:
+        assert 'loading="lazy"' in tag, f'<img> tag missing loading="lazy": {tag}'
+
+
+def test_history_page_all_imgs_have_decoding_async(client, device_config_dev, tmp_path):
+    """Every <img> rendered on /history must carry decoding="async"."""
+    history_dir = device_config_dev.history_image_dir
+    for name in ("display_20240101_120000.png", "display_20240102_130000.png"):
+        open(os.path.join(history_dir, name), "w").close()
+
+    html = _html(client, "/history")
+    imgs = _get_img_tags(html)
+    assert imgs, "Expected at least one <img> tag on /history with dummy images"
+    for tag in imgs:
+        assert 'decoding="async"' in tag, f'<img> tag missing decoding="async": {tag}'
+
+
+def test_history_page_scripts_use_defer(client):
+    """lightbox.js and history_page.js must be loaded with defer to avoid blocking parse."""
+    html = _html(client, "/history")
+
+    # Find script tags that reference the history-specific scripts
+    script_tags = re.findall(r"<script\b[^>]*>", html, flags=re.IGNORECASE)
+    history_scripts = [
+        t for t in script_tags if "lightbox.js" in t or "history_page.js" in t
+    ]
+    assert (
+        history_scripts
+    ), "Expected to find lightbox.js and history_page.js script tags"
+    for tag in history_scripts:
+        assert (
+            "defer" in tag
+        ), f"Script tag missing defer attribute (blocks HTML parse): {tag}"
+
+
+def test_history_page_empty_state_no_imgs(client):
+    """When history is empty the grid is not rendered and there are no .history-image tags."""
+    html = _html(client, "/history")
+    # history-image class should not appear when there are no images
+    assert 'class="history-image"' not in html


### PR DESCRIPTION
## Summary
- Added `decoding="async"` to the `<img class="history-image">` tag in `history.html` (it already had `loading="lazy"`)
- Added `defer` to the `<script>` tags for `lightbox.js` and `history_page.js` so they no longer block HTML parsing while the browser waits for the scripts to download and execute
- Added `tests/unit/test_history_lazy_loading.py` with 4 tests asserting every `<img>` on `/history` carries both `loading="lazy"` and `decoding="async"`, that the page-level scripts use `defer`, and that the empty-state renders no image tags

## Root cause
The Playwright `networkidle` / `load` timeout on `/history` had two contributing factors:
1. `lightbox.js` and `history_page.js` were loaded in `<head>` without `defer`, blocking HTML parsing until both scripts downloaded and parsed — on a slow network (or with many pending image fetches) this pushes the `load` event past Playwright's default timeout.
2. Each history `<img>` was missing `decoding="async"`, causing the browser to block the main thread for image decoding even though images were lazy-loaded.

## Test plan
- [ ] All 2433 unit tests pass (`SKIP_BROWSER=1 pytest tests/ -q`)
- [ ] `scripts/lint.sh` passes (ruff + black clean; mypy non-blocking pre-existing)
- [ ] `/history` page renders correctly with images grid and pagination
- [ ] Lightbox still opens when clicking a history thumbnail
- [ ] Delete / redisplay / clear actions still work (deferred JS runs before `DOMContentLoaded` handler fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized script loading on the History page for faster rendering
  * Enhanced image rendering performance with asynchronous decoding

* **Tests**
  * Added tests to verify lazy-loading optimizations on the History page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->