### PR TITLE
feat: validate plugin output dimensions before display (JTN-455)

### DIFF
--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -26,6 +26,7 @@ from utils.metrics import (
     record_refresh_success,
     set_circuit_breaker_open,
 )
+from utils.output_validator import OutputDimensionMismatch, validate_image_dimensions
 from utils.progress import ProgressTracker, track_progress
 from utils.progress_events import get_progress_bus
 from utils.time_utils import now_device_tz
@@ -374,6 +375,55 @@ class RefreshTask:
         )
         if image is None:
             raise RuntimeError("Plugin returned None image; cannot refresh display.")
+
+        # Validate dimensions before doing anything expensive (hash / display push).
+        expected_w, expected_h = self.device_config.get_resolution()
+        try:
+            image = validate_image_dimensions(
+                image,
+                expected_w,
+                expected_h,
+                plugin_id=plugin_id,
+            )
+        except OutputDimensionMismatch as exc:
+            logger.error(
+                "plugin_lifecycle: dimension_mismatch | plugin_id=%s instance=%s "
+                "expected=%dx%d actual=%dx%d — skipping display push",
+                plugin_id,
+                instance_name,
+                exc.expected[0],
+                exc.expected[1],
+                exc.actual[0],
+                exc.actual[1],
+            )
+            self._update_plugin_health(
+                plugin_id=plugin_id,
+                instance=instance_name,
+                ok=False,
+                metrics={"retained_display": bool(self._stale_display_path())},
+                error=str(exc),
+            )
+            self.progress_bus.publish(
+                {
+                    "state": "error",
+                    "plugin_id": plugin_id,
+                    "instance": instance_name,
+                    "refresh_id": benchmark_id,
+                    "request_id": request_id,
+                    "error": str(exc),
+                    "retained_display": bool(self._stale_display_path()),
+                }
+            )
+            self.event_bus.publish(
+                "plugin_failed",
+                {
+                    "plugin": instance_name or plugin_id,
+                    "plugin_id": plugin_id,
+                    "error": str(exc),
+                },
+            )
+            return None, False, {}
+
         image_hash = compute_image_hash(image)
 
         refresh_info = refresh_action.get_refresh_info()

--- a/src/utils/output_validator.py
+++ b/src/utils/output_validator.py
@@ -1,0 +1,101 @@
+"""Output validation utilities for plugin-generated images."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class OutputDimensionMismatch(Exception):
+    """Raised when a plugin returns an image with unexpected dimensions.
+
+    Attributes:
+        plugin_id: The identifier of the offending plugin.
+        expected: The (width, height) expected from device.json.
+        actual: The (width, height) of the image that was returned.
+    """
+
+    def __init__(
+        self,
+        plugin_id: str,
+        expected: tuple[int, int],
+        actual: tuple[int, int],
+    ) -> None:
+        self.plugin_id = plugin_id
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"Plugin '{plugin_id}' returned image with wrong dimensions: "
+            f"expected {expected[0]}x{expected[1]}, got {actual[0]}x{actual[1]}"
+        )
+
+
+def validate_image_dimensions(
+    image,
+    expected_width: int,
+    expected_height: int,
+    plugin_id: str = "<unknown>",
+    *,
+    auto_rotate: bool = True,
+) -> object:
+    """Validate that *image* matches the expected display resolution.
+
+    Parameters
+    ----------
+    image:
+        A ``PIL.Image.Image`` object returned by a plugin.
+    expected_width:
+        The display width taken from device.json (pixels).
+    expected_height:
+        The display height taken from device.json (pixels).
+    plugin_id:
+        Human-readable plugin identifier used in error messages.
+    auto_rotate:
+        When ``True`` (default), attempt a 90-degree rotation if the image
+        dimensions are transposed (i.e., actual width == expected height and
+        actual height == expected width).  If the rotation fixes the mismatch
+        the corrected image is returned without raising.  Set to ``False`` to
+        disable this behaviour.
+
+    Returns
+    -------
+    image
+        The original image if dimensions match, or a rotated copy if
+        ``auto_rotate=True`` and the transposed dimensions match.
+
+    Raises
+    ------
+    OutputDimensionMismatch
+        If the image dimensions do not match the expected values (and cannot
+        be corrected by rotation when ``auto_rotate=True``).
+    """
+    actual_width, actual_height = image.size
+
+    if actual_width == expected_width and actual_height == expected_height:
+        return image
+
+    # Check whether a 90-degree rotation would fix the mismatch.
+    if (
+        auto_rotate
+        and actual_width == expected_height
+        and actual_height == expected_width
+    ):
+        logger.info(
+            "output_validator: auto-rotating image for plugin '%s' "
+            "(%dx%d -> %dx%d to match display resolution %dx%d)",
+            plugin_id,
+            actual_width,
+            actual_height,
+            actual_height,
+            actual_width,
+            expected_width,
+            expected_height,
+        )
+        return image.rotate(90, expand=True)
+
+    raise OutputDimensionMismatch(
+        plugin_id=plugin_id,
+        expected=(expected_width, expected_height),
+        actual=(actual_width, actual_height),
+    )

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -253,7 +253,7 @@ class TestRefreshTaskHooks:
         # Provide a minimal plugin config and stub _execute_with_policy to return an image
         from PIL import Image
 
-        img = Image.new("RGB", (100, 100), "white")
+        img = Image.new("RGB", device_config_dev.get_resolution(), "white")
 
         monkeypatch.setattr(task, "_execute_with_policy", lambda *a, **kw: (img, {}))
         monkeypatch.setattr(task, "_push_to_display", lambda *a, **kw: (10, 5))

--- a/tests/unit/test_output_validator.py
+++ b/tests/unit/test_output_validator.py
@@ -1,0 +1,128 @@
+# pyright: reportMissingImports=false
+"""Tests for utils.output_validator — dimension validation of plugin images."""
+
+import pytest
+from PIL import Image
+
+from utils.output_validator import OutputDimensionMismatch, validate_image_dimensions
+
+# ---------------------------------------------------------------------------
+# Unit tests for validate_image_dimensions
+# ---------------------------------------------------------------------------
+
+
+def _img(w: int, h: int) -> Image.Image:
+    return Image.new("RGB", (w, h), color="white")
+
+
+class TestValidateImageDimensions:
+    def test_matching_dims_returns_same_image(self):
+        img = _img(800, 480)
+        result = validate_image_dimensions(img, 800, 480, plugin_id="test_plugin")
+        assert result is img
+
+    def test_wrong_width_raises(self):
+        img = _img(640, 480)
+        with pytest.raises(OutputDimensionMismatch) as exc_info:
+            validate_image_dimensions(img, 800, 480, plugin_id="bad_plugin")
+        err = exc_info.value
+        assert err.plugin_id == "bad_plugin"
+        assert err.expected == (800, 480)
+        assert err.actual == (640, 480)
+        assert "bad_plugin" in str(err)
+        assert "800x480" in str(err)
+        assert "640x480" in str(err)
+
+    def test_wrong_height_raises(self):
+        img = _img(800, 600)
+        with pytest.raises(OutputDimensionMismatch) as exc_info:
+            validate_image_dimensions(img, 800, 480, plugin_id="tall_plugin")
+        err = exc_info.value
+        assert err.expected == (800, 480)
+        assert err.actual == (800, 600)
+
+    def test_both_dims_wrong_raises(self):
+        img = _img(100, 100)
+        with pytest.raises(OutputDimensionMismatch):
+            validate_image_dimensions(img, 800, 480, plugin_id="tiny_plugin")
+
+    def test_auto_rotate_transposed_dims(self):
+        # Image is 480x800 but display expects 800x480 — should auto-rotate.
+        img = _img(480, 800)
+        result = validate_image_dimensions(img, 800, 480, plugin_id="rotated_plugin")
+        assert result.size == (800, 480)
+
+    def test_auto_rotate_disabled_raises_on_transposed(self):
+        img = _img(480, 800)
+        with pytest.raises(OutputDimensionMismatch):
+            validate_image_dimensions(
+                img, 800, 480, plugin_id="rotated_plugin", auto_rotate=False
+            )
+
+    def test_default_plugin_id_in_error_message(self):
+        img = _img(100, 100)
+        with pytest.raises(OutputDimensionMismatch) as exc_info:
+            validate_image_dimensions(img, 800, 480)
+        assert "<unknown>" in str(exc_info.value)
+
+
+class TestOutputDimensionMismatch:
+    def test_attributes(self):
+        err = OutputDimensionMismatch("my_plugin", (800, 480), (640, 400))
+        assert err.plugin_id == "my_plugin"
+        assert err.expected == (800, 480)
+        assert err.actual == (640, 400)
+
+    def test_is_exception(self):
+        err = OutputDimensionMismatch("p", (1, 2), (3, 4))
+        assert isinstance(err, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Integration: RefreshTask skips display push on dimension mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_task_skips_display_on_dimension_mismatch(
+    device_config_dev, monkeypatch
+):
+    """When a plugin returns an image with wrong dimensions the display should
+    NOT be updated and plugin health should be marked as failure."""
+    from display.display_manager import DisplayManager
+    from refresh_task import ManualRefresh, RefreshTask
+
+    dm = DisplayManager(device_config_dev)
+    task = RefreshTask(device_config_dev, dm)
+
+    expected_w, expected_h = device_config_dev.get_resolution()
+    # Build a wrong-sized image (neither matching nor auto-rotatable).
+    bad_image = Image.new("RGB", (expected_w + 10, expected_h + 10), "red")
+
+    display_called = []
+
+    def _fake_execute_with_policy(
+        refresh_action, plugin_config, current_dt, request_id=None
+    ):
+        return bad_image, None
+
+    def _fake_display_image(image, **kwargs):
+        display_called.append(image)
+        return {}
+
+    monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "none")
+    monkeypatch.setattr(task, "_execute_with_policy", _fake_execute_with_policy)
+    monkeypatch.setattr(dm, "display_image", _fake_display_image)
+
+    try:
+        task.start()
+        task.manual_update(ManualRefresh("ai_text", {}))
+    except Exception:
+        pass  # The mismatch causes _perform_refresh to return early — manual_update may raise
+    finally:
+        task.stop()
+
+    assert display_called == [], "display_image must not be called for mismatched image"
+    health = task.plugin_health.get("ai_text", {})
+    assert (
+        health.get("status") == "red"
+    ), "plugin health should be red after dimension mismatch"


### PR DESCRIPTION
## Summary

- Adds `OutputDimensionMismatch` exception and `validate_image_dimensions()` helper in `src/utils/output_validator.py`
- Wires validation in `RefreshTask._perform_refresh` between `generate()` and the display push — dimension mismatches log a clear error (`plugin_id`, expected size, actual size), mark plugin health red via `_update_plugin_health`, and skip the display push for that tick without crashing the refresh loop
- Optional auto-rotate: if transposed dims (e.g. 480x800 vs 800x480 expected) match after 90° rotation, the corrected image is returned transparently
- Fixes `tests/test_sse.py::test_refresh_started_published` to use `device_config_dev.get_resolution()` instead of a hardcoded 100×100 image that now correctly triggers a dimension mismatch

## Test plan

- [x] `tests/unit/test_output_validator.py` — 10 unit + integration tests covering matching dims, wrong width, wrong height, auto-rotate, disabled auto-rotate, and integration (refresh task skips display and marks health red on mismatch)
- [x] Full suite: 2790 passed, 2 pre-existing failures unrelated to this change
- [x] ruff + black clean

Closes JTN-455

🤖 Generated with [Claude Code](https://claude.com/claude-code)