### PR TITLE
feat: add mutmut config and nightly mutation testing (JTN-290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 9 * * *'
+    - cron: '0 3 * * 0'
 
 permissions:
   contents: read
@@ -504,7 +505,7 @@ jobs:
     name: Mutation nightly
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -514,15 +515,36 @@ jobs:
           cache-dependency-path: |
             install/requirements.txt
             install/requirements-dev.txt
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libopenjp2-7 \
+            libopenblas-dev \
+            libfreetype6-dev \
+            fonts-noto-color-emoji
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel
           pip install -r install/requirements.txt -r install/requirements-dev.txt
-      - name: Run mutation validation
+      - name: Run mutmut
         env:
-          INKYPI_VALIDATE_MUTATION: '1'
+          INKYPI_ENV: dev
+          INKYPI_NO_REFRESH: '1'
+          PYTHONPATH: src
         run: |
-          scripts/preflash_validate.sh
+          mutmut run --CI
+      - name: Show mutation results
+        if: always()
+        run: |
+          mutmut results || true
+      - name: Upload mutmut cache
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutmut-cache
+          path: .mutmut-cache
+          if-no-files-found: ignore
 
   browser-smoke:
     name: Browser smoke (tabs + plugins)

--- a/docs/mutation_testing.md
+++ b/docs/mutation_testing.md
@@ -1,0 +1,100 @@
+# Mutation Testing
+
+## What is mutation testing?
+
+Mutation testing automatically introduces small code changes ("mutants") into
+the source and then runs the test suite. If at least one test fails for a given
+mutant, the mutant is **killed** — meaning our tests caught the bug. If no test
+fails, the mutant **survives** — which signals a gap in test coverage.
+
+Coverage reports tell you *which lines* were executed. Mutation testing tells
+you *whether those lines are actually verified* by assertions.
+
+## Why do we have it?
+
+InkyPi ships to devices that cannot be easily reflashed in the field. A
+high-quality test suite that catches real regressions is therefore more
+important than raw line-coverage percentages. Mutation testing gives us a
+second opinion on test quality independent of coverage metrics.
+
+## Which files are currently in scope?
+
+The initial scope is intentionally small to keep nightly run times reasonable.
+See `pyproject.toml` → `[tool.mutmut]` → `paths_to_mutate`:
+
+| File | Reason chosen |
+|------|--------------|
+| `src/utils/http_utils.py` | Core HTTP helpers used by every plugin |
+| `src/utils/image_serving.py` | Image pipeline; subtle bugs here are hard to spot |
+| `src/refresh_task/task.py` | Refresh coordinator; scheduling logic is regression-prone |
+
+## How to run locally
+
+Install dev dependencies (mutmut is already in `install/requirements-dev.txt`):
+
+```bash
+pip install -r install/requirements-dev.txt
+```
+
+Run the mutation pass against the configured files:
+
+```bash
+INKYPI_ENV=dev INKYPI_NO_REFRESH=1 PYTHONPATH=src mutmut run
+```
+
+Check the summary after the run completes:
+
+```bash
+mutmut results
+```
+
+Inspect a specific surviving mutant (replace `<id>` with the number from `results`):
+
+```bash
+mutmut show <id>
+```
+
+Apply a surviving mutant to the working tree for manual investigation:
+
+```bash
+mutmut apply <id>
+# ... investigate / add a test ...
+mutmut unapply
+```
+
+## How to expand scope
+
+1. Add the file path to `paths_to_mutate` in `pyproject.toml`:
+
+   ```toml
+   [tool.mutmut]
+   paths_to_mutate = "src/utils/http_utils.py,src/utils/image_serving.py,src/refresh_task/task.py,src/utils/new_module.py"
+   ```
+
+2. Add the new path to `EXPECTED_FILES` in `tests/test_mutmut_config.py` so the
+   config test keeps it honest.
+
+3. Open a PR with the change. The nightly job will pick up the new file on its
+   next Sunday run.
+
+## CI schedule
+
+The `mutation-nightly` job in `.github/workflows/ci.yml` runs every **Sunday at
+03:00 UTC** (`cron: '0 3 * * 0'`). It is gated by
+`if: github.event_name == 'schedule'` and will never trigger on a push or pull
+request.
+
+Results are uploaded as the `mutmut-cache` artifact and can be downloaded from
+the GitHub Actions run summary.
+
+## Interpreting results
+
+| Status | Meaning |
+|--------|---------|
+| Killed | Test suite caught the mutant — good |
+| Survived | No test detected the change — consider adding a targeted test |
+| Skipped | mutmut could not parse or apply the mutation |
+| Suspicious | Test timed out; worth investigating |
+
+A survived mutant does not automatically block CI. The nightly job is advisory:
+review the results, add targeted tests, and shrink the surviving count over time.

--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -32,3 +32,4 @@ cyclonedx-bom==6.1.0
 pre-commit==4.2.0
 python-semantic-release==9.21.1
 pip-licenses==5.5.5
+mutmut==2.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ ignore = [
 combine-as-imports = true
 known-first-party = ["src"]
 
+[tool.mutmut]
+paths_to_mutate = "src/utils/http_utils.py,src/utils/image_serving.py,src/refresh_task/task.py"
+tests_dir = "tests/"
+runner = "python -m pytest tests/ -x --tb=no -q"
+dict_synonyms = ""
+
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.semantic_release.version"]
 version = "0.11.0"

--- a/tests/test_mutmut_config.py
+++ b/tests/test_mutmut_config.py
@@ -1,0 +1,70 @@
+"""Tests that mutmut configuration is present and well-formed.
+
+This ensures future PRs cannot accidentally remove or corrupt the mutation
+testing config without a test failure drawing attention to the change.
+"""
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+EXPECTED_FILES = [
+    "src/utils/http_utils.py",
+    "src/utils/image_serving.py",
+    "src/refresh_task/task.py",
+]
+
+
+def _load_mutmut_config() -> dict:
+    with PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data.get("tool", {}).get("mutmut", {})
+
+
+class TestMutmutConfig:
+    def test_section_exists(self):
+        cfg = _load_mutmut_config()
+        assert cfg, "[tool.mutmut] section is missing from pyproject.toml"
+
+    def test_paths_to_mutate_present(self):
+        cfg = _load_mutmut_config()
+        assert (
+            "paths_to_mutate" in cfg
+        ), "paths_to_mutate key missing from [tool.mutmut]"
+
+    def test_paths_to_mutate_not_empty(self):
+        cfg = _load_mutmut_config()
+        paths = cfg.get("paths_to_mutate", "")
+        assert paths.strip(), "paths_to_mutate must not be empty"
+
+    def test_expected_files_in_scope(self):
+        cfg = _load_mutmut_config()
+        paths = cfg.get("paths_to_mutate", "")
+        for expected in EXPECTED_FILES:
+            assert expected in paths, (
+                f"{expected} is not in paths_to_mutate — "
+                "do not remove files from mutation scope without a deliberate decision"
+            )
+
+    def test_tests_dir_configured(self):
+        cfg = _load_mutmut_config()
+        assert (
+            cfg.get("tests_dir") == "tests/"
+        ), "tests_dir should be 'tests/' in [tool.mutmut]"
+
+    def test_runner_configured(self):
+        cfg = _load_mutmut_config()
+        runner = cfg.get("runner", "")
+        assert "pytest" in runner, "runner should invoke pytest"
+
+    def test_scoped_files_exist_on_disk(self):
+        root = PYPROJECT.parent
+        cfg = _load_mutmut_config()
+        paths = cfg.get("paths_to_mutate", "")
+        for rel_path in [p.strip() for p in paths.split(",") if p.strip()]:
+            full = root / rel_path
+            assert full.exists(), (
+                f"Mutation scope references {rel_path} but file does not exist. "
+                "Either create the file or remove it from paths_to_mutate."
+            )


### PR DESCRIPTION
## Summary

- Adds `mutmut==2.5.1` to `install/requirements-dev.txt`
- Adds `[tool.mutmut]` config block to `pyproject.toml` scoped to 3 high-value files: `src/utils/http_utils.py`, `src/utils/image_serving.py`, `src/refresh_task/task.py`
- Wires the existing stub `mutation-nightly` CI job to actually run `mutmut run --CI`, upload `.mutmut-cache` as an artifact, and adds a weekly Sunday 03:00 UTC cron trigger
- Job is guarded by `if: github.event_name == 'schedule'` — never runs on push or PR
- Adds `tests/test_mutmut_config.py` (7 tests) to guard the config against accidental removal/corruption
- Adds `docs/mutation_testing.md` explaining what mutation testing is, which files are in scope, how to run locally, and how to expand scope

## Test plan

- [x] `scripts/lint.sh` passes (ruff + black clean; mypy advisory only — pre-existing errors)
- [x] Full pytest suite: 2436 passed
- [x] `mutmut --help` and `mutmut run --help` verified locally against installed 2.5.1
- [x] `pyproject.toml` `[tool.mutmut]` section parses correctly via `tomllib`
- [x] No mutation pass actually executed (MVP: config only)
- [x] CI job runs only on `schedule` event — never on push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)