### PR TITLE
feat: add Prometheus /metrics endpoint (JTN-334)

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -18,3 +18,4 @@ waitress==3.0.2
 feedparser==6.0.11
 jsonschema==4.23.0
 astral==3.2
+prometheus-client==0.21.1

--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -11,6 +11,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.apikeys import apikeys_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
+    from blueprints.metrics import metrics_bp
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
@@ -22,3 +23,4 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(playlist_bp)
     app.register_blueprint(history_bp)
     app.register_blueprint(api_docs_bp)
+    app.register_blueprint(metrics_bp)

--- a/src/blueprints/metrics.py
+++ b/src/blueprints/metrics.py
@@ -1,0 +1,27 @@
+"""Prometheus /metrics endpoint (JTN-334).
+
+NOTE: This endpoint is intentionally accessible WITHOUT authentication.
+Prometheus scrapers need to reach /metrics on a regular polling interval and
+cannot easily carry session cookies or CSRF tokens.  Exposing counters and
+gauges is considered safe because the data is read-only and contains no
+user-identifying information.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response
+from prometheus_client.exposition import generate_latest
+
+from utils.metrics import metrics_registry, update_uptime
+
+metrics_bp = Blueprint("metrics", __name__)
+
+_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+
+@metrics_bp.route("/metrics", methods=["GET"])
+def prometheus_metrics():
+    """Return all InkyPi metrics in Prometheus text exposition format."""
+    update_uptime()
+    data = generate_latest(metrics_registry)
+    return Response(data, status=200, content_type=_CONTENT_TYPE)

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -19,6 +19,11 @@ from refresh_task.worker import (
     _remote_exception,
 )
 from utils.image_utils import compute_image_hash
+from utils.metrics import (
+    record_refresh_failure,
+    record_refresh_success,
+    set_circuit_breaker_open,
+)
 from utils.progress import ProgressTracker, track_progress
 from utils.progress_events import get_progress_bus
 from utils.time_utils import now_device_tz
@@ -896,6 +901,7 @@ class RefreshTask:
             entry["retained_display"] = False
             if metrics:
                 entry["last_metrics"] = metrics
+            record_refresh_success()
             self._cb_on_success(plugin_instance, plugin_id, instance)
         else:
             msg = error or "unknown error"
@@ -909,6 +915,7 @@ class RefreshTask:
             entry["retained_display"] = bool((metrics or {}).get("retained_display"))
             if metrics:
                 entry["last_metrics"] = metrics
+            record_refresh_failure(plugin_id)
             self._cb_on_failure(plugin_instance, plugin_id, instance)
         self.plugin_health[plugin_id] = entry
 
@@ -929,6 +936,7 @@ class RefreshTask:
             )
         plugin_instance.consecutive_failure_count = 0
         plugin_instance.paused = False
+        set_circuit_breaker_open(plugin_id, False)
 
     def _cb_on_failure(
         self,
@@ -950,6 +958,7 @@ class RefreshTask:
         )
         if plugin_instance.consecutive_failure_count >= threshold:
             plugin_instance.paused = True
+            set_circuit_breaker_open(plugin_id, True)
             logger.error(
                 "plugin circuit_breaker: paused | plugin_id=%s instance=%s"
                 " paused after %d consecutive failures",

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,94 @@
+"""Prometheus metrics registry for InkyPi (JTN-334).
+
+All metric instances live here so that:
+  - updates are funnelled through helpers (no scattered inc() calls),
+  - tests can clear the registry between runs,
+  - the /metrics blueprint imports a single well-known object.
+
+Usage
+-----
+from utils.metrics import record_refresh_success, record_plugin_failure, ...
+"""
+
+from __future__ import annotations
+
+import time
+
+from prometheus_client import CollectorRegistry, Counter, Gauge
+
+# ---------------------------------------------------------------------------
+# Registry — one per process; tests can create fresh instances as needed.
+# ---------------------------------------------------------------------------
+
+metrics_registry = CollectorRegistry(auto_describe=True)
+
+# ---------------------------------------------------------------------------
+# Metric definitions
+# ---------------------------------------------------------------------------
+
+refreshes_total = Counter(
+    "inkypi_refreshes_total",
+    "Total number of display refresh attempts",
+    labelnames=["status"],
+    registry=metrics_registry,
+)
+
+last_successful_refresh_timestamp = Gauge(
+    "inkypi_last_successful_refresh_timestamp_seconds",
+    "Unix timestamp of the last successful display refresh",
+    registry=metrics_registry,
+)
+
+plugin_failures_total = Counter(
+    "inkypi_plugin_failures_total",
+    "Total number of plugin failures by plugin id",
+    labelnames=["plugin"],
+    registry=metrics_registry,
+)
+
+plugin_circuit_breaker_open = Gauge(
+    "inkypi_plugin_circuit_breaker_open",
+    "1 if the plugin circuit-breaker is open (plugin paused), 0 if closed",
+    labelnames=["plugin"],
+    registry=metrics_registry,
+)
+
+uptime_seconds = Gauge(
+    "inkypi_uptime_seconds",
+    "Seconds since the InkyPi process started",
+    registry=metrics_registry,
+)
+
+# Record the process-start time so we can compute uptime on demand.
+_process_start_time: float = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Helper functions — the only public API callers should use
+# ---------------------------------------------------------------------------
+
+
+def record_refresh_success() -> None:
+    """Increment refresh counter for a successful refresh and set the timestamp."""
+    refreshes_total.labels(status="success").inc()
+    last_successful_refresh_timestamp.set(time.time())
+
+
+def record_refresh_failure(plugin_name: str) -> None:
+    """Increment refresh and plugin-failure counters for a failed refresh."""
+    refreshes_total.labels(status="failure").inc()
+    plugin_failures_total.labels(plugin=plugin_name).inc()
+
+
+def set_circuit_breaker_open(plugin_name: str, is_open: bool) -> None:
+    """Set the circuit-breaker gauge for *plugin_name*.
+
+    Pass ``is_open=True`` when the breaker trips (plugin paused),
+    ``is_open=False`` when it resets (plugin recovered).
+    """
+    plugin_circuit_breaker_open.labels(plugin=plugin_name).set(1 if is_open else 0)
+
+
+def update_uptime() -> None:
+    """Refresh the uptime gauge. Called by the /metrics handler before serialising."""
+    uptime_seconds.set(time.monotonic() - _process_start_time)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,7 @@ def flask_app(device_config_dev, monkeypatch):
     from blueprints.apikeys import apikeys_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
+    from blueprints.metrics import metrics_bp
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
@@ -305,6 +306,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(playlist_bp)
     app.register_blueprint(history_bp)
     app.register_blueprint(api_docs_bp)
+    app.register_blueprint(metrics_bp)
 
     # Lightweight health endpoints for probes/CI
     @app.route("/healthz")

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,189 @@
+"""Tests for the Prometheus /metrics endpoint (JTN-334)."""
+
+from __future__ import annotations
+
+import pytest
+from prometheus_client import CollectorRegistry, Counter, Gauge  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_registry():
+    """Return a brand-new CollectorRegistry with the five InkyPi metrics."""
+    reg = CollectorRegistry(auto_describe=True)
+    Counter(
+        "inkypi_refreshes_total",
+        "Total refresh attempts",
+        labelnames=["status"],
+        registry=reg,
+    )
+    Gauge(
+        "inkypi_last_successful_refresh_timestamp_seconds",
+        "Last successful refresh timestamp",
+        registry=reg,
+    )
+    Counter(
+        "inkypi_plugin_failures_total",
+        "Plugin failures",
+        labelnames=["plugin"],
+        registry=reg,
+    )
+    Gauge(
+        "inkypi_plugin_circuit_breaker_open",
+        "Circuit breaker open flag",
+        labelnames=["plugin"],
+        registry=reg,
+    )
+    Gauge(
+        "inkypi_uptime_seconds",
+        "Process uptime",
+        registry=reg,
+    )
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# /metrics endpoint — HTTP contract
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_endpoint_returns_200(client):
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+
+
+def test_metrics_endpoint_content_type(client):
+    resp = client.get("/metrics")
+    ct = resp.content_type
+    assert ct.startswith("text/plain")
+    assert "version=0.0.4" in ct
+
+
+def test_metrics_endpoint_no_auth_required(client):
+    """Scraping /metrics must succeed without any session or API key."""
+    resp = client.get("/metrics")
+    # Must NOT redirect to a login page
+    assert resp.status_code == 200
+    assert b"inkypi_" in resp.data
+
+
+# ---------------------------------------------------------------------------
+# Metric names present in the output
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_METRIC_NAMES = [
+    b"inkypi_refreshes_total",
+    b"inkypi_last_successful_refresh_timestamp_seconds",
+    b"inkypi_plugin_failures_total",
+    b"inkypi_plugin_circuit_breaker_open",
+    b"inkypi_uptime_seconds",
+]
+
+
+@pytest.mark.parametrize("metric_name", _EXPECTED_METRIC_NAMES)
+def test_metrics_body_contains_metric_name(client, metric_name):
+    resp = client.get("/metrics")
+    assert metric_name in resp.data, f"{metric_name!r} not found in /metrics output"
+
+
+# ---------------------------------------------------------------------------
+# Counter increments are reflected in output
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_success_counter_increments(client, monkeypatch):
+    """record_refresh_success() must bump inkypi_refreshes_total{status='success'}."""
+    import utils.metrics as m
+
+    # Capture the initial value
+    before = m.refreshes_total.labels(status="success")._value.get()
+    m.record_refresh_success()
+    after = m.refreshes_total.labels(status="success")._value.get()
+    assert after == before + 1
+
+    resp = client.get("/metrics")
+    assert b'inkypi_refreshes_total{status="success"}' in resp.data
+
+
+def test_refresh_failure_counter_increments(client):
+    """record_refresh_failure() must bump both the total and plugin counters."""
+    import utils.metrics as m
+
+    before_total = m.refreshes_total.labels(status="failure")._value.get()
+    before_plugin = m.plugin_failures_total.labels(plugin="test_plugin")._value.get()
+
+    m.record_refresh_failure("test_plugin")
+
+    assert m.refreshes_total.labels(status="failure")._value.get() == before_total + 1
+    assert (
+        m.plugin_failures_total.labels(plugin="test_plugin")._value.get()
+        == before_plugin + 1
+    )
+
+
+def test_plugin_failure_reflected_in_endpoint(client):
+    """After a simulated plugin failure the body must contain the plugin label."""
+    import utils.metrics as m
+
+    m.record_refresh_failure("my_plugin")
+    resp = client.get("/metrics")
+    assert b"my_plugin" in resp.data
+
+
+# ---------------------------------------------------------------------------
+# Circuit-breaker gauge
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_breaker_open_sets_gauge_to_1(client):
+    import utils.metrics as m
+
+    m.set_circuit_breaker_open("demo_plugin", True)
+    val = m.plugin_circuit_breaker_open.labels(plugin="demo_plugin")._value.get()
+    assert val == 1.0
+
+
+def test_circuit_breaker_close_sets_gauge_to_0(client):
+    import utils.metrics as m
+
+    m.set_circuit_breaker_open("demo_plugin", True)
+    m.set_circuit_breaker_open("demo_plugin", False)
+    val = m.plugin_circuit_breaker_open.labels(plugin="demo_plugin")._value.get()
+    assert val == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Uptime gauge is positive
+# ---------------------------------------------------------------------------
+
+
+def test_uptime_gauge_is_positive(client):
+    import utils.metrics as m
+
+    m.update_uptime()
+    val = m.uptime_seconds._value.get()
+    assert val > 0
+
+
+# ---------------------------------------------------------------------------
+# Custom registry (isolation — metrics module helper)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_registry_has_all_five_metrics():
+    """Sanity-check the helper used in isolation tests."""
+    from prometheus_client.exposition import generate_latest
+
+    reg = _fresh_registry()
+    output = generate_latest(reg).decode()
+    for name in (
+        "inkypi_refreshes_total",
+        "inkypi_last_successful_refresh_timestamp_seconds",
+        "inkypi_plugin_failures_total",
+        "inkypi_plugin_circuit_breaker_open",
+        "inkypi_uptime_seconds",
+    ):
+        assert name in output, f"{name!r} missing from fresh registry output"


### PR DESCRIPTION
## Summary
- Adds `GET /metrics` returning Prometheus text exposition format (no auth required — scraper-friendly)
- Introduces `src/utils/metrics.py` with a custom `CollectorRegistry` and 5 metrics: `inkypi_refreshes_total`, `inkypi_last_successful_refresh_timestamp_seconds`, `inkypi_plugin_failures_total`, `inkypi_plugin_circuit_breaker_open`, `inkypi_uptime_seconds`
- Wires metric updates into `RefreshTask._update_plugin_health`, `_cb_on_success`, and `_cb_on_failure` via helper functions
- Adds `prometheus-client==0.21.1` to `install/requirements.txt` (pure Python, ~50 KB, Pi Zero safe)

## Test plan
- [x] 15 new tests in `tests/unit/test_metrics.py` covering: HTTP 200, correct content-type, all 5 metric names in body, counter increments reflected live, circuit-breaker gauge 0/1, uptime > 0, no-auth access
- [x] Full suite: 2472 passed
- [x] ruff + black: clean

Closes JTN-334

🤖 Generated with [Claude Code](https://claude.com/claude-code)