### PR TITLE
feat: webhook notifications on plugin failures (JTN-449)

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,76 @@
+# Webhook Notifications
+
+InkyPi can POST a JSON payload to one or more webhook URLs whenever a plugin
+refresh fails.  This makes it easy to pipe alerts into Slack, Discord,
+Pushover, ntfy.sh, or any other service that accepts an HTTP POST.
+
+## Configuration
+
+Add a `webhook_urls` list to your device config (typically via the Settings
+page or by editing `device_config.json` directly):
+
+```json
+{
+  "webhook_urls": [
+    "https://hooks.slack.com/services/T000/B000/xxxx",
+    "https://ntfy.sh/my-inkypi-alerts"
+  ]
+}
+```
+
+You can provide as many URLs as you like.  Leave the list empty (or omit the
+key entirely) to disable webhook notifications.
+
+## Payload
+
+Every webhook receives a JSON body with the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `event` | string | Always `"plugin_failure"` |
+| `plugin_id` | string | Internal plugin identifier (e.g. `"weather"`) |
+| `instance_name` | string \| null | Human-readable instance name from the playlist |
+| `error` | string | Error message from the last failure |
+| `ts` | string | ISO-8601 timestamp (device timezone, UTC offset included) |
+
+Example:
+
+```json
+{
+  "event": "plugin_failure",
+  "plugin_id": "weather",
+  "instance_name": "Home Weather",
+  "error": "ConnectionError: failed to reach api.openweathermap.org",
+  "ts": "2026-04-08T14:23:01+00:00"
+}
+```
+
+## Behaviour
+
+- **Best-effort**: each URL receives exactly one POST attempt.  There are no
+  retries.
+- **1 second timeout**: a slow webhook endpoint will be abandoned after 1 s so
+  it cannot delay the next refresh cycle.
+- **Errors are swallowed**: a failed webhook POST is logged at `WARNING` level
+  but never raises an exception or affects the display.
+- **Circuit-breaker aware**: the webhook fires on every consecutive failure,
+  including the failure that triggers the circuit breaker (plugin paused).
+
+## Integrating with ntfy.sh
+
+ntfy.sh accepts plain HTTP POSTs and can forward them to mobile push
+notifications.  Create a topic and add its URL:
+
+```json
+{
+  "webhook_urls": ["https://ntfy.sh/my-secret-inkypi-topic"]
+}
+```
+
+The JSON body will appear in the notification body.
+
+## Integrating with Slack
+
+Use a Slack incoming webhook URL.  Note that Slack expects a `text` field;
+you may need a small intermediary (e.g. a free-tier serverless function or
+[Make](https://make.com)) to transform the InkyPi payload into Slack's format.

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -28,6 +28,7 @@ from utils.metrics import (
 from utils.progress import ProgressTracker, track_progress
 from utils.progress_events import get_progress_bus
 from utils.time_utils import now_device_tz
+from utils.webhooks import send_failure_webhook
 
 try:
     # Optional import; code must continue if unavailable
@@ -992,6 +993,27 @@ class RefreshTask:
                 plugin_id,
                 instance,
                 plugin_instance.consecutive_failure_count,
+            )
+
+        # Best-effort webhook notification — never raises.
+        try:
+            webhook_urls = self.device_config.get_config("webhook_urls", default=[])
+            if webhook_urls:
+                now_iso = now_device_tz(self.device_config).astimezone(UTC).isoformat()
+                error_msg = (
+                    self.plugin_health.get(plugin_id, {}).get("last_error") or "unknown"
+                )
+                payload = {
+                    "event": "plugin_failure",
+                    "plugin_id": plugin_id,
+                    "instance_name": instance,
+                    "error": error_msg,
+                    "ts": now_iso,
+                }
+                send_failure_webhook(webhook_urls, payload)
+        except Exception:
+            logger.warning(
+                "webhook: unexpected error building webhook payload", exc_info=True
             )
 
     def reset_circuit_breaker(self, plugin_id: str, instance: str) -> bool:

--- a/src/utils/webhooks.py
+++ b/src/utils/webhooks.py
@@ -1,0 +1,50 @@
+"""Best-effort webhook notification helper for InkyPi.
+
+Sends a JSON POST to each configured webhook URL when a plugin refresh fails
+or its circuit breaker opens.  All exceptions are swallowed — this helper
+must never block or raise so that it cannot interfere with the refresh cycle.
+"""
+
+import logging
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def send_failure_webhook(
+    urls: list[str],
+    payload: dict[str, Any],
+    timeout: float = 1.0,
+) -> None:
+    """POST *payload* as JSON to every URL in *urls* (best-effort, no retries).
+
+    Args:
+        urls: List of webhook endpoint URLs to notify.
+        payload: JSON-serialisable dictionary sent as the request body.
+        timeout: Per-request timeout in seconds (default 1.0).  Requests that
+            exceed this limit are abandoned silently.
+
+    Guarantees:
+        - Never raises any exception.
+        - Logs a WARNING on failure, INFO on success.
+        - Uses an explicit timeout so a slow webhook cannot block the caller.
+    """
+    if not urls:
+        return
+
+    for url in urls:
+        try:
+            response = requests.post(url, json=payload, timeout=timeout)
+            logger.info(
+                "webhook: sent | url=%s status=%s",
+                url,
+                response.status_code,
+            )
+        except Exception:
+            logger.warning(
+                "webhook: failed | url=%s",
+                url,
+                exc_info=True,
+            )

--- a/tests/unit/test_webhooks.py
+++ b/tests/unit/test_webhooks.py
@@ -1,0 +1,245 @@
+# pyright: reportMissingImports=false
+"""Tests for the webhook notification helper (JTN-449).
+
+Covers:
+- send_failure_webhook posts JSON to each URL
+- Timeout does not raise
+- Connection error does not raise
+- Empty URL list is a no-op
+- Each POST result (success/failure) is logged
+- Integration: _cb_on_failure triggers the webhook when webhook_urls is set
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from model import PluginInstance
+from refresh_task import RefreshTask
+from utils.webhooks import send_failure_webhook
+
+# ---------------------------------------------------------------------------
+# Helpers shared with circuit-breaker tests
+# ---------------------------------------------------------------------------
+
+
+def _make_task(device_config_dev):
+    dm = MagicMock()
+    return RefreshTask(device_config_dev, dm)
+
+
+def _make_plugin_instance(plugin_id="weather", name="my_weather"):
+    return PluginInstance(
+        plugin_id=plugin_id,
+        name=name,
+        settings={},
+        refresh={"interval": 3600},
+    )
+
+
+def _add_plugin_to_pm(device_config_dev, plugin_instance):
+    pm = device_config_dev.get_playlist_manager()
+    playlist = pm.get_playlist("Default")
+    if playlist is None:
+        pm.add_default_playlist()
+        playlist = pm.get_playlist("Default")
+    playlist.plugins.append(plugin_instance)
+    return pm
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for send_failure_webhook
+# ---------------------------------------------------------------------------
+
+
+class TestSendFailureWebhook:
+    def test_posts_json_to_each_url(self, requests_mock):
+        urls = ["https://example.com/hook1", "https://example.com/hook2"]
+        for url in urls:
+            requests_mock.post(url, status_code=200)
+
+        payload = {"event": "plugin_failure", "plugin_id": "weather"}
+        send_failure_webhook(urls, payload)
+
+        assert requests_mock.call_count == 2
+        for i, url in enumerate(urls):
+            history = requests_mock.request_history[i]
+            assert history.url == url
+            assert history.json() == payload
+
+    def test_empty_url_list_is_noop(self, requests_mock):
+        send_failure_webhook([], {"event": "plugin_failure"})
+        assert requests_mock.call_count == 0
+
+    def test_timeout_does_not_raise(self, requests_mock):
+        requests_mock.post(
+            "https://example.com/slow",
+            exc=requests.exceptions.Timeout("timed out"),
+        )
+        # Must not raise
+        send_failure_webhook(["https://example.com/slow"], {"event": "plugin_failure"})
+
+    def test_connection_error_does_not_raise(self, requests_mock):
+        requests_mock.post(
+            "https://example.com/down",
+            exc=requests.exceptions.ConnectionError("refused"),
+        )
+        # Must not raise
+        send_failure_webhook(["https://example.com/down"], {"event": "plugin_failure"})
+
+    def test_success_is_logged(self, requests_mock, caplog):
+        requests_mock.post("https://example.com/hook", status_code=204)
+        with caplog.at_level(logging.INFO, logger="utils.webhooks"):
+            send_failure_webhook(
+                ["https://example.com/hook"], {"event": "plugin_failure"}
+            )
+        assert any("sent" in r.message for r in caplog.records)
+
+    def test_failure_is_logged(self, requests_mock, caplog):
+        requests_mock.post(
+            "https://example.com/hook",
+            exc=requests.exceptions.ConnectionError("refused"),
+        )
+        with caplog.at_level(logging.WARNING, logger="utils.webhooks"):
+            send_failure_webhook(
+                ["https://example.com/hook"], {"event": "plugin_failure"}
+            )
+        assert any("failed" in r.message for r in caplog.records)
+
+    def test_second_url_is_still_called_after_first_fails(self, requests_mock):
+        requests_mock.post(
+            "https://example.com/hook1",
+            exc=requests.exceptions.ConnectionError("refused"),
+        )
+        requests_mock.post("https://example.com/hook2", status_code=200)
+
+        send_failure_webhook(
+            ["https://example.com/hook1", "https://example.com/hook2"],
+            {"event": "plugin_failure"},
+        )
+
+        assert requests_mock.call_count == 2
+
+    def test_uses_explicit_timeout(self, requests_mock):
+        """Verify the timeout kwarg is passed through to requests.post."""
+        requests_mock.post("https://example.com/hook", status_code=200)
+
+        with patch("utils.webhooks.requests.post", wraps=requests.post) as mock_post:
+            # requests_mock intercepts the actual HTTP call; we just check kwargs
+            send_failure_webhook(
+                ["https://example.com/hook"], {"event": "plugin_failure"}, timeout=0.5
+            )
+            _args, kwargs = mock_post.call_args
+            assert kwargs.get("timeout") == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Integration: _cb_on_failure calls send_failure_webhook
+# ---------------------------------------------------------------------------
+
+
+class TestCbOnFailureWebhookIntegration:
+    def test_webhook_called_on_plugin_failure(self, device_config_dev, monkeypatch):
+        """When webhook_urls is configured, _cb_on_failure should invoke the webhook."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+
+        task = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        # Patch device_config.get_config to return a webhook URL for webhook_urls key
+        original_get_config = device_config_dev.get_config
+
+        def patched_get_config(key, default=None):
+            if key == "webhook_urls":
+                return ["https://example.com/hook"]
+            return original_get_config(key, default)
+
+        device_config_dev.get_config = patched_get_config
+
+        with patch("refresh_task.task.send_failure_webhook") as mock_send:
+            task._update_plugin_health(
+                plugin_id="weather",
+                instance="my_weather",
+                ok=False,
+                metrics=None,
+                error="API error",
+            )
+
+        mock_send.assert_called_once()
+        _args, _kwargs = mock_send.call_args
+        urls, payload = _args[0], _args[1]
+        assert urls == ["https://example.com/hook"]
+        assert payload["event"] == "plugin_failure"
+        assert payload["plugin_id"] == "weather"
+        assert payload["instance_name"] == "my_weather"
+        assert "ts" in payload
+
+    def test_webhook_not_called_when_no_urls_configured(
+        self, device_config_dev, monkeypatch
+    ):
+        """When webhook_urls is empty, send_failure_webhook should not be called."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+
+        task = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        with patch("refresh_task.task.send_failure_webhook") as mock_send:
+            task._update_plugin_health(
+                plugin_id="weather",
+                instance="my_weather",
+                ok=False,
+                metrics=None,
+                error="API error",
+            )
+
+        mock_send.assert_not_called()
+
+    def test_webhook_called_when_circuit_breaker_trips(
+        self, device_config_dev, monkeypatch
+    ):
+        """Webhook fires even on the failure that triggers the circuit breaker."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "2")
+
+        task = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        original_get_config = device_config_dev.get_config
+
+        def patched_get_config(key, default=None):
+            if key == "webhook_urls":
+                return ["https://example.com/hook"]
+            return original_get_config(key, default)
+
+        device_config_dev.get_config = patched_get_config
+
+        call_count = 0
+
+        def counting_send(urls, payload, timeout=1.0):
+            nonlocal call_count
+            call_count += 1
+
+        with patch("refresh_task.task.send_failure_webhook", side_effect=counting_send):
+            # First failure — counter = 1, not yet paused
+            task._update_plugin_health(
+                plugin_id="weather",
+                instance="my_weather",
+                ok=False,
+                metrics=None,
+                error="API error",
+            )
+            # Second failure — circuit breaker trips (paused = True) and webhook fires
+            task._update_plugin_health(
+                plugin_id="weather",
+                instance="my_weather",
+                ok=False,
+                metrics=None,
+                error="API error again",
+            )
+
+        # Both failures should have triggered the webhook (paused check is inside
+        # _cb_on_failure and short-circuits further calls once paused)
+        assert call_count == 2


### PR DESCRIPTION
## Summary

- Adds `src/utils/webhooks.py` with `send_failure_webhook(urls, payload, timeout=1.0)` — best-effort JSON POST, swallows all exceptions, logs success/failure
- Hooks into `RefreshTask._cb_on_failure` to read `webhook_urls` from `device_config` and fire the webhook on every plugin failure
- Payload fields: `event`, `plugin_id`, `instance_name`, `error`, `ts` (ISO-8601)
- Documents configuration and payload schema in `docs/webhooks.md`
- 11 new tests in `tests/unit/test_webhooks.py` (requests-mock, unit + integration)

Closes JTN-449

## Test plan

- [ ] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/unit/test_webhooks.py -v` — all 11 pass
- [ ] Full suite green (minus 2 pre-existing pyenv failures in test_plugin_registry.py)
- [ ] Configure `webhook_urls: ["https://ntfy.sh/my-topic"]` in device_config, trigger a plugin failure, confirm POST arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Webhook notifications for plugin refresh failures. Configure webhook URLs in device config to receive JSON alerts with plugin ID, error details, and timestamps. Includes timeout protection and graceful error handling.

* **Documentation**
  * Added webhook configuration documentation with integration guidance for ntfy.sh and Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->