### PR TITLE
feat: plugin dry-run CLI for offline rendering

### DIFF
--- a/scripts/dry_run_plugin.py
+++ b/scripts/dry_run_plugin.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Dry-run a plugin offline — no display, no refresh task, no web server.
+
+Loads a plugin by ID, calls generate_image() with a mock device config, and
+writes the result to a PNG file. Useful for plugin development, debugging, and
+CI smoke tests.
+
+Usage examples (run from repo root):
+  python scripts/dry_run_plugin.py --plugin year_progress
+  python scripts/dry_run_plugin.py --plugin clock --width 640 --height 400
+  python scripts/dry_run_plugin.py --plugin year_progress --config /tmp/my_settings.json
+  python scripts/dry_run_plugin.py --plugin weather --output /tmp/weather.png
+"""
+
+import argparse
+import json
+import os
+import sys
+from time import perf_counter
+
+# Ensure src/ is on the import path (script may be run from any directory)
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC_DIR = os.path.join(REPO_ROOT, "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+
+class _MockDeviceConfig:
+    """Minimal device-config stub that satisfies BasePlugin.generate_image().
+
+    Only the accessors used by the base plugin and most concrete plugins are
+    implemented; everything else returns the supplied default.
+    """
+
+    def __init__(self, width: int, height: int, orientation: str, timezone: str):
+        self._width = width
+        self._height = height
+        self._orientation = orientation
+        self._timezone = timezone
+
+    def get_resolution(self):
+        return (self._width, self._height)
+
+    def get_config(self, key, default=None):
+        mapping: dict = {
+            "orientation": self._orientation,
+            "timezone": self._timezone,
+            "time_format": "12h",
+            "image_settings": {},
+        }
+        return mapping.get(key, default)
+
+    def load_env_key(self, key: str):
+        """Return the real env var so plugins that need keys can still work."""
+        return os.environ.get(key)
+
+
+def _discover_plugin_config(plugin_id: str) -> dict:
+    """Read plugin-info.json from the plugin's source directory.
+
+    Returns a minimal config dict suitable for passing to load_plugins().
+    """
+    plugins_dir = os.path.join(SRC_DIR, "plugins")
+    info_path = os.path.join(plugins_dir, plugin_id, "plugin-info.json")
+    if not os.path.isfile(info_path):
+        sys.exit(
+            f"ERROR: No plugin-info.json found for '{plugin_id}' at {info_path}\n"
+            "Check that --plugin matches a directory name under src/plugins/."
+        )
+    with open(info_path, encoding="utf-8") as f:
+        info = json.load(f)
+
+    plugin_class = info.get("class")
+    if not plugin_class:
+        sys.exit(
+            f"ERROR: plugin-info.json for '{plugin_id}' is missing the 'class' field."
+        )
+
+    return {
+        "id": plugin_id,
+        "class": plugin_class,
+        "display_name": info.get("display_name", plugin_id),
+        "api_version": info.get("api_version"),
+        "version": info.get("version"),
+    }
+
+
+def _load_settings(config_path: str | None) -> dict:
+    """Load plugin instance settings from a JSON file, or return empty dict."""
+    if not config_path:
+        return {}
+    if not os.path.isfile(config_path):
+        sys.exit(f"ERROR: --config path not found: {config_path}")
+    with open(config_path, encoding="utf-8") as f:
+        settings = json.load(f)
+    if not isinstance(settings, dict):
+        sys.exit(
+            f"ERROR: --config file must contain a JSON object, got {type(settings)}"
+        )
+    return settings
+
+
+def _default_output_path(plugin_id: str) -> str:
+    from datetime import datetime
+
+    ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+    return f"dry-run-{plugin_id}-{ts}.png"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Dry-run a plugin offline and write the result to a PNG."
+    )
+    parser.add_argument(
+        "--plugin",
+        required=True,
+        metavar="PLUGIN_ID",
+        help="Plugin ID (directory name under src/plugins/), e.g. year_progress",
+    )
+    parser.add_argument(
+        "--instance",
+        metavar="NAME",
+        default=None,
+        help="(Informational) Instance name — logged but not used for rendering.",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Output PNG path. Defaults to ./dry-run-<plugin>-<timestamp>.png",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=800,
+        help="Display width in pixels (default: 800)",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=480,
+        help="Display height in pixels (default: 480)",
+    )
+    parser.add_argument(
+        "--orientation",
+        default="horizontal",
+        choices=["horizontal", "vertical"],
+        help="Display orientation (default: horizontal)",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="America/New_York",
+        metavar="TZ",
+        help="Timezone name passed to the plugin (default: America/New_York)",
+    )
+    parser.add_argument(
+        "--config",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to a JSON file containing plugin instance settings "
+            "(key/value pairs). These override any device.json lookup."
+        ),
+    )
+    args = parser.parse_args()
+
+    plugin_id: str = args.plugin
+    output_path: str = args.output or _default_output_path(plugin_id)
+    instance_label: str = args.instance or plugin_id
+
+    print(f"[dry-run] Plugin   : {plugin_id}")
+    print(f"[dry-run] Instance : {instance_label}")
+    print(f"[dry-run] Canvas   : {args.width}x{args.height} ({args.orientation})")
+    print(f"[dry-run] Timezone : {args.timezone}")
+    print(f"[dry-run] Output   : {output_path}")
+
+    # Discover plugin metadata
+    plugin_config = _discover_plugin_config(plugin_id)
+
+    # Load plugin instance settings (may be empty)
+    settings = _load_settings(args.config)
+    if settings:
+        print(f"[dry-run] Settings : {list(settings.keys())}")
+    else:
+        print("[dry-run] Settings : (none — using plugin defaults)")
+
+    # Register the plugin with the registry so get_plugin_instance() works
+    from plugins.plugin_registry import get_plugin_instance, load_plugins
+
+    load_plugins([plugin_config])
+
+    # Build a mock device config
+    device_config = _MockDeviceConfig(
+        width=args.width,
+        height=args.height,
+        orientation=args.orientation,
+        timezone=args.timezone,
+    )
+
+    # Run generate_image() and time it
+    print("[dry-run] Running generate_image()…")
+    t0 = perf_counter()
+    plugin_instance = get_plugin_instance(plugin_config)
+    image = plugin_instance.generate_image(settings, device_config)
+    elapsed_ms = int((perf_counter() - t0) * 1000)
+
+    if image is None:
+        sys.exit("ERROR: Plugin returned None instead of an image.")
+
+    # Save the result
+    out_dir = os.path.dirname(os.path.abspath(output_path))
+    os.makedirs(out_dir, exist_ok=True)
+    image.save(output_path)
+
+    print(f"[dry-run] Done in {elapsed_ms} ms")
+    print(f"[dry-run] Image size : {image.width}x{image.height} px")
+    print(f"[dry-run] Saved to   : {os.path.abspath(output_path)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -518,9 +518,7 @@ def test_plugin_page_instance_url_plus_encoding_decoded_correctly(
     assert resp.status_code == 200
 
 
-def test_plugin_page_instance_nonexistent_returns_friendly_404(
-    client, device_config_dev
-):
+def test_plugin_page_instance_nonexistent_returns_friendly_404(client, device_config_dev):
     """GET /plugin/<id>?instance=<missing> returns 404 with a descriptive message (JTN-221)."""
     resp = client.get("/plugin/weather?instance=nonexistent instance")
     assert resp.status_code == 404

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -518,7 +518,9 @@ def test_plugin_page_instance_url_plus_encoding_decoded_correctly(
     assert resp.status_code == 200
 
 
-def test_plugin_page_instance_nonexistent_returns_friendly_404(client, device_config_dev):
+def test_plugin_page_instance_nonexistent_returns_friendly_404(
+    client, device_config_dev
+):
     """GET /plugin/<id>?instance=<missing> returns 404 with a descriptive message (JTN-221)."""
     resp = client.get("/plugin/weather?instance=nonexistent instance")
     assert resp.status_code == 404

--- a/tests/test_dry_run_plugin.py
+++ b/tests/test_dry_run_plugin.py
@@ -1,0 +1,235 @@
+# pyright: reportMissingImports=false
+"""Tests for scripts/dry_run_plugin.py — the offline plugin dry-run CLI."""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _import_dry_run():
+    """Import the dry_run_plugin script as a module (adds src/ to sys.path)."""
+    repo_root = Path(__file__).parent.parent
+    script_path = repo_root / "scripts" / "dry_run_plugin.py"
+    spec = importlib.util.spec_from_file_location("dry_run_plugin", script_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="session")
+def dry_run_mod():
+    """Session-scoped import of dry_run_plugin to share across tests."""
+    return _import_dry_run()
+
+
+# ── unit: _MockDeviceConfig ──────────────────────────────────────────────────
+
+
+def test_mock_device_config_get_resolution(dry_run_mod):
+    cfg = dry_run_mod._MockDeviceConfig(1200, 600, "horizontal", "UTC")
+    assert cfg.get_resolution() == (1200, 600)
+
+
+def test_mock_device_config_orientation(dry_run_mod):
+    cfg = dry_run_mod._MockDeviceConfig(800, 480, "vertical", "UTC")
+    assert cfg.get_config("orientation") == "vertical"
+
+
+def test_mock_device_config_timezone(dry_run_mod):
+    cfg = dry_run_mod._MockDeviceConfig(800, 480, "horizontal", "Europe/London")
+    assert cfg.get_config("timezone") == "Europe/London"
+
+
+def test_mock_device_config_missing_key_returns_default(dry_run_mod):
+    cfg = dry_run_mod._MockDeviceConfig(800, 480, "horizontal", "UTC")
+    assert cfg.get_config("does_not_exist", default="fallback") == "fallback"
+    assert cfg.get_config("does_not_exist") is None
+
+
+def test_mock_device_config_load_env_key(dry_run_mod, monkeypatch):
+    monkeypatch.setenv("MY_TEST_KEY", "secret_value")
+    cfg = dry_run_mod._MockDeviceConfig(800, 480, "horizontal", "UTC")
+    assert cfg.load_env_key("MY_TEST_KEY") == "secret_value"
+
+
+# ── unit: _discover_plugin_config ────────────────────────────────────────────
+
+
+def test_discover_plugin_config_year_progress(dry_run_mod):
+    cfg = dry_run_mod._discover_plugin_config("year_progress")
+    assert cfg["id"] == "year_progress"
+    assert cfg["class"] == "YearProgress"
+
+
+def test_discover_plugin_config_missing_plugin_exits(dry_run_mod):
+    with pytest.raises(SystemExit):
+        dry_run_mod._discover_plugin_config("plugin_does_not_exist_xyz")
+
+
+# ── unit: _load_settings ─────────────────────────────────────────────────────
+
+
+def test_load_settings_no_config(dry_run_mod):
+    assert dry_run_mod._load_settings(None) == {}
+
+
+def test_load_settings_valid_json(dry_run_mod, tmp_path):
+    cfg_file = tmp_path / "settings.json"
+    cfg_file.write_text(json.dumps({"selectedFrame": "None", "style": "dark"}))
+    result = dry_run_mod._load_settings(str(cfg_file))
+    assert result == {"selectedFrame": "None", "style": "dark"}
+
+
+def test_load_settings_missing_file_exits(dry_run_mod, tmp_path):
+    with pytest.raises(SystemExit):
+        dry_run_mod._load_settings(str(tmp_path / "nonexistent.json"))
+
+
+def test_load_settings_non_object_exits(dry_run_mod, tmp_path):
+    cfg_file = tmp_path / "bad.json"
+    cfg_file.write_text(json.dumps(["a", "b", "c"]))
+    with pytest.raises(SystemExit):
+        dry_run_mod._load_settings(str(cfg_file))
+
+
+# ── integration: year_progress generates a PNG ───────────────────────────────
+
+
+def test_year_progress_produces_png(dry_run_mod, tmp_path):
+    """Run generate_image() via the dry-run helpers and verify a PNG is created."""
+    from plugins.plugin_registry import get_plugin_instance, load_plugins
+
+    plugin_config = dry_run_mod._discover_plugin_config("year_progress")
+    load_plugins([plugin_config])
+
+    device_config = dry_run_mod._MockDeviceConfig(800, 480, "horizontal", "UTC")
+    plugin_instance = get_plugin_instance(plugin_config)
+    image = plugin_instance.generate_image({}, device_config)
+
+    output = tmp_path / "out.png"
+    image.save(str(output))
+
+    assert output.exists(), "PNG was not saved"
+    loaded = Image.open(output)
+    assert loaded.width == 800
+    assert loaded.height == 480
+
+
+def test_year_progress_custom_dimensions(dry_run_mod, tmp_path):
+    """Verify that the mock device config's resolution flows through to the image."""
+    from plugins.plugin_registry import get_plugin_instance, load_plugins
+
+    plugin_config = dry_run_mod._discover_plugin_config("year_progress")
+    load_plugins([plugin_config])
+
+    device_config = dry_run_mod._MockDeviceConfig(640, 400, "horizontal", "UTC")
+    plugin_instance = get_plugin_instance(plugin_config)
+    image = plugin_instance.generate_image({}, device_config)
+
+    output = tmp_path / "out_640.png"
+    image.save(str(output))
+
+    assert output.exists()
+    loaded = Image.open(output)
+    assert loaded.width == 640
+    assert loaded.height == 400
+
+
+def test_year_progress_config_override(dry_run_mod, tmp_path):
+    """--config JSON override is loaded and passed as settings to generate_image()."""
+    from plugins.plugin_registry import get_plugin_instance, load_plugins
+
+    # Write a settings file that year_progress will silently accept (unknown keys are ok)
+    settings = {"selectedFrame": "None", "custom_option": "value"}
+    cfg_file = tmp_path / "settings.json"
+    cfg_file.write_text(json.dumps(settings))
+
+    loaded_settings = dry_run_mod._load_settings(str(cfg_file))
+    assert loaded_settings == settings
+
+    plugin_config = dry_run_mod._discover_plugin_config("year_progress")
+    load_plugins([plugin_config])
+
+    device_config = dry_run_mod._MockDeviceConfig(800, 480, "horizontal", "UTC")
+    plugin_instance = get_plugin_instance(plugin_config)
+
+    # generate_image must succeed even with extra/unknown settings keys
+    image = plugin_instance.generate_image(loaded_settings, device_config)
+    assert isinstance(image, Image.Image)
+
+
+# ── integration: main() end-to-end via argv patching ─────────────────────────
+
+
+def test_main_writes_png_for_year_progress(tmp_path, monkeypatch):
+    """Call main() directly with year_progress and verify the PNG is created."""
+    output = tmp_path / "result.png"
+    test_argv = [
+        "dry_run_plugin.py",
+        "--plugin",
+        "year_progress",
+        "--output",
+        str(output),
+        "--width",
+        "800",
+        "--height",
+        "480",
+        "--timezone",
+        "UTC",
+    ]
+    with patch.object(sys, "argv", test_argv):
+        mod = _import_dry_run()
+        mod.main()
+
+    assert output.exists(), f"Expected PNG at {output}"
+    img = Image.open(output)
+    assert img.width == 800
+    assert img.height == 480
+
+
+def test_main_respects_config_override(tmp_path, monkeypatch):
+    """main() passes the --config JSON into generate_image settings."""
+    output = tmp_path / "result_cfg.png"
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({"selectedFrame": "None"}))
+
+    test_argv = [
+        "dry_run_plugin.py",
+        "--plugin",
+        "year_progress",
+        "--output",
+        str(output),
+        "--config",
+        str(settings_file),
+    ]
+    with patch.object(sys, "argv", test_argv):
+        mod = _import_dry_run()
+        mod.main()
+
+    assert output.exists()
+
+
+def test_main_default_output_path(tmp_path, monkeypatch):
+    """When --output is omitted the file is created in the cwd."""
+    # Change working directory to tmp_path so the default path lands there
+    monkeypatch.chdir(tmp_path)
+
+    test_argv = [
+        "dry_run_plugin.py",
+        "--plugin",
+        "year_progress",
+    ]
+    with patch.object(sys, "argv", test_argv):
+        mod = _import_dry_run()
+        mod.main()
+
+    pngs = list(tmp_path.glob("dry-run-year_progress-*.png"))
+    assert len(pngs) == 1, f"Expected one auto-named PNG, found: {pngs}"

--- a/tests/test_dry_run_plugin.py
+++ b/tests/test_dry_run_plugin.py
@@ -20,7 +20,7 @@ def _import_dry_run():
     spec = importlib.util.spec_from_file_location("dry_run_plugin", script_path)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    spec.loader.exec_module(mod)
     return mod
 
 


### PR DESCRIPTION
## Summary

- Add `scripts/dry_run_plugin.py` — a zero-dependency CLI that loads any plugin by ID, calls `generate_image()` via a lightweight `_MockDeviceConfig` stub, and writes the PNG to disk without touching the display, refresh task, or web server
- Supports `--plugin`, `--output`, `--width`, `--height`, `--orientation`, `--timezone`, and `--config` (path to a JSON file of plugin instance settings)
- Plugin discovery is done via each plugin's `plugin-info.json`; the registry is loaded lazily exactly as in production

## Test plan

- [ ] 17 new tests in `tests/test_dry_run_plugin.py` — all passing
  - Unit: `_MockDeviceConfig` API, `_discover_plugin_config`, `_load_settings` (valid/missing/non-object)
  - Integration: `year_progress` produces a PNG at the correct pixel dimensions (800×480, 640×400)
  - Integration: `--config` JSON override flows through to `generate_image()`
  - End-to-end: `main()` saves to `--output`, respects `--config`, auto-names file when `--output` omitted
- [ ] Full suite: 2631 passed (2 pre-existing env failures unrelated to this PR)
- [ ] Lint: ruff + black both clean

## Usage

```bash
# From repo root
python scripts/dry_run_plugin.py --plugin year_progress
python scripts/dry_run_plugin.py --plugin clock --width 640 --height 400 --output /tmp/clock.png
python scripts/dry_run_plugin.py --plugin year_progress --config /tmp/my_settings.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool to perform offline testing of plugins with custom configurations and output path options.

* **Tests**
  * Added comprehensive test suite for the new plugin testing tool, including validation of plugin discovery, configuration loading, and image generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->