### PR TITLE
feat: add backup/restore CLI for device config (JTN-336)

### DIFF
--- a/scripts/backup_config.py
+++ b/scripts/backup_config.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Backup InkyPi device configuration and plugin instance images to a tar.gz archive.
+
+Usage:
+    python scripts/backup_config.py [--output PATH] [--include-history]
+                                    [--config-dir PATH] [--instances-dir PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import sys
+import tarfile
+from datetime import UTC, datetime
+
+BACKUP_FORMAT_VERSION = "1"
+
+
+def _default_output_path() -> str:
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"inkypi-backup-{ts}.tar.gz"
+
+
+def _detect_instances_dir() -> str:
+    """Auto-detect plugin images directory relative to this script."""
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(scripts_dir)
+    return os.path.join(project_root, "src", "static", "images", "plugins")
+
+
+def _detect_config_dir() -> str:
+    """Detect default config directory relative to this script."""
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(scripts_dir)
+    return os.path.join(project_root, "src", "config")
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _collect_files(
+    config_dir: str,
+    instances_dir: str,
+    include_history: bool,
+    history_dir: str | None,
+) -> list[tuple[str, str]]:
+    """Return list of (filesystem_path, archive_name) tuples."""
+    entries: list[tuple[str, str]] = []
+
+    # Config JSON files
+    if os.path.isdir(config_dir):
+        for name in sorted(os.listdir(config_dir)):
+            if name.endswith(".json"):
+                full = os.path.join(config_dir, name)
+                if os.path.isfile(full):
+                    entries.append((full, os.path.join("config", name)))
+
+    # Plugin instance images directory (recursive)
+    if os.path.isdir(instances_dir):
+        for dirpath, _dirnames, filenames in os.walk(instances_dir):
+            for fname in sorted(filenames):
+                full = os.path.join(dirpath, fname)
+                rel = os.path.relpath(full, os.path.dirname(instances_dir))
+                entries.append((full, os.path.join("instances", rel)))
+
+    # History images (optional)
+    if include_history and history_dir and os.path.isdir(history_dir):
+        for dirpath, _dirnames, filenames in os.walk(history_dir):
+            for fname in sorted(filenames):
+                full = os.path.join(dirpath, fname)
+                rel = os.path.relpath(full, os.path.dirname(history_dir))
+                entries.append((full, os.path.join("history", rel)))
+
+    return entries
+
+
+def _build_manifest(
+    timestamp: str,
+    entries: list[tuple[str, str]],
+    device_json_path: str | None,
+) -> dict:
+    manifest: dict = {
+        "backup_version": BACKUP_FORMAT_VERSION,
+        "timestamp": timestamp,
+        "included_paths": [arc for _fs, arc in entries],
+        "device_json_checksum": None,
+    }
+    if device_json_path and os.path.isfile(device_json_path):
+        manifest["device_json_checksum"] = _sha256_file(device_json_path)
+    return manifest
+
+
+def run_backup(
+    output: str,
+    config_dir: str,
+    instances_dir: str,
+    include_history: bool,
+    history_dir: str | None = None,
+) -> int:
+    """Perform backup and return exit code."""
+    timestamp = datetime.now(tz=UTC).isoformat()
+    entries = _collect_files(config_dir, instances_dir, include_history, history_dir)
+
+    device_json_path = os.path.join(config_dir, "device.json")
+    manifest = _build_manifest(timestamp, entries, device_json_path)
+    manifest_json = json.dumps(manifest, indent=2).encode("utf-8")
+
+    output = os.path.abspath(output)
+    os.makedirs(
+        os.path.dirname(output) if os.path.dirname(output) else ".", exist_ok=True
+    )
+
+    with tarfile.open(output, "w:gz") as tar:
+        # Write manifest first
+        manifest_info = tarfile.TarInfo(name="manifest.json")
+        manifest_info.size = len(manifest_json)
+        tar.addfile(manifest_info, io.BytesIO(manifest_json))
+
+        # Write collected files
+        for fs_path, arc_name in entries:
+            tar.add(fs_path, arcname=arc_name)
+
+    total_size = os.path.getsize(output)
+    file_count = len(entries)
+    size_kb = total_size / 1024
+
+    print(f"Backup complete: {output}")
+    print(f"  Files archived : {file_count}")
+    print(f"  Archive size   : {size_kb:.1f} KB")
+    if manifest["device_json_checksum"]:
+        print(f"  device.json SHA256: {manifest['device_json_checksum']}")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Back up InkyPi device config and plugin instance images.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Output tar.gz path (default: ./inkypi-backup-<timestamp>.tar.gz)",
+    )
+    parser.add_argument(
+        "--include-history",
+        action="store_true",
+        default=False,
+        help="Include history images in backup (default: off — may be large)",
+    )
+    parser.add_argument(
+        "--config-dir",
+        default=None,
+        metavar="PATH",
+        help="Path to config directory (default: src/config)",
+    )
+    parser.add_argument(
+        "--instances-dir",
+        default=None,
+        metavar="PATH",
+        help="Path to plugin instance images directory (default: auto-detected)",
+    )
+    args = parser.parse_args(argv)
+
+    output = args.output or _default_output_path()
+    config_dir = args.config_dir or _detect_config_dir()
+    instances_dir = args.instances_dir or _detect_instances_dir()
+
+    # Derive history dir from instances_dir sibling
+    history_dir = os.path.join(os.path.dirname(instances_dir), "history")
+
+    return run_backup(
+        output=output,
+        config_dir=config_dir,
+        instances_dir=instances_dir,
+        include_history=args.include_history,
+        history_dir=history_dir,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/restore_config.py
+++ b/scripts/restore_config.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Restore InkyPi device configuration and plugin instance images from a backup archive.
+
+Usage:
+    python scripts/restore_config.py BACKUP_PATH [--config-dir PATH]
+                                     [--instances-dir PATH] [--yes]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tarfile
+from datetime import UTC, datetime
+
+
+def _detect_instances_dir() -> str:
+    """Auto-detect plugin images directory relative to this script."""
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(scripts_dir)
+    return os.path.join(project_root, "src", "static", "images", "plugins")
+
+
+def _detect_config_dir() -> str:
+    """Detect default config directory relative to this script."""
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(scripts_dir)
+    return os.path.join(project_root, "src", "config")
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_manifest(tar: tarfile.TarFile) -> dict:
+    """Extract and parse manifest.json from an open tarfile."""
+    try:
+        member = tar.getmember("manifest.json")
+    except KeyError as exc:
+        raise ValueError("No manifest.json found in backup archive") from exc
+    fobj = tar.extractfile(member)
+    if fobj is None:
+        raise ValueError("manifest.json is not a regular file")
+    return json.loads(fobj.read().decode("utf-8"))
+
+
+def _pre_restore_backup(config_dir: str, instances_dir: str) -> str:
+    """Create a safety backup of current state before overwriting."""
+    # Import inline so the module stays self-contained
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, scripts_dir)
+    try:
+        import backup_config  # noqa: PLC0415
+    finally:
+        sys.path.pop(0)
+
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    output = os.path.abspath(f".pre-restore-{ts}.tar.gz")
+    history_dir = os.path.join(os.path.dirname(instances_dir), "history")
+    backup_config.run_backup(
+        output=output,
+        config_dir=config_dir,
+        instances_dir=instances_dir,
+        include_history=False,
+        history_dir=history_dir,
+    )
+    return output
+
+
+def _extract_backup(
+    backup_path: str,
+    config_dir: str,
+    instances_dir: str,
+) -> None:
+    """Extract backup archive contents into the correct destination directories."""
+    instances_parent = os.path.dirname(instances_dir)
+
+    with tarfile.open(backup_path, "r:gz") as tar:
+        for member in tar.getmembers():
+            name = member.name
+            if name == "manifest.json":
+                continue
+
+            if name.startswith("config/"):
+                rel = name[len("config/") :]
+                dest = os.path.join(config_dir, rel)
+            elif name.startswith("instances/"):
+                rel = name[len("instances/") :]
+                dest = os.path.join(instances_parent, rel)
+            elif name.startswith("history/"):
+                rel = name[len("history/") :]
+                dest = os.path.join(instances_parent, rel)
+            else:
+                # Unknown prefix — skip
+                continue
+
+            if member.isdir():
+                os.makedirs(dest, exist_ok=True)
+                continue
+
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            fobj = tar.extractfile(member)
+            if fobj is not None:
+                with open(dest, "wb") as out:
+                    out.write(fobj.read())
+
+
+def run_restore(
+    backup_path: str,
+    config_dir: str,
+    instances_dir: str,
+    yes: bool = False,
+    _input_fn=input,
+) -> int:
+    """Perform restore and return exit code."""
+    backup_path = os.path.abspath(backup_path)
+    if not os.path.isfile(backup_path):
+        print(f"Error: backup file not found: {backup_path}", file=sys.stderr)
+        return 1
+
+    # Read manifest and show summary
+    try:
+        with tarfile.open(backup_path, "r:gz") as tar:
+            manifest = _read_manifest(tar)
+    except (tarfile.TarError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error reading backup archive: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Backup archive : {backup_path}")
+    print(f"Backup version : {manifest.get('backup_version', 'unknown')}")
+    print(f"Backup timestamp: {manifest.get('timestamp', 'unknown')}")
+    paths = manifest.get("included_paths", [])
+    print(f"Files to restore: {len(paths)}")
+    print(f"  Config dir     : {config_dir}")
+    print(f"  Instances dir  : {instances_dir}")
+
+    if not yes:
+        try:
+            answer = (
+                _input_fn(
+                    "\nThis will overwrite current config and plugin images. "
+                    "A safety backup will be created first.\nProceed? [y/N] "
+                )
+                .strip()
+                .lower()
+            )
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            return 1
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return 1
+
+    # Create safety backup of current state
+    print("\nCreating pre-restore safety backup...")
+    try:
+        safety_path = _pre_restore_backup(config_dir, instances_dir)
+        print(f"Safety backup saved to: {safety_path}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: could not create safety backup: {exc}", file=sys.stderr)
+
+    # Extract
+    print("Restoring files...")
+    try:
+        _extract_backup(backup_path, config_dir, instances_dir)
+    except (tarfile.TarError, OSError) as exc:
+        print(f"Error extracting backup: {exc}", file=sys.stderr)
+        return 1
+
+    # Verify device.json checksum
+    expected_checksum = manifest.get("device_json_checksum")
+    if expected_checksum:
+        device_json_path = os.path.join(config_dir, "device.json")
+        if os.path.isfile(device_json_path):
+            actual = _sha256_file(device_json_path)
+            if actual != expected_checksum:
+                print(
+                    f"Error: device.json checksum mismatch!\n"
+                    f"  Expected: {expected_checksum}\n"
+                    f"  Actual  : {actual}",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"Checksum verified: device.json OK ({actual[:16]}...)")
+        else:
+            print("Warning: device.json not found after restore", file=sys.stderr)
+
+    print("Restore complete.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Restore InkyPi device config and plugin instance images from a backup.",
+    )
+    parser.add_argument(
+        "backup_path",
+        metavar="BACKUP_PATH",
+        help="Path to the .tar.gz backup file",
+    )
+    parser.add_argument(
+        "--config-dir",
+        default=None,
+        metavar="PATH",
+        help="Path to config directory (default: src/config)",
+    )
+    parser.add_argument(
+        "--instances-dir",
+        default=None,
+        metavar="PATH",
+        help="Path to plugin instance images directory (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        default=False,
+        help="Skip confirmation prompt",
+    )
+    args = parser.parse_args(argv)
+
+    config_dir = args.config_dir or _detect_config_dir()
+    instances_dir = args.instances_dir or _detect_instances_dir()
+
+    return run_restore(
+        backup_path=args.backup_path,
+        config_dir=config_dir,
+        instances_dir=instances_dir,
+        yes=args.yes,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,384 @@
+"""Tests for scripts/backup_config.py and scripts/restore_config.py."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers to load scripts without importing from src/
+# ---------------------------------------------------------------------------
+
+
+def _load_script(script_name: str):
+    """Load a scripts/ module by file path, avoiding sys.path pollution."""
+    scripts_dir = Path(__file__).parent.parent / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        script_name, scripts_dir / f"{script_name}.py"
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def backup_mod():
+    return _load_script("backup_config")
+
+
+@pytest.fixture(scope="module")
+def restore_mod():
+    return _load_script("restore_config")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config_dir(base: Path) -> Path:
+    config_dir = base / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    device = {
+        "name": "TestDevice",
+        "display_type": "mock",
+        "resolution": [800, 480],
+        "orientation": "horizontal",
+        "plugin_order": [],
+        "playlist_config": {"playlists": [], "active_playlist": None},
+        "refresh_info": {
+            "refresh_time": None,
+            "image_hash": None,
+            "refresh_type": None,
+            "plugin_id": None,
+        },
+    }
+    (config_dir / "device.json").write_text(json.dumps(device))
+    (config_dir / "extra.json").write_text(json.dumps({"foo": "bar"}))
+    return config_dir
+
+
+def _make_instances_dir(base: Path) -> Path:
+    inst_dir = base / "instances"
+    inst_dir.mkdir(parents=True, exist_ok=True)
+    plugin_dir = inst_dir / "weather"
+    plugin_dir.mkdir()
+    (plugin_dir / "weather_default.png").write_bytes(b"\x89PNG\r\n")
+    return inst_dir
+
+
+# ---------------------------------------------------------------------------
+# backup_config tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackupConfig:
+    def test_backup_creates_valid_tar_gz(self, backup_mod, tmp_path):
+        config_dir = _make_config_dir(tmp_path / "src")
+        instances_dir = _make_instances_dir(tmp_path / "src")
+        output = str(tmp_path / "backup.tar.gz")
+
+        rc = backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        assert rc == 0
+        assert os.path.isfile(output)
+        assert tarfile.is_tarfile(output)
+
+    def test_manifest_contains_expected_fields(self, backup_mod, tmp_path):
+        config_dir = _make_config_dir(tmp_path / "src")
+        instances_dir = _make_instances_dir(tmp_path / "src")
+        output = str(tmp_path / "backup.tar.gz")
+
+        backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            member = tar.getmember("manifest.json")
+            fobj = tar.extractfile(member)
+            manifest = json.loads(fobj.read().decode("utf-8"))
+
+        assert manifest["backup_version"] == backup_mod.BACKUP_FORMAT_VERSION
+        assert "timestamp" in manifest
+        assert "included_paths" in manifest
+        assert "device_json_checksum" in manifest
+        assert manifest["device_json_checksum"] is not None
+        # All included paths should be strings
+        assert all(isinstance(p, str) for p in manifest["included_paths"])
+
+    def test_backup_includes_config_and_instance_files(self, backup_mod, tmp_path):
+        config_dir = _make_config_dir(tmp_path / "src")
+        instances_dir = _make_instances_dir(tmp_path / "src")
+        output = str(tmp_path / "backup.tar.gz")
+
+        backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "manifest.json" in names
+        assert any(n.startswith("config/") and n.endswith(".json") for n in names)
+
+    def test_backup_excludes_history_by_default(self, backup_mod, tmp_path):
+        config_dir = _make_config_dir(tmp_path / "src")
+        instances_dir = _make_instances_dir(tmp_path / "src")
+        history_dir = tmp_path / "src" / "history"
+        history_dir.mkdir()
+        (history_dir / "img_001.png").write_bytes(b"\x89PNG")
+
+        output = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+            history_dir=str(history_dir),
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert not any(n.startswith("history/") for n in names)
+
+    def test_backup_includes_history_when_flag_set(self, backup_mod, tmp_path):
+        config_dir = _make_config_dir(tmp_path / "src")
+        instances_dir = _make_instances_dir(tmp_path / "src")
+        history_dir = tmp_path / "src" / "history"
+        history_dir.mkdir()
+        (history_dir / "img_001.png").write_bytes(b"\x89PNG")
+
+        output = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=True,
+            history_dir=str(history_dir),
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert any(n.startswith("history/") for n in names)
+
+    def test_manifest_checksum_matches_device_json(self, backup_mod, tmp_path):
+        config_dir = _make_config_dir(tmp_path / "src")
+        instances_dir = _make_instances_dir(tmp_path / "src")
+        output = str(tmp_path / "backup.tar.gz")
+
+        backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        device_json_path = config_dir / "device.json"
+        h = hashlib.sha256(device_json_path.read_bytes()).hexdigest()
+
+        with tarfile.open(output, "r:gz") as tar:
+            fobj = tar.extractfile("manifest.json")
+            manifest = json.loads(fobj.read())
+
+        assert manifest["device_json_checksum"] == h
+
+
+# ---------------------------------------------------------------------------
+# restore_config tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreConfig:
+    def _make_backup(self, backup_mod, src_base: Path, output: str) -> str:
+        config_dir = _make_config_dir(src_base)
+        instances_dir = _make_instances_dir(src_base)
+        backup_mod.run_backup(
+            output=output,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+        return output
+
+    def test_restore_round_trip(self, backup_mod, restore_mod, tmp_path):
+        """backup → wipe → restore → contents match original."""
+        src = tmp_path / "original"
+        src.mkdir()
+        config_dir = _make_config_dir(src)
+        instances_dir = _make_instances_dir(src)
+        original_device = (config_dir / "device.json").read_text()
+
+        backup_path = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        # Wipe current state
+        (config_dir / "device.json").unlink()
+
+        # Restore
+        rc = restore_mod.run_restore(
+            backup_path=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            yes=True,
+        )
+
+        assert rc == 0
+        restored = (config_dir / "device.json").read_text()
+        assert json.loads(restored) == json.loads(original_device)
+
+    def test_restore_without_yes_shows_prompt(self, backup_mod, restore_mod, tmp_path):
+        """restore without --yes should call the input function for confirmation."""
+        src = tmp_path / "src"
+        src.mkdir()
+        config_dir = _make_config_dir(src)
+        instances_dir = _make_instances_dir(src)
+
+        backup_path = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        prompts: list[str] = []
+
+        def mock_input(prompt: str) -> str:
+            prompts.append(prompt)
+            return "n"  # decline
+
+        rc = restore_mod.run_restore(
+            backup_path=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            yes=False,
+            _input_fn=mock_input,
+        )
+
+        assert len(prompts) == 1
+        assert rc == 1  # user declined
+
+    def test_restore_creates_pre_restore_safety_backup(
+        self, backup_mod, restore_mod, tmp_path, monkeypatch
+    ):
+        """restore --yes should create a .pre-restore-*.tar.gz in cwd."""
+        src = tmp_path / "src"
+        src.mkdir()
+        config_dir = _make_config_dir(src)
+        instances_dir = _make_instances_dir(src)
+
+        backup_path = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        safety_outputs: list[str] = []
+        original_pre_restore = restore_mod._pre_restore_backup
+
+        def capture_pre_restore(config_dir, instances_dir):
+            result = original_pre_restore(config_dir, instances_dir)
+            safety_outputs.append(result)
+            return result
+
+        monkeypatch.setattr(restore_mod, "_pre_restore_backup", capture_pre_restore)
+
+        restore_mod.run_restore(
+            backup_path=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            yes=True,
+        )
+
+        assert len(safety_outputs) == 1
+        assert ".pre-restore-" in safety_outputs[0]
+        assert os.path.isfile(safety_outputs[0])
+
+    def test_restore_fails_on_missing_backup(self, restore_mod, tmp_path):
+        """restore should return non-zero when backup file doesn't exist."""
+        rc = restore_mod.run_restore(
+            backup_path=str(tmp_path / "nonexistent.tar.gz"),
+            config_dir=str(tmp_path / "config"),
+            instances_dir=str(tmp_path / "instances"),
+            yes=True,
+        )
+        assert rc != 0
+
+    def test_restore_verifies_checksum(self, backup_mod, restore_mod, tmp_path):
+        """After restore, device.json checksum should match the manifest."""
+        src = tmp_path / "src"
+        src.mkdir()
+        config_dir = _make_config_dir(src)
+        instances_dir = _make_instances_dir(src)
+
+        backup_path = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        rc = restore_mod.run_restore(
+            backup_path=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            yes=True,
+        )
+
+        assert rc == 0
+
+    def test_restore_detects_tampered_device_json(
+        self, backup_mod, restore_mod, tmp_path
+    ):
+        """If device.json is tampered after extraction, checksum mismatch should fail."""
+        src = tmp_path / "src"
+        src.mkdir()
+        config_dir = _make_config_dir(src)
+        instances_dir = _make_instances_dir(src)
+
+        backup_path = str(tmp_path / "backup.tar.gz")
+        backup_mod.run_backup(
+            output=backup_path,
+            config_dir=str(config_dir),
+            instances_dir=str(instances_dir),
+            include_history=False,
+        )
+
+        # Tamper with device.json after extraction by patching _sha256_file
+        with patch.object(restore_mod, "_sha256_file", return_value="deadbeef"):
+            rc = restore_mod.run_restore(
+                backup_path=backup_path,
+                config_dir=str(config_dir),
+                instances_dir=str(instances_dir),
+                yes=True,
+            )
+
+        assert rc != 0


### PR DESCRIPTION
## Summary
- `scripts/backup_config.py` — creates a timestamped `.tar.gz` containing `device.json`, other config JSON files, and plugin instance images; includes a `manifest.json` with backup version, ISO timestamp, included paths, and SHA-256 checksum of `device.json`
- `scripts/restore_config.py` — reads manifest, shows what will be restored, prompts for confirmation (or `--yes`), creates a `.pre-restore-<timestamp>.tar.gz` safety backup first, extracts files, then verifies `device.json` checksum
- Both scripts are stdlib-only (no Flask/src imports) and work even when the app is broken; Pi Zero-safe

## Test plan
- [ ] `python scripts/backup_config.py` — creates `inkypi-backup-<timestamp>.tar.gz` with manifest
- [ ] `python scripts/backup_config.py --include-history` — includes history/ dir
- [ ] `python scripts/restore_config.py backup.tar.gz` — prompts for confirmation, creates safety backup
- [ ] `python scripts/restore_config.py backup.tar.gz --yes` — skips prompt
- [ ] 12 pytest tests in `tests/test_backup_restore.py` — all passing
- [ ] Full test suite: 2469 passing
- [ ] Ruff + Black: clean

Closes JTN-336

🤖 Generated with [Claude Code](https://claude.com/claude-code)