### PR TITLE
feat: SSE stream for live dashboard updates

### DIFF
--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -10,6 +10,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.api_docs import api_docs_bp
     from blueprints.apikeys import apikeys_bp
     from blueprints.auth import auth_bp
+    from blueprints.events import events_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
     from blueprints.metrics import metrics_bp
@@ -28,3 +29,4 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
     app.register_blueprint(version_info_bp)
+    app.register_blueprint(events_bp)

--- a/src/blueprints/events.py
+++ b/src/blueprints/events.py
@@ -1,0 +1,49 @@
+"""events.py — SSE endpoint for live dashboard updates.
+
+GET /api/events streams refresh lifecycle events (refresh_started,
+refresh_complete, plugin_failed) published by the refresh task.  The
+endpoint falls back gracefully: if the subscriber cap is reached it
+returns HTTP 503 so the client can fall back to polling.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, Response, stream_with_context
+
+from utils.event_bus import get_event_bus
+
+logger = logging.getLogger(__name__)
+
+events_bp = Blueprint("events", __name__)
+
+
+@events_bp.route("/api/events", methods=["GET"])
+def sse_events():
+    """Stream SSE events to the client.
+
+    Yields ``event: <type>`` / ``data: <json>`` pairs for each refresh
+    lifecycle event.  A ``: ping`` heartbeat comment is sent every 15 s
+    when no event arrives so the connection stays alive through proxies.
+
+    If the maximum subscriber count is reached the endpoint returns 503
+    so the caller can fall back to polling.
+    """
+    bus = get_event_bus()
+    q = bus.subscribe()
+    if q is None:
+        logger.warning("/api/events: subscriber cap reached, returning 503")
+        return Response("Too many SSE connections", status=503, mimetype="text/plain")
+
+    @stream_with_context
+    def generate():
+        try:
+            yield from bus.stream(q)
+        finally:
+            bus.unsubscribe(q)
+
+    response = Response(generate(), mimetype="text/event-stream")
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"  # Disable nginx buffering
+    return response

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -18,6 +18,7 @@ from refresh_task.worker import (
     _get_mp_context,
     _remote_exception,
 )
+from utils.event_bus import get_event_bus
 from utils.history_cleanup import cleanup_history
 from utils.image_utils import compute_image_hash
 from utils.metrics import (
@@ -62,6 +63,7 @@ class RefreshTask:
         self.running = False
         self.manual_update_requests: deque[ManualUpdateRequest] = deque(maxlen=50)
         self.progress_bus = get_progress_bus()
+        self.event_bus = get_event_bus()
         self.plugin_health: dict[str, dict] = {}
         self._tick_count: int = 0
 
@@ -294,6 +296,14 @@ class RefreshTask:
                     "request_id": request_id,
                 }
             )
+            self.event_bus.publish(
+                "refresh_started",
+                {
+                    "plugin": instance_name or plugin_id,
+                    "plugin_id": plugin_id,
+                    "ts": datetime.now(UTC).isoformat(),
+                },
+            )
             try:
                 image, plugin_meta = self._execute_with_policy(
                     refresh_action,
@@ -327,6 +337,14 @@ class RefreshTask:
                         "error": str(exc),
                         "retained_display": bool(retain_path),
                     }
+                )
+                self.event_bus.publish(
+                    "plugin_failed",
+                    {
+                        "plugin": instance_name or plugin_id,
+                        "plugin_id": plugin_id,
+                        "error": str(exc),
+                    },
                 )
                 raise
             try:
@@ -407,6 +425,14 @@ class RefreshTask:
                 "request_id": request_id,
                 "metrics": metrics,
             }
+        )
+        self.event_bus.publish(
+            "refresh_complete",
+            {
+                "plugin": instance_name or plugin_id,
+                "plugin_id": plugin_id,
+                "duration_ms": request_ms,
+            },
         )
         return refresh_info | {"benchmark_id": benchmark_id}, used_cached, metrics
 

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -154,7 +154,7 @@
         imageHash: {{ refresh_info.get('image_hash')|tojson }},
         nextUpUrl: {{ url_for('main.next_up') | tojson }},
         previewUrl: {{ url_for('main.preview_image') | tojson }},
-        pushUrl: {{ (INKYPI_PUSH_URL if INKYPI_PUSH_URL is defined else None) | tojson }},
+        pushUrl: {{ (INKYPI_PUSH_URL if INKYPI_PUSH_URL is defined else url_for('events.sse_events')) | tojson }},
         refreshInfoUrl: {{ url_for('main.refresh_info') | tojson }},
         resolution: {{ config.resolution | tojson }},
     };

--- a/src/utils/event_bus.py
+++ b/src/utils/event_bus.py
@@ -1,0 +1,134 @@
+"""event_bus.py — simple thread-safe pub/sub bus for SSE dashboard updates.
+
+Each subscriber gets its own queue so every connected browser receives every
+event independently.  The bus caps the number of concurrent subscribers to
+prevent resource exhaustion on a Pi Zero.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from collections.abc import Generator
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_SENTINEL = object()  # placed in a subscriber's queue to signal close
+
+
+class EventBus:
+    """Thread-safe pub/sub bus with per-subscriber queues.
+
+    Attributes:
+        max_subscribers: Maximum number of simultaneous subscribers (default 50).
+    """
+
+    def __init__(self, max_subscribers: int = 50) -> None:
+        self.max_subscribers = max_subscribers
+        self._lock = threading.Lock()
+        self._subscribers: list[queue.Queue] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def publish(self, event_type: str, data: dict[str, Any]) -> None:
+        """Broadcast *event_type* + *data* to all current subscribers.
+
+        Disconnected (full) queues are silently dropped; the subscriber will be
+        cleaned up the next time it tries to read.
+        """
+        payload = {"event": event_type, "ts": time.time(), **data}
+        with self._lock:
+            active: list[queue.Queue] = []
+            for q in self._subscribers:
+                try:
+                    q.put_nowait(payload)
+                    active.append(q)
+                except queue.Full:
+                    # Subscriber is too slow — drop it
+                    logger.debug("EventBus: subscriber queue full, dropping subscriber")
+                    try:
+                        q.put_nowait(_SENTINEL)
+                    except queue.Full:
+                        pass
+            self._subscribers = active
+
+    def subscribe(self) -> queue.Queue | None:
+        """Return a new subscriber queue, or *None* if the cap is reached."""
+        with self._lock:
+            if len(self._subscribers) >= self.max_subscribers:
+                logger.warning(
+                    "EventBus: max subscribers (%d) reached, rejecting new subscriber",
+                    self.max_subscribers,
+                )
+                return None
+            q: queue.Queue = queue.Queue(maxsize=200)
+            self._subscribers.append(q)
+            return q
+
+    def unsubscribe(self, q: queue.Queue) -> None:
+        """Remove *q* from the subscriber list."""
+        with self._lock:
+            try:
+                self._subscribers.remove(q)
+            except ValueError:
+                pass
+
+    def subscriber_count(self) -> int:
+        """Return the current number of active subscribers."""
+        with self._lock:
+            return len(self._subscribers)
+
+    # ------------------------------------------------------------------
+    # SSE helpers
+    # ------------------------------------------------------------------
+
+    def stream(
+        self, q: queue.Queue, heartbeat_s: float = 15.0
+    ) -> Generator[str, None, None]:
+        """Yield SSE-formatted strings from *q* until the client disconnects.
+
+        A comment heartbeat (`: ping`) is yielded every *heartbeat_s* seconds
+        when no event arrives, keeping the connection alive through proxies.
+
+        Usage::
+
+            q = bus.subscribe()
+            if q is None:
+                abort(503)
+            try:
+                yield from bus.stream(q)
+            finally:
+                bus.unsubscribe(q)
+        """
+        try:
+            while True:
+                try:
+                    item = q.get(timeout=heartbeat_s)
+                except queue.Empty:
+                    yield ": ping\n\n"
+                    continue
+                if item is _SENTINEL:
+                    return
+                event_type = item.get("event", "message")
+                data = json.dumps(item, separators=(",", ":"))
+                yield f"event: {event_type}\ndata: {data}\n\n"
+        except GeneratorExit:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_event_bus = EventBus()
+
+
+def get_event_bus() -> EventBus:
+    """Return the application-wide EventBus singleton."""
+    return _event_bus

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,7 @@ def flask_app(device_config_dev, monkeypatch):
 
     from blueprints.api_docs import api_docs_bp
     from blueprints.apikeys import apikeys_bp
+    from blueprints.events import events_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
     from blueprints.metrics import metrics_bp
@@ -311,6 +312,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
     app.register_blueprint(version_info_bp)
+    app.register_blueprint(events_bp)
 
     setup_http_metrics(app)
 

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,0 +1,350 @@
+"""Tests for the SSE event bus and /api/events endpoint."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# EventBus unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bus():
+    from utils.event_bus import EventBus
+
+    return EventBus(max_subscribers=3)
+
+
+class TestEventBus:
+    def test_subscribe_returns_queue(self, bus):
+        q = bus.subscribe()
+        assert q is not None
+        assert isinstance(q, queue.Queue)
+
+    def test_unsubscribe_removes_queue(self, bus):
+        q = bus.subscribe()
+        assert bus.subscriber_count() == 1
+        bus.unsubscribe(q)
+        assert bus.subscriber_count() == 0
+
+    def test_publish_delivers_to_subscriber(self, bus):
+        q = bus.subscribe()
+        bus.publish("refresh_started", {"plugin": "clock", "ts": "2025-01-01T00:00:00"})
+        item = q.get_nowait()
+        assert item["event"] == "refresh_started"
+        assert item["plugin"] == "clock"
+
+    def test_publish_delivers_to_multiple_subscribers(self, bus):
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+        bus.publish("refresh_complete", {"plugin": "clock", "duration_ms": 123})
+        i1 = q1.get_nowait()
+        i2 = q2.get_nowait()
+        assert i1["event"] == "refresh_complete"
+        assert i2["event"] == "refresh_complete"
+
+    def test_max_subscriber_cap_enforced(self, bus):
+        # bus has max_subscribers=3
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+        q3 = bus.subscribe()
+        q4 = bus.subscribe()  # should be rejected
+        assert q1 is not None
+        assert q2 is not None
+        assert q3 is not None
+        assert q4 is None
+        assert bus.subscriber_count() == 3
+
+    def test_unsubscribe_nonexistent_is_safe(self, bus):
+        q: queue.Queue = queue.Queue()
+        bus.unsubscribe(q)  # should not raise
+
+    def test_publish_includes_ts(self, bus):
+        q = bus.subscribe()
+        before = time.time()
+        bus.publish("plugin_failed", {"plugin": "broken", "error": "boom"})
+        after = time.time()
+        item = q.get_nowait()
+        assert before <= item["ts"] <= after
+
+    def test_subscriber_count(self, bus):
+        assert bus.subscriber_count() == 0
+        q1 = bus.subscribe()
+        assert bus.subscriber_count() == 1
+        q2 = bus.subscribe()
+        assert bus.subscriber_count() == 2
+        bus.unsubscribe(q1)
+        assert bus.subscriber_count() == 1
+        bus.unsubscribe(q2)
+        assert bus.subscriber_count() == 0
+
+
+class TestEventBusStream:
+    """Tests for the stream() generator."""
+
+    def test_stream_yields_sse_formatted_event(self, bus):
+        q = bus.subscribe()
+        bus.publish("refresh_started", {"plugin": "weather"})
+
+        chunks = []
+        gen = bus.stream(q, heartbeat_s=0.05)
+        chunks.append(next(gen))
+        gen.close()
+
+        assert chunks[0].startswith("event: refresh_started\n")
+        assert "data:" in chunks[0]
+        payload = json.loads(chunks[0].split("data:", 1)[1].strip())
+        assert payload["plugin"] == "weather"
+
+    def test_stream_yields_heartbeat_when_idle(self, bus):
+        q = bus.subscribe()
+
+        chunks = []
+
+        def _read():
+            gen = bus.stream(q, heartbeat_s=0.05)
+            chunks.append(next(gen))
+            gen.close()
+
+        t = threading.Thread(target=_read)
+        t.start()
+        t.join(timeout=1.0)
+        assert chunks, "No chunk received"
+        assert chunks[0] == ": ping\n\n"
+
+    def test_disconnected_subscriber_cleaned_up(self):
+        """A full subscriber queue is evicted on next publish."""
+        from utils.event_bus import EventBus
+
+        bus = EventBus(max_subscribers=5)
+        q = bus.subscribe()
+        assert bus.subscriber_count() == 1
+
+        # Fill the queue so the next publish can't put
+        for _ in range(q.maxsize):
+            q.put_nowait({"event": "filler"})
+
+        bus.publish("refresh_started", {"plugin": "test"})
+        # The full queue is evicted and the sentinel sent
+        assert bus.subscriber_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# /api/events endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventsEndpoint:
+    def test_get_api_events_returns_200_sse_content_type(self, client, monkeypatch):
+        """GET /api/events must return 200 with text/event-stream."""
+        from utils.event_bus import get_event_bus
+
+        bus = get_event_bus()
+        # Publish an event so the generator yields one item then we stop
+        # We test the response headers only (streaming body tested separately)
+        called = []
+
+        original_subscribe = bus.subscribe
+
+        def _subscribe_once():
+            q = original_subscribe()
+            if q is not None:
+                # Pre-load an event so the generator doesn't block
+                q.put({"event": "refresh_started", "plugin": "test", "ts": 0.0})
+                called.append(q)
+            return q
+
+        monkeypatch.setattr(bus, "subscribe", _subscribe_once)
+
+        response = client.get("/api/events")
+        assert response.status_code == 200
+        assert "text/event-stream" in response.content_type
+        # Clean up subscriber
+        for q in called:
+            bus.unsubscribe(q)
+
+    def test_get_api_events_cap_returns_503(self, client, monkeypatch):
+        """When subscriber cap is reached, /api/events returns 503."""
+        from utils.event_bus import get_event_bus
+
+        bus = get_event_bus()
+
+        monkeypatch.setattr(bus, "subscribe", lambda: None)
+
+        response = client.get("/api/events")
+        assert response.status_code == 503
+
+    def test_get_api_events_cache_control_header(self, client, monkeypatch):
+        from utils.event_bus import get_event_bus
+
+        bus = get_event_bus()
+        original_subscribe = bus.subscribe
+
+        def _subscribe_once():
+            q = original_subscribe()
+            if q is not None:
+                q.put({"event": "refresh_complete", "plugin": "test", "ts": 0.0})
+            return q
+
+        monkeypatch.setattr(bus, "subscribe", _subscribe_once)
+
+        response = client.get("/api/events")
+        assert response.headers.get("Cache-Control") == "no-cache"
+
+    def test_publish_from_refresh_task_flows_to_subscriber(self, monkeypatch):
+        """Publishing via event_bus flows through to the subscriber queue."""
+        from utils.event_bus import EventBus
+
+        bus = EventBus()
+        q = bus.subscribe()
+        assert q is not None
+        bus.publish(
+            "refresh_started",
+            {"plugin": "clock", "plugin_id": "clock", "ts": "2025-01-01T00:00:00"},
+        )
+        item = q.get_nowait()
+        assert item["event"] == "refresh_started"
+        assert item["plugin"] == "clock"
+        assert item["plugin_id"] == "clock"
+
+
+# ---------------------------------------------------------------------------
+# RefreshTask hook integration
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTaskHooks:
+    """Verify that event_bus.publish is called during a refresh cycle."""
+
+    def _make_task(self, device_config_dev, monkeypatch):
+        from display.display_manager import DisplayManager
+        from refresh_task.task import RefreshTask
+
+        dm = DisplayManager(device_config_dev)
+        task = RefreshTask(device_config_dev, dm)
+        return task
+
+    def test_refresh_task_has_event_bus(self, device_config_dev, monkeypatch):
+        task = self._make_task(device_config_dev, monkeypatch)
+        from utils.event_bus import EventBus
+
+        assert isinstance(task.event_bus, EventBus)
+
+    def test_refresh_started_published(self, device_config_dev, monkeypatch):
+        """event_bus.publish called with refresh_started during _perform_refresh."""
+        task = self._make_task(device_config_dev, monkeypatch)
+
+        published: list[tuple[str, dict]] = []
+
+        def _capture(event_type, data):
+            published.append((event_type, data))
+
+        monkeypatch.setattr(task.event_bus, "publish", _capture)
+
+        # Also stub progress_bus so it doesn't error
+        monkeypatch.setattr(task.progress_bus, "publish", lambda _d: None)
+
+        # Provide a minimal plugin config and stub _execute_with_policy to return an image
+        from PIL import Image
+
+        img = Image.new("RGB", (100, 100), "white")
+
+        monkeypatch.setattr(task, "_execute_with_policy", lambda *a, **kw: (img, {}))
+        monkeypatch.setattr(task, "_push_to_display", lambda *a, **kw: (10, 5))
+        monkeypatch.setattr(task, "_save_benchmark", lambda *a, **kw: None)
+        monkeypatch.setattr(task, "_update_plugin_health", lambda **kw: None)
+        monkeypatch.setattr(task, "_stale_display_path", lambda: None)
+
+        # Build a minimal PlaylistRefresh action
+        from refresh_task.actions import PlaylistRefresh
+
+        class _FakePlugin:
+            plugin_id = "clock"
+            name = "My Clock"
+            settings = {}
+
+        class _FakePlaylist:
+            name = "default"
+
+        action = PlaylistRefresh(_FakePlaylist(), _FakePlugin())
+
+        # Provide a plugin config
+
+        monkeypatch.setattr(
+            device_config_dev,
+            "get_plugin",
+            lambda pid: {"id": pid, "image_settings": []},
+        )
+        monkeypatch.setattr(
+            device_config_dev,
+            "get_config",
+            lambda key, default=None: [] if key == "isolated_plugins" else default,
+        )
+
+        from datetime import UTC, datetime
+
+        task._perform_refresh(
+            action, type("R", (), {"image_hash": None})(), datetime.now(UTC)
+        )
+
+        event_types = [e[0] for e in published]
+        assert "refresh_started" in event_types
+        assert "refresh_complete" in event_types
+
+    def test_plugin_failed_published(self, device_config_dev, monkeypatch):
+        """event_bus.publish called with plugin_failed when exception raised."""
+        task = self._make_task(device_config_dev, monkeypatch)
+
+        published: list[tuple[str, dict]] = []
+
+        def _capture(event_type, data):
+            published.append((event_type, data))
+
+        monkeypatch.setattr(task.event_bus, "publish", _capture)
+        monkeypatch.setattr(task.progress_bus, "publish", lambda _d: None)
+        monkeypatch.setattr(task, "_update_plugin_health", lambda **kw: None)
+        monkeypatch.setattr(task, "_stale_display_path", lambda: None)
+
+        def _fail(*a, **kw):
+            raise RuntimeError("plugin boom")
+
+        monkeypatch.setattr(task, "_execute_with_policy", _fail)
+
+        from refresh_task.actions import PlaylistRefresh
+
+        class _FakePlugin:
+            plugin_id = "broken"
+            name = "Broken"
+            settings = {}
+
+        class _FakePlaylist:
+            name = "default"
+
+        action = PlaylistRefresh(_FakePlaylist(), _FakePlugin())
+
+        monkeypatch.setattr(
+            device_config_dev,
+            "get_plugin",
+            lambda pid: {"id": pid, "image_settings": []},
+        )
+        monkeypatch.setattr(
+            device_config_dev,
+            "get_config",
+            lambda key, default=None: [] if key == "isolated_plugins" else default,
+        )
+
+        from datetime import UTC, datetime
+
+        with pytest.raises(RuntimeError, match="plugin boom"):
+            task._perform_refresh(
+                action, type("R", (), {"image_hash": None})(), datetime.now(UTC)
+            )
+
+        event_types = [e[0] for e in published]
+        assert "plugin_failed" in event_types


### PR DESCRIPTION
## Summary

- Add `src/utils/event_bus.py`: thread-safe pub/sub bus with per-subscriber queues, 50-subscriber cap, 15 s heartbeat pings, and clean sentinel-based disconnect handling
- Add `src/blueprints/events.py`: `GET /api/events` SSE endpoint; returns 503 when subscriber cap is reached so clients can fall back to polling
- Hook `event_bus.publish()` into `RefreshTask._perform_refresh` for three lifecycle events: `refresh_started`, `refresh_complete`, `plugin_failed`
- Wire `pushUrl` in `inky.html` to `/api/events` — the existing `EventSource` + polling fallback JS logic in `dashboard_page.js` activates automatically; polling code is not removed

## Test plan

- [x] 18 new tests in `tests/test_sse.py` covering: bus subscribe/unsubscribe, cap enforcement, publish delivery, SSE wire format, heartbeat, full-queue cleanup, endpoint 200/503/Cache-Control, and refresh-task hook integration
- [x] Full suite: 2632 passed, 2 pre-existing failures unrelated to this PR
- [x] Ruff + Black lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)