### PR TITLE
feat: CSP violation report endpoint /api/csp-report

### DIFF
--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -10,6 +10,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.api_docs import api_docs_bp
     from blueprints.apikeys import apikeys_bp
     from blueprints.auth import auth_bp
+    from blueprints.csp_report import csp_report_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
     from blueprints.metrics import metrics_bp
@@ -28,3 +29,4 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
     app.register_blueprint(version_info_bp)
+    app.register_blueprint(csp_report_bp)

--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -256,6 +256,8 @@ def _apply_hsts_header(response) -> None:
 def _apply_csp_header(response, *, dev_mode: bool) -> None:
     """Set the Content-Security-Policy header (report-only in dev mode)."""
     csp_value = os.getenv("INKYPI_CSP") or _DEFAULT_CSP
+    if "report-uri" not in csp_value:
+        csp_value = csp_value.rstrip("; ") + "; report-uri /api/csp-report"
     report_only = dev_mode or _env_bool("INKYPI_CSP_REPORT_ONLY")
     header_name = (
         "Content-Security-Policy-Report-Only"

--- a/src/blueprints/csp_report.py
+++ b/src/blueprints/csp_report.py
@@ -1,0 +1,114 @@
+"""CSP violation report endpoint.
+
+Receives Content-Security-Policy violation reports from browsers and logs
+them as WARNING-level messages with redacted source URLs.
+
+This endpoint intentionally requires NO authentication — browsers cannot
+pass auth headers with CSP reports.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from flask import Blueprint, Response, request
+
+from utils.rate_limiter import SlidingWindowLimiter
+
+logger = logging.getLogger(__name__)
+
+csp_report_bp = Blueprint("csp_report", __name__)
+
+# Allow up to 20 CSP reports per IP per minute — more than enough for
+# legitimate browser reports; blocks flooded or replayed traffic.
+_csp_report_limiter = SlidingWindowLimiter(20, 60)
+
+_SOURCE_FILE_RE = re.compile(r'"source-file"\s*:\s*"([^"]*)"')
+_DOCUMENT_URI_RE = re.compile(r'"document-uri"\s*:\s*"([^"]*)"')
+
+# CSP report content-types (legacy and modern Reporting API)
+_ACCEPTED_CONTENT_TYPES = {
+    "application/csp-report",
+    "application/json",
+    "application/reports+json",
+}
+
+
+def _redact_url(url: str) -> str:
+    """Strip query string and fragment from a URL for safe logging."""
+    # Keep scheme + host + path; drop ?query and #fragment
+    for sep in ("?", "#"):
+        url = url.split(sep)[0]
+    return url
+
+
+def _parse_report(body: bytes) -> dict:
+    """Parse a CSP report body; return an empty dict on failure."""
+    if not body:
+        return {}
+    try:
+        data = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return {}
+
+    # Legacy format: {"csp-report": {...}}
+    if isinstance(data, dict) and "csp-report" in data:
+        return data["csp-report"]
+
+    # Modern Reporting API: [{"type": "csp-violation", "body": {...}}, ...]
+    if isinstance(data, list):
+        for entry in data:
+            if isinstance(entry, dict) and entry.get("type") in (
+                "csp-violation",
+                "csp_violation",
+            ):
+                return entry.get("body", {})
+        # Fall back to first entry body if no typed entry found
+        if data and isinstance(data[0], dict):
+            return data[0].get("body", data[0])
+
+    if isinstance(data, dict):
+        return data
+
+    return {}
+
+
+def _sanitise_report(report: dict) -> dict:
+    """Return a copy of the report with URLs redacted."""
+    sanitised = {}
+    url_keys = {"document-uri", "referrer", "source-file", "blocked-uri"}
+    for key, value in report.items():
+        if key in url_keys and isinstance(value, str):
+            sanitised[key] = _redact_url(value)
+        else:
+            sanitised[key] = value
+    return sanitised
+
+
+@csp_report_bp.route("/api/csp-report", methods=["POST"])
+def receive_csp_report() -> Response:
+    """Accept a CSP violation report and log it.
+
+    Returns 204 No Content unconditionally (do not reveal processing details
+    to potential attackers flooding this endpoint).
+    """
+    addr = request.remote_addr or "unknown"
+    allowed, _ = _csp_report_limiter.check(addr)
+    if not allowed:
+        # Still return 204 — don't fingerprint the rate limiter to browsers
+        return Response(status=204)
+
+    content_type = (request.content_type or "").split(";")[0].strip().lower()
+    if content_type and content_type not in _ACCEPTED_CONTENT_TYPES:
+        logger.debug(
+            "CSP report endpoint received unexpected content-type: %s", content_type
+        )
+
+    body = request.get_data(cache=False)
+    report = _parse_report(body)
+    sanitised = _sanitise_report(report)
+    logger.warning("CSP violation: %s", json.dumps(sanitised))
+
+    return Response(status=204)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,7 @@ def flask_app(device_config_dev, monkeypatch):
 
     from blueprints.api_docs import api_docs_bp
     from blueprints.apikeys import apikeys_bp
+    from blueprints.csp_report import csp_report_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
     from blueprints.metrics import metrics_bp
@@ -311,6 +312,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(api_docs_bp)
     app.register_blueprint(metrics_bp)
     app.register_blueprint(version_info_bp)
+    app.register_blueprint(csp_report_bp)
 
     setup_http_metrics(app)
 

--- a/tests/test_csp_report.py
+++ b/tests/test_csp_report.py
@@ -1,0 +1,256 @@
+# pyright: reportMissingImports=false
+"""Tests for the CSP violation report endpoint (POST /api/csp-report).
+
+Coverage:
+- POST with sample CSP report JSON returns 204
+- Report body is logged via logger.warning
+- Accepts application/csp-report content-type (legacy)
+- Accepts application/json content-type (modern)
+- Empty body returns 204 (don't crash)
+- GET returns 405 Method Not Allowed
+- CSP response header now includes report-uri /api/csp-report
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+SRC_ABS = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if SRC_ABS not in sys.path:
+    sys.path.insert(0, SRC_ABS)
+
+# ---------------------------------------------------------------------------
+# Minimal app fixture (no DB / plugins needed)
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CSP_REPORT = {
+    "csp-report": {
+        "document-uri": "http://localhost/",
+        "referrer": "",
+        "violated-directive": "script-src 'self'",
+        "effective-directive": "script-src",
+        "original-policy": "default-src 'self'",
+        "blocked-uri": "https://evil.example.com/bad.js",
+        "status-code": 0,
+        "source-file": "https://localhost/page?q=secret",
+    }
+}
+
+_MODERN_CSP_REPORT = [
+    {
+        "type": "csp-violation",
+        "age": 0,
+        "url": "https://localhost/",
+        "body": {
+            "documentURL": "https://localhost/",
+            "referrer": "",
+            "blockedURL": "https://evil.example.com/x.js",
+            "effectiveDirective": "script-src-elem",
+            "originalPolicy": "default-src 'self'",
+            "statusCode": 0,
+            "sourceFile": "https://localhost/page",
+            "lineNumber": 42,
+            "columnNumber": 7,
+        },
+    }
+]
+
+
+def _make_csp_app() -> Flask:
+    """Build a bare Flask app with only the CSP report blueprint registered."""
+    app = Flask(__name__)
+    app.secret_key = "test-csp-secret"
+
+    from blueprints.csp_report import csp_report_bp
+
+    app.register_blueprint(csp_report_bp)
+    return app
+
+
+@pytest.fixture()
+def csp_client():
+    return _make_csp_app().test_client()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_post_with_legacy_csp_report_returns_204(csp_client):
+    """POST with application/csp-report and a JSON body returns 204."""
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=json.dumps(_SAMPLE_CSP_REPORT),
+        content_type="application/csp-report",
+    )
+    assert resp.status_code == 204
+
+
+def test_post_with_application_json_returns_204(csp_client):
+    """POST with application/json and a modern report body returns 204."""
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=json.dumps(_MODERN_CSP_REPORT),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+def test_post_logs_warning_via_caplog(caplog, csp_client):
+    """The violation is logged at WARNING level."""
+    with caplog.at_level(logging.WARNING, logger="blueprints.csp_report"):
+        csp_client.post(
+            "/api/csp-report",
+            data=json.dumps(_SAMPLE_CSP_REPORT),
+            content_type="application/csp-report",
+        )
+
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any(
+        "CSP violation" in msg for msg in warning_messages
+    ), f"Expected 'CSP violation' in warning log; got: {warning_messages}"
+
+
+def test_post_logs_report_content(caplog, csp_client):
+    """Logged message includes the violated directive."""
+    with caplog.at_level(logging.WARNING, logger="blueprints.csp_report"):
+        csp_client.post(
+            "/api/csp-report",
+            data=json.dumps(_SAMPLE_CSP_REPORT),
+            content_type="application/csp-report",
+        )
+
+    combined = " ".join(r.message for r in caplog.records)
+    assert "script-src" in combined, f"Expected directive in log; got: {combined}"
+
+
+def test_source_file_url_is_redacted(caplog, csp_client):
+    """Query string is stripped from source-file URLs before logging."""
+    with caplog.at_level(logging.WARNING, logger="blueprints.csp_report"):
+        csp_client.post(
+            "/api/csp-report",
+            data=json.dumps(_SAMPLE_CSP_REPORT),
+            content_type="application/csp-report",
+        )
+
+    combined = " ".join(r.message for r in caplog.records)
+    # The query param "?q=secret" must not appear in the logs
+    assert "secret" not in combined, f"Query string leaked into log: {combined}"
+
+
+def test_empty_body_returns_204(csp_client):
+    """Empty POST body must not crash — returns 204."""
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=b"",
+        content_type="application/csp-report",
+    )
+    assert resp.status_code == 204
+
+
+def test_invalid_json_body_returns_204(csp_client):
+    """Malformed JSON must not crash — returns 204."""
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=b"not-json!!!",
+        content_type="application/csp-report",
+    )
+    assert resp.status_code == 204
+
+
+def test_get_returns_405(csp_client):
+    """GET /api/csp-report must be rejected with 405."""
+    resp = csp_client.get("/api/csp-report")
+    assert resp.status_code == 405
+
+
+def test_csp_header_includes_report_uri(monkeypatch):
+    """The CSP response header must contain 'report-uri /api/csp-report'."""
+    # Clear any custom CSP so we get the default value
+    monkeypatch.delenv("INKYPI_CSP", raising=False)
+    monkeypatch.delenv("INKYPI_CSP_REPORT_ONLY", raising=False)
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+
+    from app_setup.security_middleware import _apply_csp_header
+
+    with app.test_request_context("/"):
+        from flask import Response as FlaskResponse
+
+        resp = FlaskResponse("ok")
+        _apply_csp_header(resp, dev_mode=False)
+
+    csp = resp.headers.get("Content-Security-Policy", "")
+    assert (
+        "report-uri /api/csp-report" in csp
+    ), f"Expected 'report-uri /api/csp-report' in CSP header; got: {csp!r}"
+
+
+def test_csp_header_includes_report_uri_in_report_only_mode(monkeypatch):
+    """report-uri is also present when the Report-Only header is used."""
+    monkeypatch.delenv("INKYPI_CSP", raising=False)
+    monkeypatch.setenv("INKYPI_CSP_REPORT_ONLY", "1")
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+
+    from app_setup.security_middleware import _apply_csp_header
+
+    with app.test_request_context("/"):
+        from flask import Response as FlaskResponse
+
+        resp = FlaskResponse("ok")
+        _apply_csp_header(resp, dev_mode=False)
+
+    csp = resp.headers.get("Content-Security-Policy-Report-Only", "")
+    assert (
+        "report-uri /api/csp-report" in csp
+    ), f"Expected 'report-uri /api/csp-report' in Report-Only CSP; got: {csp!r}"
+
+
+def test_custom_csp_with_existing_report_uri_not_duplicated(monkeypatch):
+    """If INKYPI_CSP already contains 'report-uri', it must not be appended again."""
+    monkeypatch.setenv(
+        "INKYPI_CSP",
+        "default-src 'self'; report-uri /api/csp-report",
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "test"
+
+    from app_setup.security_middleware import _apply_csp_header
+
+    with app.test_request_context("/"):
+        from flask import Response as FlaskResponse
+
+        resp = FlaskResponse("ok")
+        _apply_csp_header(resp, dev_mode=False)
+
+    csp = resp.headers.get("Content-Security-Policy", "")
+    assert (
+        csp.count("report-uri") == 1
+    ), f"'report-uri' must appear exactly once; got: {csp!r}"
+
+
+def test_modern_report_api_returns_204_and_logs(caplog, csp_client):
+    """Modern Reporting API (array payload) is parsed and logged."""
+    with caplog.at_level(logging.WARNING, logger="blueprints.csp_report"):
+        resp = csp_client.post(
+            "/api/csp-report",
+            data=json.dumps(_MODERN_CSP_REPORT),
+            content_type="application/json",
+        )
+
+    assert resp.status_code == 204
+    combined = " ".join(r.message for r in caplog.records)
+    assert "CSP violation" in combined

--- a/tests/unit/test_inkypi.py
+++ b/tests/unit/test_inkypi.py
@@ -474,7 +474,8 @@ def test_csp_headers_default_and_overrides(monkeypatch):
         if "Content-Security-Policy" in r3.headers
         else "Content-Security-Policy-Report-Only"
     )
-    assert r3.headers[header_name] == "default-src 'none'"
+    # The middleware appends report-uri to the custom value
+    assert r3.headers[header_name].startswith("default-src 'none'")
 
 
 # --- Request ID and hot reload ---

--- a/tests/unit/test_security_headers_csp_hsts.py
+++ b/tests/unit/test_security_headers_csp_hsts.py
@@ -44,7 +44,8 @@ def test_csp_enforcement_and_report_only(monkeypatch):
     monkeypatch.setenv("INKYPI_CSP", "default-src 'none'")
     r3 = client.get("/healthz")
     header_name = "Content-Security-Policy"
-    assert r3.headers.get(header_name) == "default-src 'none'"
+    # The middleware appends report-uri to the custom value
+    assert r3.headers.get(header_name, "").startswith("default-src 'none'")
 
 
 def test_hsts_only_under_https_or_forward_proto(monkeypatch):


### PR DESCRIPTION
## Summary

- Add `POST /api/csp-report` blueprint (`src/blueprints/csp_report.py`) that accepts both legacy `application/csp-report` and modern `application/json` / `application/reports+json` content-types
- Logs each report as `WARNING: CSP violation: <json>` with query strings stripped from source-file and document-uri URLs before they hit the log
- Returns 204 No Content unconditionally; no auth required (browsers cannot pass auth headers on CSP reports); per-IP rate limiting via `SlidingWindowLimiter` (20 req/min)
- Appends `; report-uri /api/csp-report` to the existing CSP value in `_apply_csp_header` — additive only, no refactor
- Registers the blueprint in `blueprints_registry.py` and `conftest.py` `flask_app` fixture

## Test plan

- [x] POST with `application/csp-report` returns 204
- [x] POST with `application/json` returns 204
- [x] Violation is logged via `caplog` at WARNING level
- [x] Violated directive appears in log message
- [x] Source-file query strings are redacted before logging
- [x] Empty body returns 204 (no crash)
- [x] Malformed JSON returns 204 (no crash)
- [x] GET returns 405
- [x] CSP header contains `report-uri /api/csp-report` (enforcement mode)
- [x] CSP header contains `report-uri /api/csp-report` (report-only mode)
- [x] Custom CSP with pre-existing `report-uri` is not duplicated
- [x] Modern Reporting API array payload parsed and logged

Full suite: 2626 passed, 2 pre-existing pyenv failures unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)