### PR TITLE
feat: read-only bearer token for monitoring endpoints (JTN-477)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -52,3 +52,65 @@ Add an `auth` section to your device config:
   need to invalidate all existing sessions.
 - For remote access, combine with HTTPS (see `INKYPI_FORCE_HTTPS`) so the PIN
   is not transmitted in the clear.
+
+---
+
+# Read-only API Token (JTN-477)
+
+InkyPi supports an optional read-only bearer token for monitoring scripts and
+automation tools that need to poll status endpoints without requiring an
+interactive PIN session. This feature is **independent** from PIN auth and can
+be used whether or not a PIN is configured.
+
+## Enabling the read-only token
+
+Set the `INKYPI_READONLY_TOKEN` environment variable before starting InkyPi:
+
+```bash
+export INKYPI_READONLY_TOKEN="your-long-random-token-here"
+```
+
+Use a cryptographically strong random value, for example:
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+The token is hashed with `hashlib.sha256` immediately on startup; the
+plaintext is never stored or logged.
+
+## Using the token
+
+Pass the token in the `Authorization` header of your HTTP request:
+
+```bash
+curl -H "Authorization: Bearer <your-token>" http://inkypi.local:5000/api/uptime
+```
+
+## Allowed endpoints and methods
+
+The token grants **read-only** access (GET / HEAD / OPTIONS only) to the
+following paths:
+
+| Path               | Description                  |
+|--------------------|------------------------------|
+| `/api/health`      | Service health check         |
+| `/api/version/info`| Firmware / app version       |
+| `/api/uptime`      | Device uptime                |
+| `/api/screenshot`  | Current display screenshot   |
+| `/metrics`         | Prometheus-style metrics     |
+| `/api/stats`       | Refresh statistics           |
+
+Requests to any other path, or any mutating method (POST, PUT, DELETE, PATCH)
+on the above paths, are **not** authorised by the token — a PIN session is
+required.
+
+## Security notes
+
+- The raw token is never stored; only its SHA-256 hex digest is kept in
+  application memory.
+- Comparison uses `hmac.compare_digest` to prevent timing attacks.
+- Combine with HTTPS so the token is not transmitted in the clear.
+- To rotate the token, restart InkyPi with a new `INKYPI_READONLY_TOKEN` value.
+- PIN auth and bearer-token auth are independent: having a valid token does
+  **not** grant access to admin or mutating routes.

--- a/src/app_setup/auth.py
+++ b/src/app_setup/auth.py
@@ -5,6 +5,13 @@ except the skip-list require a valid authenticated session.
 
 When neither is configured the module registers no handlers and the app
 behaves identically to today.
+
+Read-only bearer token (JTN-477)
+---------------------------------
+Set INKYPI_READONLY_TOKEN to enable a second auth path for monitoring scripts.
+GET/HEAD/OPTIONS requests to the allowlist paths below accept either a valid
+PIN session **or** an ``Authorization: Bearer <token>`` header that matches.
+Mutating endpoints always require a PIN session regardless of the token.
 """
 
 from __future__ import annotations
@@ -29,8 +36,23 @@ _AUTH_SKIP_EXACT = frozenset({"/login", "/logout", "/sw.js", "/api/health"})
 # Also skip Flask/Werkzeug internal health probes registered by health.py
 _AUTH_SKIP_HEALTH = frozenset({"/healthz", "/readyz"})
 
+# Read-only token allowlist — GET/HEAD/OPTIONS only (JTN-477)
+_READONLY_TOKEN_ALLOWLIST = frozenset(
+    {
+        "/api/health",
+        "/api/version/info",
+        "/api/uptime",
+        "/api/screenshot",
+        "/metrics",
+        "/api/stats",
+    }
+)
+
 _MAX_FAILED_ATTEMPTS = 5
 _LOCKOUT_SECONDS = 60
+
+# Safe HTTP methods eligible for read-only token access
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 # Per-process random salt — never persisted, never logged
 _SCRYPT_SALT = secrets.token_bytes(32)
@@ -58,6 +80,39 @@ def _verify_pin(candidate: str, stored_hash: bytes) -> bool:
     return hmac.compare_digest(candidate_hash, stored_hash)
 
 
+def _hash_token(token: str) -> str:
+    """Return a SHA-256 hex digest of *token*. Never stored in plaintext."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _verify_bearer_token(stored_hash: str) -> bool:
+    """Return True when the request carries a Bearer token matching *stored_hash*.
+
+    Performs a constant-time comparison to prevent timing attacks.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return False
+    candidate = auth_header[len("Bearer ") :]
+    candidate_hash = hashlib.sha256(candidate.encode()).hexdigest()
+    return hmac.compare_digest(candidate_hash, stored_hash)
+
+
+def _is_readonly_token_request(stored_hash: str) -> bool:
+    """Return True when this request may be satisfied by a valid read-only token.
+
+    Conditions (all must hold):
+    - HTTP method is safe (GET / HEAD / OPTIONS)
+    - Request path is in the token allowlist
+    - Bearer token in Authorization header matches stored hash
+    """
+    if request.method not in _SAFE_METHODS:
+        return False
+    if request.path not in _READONLY_TOKEN_ALLOWLIST:
+        return False
+    return _verify_bearer_token(stored_hash)
+
+
 def _should_skip_auth() -> bool:
     """Return True when the current request path is exempt from authentication."""
     path = request.path
@@ -69,7 +124,15 @@ def _should_skip_auth() -> bool:
 
 
 def init_auth(app: Flask, device_config: Config) -> None:
-    """Wire up PIN auth if a PIN is configured; otherwise log and return."""
+    """Wire up PIN auth and optional read-only bearer token."""
+    # --- Read-only token (JTN-477) -------------------------------------------
+    readonly_token = os.environ.get("INKYPI_READONLY_TOKEN")
+    if readonly_token and isinstance(readonly_token, str):
+        token_hash = _hash_token(readonly_token)
+        app.config["READONLY_TOKEN_HASH"] = token_hash
+        logger.info("Read-only API token enabled")
+
+    # --- PIN auth (JTN-286) --------------------------------------------------
     pin = os.environ.get("INKYPI_AUTH_PIN")
     if not pin:
         try:
@@ -97,6 +160,10 @@ def init_auth(app: Flask, device_config: Config) -> None:
         if _should_skip_auth():
             return None
         if session.get("authed") is True:
+            return None
+        # Allow valid read-only bearer token on the allowlist (safe methods only)
+        token_hash = app.config.get("READONLY_TOKEN_HASH")
+        if token_hash and _is_readonly_token_request(token_hash):
             return None
         next_url = request.url
         return redirect(url_for("auth.login_get", next=next_url))

--- a/tests/test_readonly_token.py
+++ b/tests/test_readonly_token.py
@@ -1,0 +1,249 @@
+# pyright: reportMissingImports=false
+"""Tests for the read-only bearer token auth path (JTN-477).
+
+Coverage:
+- Token unset → only PIN session grants access to protected routes
+- Token set → GET on allowlist with correct Bearer token returns 200 (no session)
+- Token set → wrong token value → 401 redirect (goes to login)
+- Token set → correct token on non-allowlist path → still requires PIN
+- Token set → correct token on allowlist but POST method → still requires PIN
+- Token works on GET /api/screenshot (allowlist)
+- Existing PIN auth tests are not broken
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+from flask import Flask
+from jinja2 import ChoiceLoader, FileSystemLoader
+
+SRC_ABS = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+TOKEN = "super-secret-monitoring-token-abc123"
+
+
+def _make_app(
+    monkeypatch,
+    *,
+    pin: str | None = "s3cr3t",
+    token: str | None = None,
+) -> Flask:
+    """Build a minimal Flask app with auth (PIN + optional token) wired up."""
+    if pin:
+        monkeypatch.setenv("INKYPI_AUTH_PIN", pin)
+    else:
+        monkeypatch.delenv("INKYPI_AUTH_PIN", raising=False)
+
+    if token:
+        monkeypatch.setenv("INKYPI_READONLY_TOKEN", token)
+    else:
+        monkeypatch.delenv("INKYPI_READONLY_TOKEN", raising=False)
+
+    import app_setup.auth as auth_mod
+
+    importlib.reload(auth_mod)
+    import blueprints.auth as auth_bp_mod
+
+    importlib.reload(auth_bp_mod)
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret-key"
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    template_dirs = [
+        os.path.join(SRC_ABS, "templates"),
+        os.path.join(SRC_ABS, "plugins"),
+    ]
+    app.jinja_loader = ChoiceLoader([FileSystemLoader(d) for d in template_dirs])
+
+    from blueprints.auth import auth_bp
+
+    app.register_blueprint(auth_bp)
+
+    # Stub out the allowlisted endpoints
+    @app.route("/api/health")
+    def api_health():
+        return ("ok", 200)
+
+    @app.route("/api/version/info")
+    def api_version_info():
+        return ("version", 200)
+
+    @app.route("/api/uptime")
+    def api_uptime():
+        return ("uptime", 200)
+
+    @app.route("/api/screenshot", methods=["GET", "POST"])
+    def api_screenshot():
+        return ("screenshot", 200)
+
+    @app.route("/metrics")
+    def metrics():
+        return ("metrics", 200)
+
+    @app.route("/api/stats")
+    def api_stats():
+        return ("stats", 200)
+
+    # A mutating endpoint NOT on the allowlist
+    @app.route("/api/settings", methods=["GET", "POST"])
+    def api_settings():
+        return ("settings", 200)
+
+    # Home page (protected, not on allowlist)
+    @app.route("/")
+    def index():
+        return ("home", 200)
+
+    class _FakeConfig:
+        def get_config(self, key, default=None):
+            return default
+
+    auth_mod.init_auth(app, _FakeConfig())
+
+    return app
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Token NOT configured
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUnset:
+    @pytest.fixture()
+    def app(self, monkeypatch):
+        return _make_app(monkeypatch, pin="s3cr3t", token=None)
+
+    @pytest.fixture()
+    def client(self, app):
+        return app.test_client()
+
+    def test_allowlist_without_token_requires_pin_session(self, client):
+        """Without a token configured, allowlist paths require PIN auth."""
+        # /api/health is always exempt — use a different allowlist path
+        resp = client.get("/api/version/info")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_bearer_header_without_token_configured_is_ignored(self, client):
+        """Sending a Bearer header when no token is configured doesn't bypass auth."""
+        resp = client.get("/api/uptime", headers=_bearer(TOKEN))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_pin_session_still_grants_access(self, client):
+        with client.session_transaction() as sess:
+            sess["authed"] = True
+        resp = client.get("/api/version/info")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Token configured — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestTokenSet:
+    @pytest.fixture()
+    def app(self, monkeypatch):
+        return _make_app(monkeypatch, pin="s3cr3t", token=TOKEN)
+
+    @pytest.fixture()
+    def client(self, app):
+        return app.test_client()
+
+    def test_correct_token_on_allowlist_returns_200(self, client):
+        resp = client.get("/api/version/info", headers=_bearer(TOKEN))
+        assert resp.status_code == 200
+
+    def test_correct_token_on_uptime_returns_200(self, client):
+        resp = client.get("/api/uptime", headers=_bearer(TOKEN))
+        assert resp.status_code == 200
+
+    def test_correct_token_on_metrics_returns_200(self, client):
+        resp = client.get("/metrics", headers=_bearer(TOKEN))
+        assert resp.status_code == 200
+
+    def test_correct_token_on_stats_returns_200(self, client):
+        resp = client.get("/api/stats", headers=_bearer(TOKEN))
+        assert resp.status_code == 200
+
+    def test_correct_token_on_screenshot_get_returns_200(self, client):
+        resp = client.get("/api/screenshot", headers=_bearer(TOKEN))
+        assert resp.status_code == 200
+
+    def test_wrong_token_on_allowlist_redirects_to_login(self, client):
+        resp = client.get("/api/version/info", headers=_bearer("bad-token"))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_no_bearer_header_on_allowlist_redirects_to_login(self, client):
+        resp = client.get("/api/version/info")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_correct_token_on_non_allowlist_path_redirects_to_login(self, client):
+        """Token is only valid on the allowlist — other paths still require PIN."""
+        resp = client.get("/api/settings", headers=_bearer(TOKEN))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_correct_token_on_home_redirects_to_login(self, client):
+        resp = client.get("/", headers=_bearer(TOKEN))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_correct_token_post_screenshot_redirects_to_login(self, client):
+        """Mutating (POST) requests are rejected even on an allowlist path."""
+        resp = client.post("/api/screenshot", headers=_bearer(TOKEN))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_correct_token_post_settings_redirects_to_login(self, client):
+        resp = client.post("/api/settings", headers=_bearer(TOKEN))
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+
+    def test_pin_session_still_works_with_token_configured(self, client):
+        """Enabling the token doesn't break existing PIN session auth."""
+        with client.session_transaction() as sess:
+            sess["authed"] = True
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Token configured, PIN disabled
+# ---------------------------------------------------------------------------
+
+
+class TestTokenSetNoPIN:
+    """Token should work even when PIN auth is not configured."""
+
+    @pytest.fixture()
+    def app(self, monkeypatch):
+        return _make_app(monkeypatch, pin=None, token=TOKEN)
+
+    @pytest.fixture()
+    def client(self, app):
+        return app.test_client()
+
+    def test_no_pin_auth_home_accessible_without_auth(self, client):
+        """When PIN is disabled, unprotected routes are open to everyone."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+    def test_token_stored_in_app_config(self, app):
+        """The token hash is stored even when PIN auth is not enabled."""
+        import hashlib
+
+        expected = hashlib.sha256(TOKEN.encode()).hexdigest()
+        assert app.config.get("READONLY_TOKEN_HASH") == expected


### PR DESCRIPTION
## Summary

- Adds `INKYPI_READONLY_TOKEN` env var to enable a bearer-token auth path independent of PIN auth (JTN-286)
- GET/HEAD/OPTIONS requests to the allowlist (`/api/health`, `/api/version/info`, `/api/uptime`, `/api/screenshot`, `/metrics`, `/api/stats`) are accepted with a matching `Authorization: Bearer <token>` header
- Mutating methods and paths outside the allowlist still require a PIN session
- Token is hashed with SHA-256 on startup (never stored in plaintext); constant-time comparison via `hmac.compare_digest` prevents timing attacks
- 17 new tests in `tests/test_readonly_token.py`; all existing tests continue to pass
- Docs extended in `docs/auth.md` with a new "Read-only API Token" section

## Test plan

- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/test_readonly_token.py` — 17 passed
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/` — 2882 passed (2 pre-existing failures in `test_plugin_registry.py`, unrelated)
- [x] `scripts/lint.sh` — All checks passed

Closes JTN-477

🤖 Generated with [Claude Code](https://claude.com/claude-code)