### PR TITLE
feat: seed test data CLI for dev environments

### DIFF
--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Populate a dev InkyPi environment with sample plugin instances, playlists,
+and history images + sidecar JSON files.
+
+Usage:
+    python scripts/seed_test_data.py --target-dir /tmp/inkypi-dev \\
+        [--count 20] [--reset]
+
+Safety:
+    Refuses to run if --target-dir resolves to anywhere under src/config, or
+    if a device.json found there has no dev marker (display_type != "mock").
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parent
+_SRC_CONFIG = (_PROJECT_ROOT / "src" / "config").resolve()
+
+# History image dimensions matching default InkyPi resolution
+_IMG_WIDTH = 800
+_IMG_HEIGHT = 480
+
+# Palette of solid colours for synthetic history images
+_COLOURS = [
+    (30, 144, 255),  # dodger-blue
+    (255, 99, 71),  # tomato
+    (60, 179, 113),  # medium-sea-green
+    (255, 215, 0),  # gold
+    (147, 112, 219),  # medium-purple
+    (255, 165, 0),  # orange
+    (64, 224, 208),  # turquoise
+    (220, 20, 60),  # crimson
+    (0, 191, 255),  # deep-sky-blue
+    (154, 205, 50),  # yellow-green
+]
+
+# Sample plugin instances to seed
+_SAMPLE_PLUGINS = [
+    {
+        "plugin_id": "year_progress",
+        "name": "Year Progress",
+        "plugin_settings": {
+            "style": "bar",
+            "show_percentage": True,
+            "show_days_remaining": True,
+        },
+        "refresh": {"interval": 3600},
+        "latest_refresh_time": None,
+    },
+    {
+        "plugin_id": "weather",
+        "name": "Weather",
+        "plugin_settings": {
+            "weatherProvider": "OpenMeteo",
+            "location": "New York, NY",
+            "latitude": "40.7128",
+            "longitude": "-74.0060",
+            "unit": "fahrenheit",
+            "apiKey": "PLACEHOLDER_API_KEY",
+        },
+        "refresh": {"interval": 1800},
+        "latest_refresh_time": None,
+    },
+    {
+        "plugin_id": "calendar",
+        "name": "Calendar",
+        "plugin_settings": {
+            "calendarUrl": "https://example.com/calendar.ics",
+            "showWeekNumbers": False,
+            "firstDayOfWeek": "monday",
+            "maxEvents": 5,
+        },
+        "refresh": {"interval": 900},
+        "latest_refresh_time": None,
+    },
+]
+
+_SAMPLE_PLAYLIST = {
+    "name": "Seed Playlist",
+    "start_time": "00:00",
+    "end_time": "24:00",
+    "plugins": _SAMPLE_PLUGINS,
+    "current_plugin_index": 0,
+}
+
+# ---------------------------------------------------------------------------
+# Safety helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(path: str) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _is_under_src_config(target: Path) -> bool:
+    """Return True if *target* is equal to or nested inside src/config."""
+    try:
+        target.relative_to(_SRC_CONFIG)
+    except ValueError:
+        return False
+    return True
+
+
+def _has_dev_marker(target: Path) -> bool:
+    """
+    Return True if the target directory looks like a dev environment.
+
+    Heuristic: a device.json whose display_type is "mock" is a dev device.
+    If no device.json exists at all we also allow seeding (empty target dir).
+    """
+    device_json = target / "device.json"
+    if not device_json.exists():
+        return True  # no config yet — safe to seed
+    try:
+        data = json.loads(device_json.read_text(encoding="utf-8"))
+    except Exception:
+        return False  # unreadable JSON — refuse
+    # Refuse if dev key is explicitly False
+    if data.get("dev") is False:
+        return False
+    # Refuse if display_type is a real hardware driver
+    display_type = data.get("display_type", "")
+    return not (display_type and display_type not in ("mock",))
+
+
+def _safety_check(target: Path) -> None:
+    """Raise SystemExit with a message if the target is unsafe."""
+    if _is_under_src_config(target):
+        sys.exit(
+            f"ERROR: --target-dir resolves to {target}, which is under "
+            f"src/config ({_SRC_CONFIG}). Refusing to seed production config."
+        )
+    if not _has_dev_marker(target):
+        sys.exit(
+            f"ERROR: {target}/device.json does not have a dev marker "
+            "(display_type must be 'mock'). Refusing to seed."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_image(colour: tuple[int, int, int]):
+    """Create a solid-colour 800x480 PIL Image."""
+    try:
+        from PIL import Image
+    except ImportError:
+        sys.exit("ERROR: Pillow is required. Install it with: pip install Pillow")
+    img = Image.new("RGB", (_IMG_WIDTH, _IMG_HEIGHT), colour)
+    return img
+
+
+def _ts_filename(dt: datetime) -> str:
+    return f"display_{dt.strftime('%Y%m%d_%H%M%S')}"
+
+
+def _seed_history(
+    history_dir: Path,
+    count: int,
+    *,
+    idempotent: bool = True,
+) -> int:
+    """Write *count* PNG + sidecar JSON pairs under *history_dir*.
+
+    Returns the number of entries actually written (0 if already present and
+    idempotent=True).
+    """
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    # Idempotency marker: check for any seed-generated files
+    existing = list(history_dir.glob("display_*.png"))
+    if idempotent and existing:
+        return 0
+
+    now = datetime.now(tz=UTC)
+    interval = timedelta(days=7) / max(count, 1)
+    statuses = ["success", "success", "success", "failure"]  # 75% success
+
+    written = 0
+    for i in range(count):
+        dt = now - timedelta(days=7) + interval * i
+        stem = _ts_filename(dt)
+        colour = _COLOURS[i % len(_COLOURS)]
+        img = _make_image(colour)
+        png_path = history_dir / f"{stem}.png"
+        img.save(str(png_path), format="PNG")
+
+        status = statuses[i % len(statuses)]
+        plugin_id = _SAMPLE_PLUGINS[i % len(_SAMPLE_PLUGINS)]["plugin_id"]
+        sidecar = {
+            "plugin_id": plugin_id,
+            "plugin_name": _SAMPLE_PLUGINS[i % len(_SAMPLE_PLUGINS)]["name"],
+            "status": status,
+            "timestamp": dt.isoformat(),
+            "error": "Simulated failure for testing" if status == "failure" else None,
+            "refresh_type": "Scheduled",
+        }
+        (history_dir / f"{stem}.json").write_text(
+            json.dumps(sidecar, indent=2), encoding="utf-8"
+        )
+        written += 1
+
+    return written
+
+
+def _seed_device_config(
+    target: Path,
+    *,
+    idempotent: bool = True,
+) -> tuple[int, int]:
+    """Write (or update) device.json with sample plugins + playlist.
+
+    Returns (plugins_written, playlists_written).
+    """
+    device_json = target / "device.json"
+
+    if device_json.exists():
+        try:
+            data = json.loads(device_json.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+    else:
+        data = {
+            "name": "InkyPi Dev (seeded)",
+            "display_type": "mock",
+            "resolution": [800, 480],
+            "orientation": "horizontal",
+        }
+
+    playlist_config = data.get("playlist_config", {})
+    playlists = playlist_config.get("playlists", [])
+
+    plugins_written = 0
+    playlists_written = 0
+
+    if idempotent:
+        playlist_names = {p.get("name") for p in playlists}
+        if _SAMPLE_PLAYLIST["name"] in playlist_names:
+            return 0, 0
+
+    playlists.append(_SAMPLE_PLAYLIST)
+    playlist_config["playlists"] = playlists
+    if not playlist_config.get("active_playlist"):
+        playlist_config["active_playlist"] = _SAMPLE_PLAYLIST["name"]
+    data["playlist_config"] = playlist_config
+
+    target.mkdir(parents=True, exist_ok=True)
+    device_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    plugins_written = len(_SAMPLE_PLUGINS)
+    playlists_written = 1
+    return plugins_written, playlists_written
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed a dev InkyPi environment with sample data.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--target-dir",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Directory to seed (must NOT be src/config; must contain a "
+            "device.json with display_type=mock or be empty)."
+        ),
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Number of synthetic history PNG+sidecar pairs to generate (default: 20).",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Wipe the target directory before seeding (non-idempotent full reset).",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+
+    target = _resolve(args.target_dir)
+    _safety_check(target)
+
+    if args.reset and target.exists():
+        shutil.rmtree(target)
+        print(f"Reset: wiped {target}")
+
+    target.mkdir(parents=True, exist_ok=True)
+
+    # Seed device config (plugins + playlist)
+    plugins_written, playlists_written = _seed_device_config(
+        target, idempotent=not args.reset
+    )
+
+    # Seed history
+    history_dir = target / "history"
+    history_written = _seed_history(history_dir, args.count, idempotent=not args.reset)
+
+    # Summary
+    print(f"Target:            {target}")
+    print(f"Plugin instances:  {plugins_written}")
+    print(f"Playlists:         {playlists_written}")
+    print(f"History entries:   {history_written}")
+    if plugins_written == 0 and playlists_written == 0 and history_written == 0:
+        print("(already seeded — use --reset to re-seed)")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_seed_test_data.py
+++ b/tests/test_seed_test_data.py
@@ -1,0 +1,235 @@
+"""Tests for scripts/seed_test_data.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helper: load the script without polluting sys.path
+# ---------------------------------------------------------------------------
+
+
+def _load_script():
+    scripts_dir = Path(__file__).parent.parent / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        "seed_test_data", scripts_dir / "seed_test_data.py"
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def seed_mod():
+    return _load_script()
+
+
+# ---------------------------------------------------------------------------
+# Helpers used across tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_device_json(directory: Path) -> None:
+    """Write a minimal mock-display device.json into *directory*."""
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "device.json").write_text(
+        json.dumps({"display_type": "mock", "name": "Test"}), encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic seeding: expected files are created
+# ---------------------------------------------------------------------------
+
+
+class TestBasicSeed:
+    def test_creates_history_pngs(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        history_dir = tmp_path / "history"
+        pngs = list(history_dir.glob("display_*.png"))
+        assert len(pngs) == 5
+
+    def test_creates_history_sidecars(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        history_dir = tmp_path / "history"
+        jsons = list(history_dir.glob("display_*.json"))
+        assert len(jsons) == 5
+
+    def test_creates_device_json(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        device_json = tmp_path / "device.json"
+        assert device_json.exists()
+
+    def test_device_json_has_playlist(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        data = json.loads((tmp_path / "device.json").read_text())
+        playlists = data["playlist_config"]["playlists"]
+        assert len(playlists) >= 1
+        assert playlists[0]["name"] == "Seed Playlist"
+
+    def test_device_json_has_plugins(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        data = json.loads((tmp_path / "device.json").read_text())
+        plugins = data["playlist_config"]["playlists"][0]["plugins"]
+        plugin_ids = {p["plugin_id"] for p in plugins}
+        assert "year_progress" in plugin_ids
+        assert "weather" in plugin_ids
+        assert "calendar" in plugin_ids
+
+    def test_no_real_api_keys(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        raw = (tmp_path / "device.json").read_text()
+        # Any real-looking credential would be a long alphanumeric string;
+        # the placeholder must be clearly labelled.
+        assert "PLACEHOLDER" in raw
+
+    def test_default_count_is_20(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path)])
+        history_dir = tmp_path / "history"
+        pngs = list(history_dir.glob("display_*.png"))
+        assert len(pngs) == 20
+
+
+# ---------------------------------------------------------------------------
+# Sidecar JSON validity
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarJson:
+    def test_sidecar_is_valid_json(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        history_dir = tmp_path / "history"
+        for sidecar in history_dir.glob("display_*.json"):
+            data = json.loads(sidecar.read_text())
+            assert isinstance(data, dict)
+
+    def test_sidecar_has_required_fields(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        history_dir = tmp_path / "history"
+        for sidecar in history_dir.glob("display_*.json"):
+            data = json.loads(sidecar.read_text())
+            assert "plugin_id" in data
+            assert "status" in data
+            assert "timestamp" in data
+
+    def test_sidecar_status_values(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "8"])
+        history_dir = tmp_path / "history"
+        statuses = set()
+        for sidecar in history_dir.glob("display_*.json"):
+            data = json.loads(sidecar.read_text())
+            assert data["status"] in ("success", "failure")
+            statuses.add(data["status"])
+        # With 8 entries we expect both success and failure to appear
+        assert "success" in statuses
+        assert "failure" in statuses
+
+    def test_png_and_sidecar_stems_match(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        history_dir = tmp_path / "history"
+        png_stems = {p.stem for p in history_dir.glob("display_*.png")}
+        json_stems = {j.stem for j in history_dir.glob("display_*.json")}
+        assert png_stems == json_stems
+
+
+# ---------------------------------------------------------------------------
+# Safety: refuse src/config target
+# ---------------------------------------------------------------------------
+
+
+class TestSafety:
+    def test_refuses_src_config(self, seed_mod):
+        src_config = str(Path(__file__).parent.parent / "src" / "config")
+        with pytest.raises(SystemExit) as exc_info:
+            seed_mod.run(["--target-dir", src_config, "--count", "1"])
+        assert exc_info.value.code != 0
+
+    def test_refuses_nested_under_src_config(self, seed_mod):
+        nested = str(Path(__file__).parent.parent / "src" / "config" / "subdir")
+        with pytest.raises(SystemExit) as exc_info:
+            seed_mod.run(["--target-dir", nested, "--count", "1"])
+        assert exc_info.value.code != 0
+
+    def test_refuses_non_mock_device_json(self, seed_mod, tmp_path):
+        (tmp_path / "device.json").write_text(
+            json.dumps({"display_type": "inky", "name": "Prod"}), encoding="utf-8"
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            seed_mod.run(["--target-dir", str(tmp_path), "--count", "1"])
+        assert exc_info.value.code != 0
+
+    def test_refuses_dev_false(self, seed_mod, tmp_path):
+        (tmp_path / "device.json").write_text(
+            json.dumps({"display_type": "mock", "dev": False}), encoding="utf-8"
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            seed_mod.run(["--target-dir", str(tmp_path), "--count", "1"])
+        assert exc_info.value.code != 0
+
+    def test_allows_empty_target_dir(self, seed_mod, tmp_path):
+        # No device.json at all — should be safe
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "2"])
+        assert (tmp_path / "history").exists()
+
+    def test_allows_mock_device_json(self, seed_mod, tmp_path):
+        _make_mock_device_json(tmp_path)
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "2"])
+        assert (tmp_path / "history").exists()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: second run is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_second_run_no_extra_pngs(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        history_dir = tmp_path / "history"
+        pngs = list(history_dir.glob("display_*.png"))
+        assert len(pngs) == 5
+
+    def test_second_run_no_extra_playlists(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        data = json.loads((tmp_path / "device.json").read_text())
+        playlists = data["playlist_config"]["playlists"]
+        seed_playlists = [p for p in playlists if p["name"] == "Seed Playlist"]
+        assert len(seed_playlists) == 1
+
+
+# ---------------------------------------------------------------------------
+# --reset: wipes and reseeds
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_wipes_history(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "5"])
+        # Add a stray file that --reset should remove
+        (tmp_path / "history" / "stray_file.png").write_bytes(b"")
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3", "--reset"])
+        history_dir = tmp_path / "history"
+        pngs = list(history_dir.glob("display_*.png"))
+        assert len(pngs) == 3
+        assert not (history_dir / "stray_file.png").exists()
+
+    def test_reset_reseeds_different_count(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "10"])
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "4", "--reset"])
+        history_dir = tmp_path / "history"
+        pngs = list(history_dir.glob("display_*.png"))
+        assert len(pngs) == 4
+
+    def test_reset_reseeds_playlist(self, seed_mod, tmp_path):
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3"])
+        seed_mod.run(["--target-dir", str(tmp_path), "--count", "3", "--reset"])
+        data = json.loads((tmp_path / "device.json").read_text())
+        playlists = data["playlist_config"]["playlists"]
+        seed_playlists = [p for p in playlists if p["name"] == "Seed Playlist"]
+        assert len(seed_playlists) == 1


### PR DESCRIPTION
## Summary

- Adds `scripts/seed_test_data.py` — a CLI tool that populates a dev InkyPi target directory with realistic sample data for screenshotting, dogfooding, and reproducible UI testing
- Generates 3 plugin instances (year_progress, weather, calendar), 1 playlist, and N synthetic history PNG + sidecar JSON pairs (default 20) spread over the last 7 days with a mix of success/failure statuses
- Idempotent by default; `--reset` wipes and reseeds; safety check refuses to run against `src/config` or any directory whose `device.json` has `display_type != mock`
- Adds 22 tests in `tests/test_seed_test_data.py` covering basic seeding, sidecar JSON validity, safety guards, idempotency, and `--reset` behaviour

## Usage

```bash
python scripts/seed_test_data.py --target-dir /tmp/inkypi-dev --count 20
python scripts/seed_test_data.py --target-dir /tmp/inkypi-dev --reset
```

## Test plan

- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/test_seed_test_data.py` — 22 passed
- [x] Full suite: 2636 passed, 2 pre-existing pyenv failures unrelated to this PR
- [x] `bash scripts/lint.sh` — ruff and black both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)