### PR TITLE
feat: image diff utility for history comparison (JTN-452)

### DIFF
--- a/scripts/image_diff.py
+++ b/scripts/image_diff.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Compare two PNG images and report pixel-level differences.
+
+Usage:
+    python scripts/image_diff.py IMAGE_A IMAGE_B
+    python scripts/image_diff.py IMAGE_A IMAGE_B --output /tmp/diff.png
+    python scripts/image_diff.py IMAGE_A IMAGE_B --threshold 10
+    python scripts/image_diff.py IMAGE_A IMAGE_B --summary-only
+    python scripts/image_diff.py IMAGE_A IMAGE_B --json
+
+Reports:
+  - Total pixel count
+  - Changed pixel count (pixels where max channel delta > threshold)
+  - Change percentage
+  - Maximum channel delta found
+
+Writes a diff PNG: image A with changed pixels overlaid in red at 50% alpha.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+def load_images(path_a: str, path_b: str) -> tuple[Image.Image, Image.Image]:
+    """Load both images, converting to RGBA for consistent channel handling."""
+    img_a = Image.open(path_a).convert("RGBA")
+    img_b = Image.open(path_b).convert("RGBA")
+    return img_a, img_b
+
+
+def resize_to_match(img_a: Image.Image, img_b: Image.Image) -> Image.Image:
+    """Resize img_b to match img_a dimensions if they differ."""
+    if img_b.size != img_a.size:
+        img_b = img_b.resize(img_a.size, Image.LANCZOS)
+    return img_b
+
+
+def compute_diff(
+    img_a: Image.Image, img_b: Image.Image, threshold: int
+) -> tuple[int, int, int]:
+    """
+    Compute per-pixel difference statistics.
+
+    Returns:
+        (total_pixels, changed_pixels, max_channel_delta)
+    """
+    pixels_a = img_a.load()
+    pixels_b = img_b.load()
+    width, height = img_a.size
+    total_pixels = width * height
+
+    changed_pixels = 0
+    max_channel_delta = 0
+
+    for y in range(height):
+        for x in range(width):
+            pa = pixels_a[x, y]  # type: ignore[index]
+            pb = pixels_b[x, y]  # type: ignore[index]
+            # Compare only RGB channels (ignore alpha for "changed" determination)
+            channel_delta = max(abs(int(pa[c]) - int(pb[c])) for c in range(3))
+            if channel_delta > max_channel_delta:
+                max_channel_delta = channel_delta
+            if channel_delta > threshold:
+                changed_pixels += 1
+
+    return total_pixels, changed_pixels, max_channel_delta
+
+
+def build_diff_image(
+    img_a: Image.Image, img_b: Image.Image, threshold: int
+) -> Image.Image:
+    """
+    Build a visual diff image: img_a with changed pixels overlaid in red at 50% alpha.
+
+    Changed pixels are those where any RGB channel differs by more than threshold.
+    """
+    pixels_a = img_a.load()
+    pixels_b = img_b.load()
+    width, height = img_a.size
+
+    # Start with a copy of img_a
+    diff_img = img_a.copy()
+    diff_pixels = diff_img.load()
+
+    # Red overlay pixel (R=255, G=0, B=0, A=128 for 50% alpha blended into RGBA)
+    for y in range(height):
+        for x in range(width):
+            pa = pixels_a[x, y]  # type: ignore[index]
+            pb = pixels_b[x, y]  # type: ignore[index]
+            channel_delta = max(abs(int(pa[c]) - int(pb[c])) for c in range(3))
+            if channel_delta > threshold:
+                # Blend 50% red over the original pixel
+                r = int(pa[0] * 0.5 + 255 * 0.5)
+                g = int(pa[1] * 0.5 + 0 * 0.5)
+                b = int(pa[2] * 0.5 + 0 * 0.5)
+                a = pa[3]
+                diff_pixels[x, y] = (r, g, b, a)  # type: ignore[index]
+
+    return diff_img
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare two PNG images and report pixel-level differences."
+    )
+    parser.add_argument("IMAGE_A", help="Path to the first (reference) image")
+    parser.add_argument("IMAGE_B", help="Path to the second (comparison) image")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="./diff.png",
+        help="Output path for the diff PNG (default: ./diff.png)",
+    )
+    parser.add_argument(
+        "--threshold",
+        "-t",
+        type=int,
+        default=5,
+        help="Per-channel difference threshold (default: 5). Pixels with max channel "
+        "delta <= threshold are treated as unchanged.",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Print statistics only; skip writing the diff PNG.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output statistics as JSON instead of human-readable text.",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> dict:
+    """
+    Main entry point. Returns a dict with diff statistics.
+
+    Useful for programmatic use and testing.
+    """
+    args = parse_args(argv)
+
+    img_a, img_b = load_images(args.IMAGE_A, args.IMAGE_B)
+    img_b = resize_to_match(img_a, img_b)
+
+    total_pixels, changed_pixels, max_channel_delta = compute_diff(
+        img_a, img_b, args.threshold
+    )
+    change_pct = (changed_pixels / total_pixels * 100) if total_pixels > 0 else 0.0
+
+    stats = {
+        "image_a": args.IMAGE_A,
+        "image_b": args.IMAGE_B,
+        "total_pixels": total_pixels,
+        "changed_pixels": changed_pixels,
+        "change_percentage": round(change_pct, 4),
+        "max_channel_delta": max_channel_delta,
+        "threshold": args.threshold,
+        "diff_output": None if args.summary_only else args.output,
+    }
+
+    if not args.summary_only:
+        diff_img = build_diff_image(img_a, img_b, args.threshold)
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        diff_img.save(output_path)
+        stats["diff_output"] = str(output_path)
+
+    if args.json_output:
+        print(json.dumps(stats, indent=2))
+    else:
+        print(f"Image A:           {args.IMAGE_A}")
+        print(f"Image B:           {args.IMAGE_B}")
+        print(f"Total pixels:      {total_pixels:,}")
+        print(f"Changed pixels:    {changed_pixels:,}")
+        print(f"Change percentage: {change_pct:.4f}%")
+        print(f"Max channel delta: {max_channel_delta}")
+        if not args.summary_only:
+            print(f"Diff image:        {stats['diff_output']}")
+
+    return stats
+
+
+if __name__ == "__main__":
+    run(sys.argv[1:])

--- a/tests/test_image_diff.py
+++ b/tests/test_image_diff.py
@@ -1,0 +1,242 @@
+"""Tests for scripts/image_diff.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+# ---------------------------------------------------------------------------
+# Module loader
+# ---------------------------------------------------------------------------
+
+
+def _load_script(script_name: str):
+    """Load a scripts/ module by file path, avoiding sys.path pollution."""
+    scripts_dir = Path(__file__).parent.parent / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        script_name, scripts_dir / f"{script_name}.py"
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def imdiff():
+    """Return the image_diff module."""
+    return _load_script("image_diff")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _solid_image(color: tuple, size: tuple = (10, 10)) -> Image.Image:
+    """Create a solid-color RGBA image."""
+    img = Image.new("RGBA", size, color)
+    return img
+
+
+def _save_image(img: Image.Image, path: Path) -> Path:
+    """Save PIL image to path and return path as str-compatible."""
+    img.save(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests (compute_diff, build_diff_image, resize_to_match)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiff:
+    def test_identical_images_zero_changed(self, imdiff):
+        img = _solid_image((100, 150, 200, 255))
+        total, changed, max_delta = imdiff.compute_diff(img, img, threshold=5)
+        assert changed == 0
+        assert total == 100  # 10x10
+        assert max_delta == 0
+
+    def test_completely_different_images(self, imdiff):
+        img_a = _solid_image((0, 0, 0, 255))
+        img_b = _solid_image((255, 255, 255, 255))
+        total, changed, max_delta = imdiff.compute_diff(img_a, img_b, threshold=5)
+        assert changed == total
+        assert max_delta == 255
+
+    def test_single_pixel_changed(self, imdiff):
+        size = (5, 5)
+        img_a = _solid_image((100, 100, 100, 255), size)
+        # Create img_b with one pixel changed significantly
+        img_b = img_a.copy()
+        pixels = img_b.load()
+        pixels[2, 2] = (200, 100, 100, 255)  # channel delta = 100 > threshold 5
+        total, changed, max_delta = imdiff.compute_diff(img_a, img_b, threshold=5)
+        assert changed == 1
+        assert total == 25
+        assert max_delta == 100
+
+    def test_below_threshold_treated_as_unchanged(self, imdiff):
+        img_a = _solid_image((100, 100, 100, 255))
+        img_b = _solid_image((103, 100, 100, 255))  # delta = 3, threshold = 5
+        total, changed, max_delta = imdiff.compute_diff(img_a, img_b, threshold=5)
+        assert changed == 0
+        assert max_delta == 3
+
+    def test_exactly_at_threshold_treated_as_unchanged(self, imdiff):
+        img_a = _solid_image((100, 100, 100, 255))
+        img_b = _solid_image((105, 100, 100, 255))  # delta = 5, threshold = 5
+        _total, changed, _max_delta = imdiff.compute_diff(img_a, img_b, threshold=5)
+        assert changed == 0
+
+    def test_one_above_threshold_treated_as_changed(self, imdiff):
+        img_a = _solid_image((100, 100, 100, 255))
+        img_b = _solid_image((106, 100, 100, 255))  # delta = 6 > threshold 5
+        _total, changed, _max_delta = imdiff.compute_diff(img_a, img_b, threshold=5)
+        assert changed == 100  # all 10x10 pixels changed
+
+
+class TestResizeToMatch:
+    def test_same_size_no_resize(self, imdiff):
+        img_a = _solid_image((0, 0, 0, 255), (20, 30))
+        img_b = _solid_image((255, 255, 255, 255), (20, 30))
+        result = imdiff.resize_to_match(img_a, img_b)
+        assert result.size == (20, 30)
+
+    def test_different_size_resizes_b(self, imdiff):
+        img_a = _solid_image((0, 0, 0, 255), (20, 30))
+        img_b = _solid_image((255, 255, 255, 255), (40, 60))
+        result = imdiff.resize_to_match(img_a, img_b)
+        assert result.size == img_a.size
+
+
+class TestBuildDiffImage:
+    def test_diff_image_same_size_as_a(self, imdiff):
+        img_a = _solid_image((100, 100, 100, 255), (8, 8))
+        img_b = _solid_image((200, 100, 100, 255), (8, 8))  # all pixels differ
+        diff = imdiff.build_diff_image(img_a, img_b, threshold=5)
+        assert isinstance(diff, Image.Image)
+        assert diff.size == img_a.size
+
+    def test_identical_images_diff_matches_original(self, imdiff):
+        img_a = _solid_image((100, 150, 200, 255), (6, 6))
+        diff = imdiff.build_diff_image(img_a, img_a, threshold=5)
+        # No changed pixels — diff should look the same as img_a
+        assert diff.tobytes() == img_a.tobytes()
+
+    def test_changed_pixels_get_red_tint(self, imdiff):
+        img_a = _solid_image((0, 0, 0, 255), (4, 4))
+        img_b = _solid_image((255, 255, 255, 255), (4, 4))
+        diff = imdiff.build_diff_image(img_a, img_b, threshold=5)
+        pixels = diff.load()
+        r, g, b, _a = pixels[0, 0]
+        # Red channel should be elevated (50% blend of 0 + 255 = ~127)
+        assert r > 100
+        # Green and blue should be low (50% blend of 0 + 0)
+        assert g == 0
+        assert b == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via run()
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_identical_images_zero_percent(self, imdiff, tmp_path):
+        img = _solid_image((128, 64, 32, 255), (10, 10))
+        path_a = str(_save_image(img, tmp_path / "a.png"))
+        path_b = str(_save_image(img, tmp_path / "b.png"))
+
+        stats = imdiff.run([path_a, path_b, "--summary-only"])
+        assert stats["changed_pixels"] == 0
+        assert stats["change_percentage"] == 0.0
+
+    def test_single_pixel_changed_count_one(self, imdiff, tmp_path):
+        size = (5, 5)
+        img_a = _solid_image((50, 50, 50, 255), size)
+        img_b = img_a.copy()
+        px = img_b.load()
+        px[0, 0] = (200, 50, 50, 255)  # big change at one pixel
+
+        path_a = str(_save_image(img_a, tmp_path / "a.png"))
+        path_b = str(_save_image(img_b, tmp_path / "b.png"))
+
+        stats = imdiff.run([path_a, path_b, "--summary-only"])
+        assert stats["changed_pixels"] == 1
+        assert stats["total_pixels"] == 25
+
+    def test_below_threshold_no_change(self, imdiff, tmp_path):
+        img_a = _solid_image((100, 100, 100, 255))
+        img_b = _solid_image((102, 100, 100, 255))  # delta=2 < threshold=5
+        path_a = str(_save_image(img_a, tmp_path / "a.png"))
+        path_b = str(_save_image(img_b, tmp_path / "b.png"))
+
+        stats = imdiff.run([path_a, path_b, "--summary-only"])
+        assert stats["changed_pixels"] == 0
+
+    def test_resize_handling(self, imdiff, tmp_path):
+        img_a = _solid_image((0, 0, 0, 255), (10, 10))
+        img_b = _solid_image((0, 0, 0, 255), (20, 20))  # different size
+        path_a = str(_save_image(img_a, tmp_path / "a.png"))
+        path_b = str(_save_image(img_b, tmp_path / "b.png"))
+
+        stats = imdiff.run([path_a, path_b, "--summary-only"])
+        assert stats["total_pixels"] == 100  # resized to 10x10
+
+    def test_diff_png_output_is_valid(self, imdiff, tmp_path):
+        img_a = _solid_image((10, 20, 30, 255), (8, 8))
+        img_b = _solid_image((200, 20, 30, 255), (8, 8))
+        path_a = str(_save_image(img_a, tmp_path / "a.png"))
+        path_b = str(_save_image(img_b, tmp_path / "b.png"))
+        out = str(tmp_path / "diff.png")
+
+        stats = imdiff.run([path_a, path_b, "--output", out])
+        assert Path(out).exists()
+        diff_img = Image.open(out)
+        assert diff_img.size == (8, 8)
+        assert stats["diff_output"] == out
+
+    def test_summary_only_skips_png_write(self, imdiff, tmp_path):
+        img = _solid_image((0, 0, 0, 255))
+        path = str(_save_image(img, tmp_path / "img.png"))
+        out = str(tmp_path / "should_not_exist.png")
+
+        stats = imdiff.run([path, path, "--output", out, "--summary-only"])
+        assert not Path(out).exists()
+        assert stats["diff_output"] is None
+
+    def test_json_output_format(self, imdiff, tmp_path, capsys):
+        img = _solid_image((10, 10, 10, 255))
+        path = str(_save_image(img, tmp_path / "img.png"))
+
+        stats = imdiff.run([path, path, "--summary-only", "--json"])
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+
+        assert "total_pixels" in parsed
+        assert "changed_pixels" in parsed
+        assert "change_percentage" in parsed
+        assert "max_channel_delta" in parsed
+        assert "threshold" in parsed
+        assert parsed["changed_pixels"] == 0
+        # Returned dict should match printed JSON
+        assert parsed["total_pixels"] == stats["total_pixels"]
+
+    def test_custom_threshold_applied(self, imdiff, tmp_path):
+        img_a = _solid_image((100, 100, 100, 255))
+        img_b = _solid_image((110, 100, 100, 255))  # delta=10
+        path_a = str(_save_image(img_a, tmp_path / "a.png"))
+        path_b = str(_save_image(img_b, tmp_path / "b.png"))
+
+        # With threshold=5: delta 10 > 5 → all pixels changed
+        stats_low = imdiff.run([path_a, path_b, "--threshold", "5", "--summary-only"])
+        assert stats_low["changed_pixels"] == 100
+
+        # With threshold=15: delta 10 <= 15 → no pixels changed
+        stats_high = imdiff.run([path_a, path_b, "--threshold", "15", "--summary-only"])
+        assert stats_high["changed_pixels"] == 0


### PR DESCRIPTION
## Summary

- Adds `scripts/image_diff.py` — a standalone CLI tool that compares two PNG files and reports pixel-level differences
- Reports: total pixels, changed pixel count, change percentage, max channel delta
- Writes a visual diff PNG with changed pixels overlaid in red at 50% alpha
- Supports `--threshold N` (per-channel delta threshold, default 5), `--summary-only` (skip PNG write), `--json` (machine-readable output), `--output PATH`
- Automatically resizes image B to match image A if dimensions differ

## Test plan

- [x] Identical images → 0% changed
- [x] Single pixel changed → count = 1
- [x] Below-threshold differences → 0% changed
- [x] Exactly at threshold → treated as unchanged
- [x] Resize handling (B resized to match A)
- [x] Diff PNG output is a valid image with correct size
- [x] `--summary-only` skips PNG write
- [x] `--json` flag outputs parseable JSON with all expected keys
- [x] Custom threshold applied correctly (19 tests, all passing)
- [x] Lint clean (ruff + black)

Closes JTN-452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line image comparison tool that performs pixel-level analysis of PNG images.
  * Generates diff statistics including changed pixels, change percentage, and maximum channel delta.
  * Optionally creates a visual diff image highlighting detected differences.
  * Supports JSON output and configurable comparison thresholds.
  * Automatically resizes images to matching dimensions for comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->