### PR TITLE
feat: aggregated refresh stats endpoint /api/stats

### DIFF
--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -16,6 +16,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
+    from blueprints.stats import stats_bp
     from blueprints.version_info import version_info_bp
 
     app.register_blueprint(auth_bp)
@@ -27,4 +28,5 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(history_bp)
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
+    app.register_blueprint(stats_bp)
     app.register_blueprint(version_info_bp)

--- a/src/blueprints/stats.py
+++ b/src/blueprints/stats.py
@@ -1,0 +1,51 @@
+"""Aggregated refresh stats endpoint (GET /api/stats).
+
+Returns rolling refresh aggregates over three time windows:
+  - last_1h   (last 3 600 seconds)
+  - last_24h  (last 86 400 seconds)
+  - last_7d   (last 604 800 seconds)
+
+Each window contains:
+    total, success, failure, success_rate,
+    p50_duration_ms, p95_duration_ms, top_failing
+
+Results are cached in-process for 60 seconds (handled by compute_stats) and
+the response carries Cache-Control: public, max-age=60.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, current_app, jsonify
+
+from utils.refresh_stats import compute_stats
+
+logger = logging.getLogger(__name__)
+
+stats_bp = Blueprint("stats", __name__)
+
+_WINDOW_1H = 3_600
+_WINDOW_24H = 86_400
+_WINDOW_7D = 604_800
+
+
+@stats_bp.route("/api/stats", methods=["GET"])
+def refresh_stats():
+    """Return aggregated refresh statistics for 1h, 24h, and 7d windows."""
+    device_config = current_app.config.get("DEVICE_CONFIG")
+    history_dir: str = getattr(device_config, "history_image_dir", "")
+
+    try:
+        payload = {
+            "last_1h": compute_stats(history_dir, _WINDOW_1H),
+            "last_24h": compute_stats(history_dir, _WINDOW_24H),
+            "last_7d": compute_stats(history_dir, _WINDOW_7D),
+        }
+    except Exception:
+        logger.exception("Failed to compute refresh stats")
+        return jsonify({"error": "failed to compute stats"}), 500
+
+    response = jsonify(payload)
+    response.headers["Cache-Control"] = "public, max-age=60"
+    return response, 200

--- a/src/utils/refresh_stats.py
+++ b/src/utils/refresh_stats.py
@@ -1,0 +1,164 @@
+"""refresh_stats — compute rolling refresh aggregates from history sidecar files.
+
+Reads JSON sidecar files written alongside PNG history images and produces
+window-based statistics (1h, 24h, 7d).  Results are cached in-process for
+60 seconds to avoid repeated directory scans on high-frequency polling.
+
+Sidecar schema (subset used here)
+----------------------------------
+{
+    "status": "success" | "failure",
+    "duration_ms": <int>,          # total refresh wall-clock time
+    "plugin_id": "<str>",          # plugin that generated the image
+    "timestamp": <float>,          # Unix epoch of the refresh
+}
+
+Any field may be absent; absent fields cause that sidecar to be excluded from
+the relevant aggregate (e.g. a missing ``duration_ms`` does not affect totals).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections import Counter
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cache — one entry per (history_dir, window_seconds) pair
+# ---------------------------------------------------------------------------
+
+_CACHE_TTL_SECONDS = 60
+
+_cache: dict[tuple[str, int], tuple[float, dict]] = {}
+
+
+def _now() -> float:
+    """Return the current time as a Unix timestamp (mockable in tests)."""
+    return time.time()
+
+
+def _percentile(sorted_values: list[float], pct: float) -> int:
+    """Return the *pct*-th percentile of *sorted_values* (0-100), or 0 if empty."""
+    if not sorted_values:
+        return 0
+    idx = max(0, min(len(sorted_values) - 1, int(len(sorted_values) * pct / 100)))
+    return int(sorted_values[idx])
+
+
+def _load_sidecars(history_dir: str, since: float) -> list[dict[str, Any]]:
+    """Read all JSON sidecar files from *history_dir* whose timestamp >= *since*.
+
+    Only reads files that end with ``.json``.  Malformed or unreadable files are
+    silently skipped.
+    """
+    records: list[dict[str, Any]] = []
+    try:
+        names = os.listdir(history_dir)
+    except OSError:
+        logger.debug("refresh_stats: cannot list %s", history_dir)
+        return records
+
+    for name in names:
+        if not name.lower().endswith(".json"):
+            continue
+        full_path = os.path.join(history_dir, name)
+        if os.path.islink(full_path):
+            continue
+        try:
+            mtime = os.path.getmtime(full_path)
+        except OSError:
+            continue
+        # Quick pre-filter on mtime before reading the file
+        if mtime < since:
+            continue
+        try:
+            with open(full_path, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        # Use explicit ``timestamp`` field when available, fall back to mtime
+        ts = data.get("timestamp")
+        if not isinstance(ts, int | float):
+            ts = mtime
+        if ts < since:
+            continue
+        records.append({**data, "_ts": float(ts)})
+
+    return records
+
+
+def _compute_window(records: list[dict[str, Any]]) -> dict:
+    """Build the stats dict for a pre-filtered list of sidecar records."""
+    total = len(records)
+    success = sum(1 for r in records if r.get("status") == "success")
+    failure = total - success
+    success_rate = (success / total) if total else 0.0
+
+    durations = sorted(
+        r["duration_ms"]
+        for r in records
+        if isinstance(r.get("duration_ms"), int | float)
+    )
+
+    p50 = _percentile(durations, 50)
+    p95 = _percentile(durations, 95)
+
+    # Top failing plugins — plugins that appear in failure records
+    fail_counter: Counter[str] = Counter()
+    for r in records:
+        if r.get("status") == "failure":
+            plugin = r.get("plugin_id") or r.get("plugin") or "unknown"
+            fail_counter[plugin] += 1
+
+    top_failing = [
+        {"plugin": plugin, "count": count}
+        for plugin, count in fail_counter.most_common(5)
+    ]
+
+    return {
+        "total": total,
+        "success": success,
+        "failure": failure,
+        "success_rate": round(success_rate, 4),
+        "p50_duration_ms": p50,
+        "p95_duration_ms": p95,
+        "top_failing": top_failing,
+    }
+
+
+def compute_stats(history_dir: str, window_seconds: int) -> dict:
+    """Return refresh aggregates for the last *window_seconds* seconds.
+
+    Results are cached for 60 seconds per (history_dir, window_seconds) pair.
+
+    Returns
+    -------
+    dict with keys:
+        total, success, failure, success_rate, p50_duration_ms,
+        p95_duration_ms, top_failing
+    """
+    cache_key = (history_dir, window_seconds)
+    now = _now()
+
+    cached_at, cached_result = _cache.get(cache_key, (0.0, {}))
+    if now - cached_at < _CACHE_TTL_SECONDS and cached_result:
+        return cached_result
+
+    since = now - window_seconds
+    records = _load_sidecars(history_dir, since)
+    result = _compute_window(records)
+
+    _cache[cache_key] = (now, result)
+    return result
+
+
+def _clear_cache() -> None:
+    """Evict all cached entries.  Intended for tests only."""
+    _cache.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,6 +250,7 @@ def flask_app(device_config_dev, monkeypatch):
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
     from blueprints.settings import settings_bp
+    from blueprints.stats import stats_bp
     from blueprints.version_info import version_info_bp
     from display.display_manager import DisplayManager
     from plugins.plugin_registry import load_plugins
@@ -310,6 +311,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(history_bp)
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
+    app.register_blueprint(stats_bp)
     app.register_blueprint(version_info_bp)
 
     setup_http_metrics(app)

--- a/tests/test_refresh_stats.py
+++ b/tests/test_refresh_stats.py
@@ -1,0 +1,305 @@
+"""Tests for utils/refresh_stats.py and GET /api/stats.
+
+Covers:
+  - success_rate calculation
+  - P50/P95 from a known distribution
+  - top_failing aggregation
+  - in-process cache: same call within 60 s returns same dict object
+  - GET /api/stats returns 200 with the correct shape
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_sidecar(directory, filename, **kwargs):
+    """Write a JSON sidecar file with the given fields into *directory*."""
+    path = directory / filename
+    path.write_text(json.dumps(kwargs), encoding="utf-8")
+    return path
+
+
+def _make_sidecars(tmp_path, records):
+    """Write a list of sidecar dicts (with auto-generated names) and return the dir."""
+    for i, rec in enumerate(records):
+        _write_sidecar(tmp_path, f"display_{i:04d}.json", **rec)
+    return str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for compute_stats
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStats:
+    def setup_method(self):
+        # Always start each test with a clean cache
+        from utils.refresh_stats import _clear_cache
+
+        _clear_cache()
+
+    def _now_ts(self):
+        return time.time()
+
+    def test_empty_directory(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        result = compute_stats(str(tmp_path), 3600)
+        assert result["total"] == 0
+        assert result["success"] == 0
+        assert result["failure"] == 0
+        assert result["success_rate"] == 0.0
+        assert result["p50_duration_ms"] == 0
+        assert result["p95_duration_ms"] == 0
+        assert result["top_failing"] == []
+
+    def test_success_rate_calculation(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        records = [
+            {"status": "success", "duration_ms": 100, "timestamp": now - 10},
+            {"status": "success", "duration_ms": 200, "timestamp": now - 20},
+            {
+                "status": "failure",
+                "duration_ms": 50,
+                "plugin_id": "clock",
+                "timestamp": now - 30,
+            },
+            {
+                "status": "failure",
+                "duration_ms": 75,
+                "plugin_id": "weather",
+                "timestamp": now - 40,
+            },
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+        result = compute_stats(hist_dir, 3600)
+
+        assert result["total"] == 4
+        assert result["success"] == 2
+        assert result["failure"] == 2
+        assert result["success_rate"] == pytest.approx(0.5, abs=1e-4)
+
+    def test_all_success(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        records = [
+            {"status": "success", "duration_ms": 100, "timestamp": now - 5},
+            {"status": "success", "duration_ms": 150, "timestamp": now - 10},
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+        result = compute_stats(hist_dir, 3600)
+        assert result["success_rate"] == 1.0
+        assert result["failure"] == 0
+        assert result["top_failing"] == []
+
+    def test_p50_p95_known_distribution(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        # 10 values: 100, 200, 300, ... 1000 ms (sorted)
+        records = [
+            {"status": "success", "duration_ms": (i + 1) * 100, "timestamp": now - i}
+            for i in range(10)
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+        result = compute_stats(hist_dir, 3600)
+
+        assert result["total"] == 10
+        # P50 index = int(10 * 50 / 100) = 5 → value at index 5 = 600
+        assert result["p50_duration_ms"] == 600
+        # P95 index = int(10 * 95 / 100) = 9 → value at index 9 = 1000
+        assert result["p95_duration_ms"] == 1000
+
+    def test_top_failing_aggregation(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        records = [
+            {"status": "failure", "plugin_id": "clock", "timestamp": now - 1},
+            {"status": "failure", "plugin_id": "clock", "timestamp": now - 2},
+            {"status": "failure", "plugin_id": "clock", "timestamp": now - 3},
+            {"status": "failure", "plugin_id": "weather", "timestamp": now - 4},
+            {"status": "failure", "plugin_id": "weather", "timestamp": now - 5},
+            {"status": "failure", "plugin_id": "nasa", "timestamp": now - 6},
+            {"status": "success", "plugin_id": "clock", "timestamp": now - 7},
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+        result = compute_stats(hist_dir, 3600)
+
+        top = result["top_failing"]
+        assert len(top) >= 1
+        # clock should be first (3 failures)
+        assert top[0]["plugin"] == "clock"
+        assert top[0]["count"] == 3
+        # weather is second (2 failures)
+        assert top[1]["plugin"] == "weather"
+        assert top[1]["count"] == 2
+        # nasa is third (1 failure)
+        assert top[2]["plugin"] == "nasa"
+        assert top[2]["count"] == 1
+
+    def test_window_filters_old_records(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        records = [
+            # inside 1h window
+            {"status": "success", "duration_ms": 100, "timestamp": now - 1800},
+            # outside 1h but inside 24h
+            {
+                "status": "failure",
+                "plugin_id": "clock",
+                "duration_ms": 200,
+                "timestamp": now - 7200,
+            },
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+
+        result_1h = compute_stats(hist_dir, 3600)
+        assert result_1h["total"] == 1
+        assert result_1h["success"] == 1
+
+        from utils.refresh_stats import _clear_cache
+
+        _clear_cache()
+
+        result_24h = compute_stats(hist_dir, 86400)
+        assert result_24h["total"] == 2
+        assert result_24h["failure"] == 1
+
+    def test_cache_returns_same_dict_within_60s(self, tmp_path, monkeypatch):
+        """Same call within 60 s returns the cached dict without re-reading files."""
+        import utils.refresh_stats as rs
+
+        now_val = time.time()
+        call_count = 0
+
+        original_load = rs._load_sidecars
+
+        def counting_load(hdir, since):
+            nonlocal call_count
+            call_count += 1
+            return original_load(hdir, since)
+
+        monkeypatch.setattr(rs, "_load_sidecars", counting_load)
+
+        # Freeze time so the second call is within the TTL
+        monkeypatch.setattr(rs, "_now", lambda: now_val)
+
+        hist_dir = str(tmp_path)
+        result_first = rs.compute_stats(hist_dir, 3600)
+        result_second = rs.compute_stats(hist_dir, 3600)
+
+        assert call_count == 1, "second call within TTL should hit cache"
+        assert result_first is result_second
+
+    def test_cache_expires_after_ttl(self, tmp_path, monkeypatch):
+        """After the TTL, the next call re-reads the directory."""
+        import utils.refresh_stats as rs
+
+        call_count = 0
+
+        original_load = rs._load_sidecars
+
+        def counting_load(hdir, since):
+            nonlocal call_count
+            call_count += 1
+            return original_load(hdir, since)
+
+        monkeypatch.setattr(rs, "_load_sidecars", counting_load)
+
+        start = time.time()
+        monkeypatch.setattr(rs, "_now", lambda: start)
+        rs.compute_stats(str(tmp_path), 3600)
+
+        # Advance time past the TTL
+        monkeypatch.setattr(rs, "_now", lambda: start + rs._CACHE_TTL_SECONDS + 1)
+        rs.compute_stats(str(tmp_path), 3600)
+
+        assert call_count == 2, "cache should expire after TTL"
+
+    def test_missing_duration_skipped_in_percentiles(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        records = [
+            # no duration_ms field
+            {"status": "success", "timestamp": now - 1},
+            {"status": "success", "duration_ms": 500, "timestamp": now - 2},
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+        result = compute_stats(hist_dir, 3600)
+        assert result["total"] == 2
+        # Only one duration contributed; p50 should be 500
+        assert result["p50_duration_ms"] == 500
+
+    def test_unknown_plugin_id_on_failure(self, tmp_path):
+        from utils.refresh_stats import compute_stats
+
+        now = self._now_ts()
+        records = [
+            {"status": "failure", "timestamp": now - 1},  # no plugin_id
+        ]
+        hist_dir = _make_sidecars(tmp_path, records)
+        result = compute_stats(hist_dir, 3600)
+        assert result["top_failing"][0]["plugin"] == "unknown"
+
+    def test_nonexistent_directory(self):
+        from utils.refresh_stats import compute_stats
+
+        result = compute_stats("/nonexistent/path/xyz123", 3600)
+        assert result["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration test via Flask test client
+# ---------------------------------------------------------------------------
+
+
+class TestApiStatsEndpoint:
+    """Tests for GET /api/stats via the Flask test client."""
+
+    def test_returns_200_with_correct_shape(self, client):
+        resp = client.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data is not None
+        for window in ("last_1h", "last_24h", "last_7d"):
+            assert window in data, f"missing window {window!r}"
+            w = data[window]
+            for key in (
+                "total",
+                "success",
+                "failure",
+                "success_rate",
+                "p50_duration_ms",
+                "p95_duration_ms",
+                "top_failing",
+            ):
+                assert key in w, f"{window} missing key {key!r}"
+            assert isinstance(w["top_failing"], list)
+            assert 0.0 <= w["success_rate"] <= 1.0
+
+    def test_cache_control_header(self, client):
+        resp = client.get("/api/stats")
+        assert resp.status_code == 200
+        cc = resp.headers.get("Cache-Control", "")
+        assert "max-age=60" in cc
+
+    def test_empty_history_returns_zeros(self, client, device_config_dev):
+        """When the history dir is empty all totals should be 0."""
+        resp = client.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["last_1h"]["total"] == 0


### PR DESCRIPTION
## Summary

- Adds `GET /api/stats` returning rolling refresh aggregates for 1h, 24h, and 7d windows
- Each window reports: `total`, `success`, `failure`, `success_rate`, `p50_duration_ms`, `p95_duration_ms`, `top_failing` (top 5 plugins by failure count)
- Computed entirely from existing history JSON sidecar files — no external state or Prometheus dependency
- Results are cached in-process for 60 s (per window) to avoid re-scanning on every request; response carries `Cache-Control: public, max-age=60`

## Test plan

- [x] `TestComputeStats` unit tests: empty dir, success_rate, all-success, P50/P95 known distribution, top_failing aggregation, window filtering, cache hit within TTL, cache expiry after TTL, missing duration, unknown plugin_id, nonexistent directory
- [x] `TestApiStatsEndpoint` integration tests: 200 shape, Cache-Control header, zeros on empty history dir
- [x] 14 new tests; full suite: 2628 passed, 2 pre-existing failures unchanged
- [x] ruff + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)