### PR TITLE
feat: optional JSON structured logging via INKYPI_LOG_FORMAT (JTN-337)

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,68 @@
+# Logging
+
+## Default (human-readable)
+
+InkyPi uses Python's standard `logging` module configured via
+`src/config/logging.conf`.  Log lines look like:
+
+```
+2026-04-08 12:00:00,123 INFO inkypi Starting display refresh
+```
+
+## Structured JSON logging
+
+Set `INKYPI_LOG_FORMAT=json` to switch to one-JSON-object-per-line output.
+This is opt-in — the default plain-text format is unchanged.
+
+```bash
+INKYPI_LOG_FORMAT=json python src/inkypi.py
+```
+
+Each line is a valid JSON object with the following fields:
+
+| Field           | Type    | Description                              |
+|-----------------|---------|------------------------------------------|
+| `ts`            | string  | ISO 8601 UTC timestamp                   |
+| `level`         | string  | Log level (`DEBUG`, `INFO`, …)           |
+| `logger`        | string  | Logger name                              |
+| `msg`           | string  | Formatted log message                    |
+| `module`        | string  | Python module name                       |
+| `func`          | string  | Function name                            |
+| `line`          | integer | Line number                              |
+| `pid`           | integer | Process ID                               |
+| `extra`         | object  | Any extra fields passed via `extra={}`   |
+| `exc_type`      | string  | Exception class name (only on errors)    |
+| `exc_message`   | string  | Exception message (only on errors)       |
+| `exc_traceback` | string  | Full traceback (only on errors)          |
+
+### Example output
+
+```json
+{"ts": "2026-04-08T12:00:00.123456+00:00", "level": "INFO", "logger": "inkypi", "msg": "Starting display refresh", "module": "inkypi", "func": "refresh", "line": 42, "pid": 1234}
+```
+
+### Shipping to Loki / Elasticsearch
+
+Because each line is valid JSON you can pipe stdout directly to
+[promtail](https://grafana.com/docs/loki/latest/clients/promtail/) or
+[Filebeat](https://www.elastic.co/beats/filebeat) without any parsing rules:
+
+```bash
+# systemd unit: add to [Service]
+Environment=INKYPI_LOG_FORMAT=json
+```
+
+### Log level
+
+Set `INKYPI_LOG_LEVEL` (default `INFO`) independently of the format:
+
+```bash
+INKYPI_LOG_FORMAT=json INKYPI_LOG_LEVEL=DEBUG python src/inkypi.py
+```
+
+### Notes
+
+- No additional dependencies — uses only Python stdlib `json` + `logging`.
+- Non-JSON-serialisable extra values are automatically converted to strings.
+- Secrets are **not** automatically redacted; avoid passing sensitive data
+  via `extra={}`.

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -1,77 +1,113 @@
+"""JSON log formatter for structured logging (JTN-337).
+
+Enabled via INKYPI_LOG_FORMAT=json.  Default behaviour is unchanged
+(plain-text via logging.conf).
+"""
+
+from __future__ import annotations
+
 import json
 import logging
 from datetime import UTC, datetime
 from typing import Any
 
-_DEFAULT_LOGRECORD_KEYS: set[str] = {
-    "name",
-    "msg",
-    "args",
-    "levelname",
-    "levelno",
-    "pathname",
-    "filename",
-    "module",
-    "exc_info",
-    "exc_text",
-    "stack_info",
-    "lineno",
-    "funcName",
-    "created",
-    "msecs",
-    "relativeCreated",
-    "thread",
-    "threadName",
-    "processName",
-    "process",
-}
+# All keys that exist on a bare LogRecord.  Extras are anything in
+# record.__dict__ that is NOT in this set and does NOT start with "_".
+_LOGRECORD_BUILTIN_KEYS: frozenset[str] = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",  # Python 3.12+
+        "message",  # set by Formatter.format() before our call; exclude it
+    }
+)
 
 
 class JsonFormatter(logging.Formatter):
+    """Emit one JSON object per log record.
+
+    Field names follow the spec (JTN-337):
+      ts, level, logger, msg, module, func, line, pid
+
+    Exception records gain: exc_type, exc_message, exc_traceback.
+    Caller-supplied extras appear under the top-level "extra" key.
+    Non-serialisable values are stringified via *default=str*.
+    """
+
     def __init__(
         self,
         *,
         default_fields: dict[str, Any] | None = None,
         datefmt: str | None = None,
-    ):
+    ) -> None:
         super().__init__(datefmt=datefmt)
-        self.default_fields = default_fields or {}
+        self.default_fields: dict[str, Any] = default_fields or {}
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
 
     def format(self, record: logging.LogRecord) -> str:
-        payload = self._record_to_dict(record)
-        if record.exc_info:
-            payload["exc_info"] = self.formatException(record.exc_info)
-        if record.stack_info:
-            payload["stack_info"] = self.formatStack(record.stack_info)
-        return json.dumps(payload, ensure_ascii=False, default=self._stringify)
+        payload = self._build_payload(record)
+        return json.dumps(payload, ensure_ascii=False, default=str)
 
-    def _record_to_dict(self, record: logging.LogRecord) -> dict[str, Any]:
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_payload(self, record: logging.LogRecord) -> dict[str, Any]:
         ts = datetime.fromtimestamp(record.created, tz=UTC).isoformat()
-        data: dict[str, Any] = {
-            "timestamp": ts,
+
+        payload: dict[str, Any] = {
+            "ts": ts,
             "level": record.levelname,
             "logger": record.name,
-            "message": record.getMessage(),
+            "msg": record.getMessage(),
             "module": record.module,
-            "function": record.funcName,
+            "func": record.funcName,
             "line": record.lineno,
-            "process": record.process,
-            "thread": record.thread,
+            "pid": record.process,
         }
-        data.update(self.default_fields)
 
+        # Stable, user-supplied defaults (e.g. {"host": "pi-zero"})
+        payload.update(self.default_fields)
+
+        # Exception info
+        if record.exc_info:
+            exc_type, exc_value, tb = record.exc_info
+            payload["exc_type"] = exc_type.__name__ if exc_type is not None else None
+            payload["exc_message"] = str(exc_value) if exc_value is not None else None
+            payload["exc_traceback"] = self.formatException(record.exc_info)
+
+        # Stack info (rare, but respect it)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+
+        # Caller-supplied extras
         extras = {
             k: v
             for k, v in record.__dict__.items()
-            if k not in _DEFAULT_LOGRECORD_KEYS and not k.startswith("_")
+            if k not in _LOGRECORD_BUILTIN_KEYS and not k.startswith("_")
         }
         if extras:
-            data["extra"] = extras
-        return data
+            payload["extra"] = extras
 
-    @staticmethod
-    def _stringify(obj: Any) -> str:
-        try:
-            return str(obj)
-        except Exception:
-            return "<unserializable>"
+        return payload

--- a/tests/test_json_logging.py
+++ b/tests/test_json_logging.py
@@ -1,0 +1,82 @@
+"""Top-level test module for JSON structured logging (JTN-337).
+
+The detailed formatter unit tests live in tests/unit/test_json_formatter.py.
+This module re-runs the key acceptance scenarios at the integration level so
+they are discoverable by a plain ``pytest tests/`` invocation.
+"""
+
+import json
+import logging
+import sys
+
+from utils.logging_utils import JsonFormatter
+
+
+def _record(msg="hello", level=logging.INFO, name="root", exc_info=None, **extras):
+    r = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=exc_info,
+    )
+    for k, v in extras.items():
+        setattr(r, k, v)
+    return r
+
+
+def test_format_logrecord_all_spec_fields():
+    data = json.loads(JsonFormatter().format(_record()))
+    for field in ("ts", "level", "logger", "msg", "module", "func", "line", "pid"):
+        assert field in data, f"Missing spec field: {field}"
+
+
+def test_exception_record_has_exc_fields():
+    try:
+        raise RuntimeError("kaboom")
+    except RuntimeError:
+        exc = sys.exc_info()
+
+    data = json.loads(
+        JsonFormatter().format(_record(level=logging.ERROR, exc_info=exc))
+    )
+    assert data["exc_type"] == "RuntimeError"
+    assert data["exc_message"] == "kaboom"
+    assert "RuntimeError" in data["exc_traceback"]
+
+
+def test_extras_present_in_output():
+    data = json.loads(JsonFormatter().format(_record(trace_id="t-1", user="alice")))
+    assert data["extra"]["trace_id"] == "t-1"
+    assert data["extra"]["user"] == "alice"
+
+
+def test_non_serialisable_extra_does_not_crash():
+    class _Blob:
+        pass
+
+    data = json.loads(JsonFormatter().format(_record(blob=_Blob())))
+    assert "blob" in data["extra"]
+
+
+def test_env_var_detection(monkeypatch):
+    """Root logger must use JsonFormatter when INKYPI_LOG_FORMAT=json."""
+    monkeypatch.setenv("INKYPI_LOG_FORMAT", "json")
+
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    root.handlers = []
+
+    try:
+        from app_setup.logging_setup import setup_logging
+
+        setup_logging()
+        handlers = logging.getLogger().handlers
+        assert handlers, "No handlers attached to root logger"
+        assert isinstance(handlers[0].formatter, JsonFormatter)
+    finally:
+        root.handlers = saved_handlers
+        root.level = saved_level

--- a/tests/unit/test_json_formatter.py
+++ b/tests/unit/test_json_formatter.py
@@ -1,143 +1,181 @@
+"""Tests for JsonFormatter in utils.logging_utils (JTN-337)."""
+
 import json
 import logging
+import sys
 
 from utils.logging_utils import JsonFormatter
 
 
-def test_json_formatter_basic():
-    record = logging.LogRecord(
-        name="test.logger",
-        level=logging.INFO,
+def _make_record(
+    name="test.logger",
+    level=logging.INFO,
+    msg="Hello %s",
+    args=("world",),
+    lineno=42,
+    exc_info=None,
+):
+    return logging.LogRecord(
+        name=name,
+        level=level,
         pathname=__file__,
-        lineno=42,
-        msg="Hello %s",
-        args=("world",),
-        exc_info=None,
+        lineno=lineno,
+        msg=msg,
+        args=args,
+        exc_info=exc_info,
     )
-    f = JsonFormatter()
-    out = f.format(record)
-    data = json.loads(out)
-    assert data["level"] == "INFO"
-    assert data["logger"] == "test.logger"
-    assert data["message"] == "Hello world"
-    assert data["line"] == 42
-    assert "timestamp" in data
 
 
-def test_json_formatter_includes_extras():
-    record = logging.LogRecord(
-        name="t",
-        level=logging.WARNING,
-        pathname=__file__,
-        lineno=1,
-        msg="X",
-        args=(),
-        exc_info=None,
-    )
-    record.request_id = "abc123"
-    out = JsonFormatter().format(record)
-    data = json.loads(out)
-    assert data["extra"]["request_id"] == "abc123"
+# ---------------------------------------------------------------------------
+# Basic fields
+# ---------------------------------------------------------------------------
 
 
-def test_json_format_basic_fields():
-    record = logging.LogRecord(
+def test_basic_fields_present():
+    record = _make_record()
+    data = json.loads(JsonFormatter().format(record))
+    for key in ("ts", "level", "logger", "msg", "module", "func", "line", "pid"):
+        assert key in data, f"Expected key '{key}' missing from output"
+
+
+def test_basic_field_values():
+    record = _make_record(
         name="myapp.module",
         level=logging.DEBUG,
-        pathname=__file__,
-        lineno=99,
         msg="checking fields",
         args=(),
-        exc_info=None,
+        lineno=99,
     )
     data = json.loads(JsonFormatter().format(record))
-    for key in (
-        "timestamp",
-        "level",
-        "logger",
-        "message",
-        "module",
-        "function",
-        "line",
-    ):
-        assert key in data, f"Expected key '{key}' missing from output"
     assert data["level"] == "DEBUG"
     assert data["logger"] == "myapp.module"
-    assert data["message"] == "checking fields"
+    assert data["msg"] == "checking fields"
     assert data["line"] == 99
 
 
-def test_json_format_exception_info():
+def test_msg_arg_interpolation():
+    record = _make_record(msg="Hello %s", args=("world",))
+    data = json.loads(JsonFormatter().format(record))
+    assert data["msg"] == "Hello world"
+
+
+def test_ts_is_iso8601_utc():
+    record = _make_record()
+    data = json.loads(JsonFormatter().format(record))
+    ts = data["ts"]
+    assert "T" in ts
+    assert ts.endswith("+00:00") or ts.endswith("Z"), f"Expected UTC ts, got: {ts}"
+
+
+def test_pid_is_integer():
+    record = _make_record()
+    data = json.loads(JsonFormatter().format(record))
+    assert isinstance(data["pid"], int)
+
+
+# ---------------------------------------------------------------------------
+# Exception records
+# ---------------------------------------------------------------------------
+
+
+def test_exception_fields_present():
     try:
         raise ValueError("boom")
     except ValueError:
-        import sys
-
         exc = sys.exc_info()
 
-    record = logging.LogRecord(
-        name="t",
-        level=logging.ERROR,
-        pathname=__file__,
-        lineno=1,
-        msg="error",
-        args=(),
-        exc_info=exc,
-    )
+    record = _make_record(level=logging.ERROR, msg="error", args=(), exc_info=exc)
     data = json.loads(JsonFormatter().format(record))
-    assert "exc_info" in data
-    assert "ValueError" in data["exc_info"]
+    assert data["exc_type"] == "ValueError"
+    assert data["exc_message"] == "boom"
+    assert "ValueError" in data["exc_traceback"]
 
 
-def test_json_format_extra_fields():
-    record = logging.LogRecord(
-        name="t",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=1,
-        msg="msg",
-        args=(),
-        exc_info=None,
-    )
-    record.trace_id = "xyz-789"
+def test_exception_no_exc_type_key_when_no_exception():
+    record = _make_record()
+    data = json.loads(JsonFormatter().format(record))
+    assert "exc_type" not in data
+    assert "exc_message" not in data
+    assert "exc_traceback" not in data
+
+
+# ---------------------------------------------------------------------------
+# Extra fields
+# ---------------------------------------------------------------------------
+
+
+def test_extras_passed_through():
+    record = _make_record()
+    record.request_id = "abc123"
     record.user_id = 42
     data = json.loads(JsonFormatter().format(record))
-    assert data["extra"]["trace_id"] == "xyz-789"
+    assert data["extra"]["request_id"] == "abc123"
     assert data["extra"]["user_id"] == 42
 
 
-def test_json_format_default_fields():
+def test_no_extra_key_when_no_extras():
+    record = _make_record()
+    data = json.loads(JsonFormatter().format(record))
+    assert "extra" not in data
+
+
+# ---------------------------------------------------------------------------
+# Non-serialisable extras must not crash
+# ---------------------------------------------------------------------------
+
+
+def test_non_serialisable_extra_does_not_crash():
+    class Unserializable:
+        def __repr__(self):
+            return "<Unserializable>"
+
+    record = _make_record()
+    record.bad_field = Unserializable()
+    out = JsonFormatter().format(record)
+    data = json.loads(out)
+    assert "bad_field" in data["extra"]
+
+
+# ---------------------------------------------------------------------------
+# default_fields
+# ---------------------------------------------------------------------------
+
+
+def test_default_fields_merged():
     formatter = JsonFormatter(default_fields={"app": "inkypi", "env": "test"})
-    record = logging.LogRecord(
-        name="t",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=1,
-        msg="hi",
-        args=(),
-        exc_info=None,
-    )
+    record = _make_record()
     data = json.loads(formatter.format(record))
     assert data["app"] == "inkypi"
     assert data["env"] == "test"
 
 
-def test_stringify_fallback():
-    class Unserializable:
-        def __repr__(self):
-            return "<Unserializable>"
+# ---------------------------------------------------------------------------
+# Env-var detection: monkeypatch INKYPI_LOG_FORMAT=json
+# ---------------------------------------------------------------------------
 
-    record = logging.LogRecord(
-        name="t",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=1,
-        msg="msg",
-        args=(),
-        exc_info=None,
-    )
-    record.bad_field = Unserializable()
-    # Should not raise; the non-serializable object is coerced via _stringify
-    out = JsonFormatter().format(record)
-    data = json.loads(out)
-    assert "bad_field" in data["extra"]
+
+def test_setup_logging_uses_json_formatter_when_env_set(monkeypatch, tmp_path):
+    """setup_logging() must attach JsonFormatter to root when env var is json."""
+    monkeypatch.setenv("INKYPI_LOG_FORMAT", "json")
+
+    # Remove all existing root handlers to get a clean slate
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_level = root.level
+    root.handlers = []
+
+    try:
+        from app_setup.logging_setup import setup_logging
+
+        setup_logging()
+
+        root_handlers = logging.getLogger().handlers
+        assert len(root_handlers) >= 1, "Expected at least one handler on root logger"
+        formatter = root_handlers[0].formatter
+        assert isinstance(
+            formatter, JsonFormatter
+        ), f"Expected JsonFormatter, got {type(formatter)}"
+    finally:
+        # Restore root logger state
+        root.handlers = original_handlers
+        root.level = original_level


### PR DESCRIPTION
## Summary

- Adds `JsonFormatter` in `src/utils/logging_utils.py` emitting one JSON object per log line with fields: `ts`, `level`, `logger`, `msg`, `module`, `func`, `line`, `pid`
- Exception records include `exc_type`, `exc_message`, `exc_traceback`; caller extras nested under `extra`; non-serialisable values stringified via `default=str`
- `setup_logging()` in `src/app_setup/logging_setup.py` switches to `JsonFormatter` when `INKYPI_LOG_FORMAT=json`; default plain-text format is unchanged
- Adds `docs/logging.md` explaining how to enable and ship logs to Loki/Elasticsearch
- No new dependencies — stdlib `json` + `logging` only

## Test plan

- [ ] `SKIP_BROWSER=1 python -m pytest tests/test_json_logging.py tests/unit/test_json_formatter.py -v` — all 17 tests pass
- [ ] `SKIP_BROWSER=1 python -m pytest tests/ -q` — full suite 2467 passed
- [ ] `ruff check` and `black --check` — all clean
- [ ] Manual smoke test: `INKYPI_LOG_FORMAT=json python src/inkypi.py --web-only` and confirm JSON lines on stdout

Closes JTN-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)