### PR TITLE
feat: add GET /api/screenshot endpoint (JTN-450)

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -100,6 +100,46 @@ def preview_image():
     return maybe_serve_webp(safe_root, filename, request.headers.get("Accept"))
 
 
+@main_bp.route("/api/screenshot", methods=["GET"])
+def screenshot():
+    """Return the current display image as PNG or WebP (JTN-450).
+
+    Prefer the processed image; fall back to current_image_file.  Supports
+    content negotiation via the Accept header (WebP when advertised), conditional
+    GET via If-Modified-Since / 304, and sets Cache-Control: no-cache so
+    monitoring dashboards always poll for fresh content.
+    """
+    device_config = current_app.config["DEVICE_CONFIG"]
+    path = device_config.processed_image_file
+    if not os.path.exists(path):
+        path = device_config.current_image_file
+    if not os.path.exists(path):
+        return json_error("No display image available yet", status=404)
+
+    abs_path = os.path.abspath(path)
+
+    # Conditional GET — If-Modified-Since
+    file_mtime = int(os.path.getmtime(abs_path))
+    last_modified = datetime.fromtimestamp(file_mtime, tz=UTC)
+    last_modified_str = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    if_modified_since = request.headers.get("If-Modified-Since")
+    if if_modified_since:
+        try:
+            client_mtime = parsedate_to_datetime(if_modified_since)
+            if int(client_mtime.timestamp()) >= file_mtime:
+                return "", 304
+        except (ValueError, OSError):
+            pass
+
+    safe_root = os.path.dirname(abs_path)
+    filename = os.path.basename(abs_path)
+    response = maybe_serve_webp(safe_root, filename, request.headers.get("Accept"))
+    response.headers["Last-Modified"] = last_modified_str
+    response.headers["Cache-Control"] = "no-cache, must-revalidate"
+    return response
+
+
 @main_bp.route("/api/current_image", methods=["GET"])
 def get_current_image():
     """Serve current_image.png with conditional request support (If-Modified-Since) for polling."""

--- a/tests/test_screenshot_endpoint.py
+++ b/tests/test_screenshot_endpoint.py
@@ -1,0 +1,132 @@
+"""Tests for GET /api/screenshot (JTN-450)."""
+
+from __future__ import annotations
+
+import os
+from email.utils import formatdate
+
+from PIL import Image
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_png(path: str) -> None:
+    """Write a minimal 4x4 PNG to *path*."""
+    img = Image.new("RGB", (4, 4), color=(10, 20, 30))
+    img.save(path, format="PNG")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_screenshot_returns_200_with_png(client, device_config_dev):
+    """GET /api/screenshot returns 200 with image/png when no WebP Accept."""
+    _write_png(device_config_dev.processed_image_file)
+
+    rv = client.get("/api/screenshot")
+
+    assert rv.status_code == 200
+    assert rv.content_type.startswith("image/")
+
+
+def test_screenshot_returns_webp_when_accepted(client, device_config_dev):
+    """GET /api/screenshot returns WebP when client sends Accept: image/webp."""
+    _write_png(device_config_dev.processed_image_file)
+
+    rv = client.get("/api/screenshot", headers={"Accept": "image/webp,*/*;q=0.8"})
+
+    assert rv.status_code == 200
+    assert rv.content_type == "image/webp"
+    data = rv.data
+    assert data[:4] == b"RIFF"
+    assert data[8:12] == b"WEBP"
+
+
+def test_screenshot_returns_png_when_webp_not_accepted(client, device_config_dev):
+    """GET /api/screenshot returns PNG when Accept header does not include WebP."""
+    _write_png(device_config_dev.processed_image_file)
+
+    rv = client.get("/api/screenshot", headers={"Accept": "image/png,*/*"})
+
+    assert rv.status_code == 200
+    assert rv.content_type.startswith("image/png")
+
+
+def test_screenshot_404_when_no_image(client, device_config_dev):
+    """GET /api/screenshot returns 404 when neither image file exists."""
+    # Ensure neither file exists (they shouldn't in a fresh tmp_path fixture).
+    for p in (
+        device_config_dev.processed_image_file,
+        device_config_dev.current_image_file,
+    ):
+        if os.path.exists(p):
+            os.remove(p)
+
+    rv = client.get("/api/screenshot")
+
+    assert rv.status_code == 404
+
+
+def test_screenshot_falls_back_to_current_image(client, device_config_dev):
+    """GET /api/screenshot uses current_image_file when processed is absent."""
+    # Ensure processed image is absent, then write only the fallback file.
+    processed = device_config_dev.processed_image_file
+    if os.path.exists(processed):
+        os.remove(processed)
+    _write_png(device_config_dev.current_image_file)
+
+    rv = client.get("/api/screenshot")
+
+    assert rv.status_code == 200
+    assert rv.content_type.startswith("image/")
+
+
+def test_screenshot_last_modified_header_present(client, device_config_dev):
+    """GET /api/screenshot includes a Last-Modified header."""
+    _write_png(device_config_dev.processed_image_file)
+
+    rv = client.get("/api/screenshot")
+
+    assert rv.status_code == 200
+    assert "Last-Modified" in rv.headers
+
+
+def test_screenshot_cache_control_no_cache(client, device_config_dev):
+    """GET /api/screenshot includes Cache-Control: no-cache, must-revalidate."""
+    _write_png(device_config_dev.processed_image_file)
+
+    rv = client.get("/api/screenshot")
+
+    assert rv.status_code == 200
+    cc = rv.headers.get("Cache-Control", "")
+    assert "no-cache" in cc
+    assert "must-revalidate" in cc
+
+
+def test_screenshot_304_when_not_modified(client, device_config_dev):
+    """GET /api/screenshot returns 304 when If-Modified-Since >= file mtime."""
+    _write_png(device_config_dev.processed_image_file)
+
+    # Fetch once to learn Last-Modified.
+    rv1 = client.get("/api/screenshot")
+    assert rv1.status_code == 200
+    last_modified = rv1.headers["Last-Modified"]
+
+    # Second request with the exact same timestamp should yield 304.
+    rv2 = client.get("/api/screenshot", headers={"If-Modified-Since": last_modified})
+    assert rv2.status_code == 304
+
+
+def test_screenshot_200_when_modified_since_older(client, device_config_dev):
+    """GET /api/screenshot returns 200 when If-Modified-Since is older than file."""
+    _write_png(device_config_dev.processed_image_file)
+
+    # Use a date far in the past.
+    old_date = formatdate(0, usegmt=True)  # 1970-01-01 00:00:00 GMT
+
+    rv = client.get("/api/screenshot", headers={"If-Modified-Since": old_date})
+    assert rv.status_code == 200


### PR DESCRIPTION
## Summary

- Adds `GET /api/screenshot` to `src/blueprints/main.py` that returns the current display image as PNG or WebP
- Prefers `processed_image_file`; falls back to `current_image_file`; returns 404 if neither exists
- Reuses `maybe_serve_webp` from JTN-302 for content negotiation (WebP when `Accept: image/webp` is present)
- Sets `Cache-Control: no-cache, must-revalidate` and `Last-Modified` header
- Honors `If-Modified-Since` for conditional GET (returns 304 when file unchanged)
- No auth required — endpoint is embeddable in monitoring dashboards and status pages

## Test plan

- [x] `GET /api/screenshot` returns 200 with image content-type
- [x] Returns `image/webp` when `Accept: image/webp` is in the request
- [x] Returns `image/png` when WebP is not in Accept header
- [x] Returns 404 when neither image file exists
- [x] Falls back to `current_image_file` when `processed_image_file` is absent
- [x] `Last-Modified` header is present
- [x] `Cache-Control` includes `no-cache` and `must-revalidate`
- [x] Returns 304 when `If-Modified-Since` matches or is newer than file mtime
- [x] Returns 200 when `If-Modified-Since` is older than file mtime
- [x] Full test suite: 2789 passed (2 pre-existing pyenv env failures unrelated to this change)
- [x] ruff + black clean

Closes JTN-450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added screenshot API endpoint with HTTP conditional request support (304 Not Modified responses) for improved browser caching efficiency and automatic image format negotiation between PNG and WebP based on client capabilities.

## Tests
- Added comprehensive test coverage for the new screenshot endpoint, including conditional request handling and content format negotiation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->