### PR TITLE
feat: API key validator CLI for plugin credentials (JTN-480)

### DIFF
--- a/scripts/validate_api_keys.py
+++ b/scripts/validate_api_keys.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""validate_api_keys.py — probe configured plugin API keys and report status.
+
+Usage:
+    python scripts/validate_api_keys.py [--config PATH] [--env PATH]
+                                        [--plugin PLUGIN_ID] [--timeout N]
+                                        [--json]
+
+Exit codes:
+    0  all probed keys are OK (or nothing to probe)
+    1  at least one key is Invalid
+    2  at least one key produced a network / unexpected error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Status constants
+# ---------------------------------------------------------------------------
+STATUS_OK = "OK"
+STATUS_INVALID = "Invalid"
+STATUS_QUOTA = "Quota"
+STATUS_NETWORK_ERROR = "NetworkError"
+STATUS_UNKNOWN = "Unknown"
+STATUS_SKIPPED = "Skipped"
+
+
+# ---------------------------------------------------------------------------
+# Per-plugin probe definitions
+# Each entry: env_key -> (probe_fn, plugin_ids_that_use_this_key)
+# ---------------------------------------------------------------------------
+
+
+def _probe_openweathermap(key: str, timeout: int) -> tuple[str, str]:
+    """Minimal geocoding call — returns a list, no side-effects."""
+    import requests
+
+    url = "https://api.openweathermap.org/geo/1.0/reverse"
+    params = {"lat": "51.5074", "lon": "-0.1278", "limit": "1", "appid": key}
+    try:
+        r = requests.get(url, params=params, timeout=timeout)
+    except requests.exceptions.ConnectionError as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    except requests.exceptions.Timeout:
+        return STATUS_NETWORK_ERROR, "Request timed out"
+    except requests.exceptions.RequestException as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    if r.status_code == 200:
+        return STATUS_OK, "Geocoding responded 200"
+    if r.status_code in (401, 403):
+        return STATUS_INVALID, f"HTTP {r.status_code}"
+    if r.status_code == 429:
+        return STATUS_QUOTA, "Rate limit exceeded"
+    return STATUS_UNKNOWN, f"HTTP {r.status_code}"
+
+
+def _probe_openai(key: str, timeout: int) -> tuple[str, str]:
+    """List available models — read-only, no cost."""
+    import requests
+
+    url = "https://api.openai.com/v1/models"
+    headers = {"Authorization": f"Bearer {key}"}
+    try:
+        r = requests.get(url, headers=headers, timeout=timeout)
+    except requests.exceptions.ConnectionError as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    except requests.exceptions.Timeout:
+        return STATUS_NETWORK_ERROR, "Request timed out"
+    except requests.exceptions.RequestException as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    if r.status_code == 200:
+        return STATUS_OK, "Models endpoint responded 200"
+    if r.status_code in (401, 403):
+        return STATUS_INVALID, f"HTTP {r.status_code}"
+    if r.status_code == 429:
+        return STATUS_QUOTA, "Rate limit exceeded"
+    return STATUS_UNKNOWN, f"HTTP {r.status_code}"
+
+
+def _probe_google_ai(key: str, timeout: int) -> tuple[str, str]:
+    """List Gemini models — read-only, no cost."""
+    import requests
+
+    url = "https://generativelanguage.googleapis.com/v1beta/models"
+    params = {"key": key}
+    try:
+        r = requests.get(url, params=params, timeout=timeout)
+    except requests.exceptions.ConnectionError as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    except requests.exceptions.Timeout:
+        return STATUS_NETWORK_ERROR, "Request timed out"
+    except requests.exceptions.RequestException as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    if r.status_code == 200:
+        return STATUS_OK, "Models endpoint responded 200"
+    if r.status_code in (400, 401, 403):
+        return STATUS_INVALID, f"HTTP {r.status_code}"
+    if r.status_code == 429:
+        return STATUS_QUOTA, "Rate limit exceeded"
+    return STATUS_UNKNOWN, f"HTTP {r.status_code}"
+
+
+def _probe_unsplash(key: str, timeout: int) -> tuple[str, str]:
+    """Fetch a single random photo — read-only."""
+    import requests
+
+    url = "https://api.unsplash.com/photos/random"
+    params = {"client_id": key, "count": "1"}
+    try:
+        r = requests.get(url, params=params, timeout=timeout)
+    except requests.exceptions.ConnectionError as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    except requests.exceptions.Timeout:
+        return STATUS_NETWORK_ERROR, "Request timed out"
+    except requests.exceptions.RequestException as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    if r.status_code == 200:
+        return STATUS_OK, "Random photo endpoint responded 200"
+    if r.status_code in (401, 403):
+        return STATUS_INVALID, f"HTTP {r.status_code}"
+    if r.status_code == 429:
+        return STATUS_QUOTA, "Rate limit exceeded"
+    return STATUS_UNKNOWN, f"HTTP {r.status_code}"
+
+
+def _probe_nasa(key: str, timeout: int) -> tuple[str, str]:
+    """Fetch today's APOD metadata — read-only, free tier allows DEMO_KEY."""
+    import requests
+
+    url = "https://api.nasa.gov/planetary/apod"
+    params = {"api_key": key, "thumbs": "true"}
+    try:
+        r = requests.get(url, params=params, timeout=timeout)
+    except requests.exceptions.ConnectionError as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    except requests.exceptions.Timeout:
+        return STATUS_NETWORK_ERROR, "Request timed out"
+    except requests.exceptions.RequestException as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    if r.status_code == 200:
+        return STATUS_OK, "APOD endpoint responded 200"
+    if r.status_code in (400, 401, 403):
+        return STATUS_INVALID, f"HTTP {r.status_code}"
+    if r.status_code == 429:
+        return STATUS_QUOTA, "Rate limit exceeded"
+    return STATUS_UNKNOWN, f"HTTP {r.status_code}"
+
+
+def _probe_github(key: str, timeout: int) -> tuple[str, str]:
+    """Hit /user endpoint — read-only, returns authenticated user."""
+    import requests
+
+    url = "https://api.github.com/user"
+    headers = {"Authorization": f"Bearer {key}", "Accept": "application/json"}
+    try:
+        r = requests.get(url, headers=headers, timeout=timeout)
+    except requests.exceptions.ConnectionError as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    except requests.exceptions.Timeout:
+        return STATUS_NETWORK_ERROR, "Request timed out"
+    except requests.exceptions.RequestException as exc:
+        return STATUS_NETWORK_ERROR, str(exc)
+    if r.status_code == 200:
+        return STATUS_OK, "GitHub /user responded 200"
+    if r.status_code in (401, 403):
+        return STATUS_INVALID, f"HTTP {r.status_code}"
+    if r.status_code == 429:
+        return STATUS_QUOTA, "Rate limit exceeded"
+    return STATUS_UNKNOWN, f"HTTP {r.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Registry: env-var-name -> (probe_fn, human_service_name, [plugin_ids])
+# ---------------------------------------------------------------------------
+
+PROBES: dict[str, tuple[Any, str, list[str]]] = {
+    "OPENWEATHER_API_KEY": (
+        _probe_openweathermap,
+        "OpenWeatherMap",
+        ["weather"],
+    ),
+    "OPEN_AI_SECRET": (
+        _probe_openai,
+        "OpenAI",
+        ["ai_image", "ai_text"],
+    ),
+    "GOOGLE_AI_SECRET": (
+        _probe_google_ai,
+        "Google AI",
+        ["ai_image", "ai_text"],
+    ),
+    "UNSPLASH_ACCESS_KEY": (
+        _probe_unsplash,
+        "Unsplash",
+        ["unsplash"],
+    ),
+    "NASA_SECRET": (
+        _probe_nasa,
+        "NASA APOD",
+        ["apod"],
+    ),
+    "GITHUB_SECRET": (
+        _probe_github,
+        "GitHub",
+        ["github"],
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Config / .env helpers (standalone — no src/ imports)
+# ---------------------------------------------------------------------------
+
+
+def _load_env_file(env_path: str) -> dict[str, str]:
+    """Parse a .env file and return a dict of key -> value."""
+    result: dict[str, str] = {}
+    if not os.path.isfile(env_path):
+        return result
+    with open(env_path) as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key:
+                result[key] = value
+    return result
+
+
+def _find_env_path(config_path: str) -> str:
+    """Derive the .env path from the config file location (mirror Config logic)."""
+    project_dir = os.getenv("PROJECT_DIR")
+    if project_dir:
+        return os.path.join(project_dir, ".env")
+    # config lives at <repo>/src/config/device*.json — go up two levels for repo root
+    src_dir = os.path.dirname(os.path.dirname(os.path.abspath(config_path)))
+    return os.path.join(os.path.dirname(src_dir), ".env")
+
+
+def _load_device_config(config_path: str) -> dict[str, Any]:
+    """Load device.json and return the parsed dict."""
+    with open(config_path) as fh:
+        return json.load(fh)
+
+
+def _extract_configured_plugin_ids(device_config: dict[str, Any]) -> set[str]:
+    """Walk playlist_config to find all plugin IDs that appear in playlists."""
+    ids: set[str] = set()
+    playlist_cfg = device_config.get("playlist_config", {})
+    for playlist in playlist_cfg.get("playlists", []):
+        for plugin_entry in playlist.get("plugins", []):
+            pid = plugin_entry.get("plugin_id")
+            if pid:
+                ids.add(pid)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Core probe runner
+# ---------------------------------------------------------------------------
+
+
+def run_probes(
+    env_keys: dict[str, str],
+    configured_plugin_ids: set[str],
+    plugin_filter: str | None,
+    timeout: int,
+) -> list[dict[str, str]]:
+    """Return a list of result dicts for all relevant probes."""
+    results: list[dict[str, str]] = []
+
+    for env_key, (probe_fn, service_name, plugin_ids) in PROBES.items():
+        # Apply --plugin filter
+        if plugin_filter and plugin_filter not in plugin_ids:
+            continue
+
+        key_value = env_keys.get(env_key, "")
+
+        if not key_value:
+            # Key not set — only report if the plugin is configured
+            if any(pid in configured_plugin_ids for pid in plugin_ids):
+                results.extend(
+                    {
+                        "plugin": pid,
+                        "service": service_name,
+                        "env_key": env_key,
+                        "status": STATUS_SKIPPED,
+                        "message": "Key not set in .env",
+                    }
+                    for pid in plugin_ids
+                    if pid in configured_plugin_ids
+                )
+            elif plugin_filter:
+                results.append(
+                    {
+                        "plugin": plugin_filter,
+                        "service": service_name,
+                        "env_key": env_key,
+                        "status": STATUS_SKIPPED,
+                        "message": "Key not set in .env",
+                    }
+                )
+            continue
+
+        # Run the probe once per key
+        status, message = probe_fn(key_value, timeout)
+
+        # Emit one row per relevant plugin
+        for pid in plugin_ids:
+            if plugin_filter and pid != plugin_filter:
+                continue
+            if not plugin_filter and pid not in configured_plugin_ids:
+                # Key is present but plugin not configured — still probe & report
+                pass
+            results.append(
+                {
+                    "plugin": pid,
+                    "service": service_name,
+                    "env_key": env_key,
+                    "status": status,
+                    "message": message,
+                }
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+_STATUS_EMOJI = {
+    STATUS_OK: "OK      ",
+    STATUS_INVALID: "INVALID ",
+    STATUS_QUOTA: "QUOTA   ",
+    STATUS_NETWORK_ERROR: "NETERR  ",
+    STATUS_UNKNOWN: "UNKNOWN ",
+    STATUS_SKIPPED: "skipped ",
+}
+
+
+def _print_table(results: list[dict[str, str]]) -> None:
+    if not results:
+        print("No plugins with API keys found in configuration.")
+        return
+    col_plugin = max(len(r["plugin"]) for r in results)
+    col_service = max(len(r["service"]) for r in results)
+    header = (
+        f"{'Plugin':<{col_plugin}}  {'Service':<{col_service}}  "
+        f"{'Status':<8}  Message"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        tag = _STATUS_EMOJI.get(r["status"], r["status"][:8].ljust(8))
+        print(
+            f"{r['plugin']:<{col_plugin}}  {r['service']:<{col_service}}  "
+            f"{tag}  {r['message']}"
+        )
+
+
+def _exit_code(results: list[dict[str, str]]) -> int:
+    statuses = {r["status"] for r in results}
+    if STATUS_INVALID in statuses:
+        return 1
+    if {STATUS_NETWORK_ERROR, STATUS_UNKNOWN} & statuses:
+        return 2
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate InkyPi plugin API keys by probing their endpoints."
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to device.json (default: src/config/device.json relative to repo root)",
+    )
+    parser.add_argument(
+        "--env",
+        default=None,
+        help="Path to .env file (default: derived from --config location)",
+    )
+    parser.add_argument(
+        "--plugin",
+        default=None,
+        help="Limit validation to a single plugin ID (e.g. weather)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=10,
+        help="Request timeout in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--json",
+        dest="output_json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve config path
+    config_path = args.config
+    if config_path is None:
+        # Try to find it relative to this script's location (scripts/ -> repo root)
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        repo_root = os.path.dirname(script_dir)
+        candidates = [
+            os.path.join(repo_root, "src", "config", "device.json"),
+            os.path.join(repo_root, "src", "config", "device_dev.json"),
+        ]
+        for candidate in candidates:
+            if os.path.isfile(candidate):
+                config_path = candidate
+                break
+        if config_path is None:
+            print(
+                "ERROR: Could not find device.json. Use --config to specify path.",
+                file=sys.stderr,
+            )
+            return 2
+
+    if not os.path.isfile(config_path):
+        print(f"ERROR: Config file not found: {config_path}", file=sys.stderr)
+        return 2
+
+    # Resolve .env path
+    env_path = args.env or _find_env_path(config_path)
+
+    # Load data
+    try:
+        device_config = _load_device_config(config_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"ERROR: Failed to read config: {exc}", file=sys.stderr)
+        return 2
+
+    env_keys = _load_env_file(env_path)
+    configured_plugin_ids = _extract_configured_plugin_ids(device_config)
+
+    results = run_probes(env_keys, configured_plugin_ids, args.plugin, args.timeout)
+
+    if args.output_json:
+        print(json.dumps(results, indent=2))
+    else:
+        _print_table(results)
+
+    return _exit_code(results)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_validate_api_keys.py
+++ b/tests/test_validate_api_keys.py
@@ -1,0 +1,558 @@
+"""Tests for scripts/validate_api_keys.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import helper — the script lives in scripts/, not on sys.path by default
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import validate_api_keys as vak  # noqa: E402  (import after path manipulation)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def device_json(tmp_path):
+    """Create a minimal device.json with weather + ai_image plugins configured."""
+    config = {
+        "name": "Test Device",
+        "display_type": "mock",
+        "resolution": [800, 480],
+        "orientation": "horizontal",
+        "playlist_config": {
+            "playlists": [
+                {
+                    "name": "Default",
+                    "plugins": [
+                        {"plugin_id": "weather", "plugin_settings": {}},
+                        {"plugin_id": "ai_image", "plugin_settings": {}},
+                        {"plugin_id": "unsplash", "plugin_settings": {}},
+                        {"plugin_id": "apod", "plugin_settings": {}},
+                        {"plugin_id": "github", "plugin_settings": {}},
+                    ],
+                }
+            ]
+        },
+    }
+    p = tmp_path / "device.json"
+    p.write_text(json.dumps(config))
+    return str(p)
+
+
+@pytest.fixture()
+def empty_device_json(tmp_path):
+    """A device.json with no plugins configured."""
+    config = {
+        "name": "Empty",
+        "display_type": "mock",
+        "resolution": [800, 480],
+        "orientation": "horizontal",
+        "playlist_config": {"playlists": [{"name": "Default", "plugins": []}]},
+    }
+    p = tmp_path / "device.json"
+    p.write_text(json.dumps(config))
+    return str(p)
+
+
+@pytest.fixture()
+def env_file(tmp_path):
+    """Create a .env file with keys for all supported plugins."""
+    content = (
+        "OPENWEATHER_API_KEY=owm_test_key\n"
+        "OPEN_AI_SECRET=sk-test-openai\n"
+        "GOOGLE_AI_SECRET=gai-test-key\n"
+        "UNSPLASH_ACCESS_KEY=unsplash-test\n"
+        "NASA_SECRET=nasa-test\n"
+        "GITHUB_SECRET=ghp_testtoken\n"
+    )
+    p = tmp_path / ".env"
+    p.write_text(content)
+    return str(p)
+
+
+@pytest.fixture()
+def empty_env_file(tmp_path):
+    """Empty .env — no keys at all."""
+    p = tmp_path / ".env"
+    p.write_text("")
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _load_env_file
+# ---------------------------------------------------------------------------
+
+
+def test_load_env_file_parses_entries(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("KEY1=val1\nKEY2=val2\n")
+    result = vak._load_env_file(str(f))
+    assert result["KEY1"] == "val1"
+    assert result["KEY2"] == "val2"
+
+
+def test_load_env_file_strips_quotes(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text('KEY="quoted_value"\n')
+    result = vak._load_env_file(str(f))
+    assert result["KEY"] == "quoted_value"
+
+
+def test_load_env_file_ignores_comments(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("# comment\nKEY=value\n")
+    result = vak._load_env_file(str(f))
+    assert "# comment" not in result
+    assert result["KEY"] == "value"
+
+
+def test_load_env_file_missing_returns_empty(tmp_path):
+    result = vak._load_env_file(str(tmp_path / "nonexistent.env"))
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _extract_configured_plugin_ids
+# ---------------------------------------------------------------------------
+
+
+def test_extract_configured_plugin_ids():
+    config = {
+        "playlist_config": {
+            "playlists": [
+                {
+                    "plugins": [
+                        {"plugin_id": "weather"},
+                        {"plugin_id": "clock"},
+                    ]
+                }
+            ]
+        }
+    }
+    ids = vak._extract_configured_plugin_ids(config)
+    assert "weather" in ids
+    assert "clock" in ids
+
+
+def test_extract_configured_plugin_ids_empty():
+    config = {"playlist_config": {"playlists": []}}
+    assert vak._extract_configured_plugin_ids(config) == set()
+
+
+# ---------------------------------------------------------------------------
+# Probe function tests — using requests_mock
+# ---------------------------------------------------------------------------
+
+
+def test_probe_openweathermap_ok(requests_mock):
+    requests_mock.get(
+        "https://api.openweathermap.org/geo/1.0/reverse",
+        json=[{"name": "London"}],
+        status_code=200,
+    )
+    status, msg = vak._probe_openweathermap("valid_key", timeout=5)
+    assert status == vak.STATUS_OK
+
+
+def test_probe_openweathermap_invalid(requests_mock):
+    requests_mock.get(
+        "https://api.openweathermap.org/geo/1.0/reverse",
+        json={"message": "Invalid API key"},
+        status_code=401,
+    )
+    status, msg = vak._probe_openweathermap("bad_key", timeout=5)
+    assert status == vak.STATUS_INVALID
+
+
+def test_probe_openweathermap_quota(requests_mock):
+    requests_mock.get(
+        "https://api.openweathermap.org/geo/1.0/reverse",
+        status_code=429,
+    )
+    status, msg = vak._probe_openweathermap("any_key", timeout=5)
+    assert status == vak.STATUS_QUOTA
+
+
+def test_probe_openweathermap_network_error(requests_mock):
+    import requests
+
+    requests_mock.get(
+        "https://api.openweathermap.org/geo/1.0/reverse",
+        exc=requests.exceptions.ConnectionError("connection refused"),
+    )
+    status, msg = vak._probe_openweathermap("any_key", timeout=5)
+    assert status == vak.STATUS_NETWORK_ERROR
+
+
+def test_probe_openai_ok(requests_mock):
+    requests_mock.get(
+        "https://api.openai.com/v1/models",
+        json={"data": []},
+        status_code=200,
+    )
+    status, _ = vak._probe_openai("sk-valid", timeout=5)
+    assert status == vak.STATUS_OK
+
+
+def test_probe_openai_invalid(requests_mock):
+    requests_mock.get(
+        "https://api.openai.com/v1/models",
+        json={"error": {"message": "Incorrect API key"}},
+        status_code=401,
+    )
+    status, _ = vak._probe_openai("sk-bad", timeout=5)
+    assert status == vak.STATUS_INVALID
+
+
+def test_probe_openai_quota(requests_mock):
+    requests_mock.get(
+        "https://api.openai.com/v1/models",
+        status_code=429,
+    )
+    status, _ = vak._probe_openai("sk-any", timeout=5)
+    assert status == vak.STATUS_QUOTA
+
+
+def test_probe_openai_network_error(requests_mock):
+    import requests
+
+    requests_mock.get(
+        "https://api.openai.com/v1/models",
+        exc=requests.exceptions.ConnectionError("no internet"),
+    )
+    status, _ = vak._probe_openai("sk-any", timeout=5)
+    assert status == vak.STATUS_NETWORK_ERROR
+
+
+def test_probe_google_ai_ok(requests_mock):
+    requests_mock.get(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        json={"models": []},
+        status_code=200,
+    )
+    status, _ = vak._probe_google_ai("gai-valid", timeout=5)
+    assert status == vak.STATUS_OK
+
+
+def test_probe_google_ai_invalid(requests_mock):
+    requests_mock.get(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        json={"error": {"status": "PERMISSION_DENIED"}},
+        status_code=403,
+    )
+    status, _ = vak._probe_google_ai("gai-bad", timeout=5)
+    assert status == vak.STATUS_INVALID
+
+
+def test_probe_unsplash_ok(requests_mock):
+    requests_mock.get(
+        "https://api.unsplash.com/photos/random",
+        json=[{"id": "abc"}],
+        status_code=200,
+    )
+    status, _ = vak._probe_unsplash("unsplash-valid", timeout=5)
+    assert status == vak.STATUS_OK
+
+
+def test_probe_unsplash_invalid(requests_mock):
+    requests_mock.get(
+        "https://api.unsplash.com/photos/random",
+        json={"errors": ["OAuth error: The access token is invalid."]},
+        status_code=401,
+    )
+    status, _ = vak._probe_unsplash("unsplash-bad", timeout=5)
+    assert status == vak.STATUS_INVALID
+
+
+def test_probe_unsplash_network_error(requests_mock):
+    import requests
+
+    requests_mock.get(
+        "https://api.unsplash.com/photos/random",
+        exc=requests.exceptions.Timeout(),
+    )
+    status, _ = vak._probe_unsplash("any", timeout=5)
+    assert status == vak.STATUS_NETWORK_ERROR
+
+
+def test_probe_nasa_ok(requests_mock):
+    requests_mock.get(
+        "https://api.nasa.gov/planetary/apod",
+        json={"media_type": "image", "url": "https://example.com/img.jpg"},
+        status_code=200,
+    )
+    status, _ = vak._probe_nasa("nasa-valid", timeout=5)
+    assert status == vak.STATUS_OK
+
+
+def test_probe_nasa_invalid(requests_mock):
+    requests_mock.get(
+        "https://api.nasa.gov/planetary/apod",
+        json={"error": {"code": "API_KEY_INVALID"}},
+        status_code=403,
+    )
+    status, _ = vak._probe_nasa("nasa-bad", timeout=5)
+    assert status == vak.STATUS_INVALID
+
+
+def test_probe_github_ok(requests_mock):
+    requests_mock.get(
+        "https://api.github.com/user",
+        json={"login": "testuser"},
+        status_code=200,
+    )
+    status, _ = vak._probe_github("ghp_valid", timeout=5)
+    assert status == vak.STATUS_OK
+
+
+def test_probe_github_invalid(requests_mock):
+    requests_mock.get(
+        "https://api.github.com/user",
+        json={"message": "Bad credentials"},
+        status_code=401,
+    )
+    status, _ = vak._probe_github("ghp_bad", timeout=5)
+    assert status == vak.STATUS_INVALID
+
+
+def test_probe_github_network_error(requests_mock):
+    import requests
+
+    requests_mock.get(
+        "https://api.github.com/user",
+        exc=requests.exceptions.ConnectionError("DNS failure"),
+    )
+    status, _ = vak._probe_github("ghp_any", timeout=5)
+    assert status == vak.STATUS_NETWORK_ERROR
+
+
+# ---------------------------------------------------------------------------
+# run_probes integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_probes_all_ok(requests_mock):
+    """All probes return 200 → all results OK."""
+    requests_mock.get(
+        "https://api.openweathermap.org/geo/1.0/reverse", json=[], status_code=200
+    )
+    requests_mock.get(
+        "https://api.openai.com/v1/models", json={"data": []}, status_code=200
+    )
+    requests_mock.get(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        json={"models": []},
+        status_code=200,
+    )
+    requests_mock.get(
+        "https://api.unsplash.com/photos/random", json=[{}], status_code=200
+    )
+    requests_mock.get(
+        "https://api.nasa.gov/planetary/apod",
+        json={"media_type": "image"},
+        status_code=200,
+    )
+    requests_mock.get(
+        "https://api.github.com/user", json={"login": "u"}, status_code=200
+    )
+
+    env_keys = {
+        "OPENWEATHER_API_KEY": "owmkey",
+        "OPEN_AI_SECRET": "sk-key",
+        "GOOGLE_AI_SECRET": "gaikey",
+        "UNSPLASH_ACCESS_KEY": "ukey",
+        "NASA_SECRET": "nkey",
+        "GITHUB_SECRET": "ghpkey",
+    }
+    configured = {"weather", "ai_image", "unsplash", "apod", "github"}
+    results = vak.run_probes(env_keys, configured, plugin_filter=None, timeout=5)
+    statuses = {r["status"] for r in results}
+    assert vak.STATUS_OK in statuses
+    assert vak.STATUS_INVALID not in statuses
+
+
+def test_run_probes_skips_unconfigured_missing_key():
+    """Plugin configured but key absent → Skipped."""
+    env_keys: dict[str, str] = {}  # no keys
+    configured = {"weather"}
+    results = vak.run_probes(env_keys, configured, plugin_filter=None, timeout=5)
+    weather_results = [r for r in results if r["plugin"] == "weather"]
+    assert weather_results
+    assert all(r["status"] == vak.STATUS_SKIPPED for r in weather_results)
+
+
+def test_run_probes_empty_config_empty_env():
+    """No configured plugins, no keys → no results."""
+    env_keys: dict[str, str] = {}
+    configured: set[str] = set()
+    results = vak.run_probes(env_keys, configured, plugin_filter=None, timeout=5)
+    assert results == []
+
+
+def test_run_probes_plugin_filter(requests_mock):
+    """--plugin filter limits output to that plugin only."""
+    requests_mock.get(
+        "https://api.nasa.gov/planetary/apod",
+        json={"media_type": "image"},
+        status_code=200,
+    )
+    env_keys = {"NASA_SECRET": "nkey"}
+    configured = {"weather", "apod", "github"}
+    results = vak.run_probes(env_keys, configured, plugin_filter="apod", timeout=5)
+    assert all(r["plugin"] == "apod" for r in results)
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Exit code tests
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_all_ok():
+    results = [
+        {"status": vak.STATUS_OK, "plugin": "x", "service": "S", "message": ""},
+        {"status": vak.STATUS_SKIPPED, "plugin": "y", "service": "T", "message": ""},
+    ]
+    assert vak._exit_code(results) == 0
+
+
+def test_exit_code_invalid():
+    results = [
+        {"status": vak.STATUS_INVALID, "plugin": "x", "service": "S", "message": ""},
+    ]
+    assert vak._exit_code(results) == 1
+
+
+def test_exit_code_network_error():
+    results = [
+        {
+            "status": vak.STATUS_NETWORK_ERROR,
+            "plugin": "x",
+            "service": "S",
+            "message": "",
+        },
+    ]
+    assert vak._exit_code(results) == 2
+
+
+def test_exit_code_empty():
+    assert vak._exit_code([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI (main) integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_main_missing_config_returns_2(tmp_path):
+    code = vak.main(["--config", str(tmp_path / "nonexistent.json")])
+    assert code == 2
+
+
+def test_main_json_output(tmp_path, requests_mock, device_json, env_file):
+    """--json flag produces valid JSON list."""
+    # Mock all external endpoints as OK
+    requests_mock.get(
+        "https://api.openweathermap.org/geo/1.0/reverse", json=[], status_code=200
+    )
+    requests_mock.get(
+        "https://api.openai.com/v1/models", json={"data": []}, status_code=200
+    )
+    requests_mock.get(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        json={},
+        status_code=200,
+    )
+    requests_mock.get(
+        "https://api.unsplash.com/photos/random", json=[{}], status_code=200
+    )
+    requests_mock.get(
+        "https://api.nasa.gov/planetary/apod",
+        json={"media_type": "image"},
+        status_code=200,
+    )
+    requests_mock.get(
+        "https://api.github.com/user", json={"login": "u"}, status_code=200
+    )
+
+    import io
+    from unittest.mock import patch
+
+    output = io.StringIO()
+    with patch(
+        "builtins.print", side_effect=lambda *a, **kw: output.write(str(a[0]) + "\n")
+    ):
+        code = vak.main(
+            ["--config", device_json, "--env", env_file, "--json", "--timeout", "5"]
+        )
+
+    assert code == 0
+    printed = output.getvalue()
+    parsed = json.loads(printed)
+    assert isinstance(parsed, list)
+    assert len(parsed) > 0
+
+
+def test_main_all_invalid_exits_1(tmp_path, requests_mock, device_json, env_file):
+    """If all probes return 401, main exits with code 1."""
+    requests_mock.get("https://api.openweathermap.org/geo/1.0/reverse", status_code=401)
+    requests_mock.get("https://api.openai.com/v1/models", status_code=401)
+    requests_mock.get(
+        "https://generativelanguage.googleapis.com/v1beta/models", status_code=401
+    )
+    requests_mock.get("https://api.unsplash.com/photos/random", status_code=401)
+    requests_mock.get("https://api.nasa.gov/planetary/apod", status_code=401)
+    requests_mock.get("https://api.github.com/user", status_code=401)
+
+    from unittest.mock import patch
+
+    with patch("builtins.print"):
+        code = vak.main(["--config", device_json, "--env", env_file, "--timeout", "5"])
+    assert code == 1
+
+
+def test_main_empty_config_exits_0(tmp_path, empty_device_json, empty_env_file):
+    """Empty config + empty .env → exit 0, no probes run."""
+    from unittest.mock import patch
+
+    with patch("builtins.print"):
+        code = vak.main(
+            ["--config", empty_device_json, "--env", empty_env_file, "--timeout", "5"]
+        )
+    assert code == 0
+
+
+def test_main_unknown_plugin_skipped(tmp_path, requests_mock):
+    """Plugin IDs with no probe definition produce no output (skipped silently)."""
+    config = {
+        "name": "T",
+        "display_type": "mock",
+        "resolution": [800, 480],
+        "orientation": "horizontal",
+        "playlist_config": {
+            "playlists": [{"name": "D", "plugins": [{"plugin_id": "clock"}]}]
+        },
+    }
+    cfg_path = tmp_path / "device.json"
+    cfg_path.write_text(json.dumps(config))
+    env_path = tmp_path / ".env"
+    env_path.write_text("")
+
+    from unittest.mock import patch
+
+    with patch("builtins.print"):
+        code = vak.main(
+            ["--config", str(cfg_path), "--env", str(env_path), "--timeout", "5"]
+        )
+    assert code == 0


### PR DESCRIPTION
## Summary
- Adds `scripts/validate_api_keys.py` — a standalone CLI that reads `.env` and `device.json`, then probes each plugin's API with a minimal read-only request
- Supports 6 plugins: OpenWeatherMap, OpenAI, Google AI, Unsplash, NASA APOD, GitHub
- Reports per-plugin status: OK / Invalid / Quota / NetworkError / Skipped
- Flags: `--config`, `--env`, `--plugin`, `--timeout`, `--json`; exit codes 0/1/2

## Test plan
- [x] 37 unit + integration tests in `tests/test_validate_api_keys.py` using `requests_mock`
- [x] Covers: 200→OK, 401→Invalid, 429→Quota, ConnectionError→NetworkError, missing key→Skipped, empty config→0 results, plugin filter, `--json` output, exit codes
- [x] Full test suite: 2902 passed (2 pre-existing failures in test_plugin_registry unrelated to this PR)
- [x] `scripts/lint.sh`: Ruff ✅ Black ✅

Closes JTN-480

🤖 Generated with [Claude Code](https://claude.com/claude-code)