### PR TITLE
feat: diagnostic snapshot CLI for support workflows (JTN-363)

### DIFF
--- a/scripts/diagnostic_snapshot.py
+++ b/scripts/diagnostic_snapshot.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+Collect a diagnostic snapshot tarball for InkyPi support workflows.
+
+Usage:
+    python scripts/diagnostic_snapshot.py [--output PATH] [--config-dir PATH]
+                                          [--log-path PATH] [--log-lines N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+from datetime import UTC, datetime
+
+SNAPSHOT_FORMAT_VERSION = "1"
+
+# Key name substrings that should be redacted (case-insensitive).
+_SECRET_SUBSTRINGS = ("api_key", "token", "password", "secret", "pin")
+
+
+def _default_output_path() -> str:
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"inkypi-diag-{ts}.tar.gz"
+
+
+def _detect_config_dir() -> str:
+    """Detect default config directory relative to this script."""
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(scripts_dir)
+    return os.path.join(project_root, "src", "config")
+
+
+def _detect_log_path() -> str | None:
+    """Return the first plausible log file path, or None."""
+    candidates = [
+        os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "inkypi.log"
+        ),
+        "/var/log/inkypi.log",
+        "/tmp/inkypi.log",
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _collect_system_info() -> str:
+    """Return a multi-section string with system information."""
+    lines: list[str] = []
+
+    # Platform / uname
+    lines.append("=== uname ===")
+    uname = platform.uname()
+    lines.append(f"system   : {uname.system}")
+    lines.append(f"node     : {uname.node}")
+    lines.append(f"release  : {uname.release}")
+    lines.append(f"version  : {uname.version}")
+    lines.append(f"machine  : {uname.machine}")
+    lines.append(f"processor: {uname.processor}")
+    lines.append("")
+
+    # Disk usage
+    lines.append("=== disk usage (/) ===")
+    try:
+        usage = shutil.disk_usage("/")
+        lines.append(f"total : {usage.total // (1024 ** 3)} GB")
+        lines.append(f"used  : {usage.used // (1024 ** 3)} GB")
+        lines.append(f"free  : {usage.free // (1024 ** 3)} GB")
+    except Exception as exc:  # noqa: BLE001
+        lines.append(f"(unavailable: {exc})")
+    lines.append("")
+
+    # Memory — try psutil first, fall back to /proc/meminfo
+    lines.append("=== memory ===")
+    _collected_memory = False
+    try:
+        import psutil  # type: ignore[import-not-found]
+
+        vm = psutil.virtual_memory()
+        lines.append(f"total    : {vm.total // (1024 ** 2)} MB")
+        lines.append(f"available: {vm.available // (1024 ** 2)} MB")
+        lines.append(f"used     : {vm.used // (1024 ** 2)} MB")
+        lines.append(f"percent  : {vm.percent}%")
+        _collected_memory = True
+    except ImportError:
+        pass
+
+    if not _collected_memory:
+        meminfo_path = "/proc/meminfo"
+        if os.path.isfile(meminfo_path):
+            try:
+                with open(meminfo_path) as f:
+                    lines += [
+                        line.rstrip()
+                        for line in f
+                        if any(
+                            k in line for k in ("MemTotal", "MemFree", "MemAvailable")
+                        )
+                    ]
+                _collected_memory = True
+            except OSError:
+                pass
+
+    if not _collected_memory:
+        lines.append(
+            "(memory info unavailable — psutil not installed and /proc/meminfo not found)"
+        )
+    lines.append("")
+
+    # Python version
+    lines.append("=== python ===")
+    lines.append(f"version: {sys.version}")
+    lines.append(f"executable: {sys.executable}")
+    lines.append("")
+
+    # pip freeze
+    lines.append("=== pip freeze ===")
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "freeze"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            lines.append(result.stdout.strip() or "(no packages)")
+        else:
+            lines.append(f"(pip freeze failed: {result.stderr.strip()})")
+    except Exception as exc:  # noqa: BLE001
+        lines.append(f"(pip freeze unavailable: {exc})")
+
+    return "\n".join(lines) + "\n"
+
+
+def _is_secret_key(key: str) -> bool:
+    """Return True if the key name suggests it holds a secret value."""
+    lower = key.lower()
+    return any(sub in lower for sub in _SECRET_SUBSTRINGS)
+
+
+def _redact_dict(obj: object) -> object:
+    """Recursively redact secret-looking values in a JSON-decoded structure."""
+    if isinstance(obj, dict):
+        return {
+            k: "***REDACTED***" if _is_secret_key(k) else _redact_dict(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact_dict(item) for item in obj]
+    return obj
+
+
+def _collect_redacted_config(config_dir: str) -> bytes:
+    """Return JSON bytes for a redacted copy of device.json."""
+    device_json = os.path.join(config_dir, "device.json")
+    if not os.path.isfile(device_json):
+        return json.dumps({"error": "device.json not found"}, indent=2).encode("utf-8")
+    try:
+        with open(device_json) as f:
+            data = json.load(f)
+        redacted = _redact_dict(data)
+        return json.dumps(redacted, indent=2).encode("utf-8")
+    except Exception as exc:  # noqa: BLE001
+        return json.dumps(
+            {"error": f"could not read device.json: {exc}"}, indent=2
+        ).encode("utf-8")
+
+
+def _collect_log_tail(log_path: str | None, log_lines: int) -> str | None:
+    """Return the last *log_lines* lines of the log file, or None if unavailable."""
+    if not log_path:
+        return None
+    if not os.path.isfile(log_path):
+        return None
+    try:
+        with open(log_path, errors="replace") as f:
+            all_lines = f.readlines()
+        tail = all_lines[-log_lines:]
+        header = f"--- last {log_lines} lines of {log_path} ---\n"
+        return header + "".join(tail)
+    except OSError:
+        return None
+
+
+def _collect_journal(lines: int = 200) -> str | None:
+    """Best-effort: grab recent journal entries via journalctl."""
+    try:
+        result = subprocess.run(
+            ["journalctl", "-u", "inkypi", "--no-pager", f"-n{lines}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Fallback: try without unit filter
+    try:
+        result = subprocess.run(
+            ["journalctl", "--no-pager", "-n50"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return "--- recent journal (no inkypi unit filter) ---\n" + result.stdout
+    except Exception:  # noqa: BLE001
+        pass
+
+    return None
+
+
+def run_snapshot(
+    output: str,
+    config_dir: str,
+    log_path: str | None,
+    log_lines: int,
+) -> int:
+    """Collect diagnostic snapshot and write tarball. Returns exit code."""
+    timestamp = datetime.now(tz=UTC).isoformat()
+
+    # Collect all content in memory
+    system_info = _collect_system_info().encode("utf-8")
+    redacted_config = _collect_redacted_config(config_dir)
+    log_tail_str = _collect_log_tail(log_path, log_lines)
+    journal_str = _collect_journal()
+
+    included_files: list[str] = ["system_info.txt", "config_redacted.json"]
+    if log_tail_str is not None:
+        included_files.append("recent_logs.txt")
+    if journal_str is not None:
+        included_files.append("journal.txt")
+    included_files.append("manifest.json")
+
+    manifest = {
+        "snapshot_version": SNAPSHOT_FORMAT_VERSION,
+        "timestamp": timestamp,
+        "files": included_files,
+    }
+    manifest_bytes = json.dumps(manifest, indent=2).encode("utf-8")
+
+    output = os.path.abspath(output)
+    out_dir = os.path.dirname(output)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    def _add_bytes(tar: tarfile.TarFile, name: str, data: bytes) -> None:
+        info = tarfile.TarInfo(name=name)
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    with tarfile.open(output, "w:gz") as tar:
+        _add_bytes(tar, "system_info.txt", system_info)
+        _add_bytes(tar, "config_redacted.json", redacted_config)
+        if log_tail_str is not None:
+            _add_bytes(tar, "recent_logs.txt", log_tail_str.encode("utf-8"))
+        if journal_str is not None:
+            _add_bytes(tar, "journal.txt", journal_str.encode("utf-8"))
+        _add_bytes(tar, "manifest.json", manifest_bytes)
+
+    total_size = os.path.getsize(output)
+    size_kb = total_size / 1024
+
+    print(f"Diagnostic snapshot: {output}")
+    print(f"  Files in tarball : {len(included_files)}")
+    print(f"  Archive size     : {size_kb:.1f} KB")
+    print(f"  Timestamp        : {timestamp}")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect a diagnostic snapshot tarball for InkyPi support.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Output tar.gz path (default: ./inkypi-diag-<timestamp>.tar.gz)",
+    )
+    parser.add_argument(
+        "--config-dir",
+        default=None,
+        metavar="PATH",
+        help="Path to config directory containing device.json (default: src/config)",
+    )
+    parser.add_argument(
+        "--log-path",
+        default=None,
+        metavar="PATH",
+        help="Path to inkypi.log (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--log-lines",
+        default=500,
+        type=int,
+        metavar="N",
+        help="Number of log tail lines to include (default: 500)",
+    )
+    args = parser.parse_args(argv)
+
+    output = args.output or _default_output_path()
+    config_dir = args.config_dir or _detect_config_dir()
+    log_path = args.log_path or _detect_log_path()
+
+    return run_snapshot(
+        output=output,
+        config_dir=config_dir,
+        log_path=log_path,
+        log_lines=args.log_lines,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_diagnostic_snapshot.py
+++ b/tests/test_diagnostic_snapshot.py
@@ -1,0 +1,374 @@
+"""Tests for scripts/diagnostic_snapshot.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helper: load script without importing from src/
+# ---------------------------------------------------------------------------
+
+
+def _load_script(script_name: str):
+    """Load a scripts/ module by file path, avoiding sys.path pollution."""
+    scripts_dir = Path(__file__).parent.parent / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        script_name, scripts_dir / f"{script_name}.py"
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def diag_mod():
+    return _load_script("diagnostic_snapshot")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config_dir(base: Path, extra_keys: dict | None = None) -> Path:
+    """Create a minimal config dir with device.json."""
+    config_dir = base / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    device: dict = {
+        "name": "TestDevice",
+        "display_type": "mock",
+        "resolution": [800, 480],
+        "timezone": "UTC",
+        "api_key": "super-secret-api-key-12345",
+        "weather_token": "hidden-weather-token",
+        "admin_password": "hunter2",
+        "secret_pin": "1234",
+        "safe_setting": "keep-this-value",
+        "another_safe": 42,
+    }
+    if extra_keys:
+        device.update(extra_keys)
+    (config_dir / "device.json").write_text(json.dumps(device))
+    return config_dir
+
+
+def _make_log_file(base: Path, lines: int = 20) -> Path:
+    log_file = base / "inkypi.log"
+    content = "\n".join(f"2026-01-01T00:00:00 INFO line {i}" for i in range(lines))
+    log_file.write_text(content + "\n")
+    return log_file
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticSnapshot:
+    def test_tarball_is_created(self, diag_mod, tmp_path):
+        """run_snapshot creates a valid .tar.gz file."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        rc = diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        assert rc == 0
+        assert (tmp_path / "diag.tar.gz").is_file()
+        assert tarfile.is_tarfile(output)
+
+    def test_manifest_present_and_valid(self, diag_mod, tmp_path):
+        """Tarball contains manifest.json with required fields."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            member = tar.getmember("manifest.json")
+            manifest = json.loads(tar.extractfile(member).read())
+
+        assert manifest["snapshot_version"] == diag_mod.SNAPSHOT_FORMAT_VERSION
+        assert "timestamp" in manifest
+        assert "files" in manifest
+        assert isinstance(manifest["files"], list)
+        assert len(manifest["files"]) >= 1
+
+    def test_system_info_present(self, diag_mod, tmp_path):
+        """Tarball contains system_info.txt."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "system_info.txt" in names
+
+    def test_system_info_has_expected_sections(self, diag_mod, tmp_path):
+        """system_info.txt mentions uname, disk, python sections."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            text = tar.extractfile("system_info.txt").read().decode("utf-8")
+
+        assert "uname" in text.lower() or "system" in text.lower()
+        assert "python" in text.lower()
+
+    def test_redacted_config_present(self, diag_mod, tmp_path):
+        """Tarball contains config_redacted.json."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+
+        assert "config_redacted.json" in names
+
+    def test_api_key_is_redacted(self, diag_mod, tmp_path):
+        """config_redacted.json must NOT contain the raw api_key value."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            redacted = json.loads(tar.extractfile("config_redacted.json").read())
+
+        assert redacted.get("api_key") == "***REDACTED***"
+        # Literal secret value must not appear anywhere in the JSON
+        raw_json = json.dumps(redacted)
+        assert "super-secret-api-key-12345" not in raw_json
+
+    def test_token_is_redacted(self, diag_mod, tmp_path):
+        """Keys containing 'token' are redacted."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            redacted = json.loads(tar.extractfile("config_redacted.json").read())
+
+        assert redacted.get("weather_token") == "***REDACTED***"
+        raw_json = json.dumps(redacted)
+        assert "hidden-weather-token" not in raw_json
+
+    def test_password_is_redacted(self, diag_mod, tmp_path):
+        """Keys containing 'password' are redacted."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            redacted = json.loads(tar.extractfile("config_redacted.json").read())
+
+        assert redacted.get("admin_password") == "***REDACTED***"
+        raw_json = json.dumps(redacted)
+        assert "hunter2" not in raw_json
+
+    def test_pin_is_redacted(self, diag_mod, tmp_path):
+        """Keys containing 'pin' are redacted."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            redacted = json.loads(tar.extractfile("config_redacted.json").read())
+
+        assert redacted.get("secret_pin") == "***REDACTED***"
+
+    def test_non_secret_keys_preserved(self, diag_mod, tmp_path):
+        """Non-secret keys like 'name' and 'safe_setting' must survive redaction."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            redacted = json.loads(tar.extractfile("config_redacted.json").read())
+
+        assert redacted.get("name") == "TestDevice"
+        assert redacted.get("safe_setting") == "keep-this-value"
+        assert redacted.get("another_safe") == 42
+        assert redacted.get("timezone") == "UTC"
+
+    def test_log_included_when_file_exists(self, diag_mod, tmp_path):
+        """recent_logs.txt is included when log_path points to an existing file."""
+        config_dir = _make_config_dir(tmp_path)
+        log_file = _make_log_file(tmp_path, lines=30)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=str(log_file),
+            log_lines=10,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+            assert "recent_logs.txt" in names
+            text = tar.extractfile("recent_logs.txt").read().decode("utf-8")
+
+        # Only last 10 lines of 30 should be present (lines 20-29)
+        assert "line 29" in text
+        assert "line 20" in text
+        # Lines before the tail window should not appear
+        assert "line 0" not in text
+        assert "line 19" not in text
+
+    def test_missing_log_file_handled_gracefully(self, diag_mod, tmp_path):
+        """run_snapshot succeeds even when the log file does not exist."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        rc = diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=str(tmp_path / "nonexistent.log"),
+            log_lines=500,
+        )
+
+        assert rc == 0
+        assert tarfile.is_tarfile(output)
+
+        with tarfile.open(output, "r:gz") as tar:
+            names = tar.getnames()
+        # recent_logs.txt should be absent, not an error entry
+        assert "recent_logs.txt" not in names
+
+    def test_missing_log_omitted_from_manifest(self, diag_mod, tmp_path):
+        """When log is missing, manifest.files should not list recent_logs.txt."""
+        config_dir = _make_config_dir(tmp_path)
+        output = str(tmp_path / "diag.tar.gz")
+
+        diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(config_dir),
+            log_path=None,
+            log_lines=500,
+        )
+
+        with tarfile.open(output, "r:gz") as tar:
+            manifest = json.loads(tar.extractfile("manifest.json").read())
+
+        assert "recent_logs.txt" not in manifest["files"]
+
+    def test_missing_device_json_handled_gracefully(self, diag_mod, tmp_path):
+        """run_snapshot does not crash when device.json is absent."""
+        empty_config = tmp_path / "empty_config"
+        empty_config.mkdir()
+        output = str(tmp_path / "diag.tar.gz")
+
+        rc = diag_mod.run_snapshot(
+            output=output,
+            config_dir=str(empty_config),
+            log_path=None,
+            log_lines=500,
+        )
+
+        assert rc == 0
+        assert tarfile.is_tarfile(output)
+
+    def test_redact_dict_nested(self, diag_mod):
+        """_redact_dict handles nested structures recursively."""
+        data = {
+            "outer": "visible",
+            "nested": {
+                "api_key": "nested-secret",
+                "safe": "still-visible",
+            },
+            "list_field": [
+                {"token": "list-secret"},
+                {"plain": "list-plain"},
+            ],
+        }
+        result = diag_mod._redact_dict(data)
+        assert result["outer"] == "visible"
+        assert result["nested"]["api_key"] == "***REDACTED***"
+        assert result["nested"]["safe"] == "still-visible"
+        assert result["list_field"][0]["token"] == "***REDACTED***"
+        assert result["list_field"][1]["plain"] == "list-plain"
+
+    def test_default_output_path_format(self, diag_mod):
+        """_default_output_path returns an inkypi-diag-*.tar.gz string."""
+        path = diag_mod._default_output_path()
+        assert path.startswith("inkypi-diag-")
+        assert path.endswith(".tar.gz")
+
+    def test_is_secret_key_detection(self, diag_mod):
+        """_is_secret_key correctly identifies secret-like key names."""
+        assert diag_mod._is_secret_key("api_key") is True
+        assert diag_mod._is_secret_key("weather_token") is True
+        assert diag_mod._is_secret_key("admin_password") is True
+        assert diag_mod._is_secret_key("SECRET") is True
+        assert diag_mod._is_secret_key("secret_pin") is True
+        assert diag_mod._is_secret_key("MY_API_KEY") is True
+        # Non-secret keys
+        assert diag_mod._is_secret_key("name") is False
+        assert diag_mod._is_secret_key("display_type") is False
+        assert diag_mod._is_secret_key("resolution") is False
+        assert diag_mod._is_secret_key("timezone") is False


### PR DESCRIPTION
## Summary
- Adds `scripts/diagnostic_snapshot.py`: a standalone support tool that collects a `.tar.gz` tarball containing system info, redacted config, log tail, and journal entries
- API keys, tokens, passwords, secrets, and pins are masked as `***REDACTED***` before inclusion — tested explicitly
- No imports from `src/`; stdlib only (psutil is optional with graceful fallback to `/proc/meminfo`)
- Adds `tests/test_diagnostic_snapshot.py` with 17 tests covering redaction correctness, missing-log handling, manifest structure, and nested secret key detection

## Files in tarball
- `system_info.txt` — uname, disk usage, memory, Python version, pip freeze
- `config_redacted.json` — device.json with secret keys masked
- `recent_logs.txt` — last N lines of inkypi.log (omitted if file absent)
- `journal.txt` — journalctl output, best-effort (omitted if unavailable)
- `manifest.json` — snapshot version, ISO timestamp, file list

## Usage
```bash
python scripts/diagnostic_snapshot.py
python scripts/diagnostic_snapshot.py --output /tmp/diag.tar.gz --log-lines 200
```

## Test plan
- [x] `scripts/diagnostic_snapshot.py` — standalone, no src/ imports
- [x] Tarball created with manifest — `test_tarball_is_created`, `test_manifest_present_and_valid`
- [x] Redacted config does NOT contain raw API key value — `test_api_key_is_redacted`
- [x] token, password, pin, secret all redacted — individual tests per secret type
- [x] Non-secret keys (`name`, `safe_setting`, `timezone`) preserved — `test_non_secret_keys_preserved`
- [x] Missing log file handled gracefully — `test_missing_log_file_handled_gracefully`
- [x] Lint: ruff + black pass clean
- [x] Full suite: 2527 passed (2 pre-existing pyenv env failures unrelated to this PR)

Closes JTN-363

🤖 Generated with [Claude Code](https://claude.com/claude-code)