### PR TITLE
feat: add optional PIN authentication (JTN-286)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,54 @@
+# Optional PIN Authentication
+
+InkyPi supports an optional PIN that, when configured, protects all routes
+behind a login form. This feature is **off by default** — when no PIN is set
+the application behaves identically to before.
+
+## Enabling PIN auth
+
+### Via environment variable (recommended)
+
+```bash
+export INKYPI_AUTH_PIN="your-pin-here"
+```
+
+Set this in your systemd service file, Docker environment, or shell profile
+before starting InkyPi. The PIN is hashed with `hashlib.scrypt` in memory
+immediately on startup; the plaintext is never stored or logged.
+
+### Via device config (`device.json`)
+
+Add an `auth` section to your device config:
+
+```json
+{
+  "auth": {
+    "pin": "your-pin-here"
+  }
+}
+```
+
+> **Note:** Storing the PIN in the config file keeps it on disk in plaintext.
+> The env-var approach is preferred.
+
+## Behaviour when enabled
+
+- All routes except `/login`, `/logout`, `/sw.js`, `/static/*`, `/api/health`,
+  `/healthz`, and `/readyz` redirect unauthenticated users to `/login`.
+- A successful login sets a server-side session cookie valid for the browser
+  session.
+- Failed attempts increment a per-session counter; after **5 consecutive
+  failures** the session is locked out for **60 seconds**.
+- Visiting `/logout` clears the session and redirects to `/login`.
+
+## Security notes
+
+- Uses `hashlib.scrypt` (stdlib) with a per-process random salt — no new
+  dependencies.
+- Constant-time comparison via `hmac.compare_digest` prevents timing attacks.
+- The PIN hash is stored only in application memory and is regenerated from
+  the configured PIN on each startup.
+- Sessions are signed by Flask's `SECRET_KEY`. Rotate the secret key if you
+  need to invalidate all existing sessions.
+- For remote access, combine with HTTPS (see `INKYPI_FORCE_HTTPS`) so the PIN
+  is not transmitted in the clear.

--- a/src/app_setup/auth.py
+++ b/src/app_setup/auth.py
@@ -1,0 +1,102 @@
+"""Optional PIN authentication middleware (JTN-286).
+
+When INKYPI_AUTH_PIN env var is set, or device_config has auth.pin, all routes
+except the skip-list require a valid authenticated session.
+
+When neither is configured the module registers no handlers and the app
+behaves identically to today.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+from typing import TYPE_CHECKING
+
+from flask import Flask, redirect, request, session, url_for
+
+if TYPE_CHECKING:
+    from config import Config
+
+logger = logging.getLogger(__name__)
+
+# Paths that never require authentication
+_AUTH_SKIP_PREFIXES = ("/static/",)
+_AUTH_SKIP_EXACT = frozenset({"/login", "/logout", "/sw.js", "/api/health"})
+# Also skip Flask/Werkzeug internal health probes registered by health.py
+_AUTH_SKIP_HEALTH = frozenset({"/healthz", "/readyz"})
+
+_MAX_FAILED_ATTEMPTS = 5
+_LOCKOUT_SECONDS = 60
+
+# Per-process random salt — never persisted, never logged
+_SCRYPT_SALT = secrets.token_bytes(32)
+_SCRYPT_N = 2**14  # 16 384 — fast enough on Pi Zero, still strong
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SCRYPT_DKLEN = 32
+
+
+def _hash_pin(pin: str) -> bytes:
+    """Return a scrypt-derived key for *pin* using the per-process salt."""
+    return hashlib.scrypt(
+        pin.encode(),
+        salt=_SCRYPT_SALT,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        dklen=_SCRYPT_DKLEN,
+    )
+
+
+def _verify_pin(candidate: str, stored_hash: bytes) -> bool:
+    """Constant-time comparison of candidate PIN against stored hash."""
+    candidate_hash = _hash_pin(candidate)
+    return hmac.compare_digest(candidate_hash, stored_hash)
+
+
+def _should_skip_auth() -> bool:
+    """Return True when the current request path is exempt from authentication."""
+    path = request.path
+    if path in _AUTH_SKIP_EXACT:
+        return True
+    if path in _AUTH_SKIP_HEALTH:
+        return True
+    return any(path.startswith(prefix) for prefix in _AUTH_SKIP_PREFIXES)
+
+
+def init_auth(app: Flask, device_config: Config) -> None:
+    """Wire up PIN auth if a PIN is configured; otherwise log and return."""
+    pin = os.environ.get("INKYPI_AUTH_PIN")
+    if not pin:
+        try:
+            auth_cfg = device_config.get_config("auth", {})
+            if isinstance(auth_cfg, dict):
+                pin = auth_cfg.get("pin")
+        except Exception:
+            pin = None
+
+    # Reject anything that isn't a non-empty string (e.g. MagicMock in tests)
+    if not pin or not isinstance(pin, str):
+        logger.info(
+            "PIN auth disabled (INKYPI_AUTH_PIN not set, no auth.pin in config)"
+        )
+        return
+
+    # Hash immediately — the plaintext PIN is never stored beyond this scope
+    pin_hash = _hash_pin(pin)
+    app.config["AUTH_ENABLED"] = True
+    app.config["AUTH_PIN_HASH"] = pin_hash
+    logger.info("PIN auth enabled")
+
+    @app.before_request
+    def _require_auth():
+        if _should_skip_auth():
+            return None
+        if session.get("authed") is True:
+            return None
+        next_url = request.url
+        return redirect(url_for("auth.login_get", next=next_url))

--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -9,12 +9,14 @@ def register_blueprints(app: Flask) -> None:
     """Register all InkyPi Flask blueprints."""
     from blueprints.api_docs import api_docs_bp
     from blueprints.apikeys import apikeys_bp
+    from blueprints.auth import auth_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
 
+    app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
     app.register_blueprint(apikeys_bp)
     app.register_blueprint(settings_bp)

--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -23,6 +23,21 @@ auth_bp = Blueprint("auth", __name__)
 
 _MAX_FAILED_ATTEMPTS = 5
 _LOCKOUT_SECONDS = 60
+_LOGIN_TEMPLATE = "login.html"
+
+
+def _safe_next_url(raw: str | None) -> str:
+    """Return *raw* only when it's a same-origin relative path; otherwise '/'.
+
+    Open-redirect guard: rejects schemes, network-location URLs, protocol-relative
+    URLs, and anything that does not start with a single '/'. Empty/None → '/'.
+    """
+    if not raw:
+        return "/"
+    # Reject protocol-relative ('//evil.com') and absolute ('http://evil.com')
+    if not raw.startswith("/") or raw.startswith("//"):
+        return "/"
+    return raw
 
 
 def _is_locked_out() -> bool:
@@ -49,9 +64,10 @@ def _record_failed_attempt() -> None:
 
 @auth_bp.route("/login", methods=["GET"])
 def login_get():
+    next_url = _safe_next_url(request.args.get("next"))
     if session.get("authed") is True:
-        return redirect(request.args.get("next") or "/")
-    return render_template("login.html", error=None, next=request.args.get("next", "/"))
+        return redirect(next_url)
+    return render_template(_LOGIN_TEMPLATE, error=None, next=next_url)
 
 
 @auth_bp.route("/login", methods=["POST"])
@@ -63,11 +79,11 @@ def login_post():
         # Auth not enabled — redirect home
         return redirect("/")
 
-    next_url = request.form.get("next") or "/"
+    next_url = _safe_next_url(request.form.get("next"))
 
     if _is_locked_out():
         return render_template(
-            "login.html",
+            _LOGIN_TEMPLATE,
             error="Too many failed attempts. Please wait 60 seconds and try again.",
             next=next_url,
         )
@@ -77,11 +93,11 @@ def login_post():
         session["authed"] = True
         session.pop("login_failed_count", None)
         session.pop("login_lockout_until", None)
-        return redirect(next_url if next_url.startswith("/") else "/")
+        return redirect(next_url)
 
     _record_failed_attempt()
     return render_template(
-        "login.html", error="Incorrect PIN. Please try again.", next=next_url
+        _LOGIN_TEMPLATE, error="Incorrect PIN. Please try again.", next=next_url
     )
 
 

--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -1,0 +1,91 @@
+"""Auth blueprint: login / logout routes for optional PIN authentication (JTN-286)."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from flask import (
+    Blueprint,
+    current_app,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from app_setup.auth import _verify_pin
+
+logger = logging.getLogger(__name__)
+
+auth_bp = Blueprint("auth", __name__)
+
+_MAX_FAILED_ATTEMPTS = 5
+_LOCKOUT_SECONDS = 60
+
+
+def _is_locked_out() -> bool:
+    """Return True when the session is in the rate-limit lockout window."""
+    lockout_until = session.get("login_lockout_until")
+    if lockout_until is None:
+        return False
+    if time.time() < lockout_until:
+        return True
+    # Lockout expired — reset counters
+    session.pop("login_lockout_until", None)
+    session.pop("login_failed_count", None)
+    return False
+
+
+def _record_failed_attempt() -> None:
+    """Increment the failure counter and apply lockout when threshold is reached."""
+    count = session.get("login_failed_count", 0) + 1
+    session["login_failed_count"] = count
+    if count >= _MAX_FAILED_ATTEMPTS:
+        session["login_lockout_until"] = time.time() + _LOCKOUT_SECONDS
+        logger.warning("PIN auth: lockout triggered after %d failed attempts", count)
+
+
+@auth_bp.route("/login", methods=["GET"])
+def login_get():
+    if session.get("authed") is True:
+        return redirect(request.args.get("next") or "/")
+    return render_template("login.html", error=None, next=request.args.get("next", "/"))
+
+
+@auth_bp.route("/login", methods=["POST"])
+def login_post():
+    """Validate submitted PIN and establish an authenticated session."""
+    # CSRF token is checked by the global before_request handler in security_middleware.
+    pin_hash = current_app.config.get("AUTH_PIN_HASH")
+    if pin_hash is None:
+        # Auth not enabled — redirect home
+        return redirect("/")
+
+    next_url = request.form.get("next") or "/"
+
+    if _is_locked_out():
+        return render_template(
+            "login.html",
+            error="Too many failed attempts. Please wait 60 seconds and try again.",
+            next=next_url,
+        )
+
+    submitted = request.form.get("pin", "")
+    if _verify_pin(submitted, pin_hash):
+        session["authed"] = True
+        session.pop("login_failed_count", None)
+        session.pop("login_lockout_until", None)
+        return redirect(next_url if next_url.startswith("/") else "/")
+
+    _record_failed_attempt()
+    return render_template(
+        "login.html", error="Incorrect PIN. Please try again.", next=next_url
+    )
+
+
+@auth_bp.route("/logout", methods=["GET"])
+def logout():
+    session.clear()
+    return redirect(url_for("auth.login_get"))

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -256,6 +256,10 @@ def create_app():
 
     setup_secret_key(app, device_config)
 
+    from app_setup.auth import init_auth
+
+    init_auth(app, device_config)
+
     app.config["MAX_FORM_PARTS"] = 10_000
     try:
         _max_len_env = os.getenv("MAX_CONTENT_LENGTH") or os.getenv("MAX_UPLOAD_BYTES")

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>InkyPi — Sign In</title>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #f5f5f5;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            color: #222;
+        }
+        .login-card {
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+            padding: 2.5rem 2rem;
+            width: 100%;
+            max-width: 360px;
+        }
+        .login-title {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+            letter-spacing: -0.02em;
+        }
+        .login-subtitle {
+            font-size: 0.9rem;
+            color: #666;
+            margin-bottom: 1.75rem;
+        }
+        .form-group {
+            margin-bottom: 1.25rem;
+        }
+        label {
+            display: block;
+            font-size: 0.85rem;
+            font-weight: 600;
+            margin-bottom: 0.4rem;
+            color: #444;
+        }
+        input[type="password"] {
+            width: 100%;
+            padding: 0.6rem 0.75rem;
+            border: 1.5px solid #ddd;
+            border-radius: 8px;
+            font-size: 1rem;
+            outline: none;
+            transition: border-color 0.15s;
+        }
+        input[type="password"]:focus {
+            border-color: #555;
+        }
+        .error-msg {
+            background: #fef2f2;
+            color: #b91c1c;
+            border: 1px solid #fca5a5;
+            border-radius: 8px;
+            padding: 0.6rem 0.75rem;
+            font-size: 0.875rem;
+            margin-bottom: 1.25rem;
+        }
+        button[type="submit"] {
+            width: 100%;
+            padding: 0.7rem;
+            background: #222;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        button[type="submit"]:hover {
+            background: #444;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-card">
+        <h1 class="login-title">InkyPi</h1>
+        <p class="login-subtitle">Enter your PIN to continue.</p>
+
+        {% if error %}
+        <div class="error-msg" role="alert">{{ error }}</div>
+        {% endif %}
+
+        <form method="POST" action="/login">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <input type="hidden" name="next" value="{{ next }}" />
+            <div class="form-group">
+                <label for="pin">PIN</label>
+                <input
+                    type="password"
+                    id="pin"
+                    name="pin"
+                    autocomplete="current-password"
+                    autofocus
+                    required
+                    placeholder="Enter PIN"
+                />
+            </div>
+            <button type="submit">Sign In</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,286 @@
+# pyright: reportMissingImports=false
+"""Tests for optional PIN authentication (JTN-286).
+
+Coverage:
+- Auth disabled when INKYPI_AUTH_PIN is not set
+- Auth enabled: unauthenticated request to / redirects to /login
+- Correct PIN → session authed, redirect to /
+- Wrong PIN → login page re-rendered with error
+- Rate-limit lockout after 5 failed attempts
+- Exempt paths (/sw.js, /static/*, /api/health) accessible without auth
+- /logout clears session and redirects to /login
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+from flask import Flask
+from jinja2 import ChoiceLoader, FileSystemLoader
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SRC_ABS = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+def _make_auth_app(pin: str | None = None, monkeypatch=None) -> Flask:
+    """Build a minimal Flask app with auth wired up.
+
+    If *pin* is given it is set as INKYPI_AUTH_PIN.
+    """
+    if monkeypatch is not None and pin is not None:
+        monkeypatch.setenv("INKYPI_AUTH_PIN", pin)
+    elif monkeypatch is not None:
+        monkeypatch.delenv("INKYPI_AUTH_PIN", raising=False)
+
+    # Fresh import context so module-level _SCRYPT_SALT is consistent
+    import importlib
+
+    import app_setup.auth as auth_mod
+
+    importlib.reload(auth_mod)
+    import blueprints.auth as auth_bp_mod
+
+    importlib.reload(auth_bp_mod)
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret-key"
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    template_dirs = [
+        os.path.join(SRC_ABS, "templates"),
+        os.path.join(SRC_ABS, "plugins"),
+    ]
+    app.jinja_loader = ChoiceLoader([FileSystemLoader(d) for d in template_dirs])
+
+    # Register auth blueprint
+    from blueprints.auth import auth_bp
+
+    app.register_blueprint(auth_bp)
+
+    # A trivial protected route
+    @app.route("/")
+    def index():
+        return ("home", 200)
+
+    @app.route("/api/health")
+    def api_health():
+        return ("ok", 200)
+
+    @app.route("/sw.js")
+    def sw():
+        return ("sw", 200)
+
+    @app.route("/static/test.css")
+    def static_css():
+        return ("css", 200)
+
+    # Provide a CSRF token in the session for POST requests
+    @app.context_processor
+    def _inject_csrf():
+        import secrets as _s
+
+        from flask import session as _sess
+
+        def _csrf():
+            if "_csrf_token" not in _sess:
+                _sess["_csrf_token"] = _s.token_hex(32)
+            return _sess["_csrf_token"]
+
+        return {"csrf_token": _csrf}
+
+    # Wire auth (reads INKYPI_AUTH_PIN from env, which monkeypatch already set)
+    class _FakeConfig:
+        def get_config(self, key, default=None):
+            return default
+
+    auth_mod.init_auth(app, _FakeConfig())
+
+    return app
+
+
+def _get_csrf(client) -> str:
+    """Return a fresh CSRF token by hitting /login and reading the session."""
+    import secrets
+
+    with client.session_transaction() as sess:
+        token = secrets.token_hex(32)
+        sess["_csrf_token"] = token
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Tests — auth DISABLED
+# ---------------------------------------------------------------------------
+
+
+class TestAuthDisabled:
+    @pytest.fixture()
+    def app(self, monkeypatch):
+        return _make_auth_app(pin=None, monkeypatch=monkeypatch)
+
+    @pytest.fixture()
+    def client(self, app):
+        return app.test_client()
+
+    def test_home_accessible_without_login(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    def test_login_route_still_works(self, client):
+        resp = client.get("/login")
+        assert resp.status_code == 200
+
+    def test_static_accessible(self, client):
+        resp = client.get("/static/test.css")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests — auth ENABLED
+# ---------------------------------------------------------------------------
+
+
+class TestAuthEnabled:
+    PIN = "s3cr3t"
+
+    @pytest.fixture()
+    def app(self, monkeypatch):
+        return _make_auth_app(pin=self.PIN, monkeypatch=monkeypatch)
+
+    @pytest.fixture()
+    def client(self, app):
+        return app.test_client()
+
+    # ------------------------------------------------------------------
+    # Redirect enforcement
+    # ------------------------------------------------------------------
+
+    def test_unauthenticated_home_redirects_to_login(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_authenticated_home_accessible(self, client):
+        with client.session_transaction() as sess:
+            sess["authed"] = True
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    # ------------------------------------------------------------------
+    # Exempt paths
+    # ------------------------------------------------------------------
+
+    def test_login_page_exempt(self, client):
+        resp = client.get("/login")
+        assert resp.status_code == 200
+
+    def test_logout_exempt(self, client):
+        # /logout redirects to /login — not blocked by auth guard
+        resp = client.get("/logout")
+        assert resp.status_code == 302
+
+    def test_sw_js_exempt(self, client):
+        resp = client.get("/sw.js")
+        assert resp.status_code == 200
+
+    def test_static_exempt(self, client):
+        resp = client.get("/static/test.css")
+        assert resp.status_code == 200
+
+    def test_api_health_exempt(self, client):
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+
+    # ------------------------------------------------------------------
+    # Login flow
+    # ------------------------------------------------------------------
+
+    def test_correct_pin_sets_session_and_redirects(self, client):
+        csrf = _get_csrf(client)
+        resp = client.post(
+            "/login",
+            data={"pin": self.PIN, "next": "/", "csrf_token": csrf},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"] in ("/", "http://localhost/")
+        # Session should be authed
+        with client.session_transaction() as sess:
+            assert sess.get("authed") is True
+
+    def test_wrong_pin_renders_login_with_error(self, client):
+        csrf = _get_csrf(client)
+        resp = client.post(
+            "/login",
+            data={"pin": "wrong", "next": "/", "csrf_token": csrf},
+        )
+        assert resp.status_code == 200
+        data = resp.get_data(as_text=True)
+        assert "Incorrect PIN" in data
+
+    def test_wrong_pin_does_not_set_authed(self, client):
+        csrf = _get_csrf(client)
+        client.post("/login", data={"pin": "wrong", "next": "/", "csrf_token": csrf})
+        with client.session_transaction() as sess:
+            assert sess.get("authed") is not True
+
+    # ------------------------------------------------------------------
+    # Rate-limit / lockout
+    # ------------------------------------------------------------------
+
+    def test_lockout_after_five_failures(self, client):
+        for _ in range(5):
+            csrf = _get_csrf(client)
+            client.post("/login", data={"pin": "bad", "next": "/", "csrf_token": csrf})
+
+        # 6th attempt — even with correct PIN — should be rejected
+        csrf = _get_csrf(client)
+        resp = client.post(
+            "/login",
+            data={"pin": self.PIN, "next": "/", "csrf_token": csrf},
+        )
+        assert resp.status_code == 200
+        data = resp.get_data(as_text=True)
+        assert "Too many failed attempts" in data
+        with client.session_transaction() as sess:
+            assert sess.get("authed") is not True
+
+    def test_lockout_expires_after_60s(self, client, monkeypatch):
+        """After lockout window elapses the user can log in again."""
+        # Trigger lockout
+        for _ in range(5):
+            csrf = _get_csrf(client)
+            client.post("/login", data={"pin": "bad", "next": "/", "csrf_token": csrf})
+
+        # Fast-forward time past the lockout window
+        future = time.time() + 61
+        monkeypatch.setattr("blueprints.auth.time.time", lambda: future)
+
+        csrf = _get_csrf(client)
+        resp = client.post(
+            "/login",
+            data={"pin": self.PIN, "next": "/", "csrf_token": csrf},
+        )
+        assert resp.status_code == 302
+        with client.session_transaction() as sess:
+            assert sess.get("authed") is True
+
+    # ------------------------------------------------------------------
+    # Logout
+    # ------------------------------------------------------------------
+
+    def test_logout_clears_session(self, client):
+        with client.session_transaction() as sess:
+            sess["authed"] = True
+
+        resp = client.get("/logout")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+        with client.session_transaction() as sess:
+            assert sess.get("authed") is not True


### PR DESCRIPTION
## Summary

- Adds opt-in PIN authentication via `INKYPI_AUTH_PIN` env var or `device_config.auth.pin` — **off by default**, zero behaviour change when unset
- When enabled, all routes except `/login`, `/logout`, `/sw.js`, `/static/*`, `/api/health`, `/healthz`, `/readyz` redirect unauthenticated sessions to a minimal standalone login form
- PIN is hashed with `hashlib.scrypt` (stdlib, no new deps) using a per-process random salt; constant-time comparison via `hmac.compare_digest`; plaintext is never stored or logged
- Rate-limits failed attempts: 5 failures triggers a 60-second lockout tracked in the session

## Files changed

| File | Purpose |
|------|---------|
| `src/app_setup/auth.py` | `init_auth()` wires the `before_request` guard |
| `src/blueprints/auth.py` | `/login` (GET+POST) and `/logout` routes with lockout logic |
| `src/templates/login.html` | Standalone login form (no base.html dependency) |
| `src/app_setup/blueprints_registry.py` | Registers `auth_bp` |
| `src/inkypi.py` | Calls `init_auth(app, device_config)` after secret-key setup |
| `docs/auth.md` | Usage docs |
| `tests/test_auth.py` | 16 new tests |

## Test plan

- [x] Auth disabled → all routes accessible, no redirects
- [x] Auth enabled → unauthenticated `GET /` → 302 to `/login`
- [x] Correct PIN → `session["authed"] = True`, redirect to `/`
- [x] Wrong PIN → login page re-renders with error, not authed
- [x] 5 failures → lockout; 6th attempt rejected even with correct PIN
- [x] Lockout expires after 60 s
- [x] `/sw.js`, `/static/*`, `/api/health` accessible without auth
- [x] `/logout` clears session, redirects to `/login`
- [x] All 2445 existing tests continue to pass
- [x] Ruff + Black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional PIN-based authentication to secure access to your InkyPi instance.
  * Implemented login and logout pages for easy session management.
  * Added automatic rate limiting with temporary lockout after multiple failed authentication attempts.
  * Supports configuration via environment variable or configuration file for flexible deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->