### PR TITLE
feat: per-IP rate limiting for /login and /display-next (JTN-447)

### DIFF
--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -15,10 +15,11 @@ import os
 import secrets
 from time import perf_counter
 
-from flask import Flask, g, redirect, request, session
+from flask import Flask, g, make_response, redirect, request, session
 
 from config import Config
 from utils.http_utils import json_error
+from utils.rate_limit import make_auth_bucket, make_refresh_bucket
 from utils.rate_limiter import SlidingWindowLimiter
 
 logger = logging.getLogger(__name__)
@@ -148,12 +149,30 @@ def setup_csrf_protection(app: Flask) -> None:
 # Rate limiting
 # ---------------------------------------------------------------------------
 
+#: Paths that receive stricter per-IP token-bucket limiting (POST only).
+#: /display-next is the canonical refresh endpoint; /refresh is a backward-
+#: compatible alias; /login is the PIN-auth endpoint.
+_AUTH_RATE_PATHS = frozenset({"/login"})
+_REFRESH_RATE_PATHS = frozenset({"/display-next", "/refresh"})
 
 _mutation_limiter = SlidingWindowLimiter(_MUTATE_MAX, _MUTATE_WINDOW)
 
+# Endpoint-specific token-bucket limiters (lazy-initialised at first call to
+# setup_rate_limiting so env vars set after import are respected).
+_auth_bucket = None
+_refresh_bucket = None
+
 
 def setup_rate_limiting(app: Flask) -> None:
-    """Sliding-window per-IP rate limit on mutating requests."""
+    """Sliding-window per-IP rate limit on mutating requests.
+
+    Also applies stricter token-bucket limits to the /login and
+    /display-next (refresh) endpoints to prevent brute-force and
+    refresh-storming attacks (JTN-447).
+    """
+    global _auth_bucket, _refresh_bucket
+    _auth_bucket = make_auth_bucket()
+    _refresh_bucket = make_refresh_bucket()
 
     @app.before_request
     def _rate_limit_mutations():
@@ -162,6 +181,24 @@ def setup_rate_limiting(app: Flask) -> None:
         if request.path in _RATE_EXEMPT:
             return None
         addr = request.remote_addr or "unknown"
+
+        # --- Endpoint-specific token-bucket limits (stricter) ---
+        if request.path in _AUTH_RATE_PATHS and not _auth_bucket.try_acquire(addr):  # type: ignore[union-attr]
+            body, code = json_error(
+                "Too many login attempts — try again later", status=429
+            )
+            resp = make_response(body, code)
+            resp.headers["Retry-After"] = "30"
+            return resp
+        elif request.path in _REFRESH_RATE_PATHS and not _refresh_bucket.try_acquire(addr):  # type: ignore[union-attr]
+            body, code = json_error(
+                "Refresh rate limit exceeded — try again later", status=429
+            )
+            resp = make_response(body, code)
+            resp.headers["Retry-After"] = "6"
+            return resp
+
+        # --- General sliding-window limit (all other mutations) ---
         allowed, _ = _mutation_limiter.check(addr)
         if not allowed:
             return json_error("Rate limit exceeded — try again shortly", status=429)

--- a/src/utils/rate_limit.py
+++ b/src/utils/rate_limit.py
@@ -1,0 +1,143 @@
+"""Token-bucket rate limiter (stdlib-only, thread-safe).
+
+Designed for per-IP limiting of specific Flask endpoints such as /login and
+/display-next.  No external dependencies — uses only threading, time, and
+os from the standard library.
+
+Usage::
+
+    limiter = TokenBucket(capacity=5, refill_rate=1/30)
+    if limiter.try_acquire("192.168.1.1"):
+        # process request
+    else:
+        # return 429
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+
+class TokenBucket:
+    """Per-key token-bucket rate limiter.
+
+    Args:
+        capacity:    Maximum number of tokens (burst size).
+        refill_rate: Tokens added per second (e.g. ``1/30`` ≈ one token per
+                     30 seconds).
+        ttl:         Seconds of inactivity before a bucket is evicted.
+                     Defaults to 300 (5 minutes).
+    """
+
+    def __init__(
+        self,
+        capacity: float,
+        refill_rate: float,
+        ttl: float = 300.0,
+    ) -> None:
+        self._capacity = float(capacity)
+        self._refill_rate = float(refill_rate)
+        self._ttl = float(ttl)
+        # keyed by (str -> [tokens: float, last_refill: float, last_used: float])
+        self._buckets: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def try_acquire(self, key: str) -> bool:
+        """Attempt to consume one token from the bucket for *key*.
+
+        Returns ``True`` when a token was available (request allowed),
+        ``False`` otherwise (request should be rate-limited).
+
+        Side-effect: performs cheap O(n) eviction of stale buckets on every
+        call so memory stays bounded without a background thread.
+        """
+        with self._lock:
+            now = time.monotonic()
+            self._evict_stale(now)
+
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                # New bucket: start at capacity minus the one token we consume.
+                self._buckets[key] = [self._capacity - 1.0, now, now]
+                return True
+
+            tokens, last_refill, _last_used = bucket
+            # Refill tokens based on elapsed time
+            elapsed = now - last_refill
+            tokens = min(self._capacity, tokens + elapsed * self._refill_rate)
+
+            if tokens < 1.0:
+                # No token available — update last_used so we don't evict while
+                # the IP is still hammering us.
+                bucket[2] = now
+                return False
+
+            bucket[0] = tokens - 1.0
+            bucket[1] = now
+            bucket[2] = now
+            return True
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _evict_stale(self, now: float) -> None:
+        """Remove buckets idle for longer than *ttl* seconds.
+
+        Must be called while holding ``self._lock``.
+        """
+        stale = [k for k, v in self._buckets.items() if now - v[2] > self._ttl]
+        for k in stale:
+            del self._buckets[k]
+
+
+# ---------------------------------------------------------------------------
+# Env-var config helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_AUTH_CAPACITY = 5
+_DEFAULT_AUTH_REFILL = 1 / 30  # 1 token per 30 s
+
+_DEFAULT_REFRESH_CAPACITY = 10
+_DEFAULT_REFRESH_REFILL = 1 / 6  # 1 token per 6 s
+
+
+def _parse_rate_env(name: str, capacity_default: int, rate_default: float):
+    """Parse ``N/Sseconds`` from *name* env var.
+
+    Format: ``"5/30"`` → capacity=5, refill_rate=1/30.
+    Returns *(capacity, refill_rate)* as floats.
+    """
+    raw = os.getenv(name, "").strip()
+    if raw:
+        try:
+            parts = raw.split("/")
+            cap = float(parts[0])
+            secs = float(parts[1]) if len(parts) > 1 else 1.0
+            if cap > 0 and secs > 0:
+                return cap, 1.0 / secs
+        except (ValueError, IndexError):
+            pass
+    return float(capacity_default), rate_default
+
+
+def make_auth_bucket() -> TokenBucket:
+    """Return a TokenBucket configured for the /login endpoint."""
+    cap, rate = _parse_rate_env(
+        "INKYPI_RATE_LIMIT_AUTH", _DEFAULT_AUTH_CAPACITY, _DEFAULT_AUTH_REFILL
+    )
+    return TokenBucket(capacity=cap, refill_rate=rate)
+
+
+def make_refresh_bucket() -> TokenBucket:
+    """Return a TokenBucket configured for the /display-next endpoint."""
+    cap, rate = _parse_rate_env(
+        "INKYPI_RATE_LIMIT_REFRESH", _DEFAULT_REFRESH_CAPACITY, _DEFAULT_REFRESH_REFILL
+    )
+    return TokenBucket(capacity=cap, refill_rate=rate)

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,309 @@
+"""Tests for utils.rate_limit (TokenBucket) and per-endpoint middleware (JTN-447)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from utils.rate_limit import (
+    TokenBucket,
+    _parse_rate_env,
+    make_auth_bucket,
+    make_refresh_bucket,
+)
+
+# ---------------------------------------------------------------------------
+# TokenBucket unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBucket:
+    def test_initial_acquire_succeeds(self):
+        bucket = TokenBucket(capacity=5, refill_rate=1 / 30)
+        assert bucket.try_acquire("192.168.1.1") is True
+
+    def test_acquire_up_to_capacity(self):
+        bucket = TokenBucket(capacity=3, refill_rate=0)
+        # First acquisition uses up one token from a new bucket that starts at capacity
+        assert bucket.try_acquire("ip") is True  # capacity-1 = 2 tokens remain
+        assert bucket.try_acquire("ip") is True  # 1 token remains
+        assert bucket.try_acquire("ip") is True  # 0 tokens remain
+        assert bucket.try_acquire("ip") is False  # denied
+
+    def test_acquire_denied_when_empty(self):
+        bucket = TokenBucket(capacity=1, refill_rate=0)
+        assert bucket.try_acquire("ip") is True
+        assert bucket.try_acquire("ip") is False
+
+    def test_refill_after_time_passes(self):
+        bucket = TokenBucket(capacity=3, refill_rate=1)  # 1 token/second
+        with patch("utils.rate_limit.time.monotonic", return_value=100.0):
+            # Drain: first call creates bucket at cap-1=2, then two more
+            bucket.try_acquire("ip")
+            bucket.try_acquire("ip")
+            bucket.try_acquire("ip")  # now empty
+            assert bucket.try_acquire("ip") is False
+
+        # After 2 seconds, 2 tokens should have refilled
+        with patch("utils.rate_limit.time.monotonic", return_value=102.0):
+            assert bucket.try_acquire("ip") is True
+            assert bucket.try_acquire("ip") is True
+            assert bucket.try_acquire("ip") is False
+
+    def test_different_keys_tracked_separately(self):
+        bucket = TokenBucket(capacity=1, refill_rate=0)
+        assert bucket.try_acquire("ip-a") is True
+        assert bucket.try_acquire("ip-a") is False
+        # ip-b is unaffected
+        assert bucket.try_acquire("ip-b") is True
+
+    def test_stale_buckets_evicted(self):
+        bucket = TokenBucket(capacity=5, refill_rate=1, ttl=10)
+        with patch("utils.rate_limit.time.monotonic", return_value=100.0):
+            bucket.try_acquire("stale-ip")
+        assert "stale-ip" in bucket._buckets
+
+        # Advance time past ttl, trigger eviction via a new acquire call
+        with patch("utils.rate_limit.time.monotonic", return_value=115.0):
+            bucket.try_acquire("new-ip")
+
+        assert "stale-ip" not in bucket._buckets
+
+    def test_capacity_not_exceeded_by_refill(self):
+        bucket = TokenBucket(capacity=5, refill_rate=100)  # fast refill
+        with patch("utils.rate_limit.time.monotonic", return_value=100.0):
+            bucket.try_acquire("ip")  # creates bucket
+        # Long time passes — tokens should be capped at capacity
+        with patch("utils.rate_limit.time.monotonic", return_value=200.0):
+            # Acquire 5 times — should all succeed (capacity = 5)
+            results = [bucket.try_acquire("ip") for _ in range(5)]
+            assert all(results)
+            # 6th should fail
+            assert bucket.try_acquire("ip") is False
+
+    def test_thread_safety(self):
+        import threading
+
+        bucket = TokenBucket(capacity=100, refill_rate=0)
+        allowed_count = {"n": 0}
+        lock = threading.Lock()
+
+        def worker():
+            local = sum(1 for _ in range(20) if bucket.try_acquire("shared"))
+            with lock:
+                allowed_count["n"] += local
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Must never exceed capacity
+        assert allowed_count["n"] <= 100
+
+
+# ---------------------------------------------------------------------------
+# Env-var config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseRateEnv:
+    def test_defaults_returned_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("INKYPI_RATE_LIMIT_AUTH", raising=False)
+        cap, rate = _parse_rate_env("INKYPI_RATE_LIMIT_AUTH", 5, 1 / 30)
+        assert cap == 5.0
+        assert rate == pytest.approx(1 / 30)
+
+    def test_parses_valid_env(self, monkeypatch):
+        monkeypatch.setenv("INKYPI_RATE_LIMIT_AUTH", "10/60")
+        cap, rate = _parse_rate_env("INKYPI_RATE_LIMIT_AUTH", 5, 1 / 30)
+        assert cap == 10.0
+        assert rate == pytest.approx(1 / 60)
+
+    def test_invalid_env_falls_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("INKYPI_RATE_LIMIT_AUTH", "bad/value")
+        cap, rate = _parse_rate_env("INKYPI_RATE_LIMIT_AUTH", 5, 1 / 30)
+        assert cap == 5.0
+        assert rate == pytest.approx(1 / 30)
+
+    def test_make_auth_bucket_uses_defaults(self, monkeypatch):
+        monkeypatch.delenv("INKYPI_RATE_LIMIT_AUTH", raising=False)
+        b = make_auth_bucket()
+        assert b._capacity == 5.0
+
+    def test_make_refresh_bucket_uses_defaults(self, monkeypatch):
+        monkeypatch.delenv("INKYPI_RATE_LIMIT_REFRESH", raising=False)
+        b = make_refresh_bucket()
+        assert b._capacity == 10.0
+
+    def test_make_auth_bucket_respects_env(self, monkeypatch):
+        monkeypatch.setenv("INKYPI_RATE_LIMIT_AUTH", "7/45")
+        b = make_auth_bucket()
+        assert b._capacity == 7.0
+        assert b._refill_rate == pytest.approx(1 / 45)
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint middleware integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def rate_limit_app():
+    """Minimal Flask app with per-endpoint token-bucket rate limiting."""
+    from utils.rate_limit import TokenBucket
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.config["TESTING"] = True
+
+    # Tight buckets for fast testing
+    auth_b = TokenBucket(capacity=5, refill_rate=0)
+    refresh_b = TokenBucket(capacity=10, refill_rate=0)
+
+    _AUTH_PATHS = frozenset({"/login"})
+    _REFRESH_PATHS = frozenset({"/display-next", "/refresh"})
+
+    from utils.http_utils import json_error
+
+    @app.before_request
+    def _rl():
+        from flask import make_response, request
+
+        if request.method in ("GET", "HEAD", "OPTIONS"):
+            return None
+        addr = request.remote_addr or "unknown"
+        if request.path in _AUTH_PATHS and not auth_b.try_acquire(addr):
+            body, code = json_error(
+                "Too many login attempts — try again later", status=429
+            )
+            resp = make_response(body, code)
+            resp.headers["Retry-After"] = "30"
+            return resp
+        elif request.path in _REFRESH_PATHS and not refresh_b.try_acquire(addr):
+            body, code = json_error(
+                "Refresh rate limit exceeded — try again later", status=429
+            )
+            resp = make_response(body, code)
+            resp.headers["Retry-After"] = "6"
+            return resp
+        return None
+
+    @app.route("/login", methods=["POST"])
+    def login():
+        return {"ok": True}
+
+    @app.route("/display-next", methods=["POST"])
+    def display_next():
+        return {"ok": True}
+
+    @app.route("/refresh", methods=["POST"])
+    def refresh_alias():
+        return {"ok": True}
+
+    @app.route("/api/health", methods=["GET"])
+    def health():
+        return {"status": "ok"}
+
+    @app.route("/api/other", methods=["POST"])
+    def other():
+        return {"ok": True}
+
+    return app
+
+
+class TestLoginEndpointRateLimit:
+    def test_five_logins_succeed(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(5):
+            resp = client.post("/login")
+            assert resp.status_code == 200
+
+    def test_sixth_login_returns_429(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(5):
+            client.post("/login")
+        resp = client.post("/login")
+        assert resp.status_code == 429
+
+    def test_sixth_login_has_retry_after_header(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(5):
+            client.post("/login")
+        resp = client.post("/login")
+        assert resp.headers.get("Retry-After") == "30"
+
+    def test_sixth_login_has_json_error_body(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(5):
+            client.post("/login")
+        resp = client.post("/login")
+        data = resp.get_json()
+        assert data is not None
+        assert (
+            "rate" in data.get("error", "").lower()
+            or "attempt" in data.get("error", "").lower()
+        )
+
+
+class TestRefreshEndpointRateLimit:
+    def test_ten_refresh_calls_succeed(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(10):
+            resp = client.post("/display-next")
+            assert resp.status_code == 200
+
+    def test_eleventh_refresh_returns_429(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(10):
+            client.post("/display-next")
+        resp = client.post("/display-next")
+        assert resp.status_code == 429
+
+    def test_eleventh_refresh_has_retry_after_header(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(10):
+            client.post("/display-next")
+        resp = client.post("/display-next")
+        assert resp.headers.get("Retry-After") == "6"
+
+    def test_refresh_alias_also_rate_limited(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(10):
+            client.post("/refresh")
+        resp = client.post("/refresh")
+        assert resp.status_code == 429
+
+
+class TestIpIsolation:
+    def test_different_ips_tracked_separately(self, rate_limit_app):
+        """Exhausting one IP's bucket should not affect another IP."""
+        with rate_limit_app.test_client() as client:
+            # Exhaust ip-a by overriding remote_addr via environ_base
+            for _ in range(5):
+                client.post("/login", environ_base={"REMOTE_ADDR": "10.0.0.1"})
+            # ip-a is now denied
+            resp = client.post("/login", environ_base={"REMOTE_ADDR": "10.0.0.1"})
+            assert resp.status_code == 429
+            # ip-b is still fine
+            resp_b = client.post("/login", environ_base={"REMOTE_ADDR": "10.0.0.2"})
+            assert resp_b.status_code == 200
+
+
+class TestNonRateLimitedEndpoints:
+    def test_health_get_not_rate_limited(self, rate_limit_app):
+        client = rate_limit_app.test_client()
+        for _ in range(20):
+            resp = client.get("/api/health")
+            assert resp.status_code == 200
+
+    def test_other_post_not_covered_by_endpoint_limiter(self, rate_limit_app):
+        """General endpoints should not be blocked by the per-endpoint bucket."""
+        client = rate_limit_app.test_client()
+        # The other endpoint has no rate limit in this fixture
+        for _ in range(15):
+            resp = client.post("/api/other")
+            assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Adds `src/utils/rate_limit.py` — stdlib-only `TokenBucket` class with per-key token tracking, thread-safe via `threading.Lock`, and automatic TTL-based eviction of idle buckets (no background thread needed)
- Applies a stricter auth bucket (capacity=5, 1 token/30s) to `POST /login` and a refresh bucket (capacity=10, 1 token/6s) to `POST /display-next` and its `/refresh` alias, layered on top of the existing general sliding-window limiter
- Configurable via `INKYPI_RATE_LIMIT_AUTH=N/Sseconds` and `INKYPI_RATE_LIMIT_REFRESH=N/Sseconds` env vars
- Returns 429 with a `Retry-After` header on rejection
- 25 new tests covering: token exhaustion, refill, per-IP isolation, env-var parsing, Retry-After header, and non-rate-limited endpoints

Closes JTN-447. Defense-in-depth on top of the session-level PIN lockout from JTN-286.

## Test plan

- [x] `SKIP_BROWSER=1 pytest tests/unit/test_rate_limit.py` — 25 passed
- [x] Full suite: 2639 passed (2 pre-existing pyenv failures in test_plugin_registry.py, unrelated)
- [x] `scripts/lint.sh` — ruff + black clean; mypy advisory only (pre-existing issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)