### PR TITLE
feat: validate device.json schema on startup (JTN-335)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,24 +1,16 @@
-import functools
 import hashlib
-import importlib
 import json
 import logging
 import os
 import shutil
 import tempfile
 import threading
-from typing import Any, cast
+from typing import Any
 
 from dotenv import load_dotenv, set_key, unset_key
 
 from model import PlaylistManager, RefreshInfo
-
-# Optional dependency: jsonschema for validating device.json (loaded dynamically to avoid typing issues)
-jsonschema: Any = None
-try:
-    jsonschema = importlib.import_module("jsonschema")
-except Exception:  # pragma: no cover
-    jsonschema = None
+from utils.config_schema import validate_device_config
 
 logger = logging.getLogger(__name__)
 
@@ -72,16 +64,6 @@ def _summarize_playlist(pl: Any) -> dict:
         }
     except Exception:
         return {"name": "<unknown>", "num_plugins": 0}
-
-
-@functools.lru_cache(maxsize=4)
-def _load_json_schema(schema_path: str) -> dict[str, Any]:
-    """Load and cache a JSON Schema from disk.
-
-    Cached by absolute schema path to avoid repeated disk I/O and parsing.
-    """
-    with open(schema_path) as f:
-        return cast(dict[str, Any], json.load(f))
 
 
 class Config:
@@ -266,8 +248,8 @@ class Config:
         with open(self.config_file) as f:
             config = json.load(f)
 
-        # Validate against JSON Schema if available
-        self._validate_device_config(config)
+        # Validate against JSON Schema — raises ConfigValidationError on failure
+        validate_device_config(config)
 
         # Log a sanitized summary instead of full config to avoid leaking secrets
         try:
@@ -501,78 +483,6 @@ class Config:
         # Create a temporary plugin instance to get the image path
         plugin_instance = PluginInstance(plugin_id, instance_name, {}, {})
         return os.path.join(self.plugin_image_dir, plugin_instance.get_image_path())
-
-    def _schema_dir(self):
-        """Return absolute path to the config schemas directory."""
-        return os.path.join(self.BASE_DIR, "config", "schemas")
-
-    @staticmethod
-    def _format_validation_message(ve) -> str:
-        """Build a user-friendly error message from a jsonschema ValidationError.
-
-        Prepends the failing field path (if any) and appends a (safely truncated)
-        representation of the invalid value.
-        """
-        msg = getattr(ve, "message", str(ve))
-        try:
-            if hasattr(ve, "path") and ve.path:
-                path = ".".join(str(p) for p in ve.path)
-                msg = f"{path}: {msg}"
-            bad = getattr(ve, "instance", None)
-            bad_repr = repr(bad)
-            if len(bad_repr) > 200:
-                bad_repr = bad_repr[:197] + "..."
-            msg = f"{msg} (got: {bad_repr})"
-        except (AttributeError, TypeError, IndexError):
-            pass
-        return msg
-
-    def _validate_device_config(self, config: dict):
-        """Validate device.json against the bundled JSON Schema.
-
-        Uses draft 2020-12. On schema violations, raises ValueError with a concise
-        message including the failing path and (safely) the invalid value when helpful.
-        If the validator or schema is unavailable, validation is skipped.
-        """
-        # First: fallback validation when jsonschema isn't available
-        if jsonschema is None:
-            # Only validate orientation if provided; schema does not require it
-            if "orientation" in config:
-                orientation = config.get("orientation")
-                if orientation not in ("horizontal", "vertical"):
-                    raise ValueError(
-                        f"device.json failed schema validation: orientation: invalid value (got: {repr(orientation)})"
-                    )
-            # No further schema checks available; exit early
-            return
-
-        # jsonschema is available, proceed with full validation inside a try/except
-        try:
-            schema_path = os.path.join(self._schema_dir(), "device_config.schema.json")
-            if not os.path.isfile(schema_path):
-                logger.warning(
-                    "Device config schema not found at %s; skipping validation",
-                    schema_path,
-                )
-                return
-            schema = _load_json_schema(schema_path)
-            jsonschema.Draft202012Validator(schema).validate(config)
-        except Exception as ex:
-            # If this is a jsonschema ValidationError, wrap with user-friendly ValueError; else warn
-            try:
-                is_validation_error = (
-                    jsonschema is not None
-                    and hasattr(jsonschema, "exceptions")
-                    and isinstance(ex, jsonschema.exceptions.ValidationError)
-                )
-            except (AttributeError, TypeError):
-                is_validation_error = False
-            if is_validation_error:
-                msg = self._format_validation_message(ex)
-                raise ValueError(f"device.json failed schema validation: {msg}") from ex
-            logger.warning(
-                "device.json validation encountered a non-fatal error: %s", ex
-            )
 
     @staticmethod
     def _sanitize_config_for_log(config_dict):

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -49,6 +49,7 @@ from display.display_manager import DisplayManager
 from plugins.plugin_registry import load_plugins, pop_hot_reload_info
 from refresh_task import RefreshTask
 from utils.app_utils import generate_startup_image, get_ip_address
+from utils.config_schema import ConfigValidationError
 
 # Re-exported for tests/unit/test_inkypi.py monkey-patches.
 __all__ = [
@@ -234,7 +235,11 @@ def create_app():
 
         return {"app_version": version, "url_for": versioned_url_for}
 
-    device_config = Config()
+    try:
+        device_config = Config()
+    except ConfigValidationError as exc:
+        logger.error("Config invalid: %s", exc)
+        raise SystemExit(1) from exc
     display_manager = DisplayManager(device_config)
     refresh_task = RefreshTask(device_config, display_manager)
 

--- a/src/utils/config_schema.py
+++ b/src/utils/config_schema.py
@@ -1,0 +1,117 @@
+"""Config schema validation utilities for InkyPi.
+
+Provides validate_device_config() which checks a loaded device.json dict against
+the bundled JSON Schema (src/config/schemas/device_config.schema.json).
+
+On violation, raises ConfigValidationError with a human-readable message that
+includes the failing field path so the user can fix it without reading a traceback.
+"""
+
+import json
+import logging
+import os
+from functools import lru_cache
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Resolved once at import time — callers can override SCHEMA_PATH for testing.
+_SRC_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCHEMA_PATH = os.path.join(_SRC_DIR, "config", "schemas", "device_config.schema.json")
+
+# Module-level reference so tests can monkeypatch: e.g.
+#   monkeypatch.setattr("utils.config_schema.jsonschema", None)
+try:
+    import jsonschema as jsonschema  # type: ignore[assignment]
+except ImportError:  # pragma: no cover
+    jsonschema = None  # type: ignore[assignment]
+
+
+class ConfigValidationError(ValueError):
+    """Raised when device.json fails JSON Schema validation.
+
+    Inherits from ValueError for backward compatibility with existing callers
+    that catch ValueError.  The message always includes the failing field path
+    so the user can locate the offending key without reading a Python traceback.
+    """
+
+
+@lru_cache(maxsize=1)
+def _load_schema(schema_path: str) -> dict[str, Any]:
+    """Load and cache the device config JSON Schema from *schema_path*."""
+    with open(schema_path) as fh:
+        return json.load(fh)  # type: ignore[return-value]
+
+
+def _format_error(ve: Any) -> str:
+    """Return a concise, path-prefixed message from a jsonschema ValidationError."""
+    msg: str = getattr(ve, "message", str(ve))
+    try:
+        if hasattr(ve, "path") and ve.path:
+            path = ".".join(str(p) for p in ve.path)
+            msg = f"{path}: {msg}"
+        bad = getattr(ve, "instance", None)
+        bad_repr = repr(bad)
+        if len(bad_repr) > 200:
+            bad_repr = bad_repr[:197] + "..."
+        msg = f"{msg} (got: {bad_repr})"
+    except (AttributeError, TypeError, IndexError):
+        pass
+    return msg
+
+
+def validate_device_config(config_dict: dict[str, Any]) -> None:
+    """Validate *config_dict* against the InkyPi device config JSON Schema.
+
+    Validation is intentionally permissive — unknown keys are allowed so that
+    old or extended configs do not break.  Only the shape and types of the
+    *known* keys are enforced.
+
+    Raises:
+        ConfigValidationError: if any known field has the wrong type or value.
+    """
+    # Use the module-level jsonschema binding (patchable in tests).
+    _js = jsonschema
+    if _js is None:
+        # Degrade gracefully: only validate orientation since that is the most
+        # common user-facing mistake and doesn't require the library.
+        _fallback_validate(config_dict)
+        return
+
+    schema_path = SCHEMA_PATH
+    if not os.path.isfile(schema_path):
+        logger.warning(
+            "Device config schema not found at %s; skipping validation", schema_path
+        )
+        return
+
+    try:
+        schema = _load_schema(schema_path)
+        _js.Draft202012Validator(schema).validate(config_dict)
+    except Exception as exc:
+        # Detect jsonschema.exceptions.ValidationError without a hard import.
+        try:
+            is_ve = hasattr(_js, "exceptions") and isinstance(
+                exc, _js.exceptions.ValidationError
+            )
+        except (AttributeError, TypeError):
+            is_ve = False
+
+        if is_ve:
+            raise ConfigValidationError(
+                f"device.json failed schema validation: {_format_error(exc)}"
+            ) from exc
+
+        # Any other error (e.g. schema file unreadable) — warn but do not crash.
+        logger.warning("device.json validation encountered a non-fatal error: %s", exc)
+
+
+def _fallback_validate(config_dict: dict[str, Any]) -> None:
+    """Minimal validation used when jsonschema is not installed."""
+    if "orientation" in config_dict:
+        orientation = config_dict.get("orientation")
+        if orientation not in ("horizontal", "vertical"):
+            raise ConfigValidationError(
+                f"device.json failed schema validation: "
+                f"orientation: invalid value (got: {orientation!r})"
+            )

--- a/tests/unit/test_config_coverage_completion.py
+++ b/tests/unit/test_config_coverage_completion.py
@@ -123,7 +123,7 @@ def test_flask_env_development_fallback(tmp_path, monkeypatch):
 
 
 def test_validate_device_config_called_on_read(tmp_path, monkeypatch):
-    """Test that _validate_device_config is invoked when reading config (line 151)."""
+    """Test that validate_device_config is invoked when reading config."""
     # Create a valid config
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -152,6 +152,7 @@ def test_validate_device_config_called_on_read(tmp_path, monkeypatch):
     config_file.write_text(json.dumps(cfg_data))
 
     import config as config_mod
+    import utils.config_schema as schema_mod
 
     monkeypatch.setattr(config_mod.Config, "BASE_DIR", str(tmp_path))
     monkeypatch.setattr(
@@ -167,21 +168,21 @@ def test_validate_device_config_called_on_read(tmp_path, monkeypatch):
         config_mod.Config, "history_image_dir", str(tmp_path / "history")
     )
 
-    # Track if _validate_device_config was called
+    # Track if validate_device_config was called
     validate_called = {"count": 0}
-    original_validate = config_mod.Config._validate_device_config
+    original_validate = schema_mod.validate_device_config
 
-    def track_validate(self, config_dict):
+    def track_validate(config_dict):
         validate_called["count"] += 1
-        return original_validate(self, config_dict)
+        return original_validate(config_dict)
 
-    monkeypatch.setattr(config_mod.Config, "_validate_device_config", track_validate)
+    monkeypatch.setattr(config_mod, "validate_device_config", track_validate)
 
     # Create Config - should call validate during read_config
     config_mod.Config()
 
     # Verify validation was called
-    assert validate_called["count"] > 0, "_validate_device_config should be called"
+    assert validate_called["count"] > 0, "validate_device_config should be called"
 
 
 def test_validation_with_jsonschema_available(tmp_path, monkeypatch):
@@ -282,6 +283,7 @@ def test_validation_without_jsonschema(tmp_path, monkeypatch):
     config_file.write_text(json.dumps(cfg_data))
 
     import config as config_mod
+    import utils.config_schema as schema_mod
 
     monkeypatch.setattr(config_mod.Config, "BASE_DIR", str(tmp_path))
     monkeypatch.setattr(
@@ -297,16 +299,12 @@ def test_validation_without_jsonschema(tmp_path, monkeypatch):
         config_mod.Config, "history_image_dir", str(tmp_path / "history")
     )
 
-    # Temporarily disable jsonschema
-    original_jsonschema = config_mod.jsonschema
-    monkeypatch.setattr(config_mod, "jsonschema", None)
+    # Temporarily disable jsonschema in the schema validation module
+    monkeypatch.setattr(schema_mod, "jsonschema", None)
 
-    # Should still load without validation
+    # Should still load without validation (valid orientation so fallback passes)
     cfg = config_mod.Config()
     assert cfg.get_config("name") == "InkyPi No Schema"
-
-    # Restore
-    monkeypatch.setattr(config_mod, "jsonschema", original_jsonschema)
 
 
 def test_env_mode_with_whitespace(tmp_path, monkeypatch):

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -1,0 +1,217 @@
+"""Tests for utils/config_schema.py — validate_device_config and ConfigValidationError.
+
+Coverage targets:
+- Valid minimal config passes without error.
+- Wrong type for a known field raises ConfigValidationError with path in message.
+- Missing a required field (playlist item name) raises with helpful message.
+- Unknown extra fields PASS (permissive additionalProperties: true).
+- Real device_dev.json validates cleanly (regression guard).
+- Fallback validation (jsonschema=None) catches bad orientation.
+- Fallback allows valid orientation.
+- Missing schema file skips validation without error.
+"""
+
+import json
+import os
+
+import pytest
+
+import utils.config_schema as schema_mod
+from utils.config_schema import ConfigValidationError, validate_device_config
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_VALID = {
+    "name": "TestDevice",
+    "display_type": "mock",
+    "resolution": [800, 480],
+    "orientation": "horizontal",
+    "playlist_config": {
+        "playlists": [],
+        "active_playlist": None,
+    },
+    "refresh_info": {},
+}
+
+
+def _with(**overrides):
+    """Return a copy of the minimal valid config with fields overridden."""
+    cfg = dict(_MINIMAL_VALID)
+    cfg.update(overrides)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Valid minimal config passes
+# ---------------------------------------------------------------------------
+
+
+def test_valid_minimal_config_passes():
+    """A well-formed minimal config should not raise."""
+    validate_device_config(_MINIMAL_VALID)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# Wrong type for known field raises ConfigValidationError with path
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_type_resolution_raises():
+    """resolution must be an array of integers — passing strings should fail."""
+    bad = _with(resolution=["wide", "tall"])
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_device_config(bad)
+    msg = str(exc_info.value)
+    assert "resolution" in msg or "schema validation" in msg
+
+
+def test_wrong_type_plugin_cycle_interval_raises():
+    """plugin_cycle_interval_seconds must be an integer, not a string."""
+    bad = _with(plugin_cycle_interval_seconds="fast")
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_device_config(bad)
+    msg = str(exc_info.value)
+    assert "schema validation" in msg
+
+
+def test_invalid_orientation_raises():
+    """orientation must be 'horizontal' or 'vertical'."""
+    bad = _with(orientation="diagonal")
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_device_config(bad)
+    msg = str(exc_info.value)
+    assert "orientation" in msg
+
+
+# ---------------------------------------------------------------------------
+# ConfigValidationError is a subclass of ValueError (backward compat)
+# ---------------------------------------------------------------------------
+
+
+def test_config_validation_error_is_value_error():
+    bad = _with(orientation="sideways")
+    with pytest.raises(ValueError):
+        validate_device_config(bad)
+
+
+# ---------------------------------------------------------------------------
+# Missing required field in playlist item raises with helpful message
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_playlist_item_field_raises():
+    """A playlist item without 'name' violates the schema."""
+    bad = _with(
+        playlist_config={
+            "playlists": [
+                # 'name' is required but omitted
+                {"plugins": [], "start_time": "00:00", "end_time": "24:00"}
+            ],
+            "active_playlist": None,
+        }
+    )
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_device_config(bad)
+    msg = str(exc_info.value)
+    assert "schema validation" in msg
+
+
+# ---------------------------------------------------------------------------
+# Unknown extra fields PASS (permissive schema)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_extra_fields_pass():
+    """Extra keys not in the schema must not cause a validation error."""
+    cfg = _with(
+        completely_unknown_key="hello",
+        another_unknown={"nested": True},
+    )
+    validate_device_config(cfg)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# Real device_dev.json validates cleanly (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_real_device_dev_json_validates():
+    """The checked-in device_dev.json must pass schema validation."""
+    dev_json_path = os.path.join(
+        os.path.dirname(__file__),  # tests/unit/
+        "..",
+        "..",
+        "src",
+        "config",
+        "device_dev.json",
+    )
+    dev_json_path = os.path.abspath(dev_json_path)
+    assert os.path.isfile(
+        dev_json_path
+    ), f"device_dev.json not found at {dev_json_path}"
+
+    with open(dev_json_path) as fh:
+        cfg = json.load(fh)
+
+    validate_device_config(cfg)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# Fallback validation (jsonschema=None) — catches bad orientation
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_catches_bad_orientation(monkeypatch):
+    """When jsonschema is unavailable, the fallback catches invalid orientation."""
+    monkeypatch.setattr(schema_mod, "jsonschema", None)
+    bad = _with(orientation="upside_down")
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_device_config(bad)
+    msg = str(exc_info.value)
+    assert "orientation" in msg
+    assert "invalid value" in msg
+
+
+def test_fallback_allows_valid_orientation(monkeypatch):
+    """When jsonschema is unavailable, a valid orientation passes the fallback."""
+    monkeypatch.setattr(schema_mod, "jsonschema", None)
+    validate_device_config(_MINIMAL_VALID)  # no exception
+
+
+def test_fallback_no_orientation_key_passes(monkeypatch):
+    """Fallback must not crash when orientation key is absent."""
+    monkeypatch.setattr(schema_mod, "jsonschema", None)
+    cfg = {k: v for k, v in _MINIMAL_VALID.items() if k != "orientation"}
+    validate_device_config(cfg)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# Missing schema file skips validation without error
+# ---------------------------------------------------------------------------
+
+
+def test_missing_schema_file_skips_silently(monkeypatch, tmp_path):
+    """If the schema file is absent, validation is skipped (no crash)."""
+    missing_path = str(tmp_path / "nonexistent_schema.json")
+    monkeypatch.setattr(schema_mod, "SCHEMA_PATH", missing_path)
+    # Clear lru_cache so new path takes effect
+    schema_mod._load_schema.cache_clear()
+    validate_device_config(
+        _with(orientation="diagonal")
+    )  # no exception even with bad data
+
+
+# ---------------------------------------------------------------------------
+# Error message includes the path to the invalid field
+# ---------------------------------------------------------------------------
+
+
+def test_error_message_includes_field_path():
+    """ConfigValidationError message must include the offending field name/path."""
+    bad = _with(orientation="sideways")
+    with pytest.raises(ConfigValidationError) as exc_info:
+        validate_device_config(bad)
+    # The path 'orientation' must appear somewhere in the message
+    assert "orientation" in str(exc_info.value)

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -131,12 +131,13 @@ def test_invalid_orientation_raises_value_error(tmp_path, monkeypatch):
 
     # Point Config to this file
     import config as config_mod
+    import utils.config_schema as schema_mod
 
     monkeypatch.setattr(config_mod.Config, "config_file", str(cfg_path), raising=True)
 
-    # When jsonschema is missing, fallback validation should catch orientation
-    # Force jsonschema to None
-    monkeypatch.setattr(config_mod, "jsonschema", None, raising=True)
+    # When jsonschema is missing, fallback validation should catch orientation.
+    # Patch the module-level binding in config_schema (the validation now lives there).
+    monkeypatch.setattr(schema_mod, "jsonschema", None, raising=True)
 
     # Attempt to construct Config should raise due to validation
     try:


### PR DESCRIPTION
## Summary

- Extracts JSON Schema validation into `src/utils/config_schema.py` with `ConfigValidationError` (subclasses `ValueError` for backward compat) and `validate_device_config()`
- Wires `validate_device_config()` into `Config.read_config()` replacing the previous inline implementation
- Adds clean startup error handling in `create_app()`: on `ConfigValidationError`, logs `Config invalid: <message>` and calls `exit(1)` instead of crashing with a traceback
- Schema (`src/config/schemas/device_config.schema.json`) is permissive (`additionalProperties: true`) — only validates types of known keys
- `jsonschema` is already in `install/requirements.txt` (runtime dep confirmed)
- 6 schema rules enforced: `name`, `display_type`, `resolution`, `orientation`, `plugin_cycle_interval_seconds`, `playlist_config` item shape

## Test plan

- [x] 13 new tests in `tests/unit/test_config_schema.py` covering: valid config, wrong types, bad orientation, missing required playlist field, unknown extra keys (passes), real `device_dev.json` regression guard, fallback path (no jsonschema), missing schema file
- [x] Updated `test_config_validation.py` and `test_config_coverage_completion.py` to patch `utils.config_schema.jsonschema` instead of removed `config.jsonschema`
- [x] Full suite: 2470 passed
- [x] Lint: ruff + black clean

Closes JTN-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)