### PR TITLE
feat: add /api/version/info and /api/uptime JSON endpoints (JTN-360)

### DIFF
--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -15,6 +15,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
+    from blueprints.version_info import version_info_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(apikeys_bp)
@@ -24,3 +25,4 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(history_bp)
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
+    app.register_blueprint(version_info_bp)

--- a/src/blueprints/version_info.py
+++ b/src/blueprints/version_info.py
@@ -1,0 +1,127 @@
+"""Version and uptime info endpoints (JTN-360).
+
+These endpoints are intentionally accessible WITHOUT authentication.
+They expose read-only metadata useful for monitoring dashboards,
+deployment verification, and support workflows.
+
+Routes
+------
+GET /api/version/info
+    Returns: version, git_sha, git_branch, build_time, python_version
+
+GET /api/uptime
+    Returns: process_uptime_seconds, system_uptime_seconds, process_started_at
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from flask import Blueprint, jsonify
+
+version_info_bp = Blueprint("version_info", __name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants — computed once at import time, never on each request
+# ---------------------------------------------------------------------------
+
+_PROCESS_START_TIME: float = time.monotonic()
+_PROCESS_START_DATETIME: datetime = datetime.now(UTC)
+
+
+def _read_app_version() -> str:
+    """Read the application version from the VERSION file at the repo root."""
+    try:
+        version_path = Path(__file__).parent.parent.parent / "VERSION"
+        return version_path.read_text().strip()
+    except Exception:
+        return "unknown"
+
+
+def _run_git(*args: str) -> str:
+    """Run a git command and return stdout, or 'unknown' on any error."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _read_build_time() -> str:
+    """Return build timestamp from build_time.txt if present, else process start ISO."""
+    try:
+        build_path = Path(__file__).parent.parent.parent / "build_time.txt"
+        text = build_path.read_text().strip()
+        if text:
+            return text
+    except Exception:
+        pass
+    return _PROCESS_START_DATETIME.isoformat()
+
+
+# Cached at module import — never recomputed per request
+_APP_VERSION: str = _read_app_version()
+_GIT_SHA: str = _run_git("rev-parse", "--short", "HEAD")
+_GIT_BRANCH: str = _run_git("rev-parse", "--abbrev-ref", "HEAD")
+_BUILD_TIME: str = _read_build_time()
+_PYTHON_VERSION: str = sys.version
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@version_info_bp.route("/api/version/info", methods=["GET"])
+def api_version_info():
+    """Return build and runtime version metadata.
+
+    All fields are read-only. git_sha and git_branch may be 'unknown' in
+    environments where git is not installed or the repo history is unavailable
+    (e.g. Docker images built without .git).
+    """
+    return jsonify(
+        {
+            "version": _APP_VERSION,
+            "git_sha": _GIT_SHA,
+            "git_branch": _GIT_BRANCH,
+            "build_time": _BUILD_TIME,
+            "python_version": _PYTHON_VERSION,
+        }
+    )
+
+
+def _system_uptime_seconds() -> int | None:
+    """Return system uptime in seconds from /proc/uptime (Linux only).
+
+    Returns None on macOS, Windows, or any read/parse failure.
+    """
+    try:
+        text = Path("/proc/uptime").read_text()
+        return int(float(text.split()[0]))
+    except Exception:
+        return None
+
+
+@version_info_bp.route("/api/uptime", methods=["GET"])
+def api_uptime():
+    """Return process and system uptime information."""
+    process_uptime = time.monotonic() - _PROCESS_START_TIME
+    return jsonify(
+        {
+            "process_uptime_seconds": process_uptime,
+            "system_uptime_seconds": _system_uptime_seconds(),
+            "process_started_at": _PROCESS_START_DATETIME.isoformat(),
+        }
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,6 +250,7 @@ def flask_app(device_config_dev, monkeypatch):
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
+    from blueprints.version_info import version_info_bp
     from display.display_manager import DisplayManager
     from plugins.plugin_registry import load_plugins
     from refresh_task import RefreshTask
@@ -307,6 +308,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(history_bp)
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
+    app.register_blueprint(version_info_bp)
 
     # Lightweight health endpoints for probes/CI
     @app.route("/healthz")

--- a/tests/test_version_uptime.py
+++ b/tests/test_version_uptime.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import subprocess
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -129,3 +132,92 @@ def test_uptime_process_started_at_in_past(client):
     data = resp.get_json()
     parsed = datetime.fromisoformat(data["process_started_at"])
     assert parsed <= datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions (coverage of exception / Linux paths)
+# ---------------------------------------------------------------------------
+
+
+def test_read_app_version_fallback_on_missing_file():
+    """_read_app_version returns 'unknown' when VERSION file is missing."""
+    from blueprints.version_info import _read_app_version
+
+    with patch("pathlib.Path.read_text", side_effect=FileNotFoundError("no file")):
+        result = _read_app_version()
+
+    assert result == "unknown"
+
+
+def test_run_git_returns_unknown_on_nonzero_returncode():
+    """_run_git returns 'unknown' when git exits with non-zero."""
+    from blueprints.version_info import _run_git
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = "some error"
+    with patch("blueprints.version_info.subprocess.run", return_value=mock_result):
+        result = _run_git("rev-parse", "--short", "HEAD")
+
+    assert result == "unknown"
+
+
+def test_run_git_returns_unknown_on_exception():
+    """_run_git returns 'unknown' when subprocess.run raises."""
+    from blueprints.version_info import _run_git
+
+    with patch(
+        "blueprints.version_info.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["git"], 1),
+    ):
+        result = _run_git("rev-parse", "--short", "HEAD")
+
+    assert result == "unknown"
+
+
+def test_read_build_time_uses_file_when_present(tmp_path):
+    """_read_build_time returns file content when build_time.txt exists."""
+    from blueprints.version_info import _read_build_time
+
+    build_time_content = "2024-01-15T10:30:00+00:00"
+    build_file = tmp_path / "build_time.txt"
+    build_file.write_text(build_time_content)
+
+    with patch("blueprints.version_info.Path") as mock_path_cls:
+        # Make Path(__file__) chain work: Path(...).parent.parent.parent / "build_time.txt"
+        mock_path = MagicMock(spec=Path)
+        # Each .parent returns a new mock; final / returns our real file
+        mock_parent = MagicMock(spec=Path)
+        mock_path.parent = mock_parent
+        mock_parent.parent = mock_parent
+        mock_parent.__truediv__ = lambda self, other: build_file
+        mock_path_cls.return_value = mock_path
+        result = _read_build_time()
+
+    assert result == build_time_content
+
+
+def test_system_uptime_seconds_on_linux(tmp_path):
+    """_system_uptime_seconds returns int when /proc/uptime is readable."""
+    from blueprints.version_info import _system_uptime_seconds
+
+    fake_uptime = tmp_path / "uptime"
+    fake_uptime.write_text("12345.67 98765.43\n")
+
+    with patch("blueprints.version_info.Path", return_value=fake_uptime):
+        result = _system_uptime_seconds()
+
+    assert result == 12345
+
+
+def test_system_uptime_seconds_returns_none_on_error():
+    """_system_uptime_seconds returns None when /proc/uptime is unreadable."""
+    from blueprints.version_info import _system_uptime_seconds
+
+    with patch(
+        "blueprints.version_info.Path",
+        side_effect=OSError("no such file"),
+    ):
+        result = _system_uptime_seconds()
+
+    assert result is None

--- a/tests/test_version_uptime.py
+++ b/tests/test_version_uptime.py
@@ -1,0 +1,131 @@
+# pyright: reportMissingImports=false
+"""Tests for /api/version/info and /api/uptime endpoints (JTN-360)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+
+@pytest.fixture()
+def client(flask_app):
+    """Return a Flask test client."""
+    return flask_app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# /api/version/info
+# ---------------------------------------------------------------------------
+
+
+def test_version_info_returns_200(client):
+    """GET /api/version/info should return HTTP 200."""
+    resp = client.get("/api/version/info")
+    assert resp.status_code == 200
+
+
+def test_version_info_has_expected_keys(client):
+    """Response must contain all required keys."""
+    resp = client.get("/api/version/info")
+    data = resp.get_json()
+    assert data is not None
+    for key in ("version", "git_sha", "git_branch", "build_time", "python_version"):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_version_info_version_non_empty(client):
+    """The version field must be a non-empty string."""
+    resp = client.get("/api/version/info")
+    data = resp.get_json()
+    assert isinstance(data["version"], str)
+    assert len(data["version"]) > 0
+
+
+def test_version_info_git_sha_is_string(client):
+    """git_sha must be a string (may be 'unknown' in CI without git history)."""
+    resp = client.get("/api/version/info")
+    data = resp.get_json()
+    assert isinstance(data["git_sha"], str)
+
+
+def test_version_info_git_branch_is_string(client):
+    """git_branch must be a string."""
+    resp = client.get("/api/version/info")
+    data = resp.get_json()
+    assert isinstance(data["git_branch"], str)
+
+
+def test_version_info_python_version_non_empty(client):
+    """python_version must be a non-empty string."""
+    resp = client.get("/api/version/info")
+    data = resp.get_json()
+    assert isinstance(data["python_version"], str)
+    assert len(data["python_version"]) > 0
+
+
+def test_version_info_build_time_non_empty(client):
+    """build_time must be a non-empty string."""
+    resp = client.get("/api/version/info")
+    data = resp.get_json()
+    assert isinstance(data["build_time"], str)
+    assert len(data["build_time"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# /api/uptime
+# ---------------------------------------------------------------------------
+
+
+def test_uptime_returns_200(client):
+    """GET /api/uptime should return HTTP 200."""
+    resp = client.get("/api/uptime")
+    assert resp.status_code == 200
+
+
+def test_uptime_has_expected_keys(client):
+    """Response must contain all required keys."""
+    resp = client.get("/api/uptime")
+    data = resp.get_json()
+    assert data is not None
+    for key in (
+        "process_uptime_seconds",
+        "system_uptime_seconds",
+        "process_started_at",
+    ):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_uptime_process_uptime_positive(client):
+    """process_uptime_seconds must be greater than zero."""
+    resp = client.get("/api/uptime")
+    data = resp.get_json()
+    assert isinstance(data["process_uptime_seconds"], int | float)
+    assert data["process_uptime_seconds"] > 0
+
+
+def test_uptime_system_uptime_int_or_null(client):
+    """system_uptime_seconds must be an integer or null (None on macOS/Windows)."""
+    resp = client.get("/api/uptime")
+    data = resp.get_json()
+    value = data["system_uptime_seconds"]
+    assert value is None or isinstance(value, int)
+
+
+def test_uptime_process_started_at_is_valid_iso8601(client):
+    """process_started_at must be a parseable ISO 8601 timestamp."""
+    resp = client.get("/api/uptime")
+    data = resp.get_json()
+    ts = data["process_started_at"]
+    assert isinstance(ts, str)
+    # datetime.fromisoformat raises ValueError on invalid format
+    parsed = datetime.fromisoformat(ts)
+    assert parsed.tzinfo is not None, "Timestamp must include timezone info"
+
+
+def test_uptime_process_started_at_in_past(client):
+    """process_started_at must be earlier than now."""
+    resp = client.get("/api/uptime")
+    data = resp.get_json()
+    parsed = datetime.fromisoformat(data["process_started_at"])
+    assert parsed <= datetime.now(UTC)


### PR DESCRIPTION
## Summary

- Adds `GET /api/version/info` returning `version`, `git_sha`, `git_branch`, `build_time`, and `python_version` — all cached at module import time, never computed per-request
- Adds `GET /api/uptime` returning `process_uptime_seconds`, `system_uptime_seconds` (reads `/proc/uptime` on Linux, `null` on macOS/Windows), and `process_started_at` as an ISO 8601 timestamp
- Both endpoints are unauthenticated (read-only info, same pattern as `/metrics`)
- New blueprint `src/blueprints/version_info.py` registered in `blueprints_registry.py` and test `conftest.py`
- Route uses `/api/version/info` (not `/api/version`) to avoid conflict with the existing update-check endpoint in `settings._updates`

## Test plan

- [ ] `GET /api/version/info` returns 200 with all 5 expected keys
- [ ] `version` field is non-empty string
- [ ] `git_sha` is a string (may be `"unknown"` in CI without git history)
- [ ] `GET /api/uptime` returns 200 with all 3 expected keys
- [ ] `process_uptime_seconds` > 0
- [ ] `system_uptime_seconds` is int or null
- [ ] `process_started_at` is valid ISO 8601 with timezone
- [ ] Full test suite: 2523 passed, 2 pre-existing failures unrelated to this change
- [ ] Lint: ruff + black clean; mypy non-blocking (pre-existing issues)

Closes JTN-360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/api/version/info` endpoint exposing application version, Git details, build time, and Python version information
  * Added `/api/uptime` endpoint exposing process and system uptime metrics with timestamps

* **Tests**
  * Added comprehensive tests validating both endpoints and their fallback behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->