### PR TITLE
feat: plugin instance config history and diff endpoint (JTN-479)

### DIFF
--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -18,6 +18,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.metrics import metrics_bp
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
+    from blueprints.plugin_history_bp import plugin_history_bp
     from blueprints.plugin_io import plugin_io_bp
     from blueprints.settings import settings_bp
     from blueprints.stats import stats_bp
@@ -29,6 +30,7 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(client_error_bp)
     app.register_blueprint(settings_bp)
     app.register_blueprint(plugin_bp)
+    app.register_blueprint(plugin_history_bp)
     app.register_blueprint(plugin_io_bp)
     app.register_blueprint(playlist_bp)
     app.register_blueprint(history_bp)

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -20,6 +20,7 @@ from refresh_task import ManualRefresh, PlaylistRefresh
 from utils.app_utils import handle_request_files, parse_form, resolve_path
 from utils.http_utils import APIError, json_error
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
+from utils.plugin_history import record_change as _record_plugin_change
 from utils.progress import track_progress
 
 logger = logging.getLogger(__name__)
@@ -345,8 +346,13 @@ def update_plugin_instance(instance_name: str):
             except Exception:
                 logger.debug("Could not validate plugin schema for %s", plugin_id)
 
+        before_settings = dict(plugin_instance.settings or {})
         plugin_instance.settings = plugin_settings
         device_config.write_config()
+        config_dir = os.path.dirname(device_config.config_file)
+        _record_plugin_change(
+            config_dir, instance_name, before_settings, plugin_settings
+        )
     except APIError as e:
         return json_error(e.message, status=e.status, code=e.code, details=e.details)
     except Exception:
@@ -579,7 +585,9 @@ def _save_plugin_settings_common(
 
     instance_name = f"{plugin_id}_saved_settings"
     existing_instance = playlist.find_plugin(plugin_id, instance_name)
+    before_settings: dict = {}
     if existing_instance:
+        before_settings = dict(existing_instance.settings or {})
         existing_instance.settings = plugin_settings
     else:
         playlist.add_plugin(
@@ -594,6 +602,8 @@ def _save_plugin_settings_common(
     # Preserve legacy failure surface for callers/tests that patch config mutation hooks.
     device_config.update_value("playlist_config", playlist_manager.to_dict())
     device_config.write_config()
+    config_dir = os.path.dirname(device_config.config_file)
+    _record_plugin_change(config_dir, instance_name, before_settings, plugin_settings)
     return (
         jsonify(
             {

--- a/src/blueprints/plugin_history_bp.py
+++ b/src/blueprints/plugin_history_bp.py
@@ -24,18 +24,26 @@ logger = logging.getLogger(__name__)
 plugin_history_bp = Blueprint("plugin_history", __name__)
 
 _CONFIG_KEY = "DEVICE_CONFIG"
-# Only allow instance names that are safe filesystem identifiers
-_VALID_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
-_MAX_LIMIT = 100
+# Only allow instance names that are safe filesystem identifiers.
+# Strict allowlist regex makes this an explicit barrier for taint analyzers.
+_VALID_NAME_RE = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9_\-]{0,63}\Z")
 
 
-def _validate_instance_name(name: str) -> str | None:
-    """Return an error string if *name* is invalid, else None."""
-    if not name or "/" in name or "\\" in name or ".." in name:
-        return "Invalid instance name"
+def _safe_instance_name(name: str) -> str | None:
+    """Return *name* if it matches the strict allowlist, else None.
+
+    This is the single point of validation for any user-controlled instance
+    name before it is used to build a filesystem path. CodeQL recognises
+    regex full-match as a sanitizer barrier (py/path-injection).
+    """
+    if not name or len(name) > 64:
+        return None
     if not _VALID_NAME_RE.match(name):
-        return "Invalid instance name: only letters, digits, hyphens and underscores allowed"
-    return None
+        return None
+    return name
+
+
+_MAX_LIMIT = 100
 
 
 def _config_dir(device_config) -> str:
@@ -62,27 +70,24 @@ def _instance_exists(device_config, instance_name: str) -> bool:
 )
 def plugin_instance_history(instance_name: str):
     """Return recent config-change history for a plugin instance."""
-    err = _validate_instance_name(instance_name)
-    if err:
-        return json_error(err, status=400)
+    safe_name = _safe_instance_name(instance_name)
+    if safe_name is None:
+        return json_error("Invalid instance name", status=400)
 
     device_config = current_app.config[_CONFIG_KEY]
 
-    if not _instance_exists(device_config, instance_name):
-        return json_error(f"Plugin instance '{instance_name}' not found", status=404)
+    if not _instance_exists(device_config, safe_name):
+        return json_error("Plugin instance not found", status=404)
 
     try:
         limit_raw = request.args.get("limit", "20")
         limit = int(limit_raw)
-        if limit < 1:
-            limit = 1
-        elif limit > _MAX_LIMIT:
-            limit = _MAX_LIMIT
+        limit = max(1, min(limit, _MAX_LIMIT))
     except ValueError:
         return json_error("'limit' must be an integer", status=400)
 
-    history = get_history(_config_dir(device_config), instance_name, limit=limit)
-    return jsonify({"instance": instance_name, "history": history})
+    history = get_history(_config_dir(device_config), safe_name, limit=limit)
+    return jsonify({"instance": safe_name, "history": history})
 
 
 @plugin_history_bp.route(
@@ -90,16 +95,16 @@ def plugin_instance_history(instance_name: str):
 )
 def plugin_instance_diff(instance_name: str):
     """Return the diff between the two most-recent history entries."""
-    err = _validate_instance_name(instance_name)
-    if err:
-        return json_error(err, status=400)
+    safe_name = _safe_instance_name(instance_name)
+    if safe_name is None:
+        return json_error("Invalid instance name", status=400)
 
     device_config = current_app.config[_CONFIG_KEY]
 
-    if not _instance_exists(device_config, instance_name):
-        return json_error(f"Plugin instance '{instance_name}' not found", status=404)
+    if not _instance_exists(device_config, safe_name):
+        return json_error("Plugin instance not found", status=404)
 
-    history = get_history(_config_dir(device_config), instance_name, limit=2)
+    history = get_history(_config_dir(device_config), safe_name, limit=2)
     if len(history) < 2:
         return json_error(
             "Not enough history to compute a diff (need at least 2 entries)",
@@ -112,7 +117,7 @@ def plugin_instance_diff(instance_name: str):
     diff = compute_diff(previous.get("after", {}), latest.get("after", {}))
     return jsonify(
         {
-            "instance": instance_name,
+            "instance": safe_name,
             "from_ts": previous.get("ts"),
             "to_ts": latest.get("ts"),
             "diff": diff,

--- a/src/blueprints/plugin_history_bp.py
+++ b/src/blueprints/plugin_history_bp.py
@@ -1,0 +1,120 @@
+"""Plugin instance config history and diff API endpoints (JTN-479).
+
+GET /api/plugins/instance/<name>/history?limit=N
+    Returns a JSON list of recent settings changes for the named plugin instance,
+    newest-first.  404 if the instance doesn't exist; 400 on bad input.
+
+GET /api/plugins/instance/<name>/diff
+    Returns the diff between the two most-recent history entries.
+    404 if the instance doesn't exist or fewer than two history entries exist.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from flask import Blueprint, current_app, jsonify, request
+
+from utils.http_utils import json_error
+from utils.plugin_history import compute_diff, get_history
+
+logger = logging.getLogger(__name__)
+
+plugin_history_bp = Blueprint("plugin_history", __name__)
+
+_CONFIG_KEY = "DEVICE_CONFIG"
+# Only allow instance names that are safe filesystem identifiers
+_VALID_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
+_MAX_LIMIT = 100
+
+
+def _validate_instance_name(name: str) -> str | None:
+    """Return an error string if *name* is invalid, else None."""
+    if not name or "/" in name or "\\" in name or ".." in name:
+        return "Invalid instance name"
+    if not _VALID_NAME_RE.match(name):
+        return "Invalid instance name: only letters, digits, hyphens and underscores allowed"
+    return None
+
+
+def _config_dir(device_config) -> str:
+    import os
+
+    return os.path.dirname(device_config.config_file)
+
+
+def _instance_exists(device_config, instance_name: str) -> bool:
+    """Return True if the named plugin instance exists in any playlist."""
+    playlist_manager = device_config.get_playlist_manager()
+    for pname in playlist_manager.get_playlist_names():
+        playlist = playlist_manager.get_playlist(pname)
+        if playlist is None:
+            continue
+        for plugin_entry in getattr(playlist, "plugins", []):
+            if getattr(plugin_entry, "name", None) == instance_name:
+                return True
+    return False
+
+
+@plugin_history_bp.route(
+    "/api/plugins/instance/<string:instance_name>/history", methods=["GET"]
+)
+def plugin_instance_history(instance_name: str):
+    """Return recent config-change history for a plugin instance."""
+    err = _validate_instance_name(instance_name)
+    if err:
+        return json_error(err, status=400)
+
+    device_config = current_app.config[_CONFIG_KEY]
+
+    if not _instance_exists(device_config, instance_name):
+        return json_error(f"Plugin instance '{instance_name}' not found", status=404)
+
+    try:
+        limit_raw = request.args.get("limit", "20")
+        limit = int(limit_raw)
+        if limit < 1:
+            limit = 1
+        elif limit > _MAX_LIMIT:
+            limit = _MAX_LIMIT
+    except ValueError:
+        return json_error("'limit' must be an integer", status=400)
+
+    history = get_history(_config_dir(device_config), instance_name, limit=limit)
+    return jsonify({"instance": instance_name, "history": history})
+
+
+@plugin_history_bp.route(
+    "/api/plugins/instance/<string:instance_name>/diff", methods=["GET"]
+)
+def plugin_instance_diff(instance_name: str):
+    """Return the diff between the two most-recent history entries."""
+    err = _validate_instance_name(instance_name)
+    if err:
+        return json_error(err, status=400)
+
+    device_config = current_app.config[_CONFIG_KEY]
+
+    if not _instance_exists(device_config, instance_name):
+        return json_error(f"Plugin instance '{instance_name}' not found", status=404)
+
+    history = get_history(_config_dir(device_config), instance_name, limit=2)
+    if len(history) < 2:
+        return json_error(
+            "Not enough history to compute a diff (need at least 2 entries)",
+            status=404,
+        )
+
+    # history is newest-first: index 0 = latest, index 1 = previous
+    latest = history[0]
+    previous = history[1]
+    diff = compute_diff(previous.get("after", {}), latest.get("after", {}))
+    return jsonify(
+        {
+            "instance": instance_name,
+            "from_ts": previous.get("ts"),
+            "to_ts": latest.get("ts"),
+            "diff": diff,
+        }
+    )

--- a/src/utils/plugin_history.py
+++ b/src/utils/plugin_history.py
@@ -84,9 +84,16 @@ def record_change(
                 pass
             raise
     except Exception as exc:
+        # Sanitize user-controlled instance_name to prevent log injection (S5145)
+        safe_name = str(instance_name).replace("\r", "").replace("\n", "")[:64]
         logger.warning(
-            "plugin_history: could not record change for %r: %s", instance_name, exc
+            "plugin_history: could not record change for %r: %s", safe_name, exc
         )
+
+
+def _safe_log_name(instance_name: str) -> str:
+    """Strip CR/LF and cap length to prevent log injection (Sonar S5145)."""
+    return str(instance_name).replace("\r", "").replace("\n", "")[:64]
 
 
 def get_history(config_dir: str, instance_name: str, limit: int = 20) -> list[dict]:
@@ -111,7 +118,9 @@ def get_history(config_dir: str, instance_name: str, limit: int = 20) -> list[di
                     continue
     except Exception as exc:
         logger.warning(
-            "plugin_history: could not read history for %r: %s", instance_name, exc
+            "plugin_history: could not read history for %r: %s",
+            _safe_log_name(instance_name),
+            exc,
         )
         return []
 

--- a/src/utils/plugin_history.py
+++ b/src/utils/plugin_history.py
@@ -19,12 +19,20 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 MAX_ENTRIES = 100
-_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9_\-]")
+# Strict allowlist regex that CodeQL recognises as a path-injection sanitizer.
+_VALID_NAME_RE = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9_\-]{0,63}\Z")
 
 
 def _safe_filename(instance_name: str) -> str:
-    """Convert an instance name to a safe filename component (no slashes etc.)."""
-    return _SAFE_NAME_RE.sub("_", instance_name)
+    """Return *instance_name* if it matches the allowlist; raise otherwise.
+
+    All callers must pass a name they have already validated against
+    ``_VALID_NAME_RE``. This function exists as a defense-in-depth boundary
+    that taint analyzers (CodeQL py/path-injection) can recognise.
+    """
+    if not isinstance(instance_name, str) or not _VALID_NAME_RE.match(instance_name):
+        raise ValueError("plugin_history: invalid instance name")
+    return instance_name
 
 
 def _history_dir(config_dir: str) -> str:

--- a/src/utils/plugin_history.py
+++ b/src/utils/plugin_history.py
@@ -1,0 +1,142 @@
+"""Plugin instance config history and diff utilities (JTN-479).
+
+Each plugin instance gets a small JSONL log file under:
+    <config_dir>/plugin_history/<safe_instance_name>.jsonl
+
+Records are appended on every settings change and capped at MAX_ENTRIES.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MAX_ENTRIES = 100
+_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9_\-]")
+
+
+def _safe_filename(instance_name: str) -> str:
+    """Convert an instance name to a safe filename component (no slashes etc.)."""
+    return _SAFE_NAME_RE.sub("_", instance_name)
+
+
+def _history_dir(config_dir: str) -> str:
+    return os.path.join(config_dir, "plugin_history")
+
+
+def _history_file(config_dir: str, instance_name: str) -> str:
+    return os.path.join(
+        _history_dir(config_dir), f"{_safe_filename(instance_name)}.jsonl"
+    )
+
+
+def record_change(
+    config_dir: str, instance_name: str, before: dict, after: dict
+) -> None:
+    """Append a change record to the instance's JSONL history file.
+
+    Silently logs and continues on any I/O error so that plugin save is never
+    blocked by a history write failure.
+
+    The file is truncated to MAX_ENTRIES after each write (oldest entries dropped).
+    """
+    try:
+        hist_dir = _history_dir(config_dir)
+        os.makedirs(hist_dir, exist_ok=True)
+        path = _history_file(config_dir, instance_name)
+
+        entry = {
+            "ts": datetime.now(UTC).isoformat(),
+            "instance": instance_name,
+            "before": before,
+            "after": after,
+        }
+        line = json.dumps(entry, separators=(",", ":"))
+
+        # Read existing lines, append new one, then truncate to MAX_ENTRIES.
+        existing: list[str] = []
+        if os.path.isfile(path):
+            with open(path, encoding="utf-8") as fh:
+                existing = [line.rstrip("\n") for line in fh if line.strip()]
+
+        existing.append(line)
+        if len(existing) > MAX_ENTRIES:
+            existing = existing[-MAX_ENTRIES:]
+
+        # Atomic write via temp file in same directory.
+        dir_path = os.path.dirname(path)
+        fd, tmp_path = tempfile.mkstemp(dir=dir_path, prefix=".phist_", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write("\n".join(existing) + "\n")
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except Exception as exc:
+        logger.warning(
+            "plugin_history: could not record change for %r: %s", instance_name, exc
+        )
+
+
+def get_history(config_dir: str, instance_name: str, limit: int = 20) -> list[dict]:
+    """Return up to *limit* most-recent history entries for *instance_name*.
+
+    Entries are returned newest-first.
+    """
+    path = _history_file(config_dir, instance_name)
+    if not os.path.isfile(path):
+        return []
+
+    entries: list[dict] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    entries.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    continue
+    except Exception as exc:
+        logger.warning(
+            "plugin_history: could not read history for %r: %s", instance_name, exc
+        )
+        return []
+
+    # Newest-first, then cap
+    entries.reverse()
+    return entries[:limit]
+
+
+def compute_diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """Return a diff dict describing what changed between *before* and *after*.
+
+    Returns a dict with three keys:
+      - added:   keys present in *after* but not in *before*
+      - removed: keys present in *before* but not in *after*
+      - changed: keys whose value changed (dict mapping key -> {before, after})
+    """
+    before_keys = set(before.keys())
+    after_keys = set(after.keys())
+
+    added = {k: after[k] for k in after_keys - before_keys}
+    removed = {k: before[k] for k in before_keys - after_keys}
+    changed = {
+        k: {"before": before[k], "after": after[k]}
+        for k in before_keys & after_keys
+        if before[k] != after[k]
+    }
+
+    return {"added": added, "removed": removed, "changed": changed}

--- a/src/utils/plugin_history.py
+++ b/src/utils/plugin_history.py
@@ -1,13 +1,16 @@
 """Plugin instance config history and diff utilities (JTN-479).
 
 Each plugin instance gets a small JSONL log file under:
-    <config_dir>/plugin_history/<safe_instance_name>.jsonl
+    <config_dir>/plugin_history/<sha256(instance_name)[:16]>.jsonl
 
-Records are appended on every settings change and capped at MAX_ENTRIES.
+The filename is a hash of the instance name (not the name itself) so that
+filesystem operations never depend on user-controlled string contents —
+this keeps CodeQL's path-injection analyzer happy.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -19,20 +22,23 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 MAX_ENTRIES = 100
-# Strict allowlist regex that CodeQL recognises as a path-injection sanitizer.
+# Strict allowlist regex used at the API boundary; defense in depth.
 _VALID_NAME_RE = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9_\-]{0,63}\Z")
 
 
-def _safe_filename(instance_name: str) -> str:
-    """Return *instance_name* if it matches the allowlist; raise otherwise.
+def _hashed_filename(instance_name: str) -> str:
+    """Return an opaque hash-based filename for *instance_name*.
 
-    All callers must pass a name they have already validated against
-    ``_VALID_NAME_RE``. This function exists as a defense-in-depth boundary
-    that taint analyzers (CodeQL py/path-injection) can recognise.
+    The filename is derived purely from a hex digest, so the resulting
+    string consists only of [0-9a-f] characters and contains no path
+    separators. CodeQL recognises hash output as path-injection-safe.
     """
-    if not isinstance(instance_name, str) or not _VALID_NAME_RE.match(instance_name):
+    if not isinstance(instance_name, str):
+        raise TypeError("instance_name must be a string")
+    if not _VALID_NAME_RE.match(instance_name):
         raise ValueError("plugin_history: invalid instance name")
-    return instance_name
+    digest = hashlib.sha256(instance_name.encode("utf-8")).hexdigest()
+    return digest[:16] + ".jsonl"
 
 
 def _history_dir(config_dir: str) -> str:
@@ -40,9 +46,7 @@ def _history_dir(config_dir: str) -> str:
 
 
 def _history_file(config_dir: str, instance_name: str) -> str:
-    return os.path.join(
-        _history_dir(config_dir), f"{_safe_filename(instance_name)}.jsonl"
-    )
+    return os.path.join(_history_dir(config_dir), _hashed_filename(instance_name))
 
 
 def record_change(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,7 @@ def flask_app(device_config_dev, monkeypatch):
     from blueprints.metrics import metrics_bp
     from blueprints.playlist import playlist_bp
     from blueprints.plugin import plugin_bp
+    from blueprints.plugin_history_bp import plugin_history_bp
     from blueprints.plugin_io import plugin_io_bp
     from blueprints.settings import settings_bp
     from blueprints.stats import stats_bp
@@ -310,6 +311,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(apikeys_bp)
     app.register_blueprint(settings_bp)
     app.register_blueprint(plugin_bp)
+    app.register_blueprint(plugin_history_bp)
     app.register_blueprint(plugin_io_bp)
     app.register_blueprint(playlist_bp)
     app.register_blueprint(history_bp)

--- a/tests/test_plugin_history.py
+++ b/tests/test_plugin_history.py
@@ -19,12 +19,19 @@ def config_dir(tmp_path):
     return str(tmp_path)
 
 
+def _hist_file_for(config_dir, instance_name):
+    """Helper that mirrors plugin_history._history_file for test assertions."""
+    from utils.plugin_history import _history_file
+
+    return _history_file(config_dir, instance_name)
+
+
 def test_record_change_creates_file(config_dir):
     from utils.plugin_history import record_change
 
     record_change(config_dir, "my_plugin", {"key": "old"}, {"key": "new"})
 
-    hist_file = os.path.join(config_dir, "plugin_history", "my_plugin.jsonl")
+    hist_file = _hist_file_for(config_dir, "my_plugin")
     assert os.path.isfile(hist_file)
     with open(hist_file) as fh:
         lines = [ln.strip() for ln in fh if ln.strip()]
@@ -42,7 +49,7 @@ def test_record_change_appends(config_dir):
     record_change(config_dir, "inst", {"a": 1}, {"a": 2})
     record_change(config_dir, "inst", {"a": 2}, {"a": 3})
 
-    hist_file = os.path.join(config_dir, "plugin_history", "inst.jsonl")
+    hist_file = _hist_file_for(config_dir, "inst")
     with open(hist_file) as fh:
         lines = [ln.strip() for ln in fh if ln.strip()]
     assert len(lines) == 2
@@ -89,7 +96,7 @@ def test_truncation_at_max_entries(config_dir):
         record_change(config_dir, "inst", {"v": i}, {"v": i + 1})
 
     # File should contain exactly MAX_ENTRIES lines
-    hist_file = os.path.join(config_dir, "plugin_history", "inst.jsonl")
+    hist_file = _hist_file_for(config_dir, "inst")
     with open(hist_file) as fh:
         lines = [ln.strip() for ln in fh if ln.strip()]
     assert len(lines) == MAX_ENTRIES

--- a/tests/test_plugin_history.py
+++ b/tests/test_plugin_history.py
@@ -1,0 +1,285 @@
+"""Tests for plugin instance config history and diff (JTN-479)."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Unit tests for utils/plugin_history.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config_dir(tmp_path):
+    """Return a temp directory to use as config_dir."""
+    return str(tmp_path)
+
+
+def test_record_change_creates_file(config_dir):
+    from utils.plugin_history import record_change
+
+    record_change(config_dir, "my_plugin", {"key": "old"}, {"key": "new"})
+
+    hist_file = os.path.join(config_dir, "plugin_history", "my_plugin.jsonl")
+    assert os.path.isfile(hist_file)
+    with open(hist_file) as fh:
+        lines = [ln.strip() for ln in fh if ln.strip()]
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["instance"] == "my_plugin"
+    assert entry["before"] == {"key": "old"}
+    assert entry["after"] == {"key": "new"}
+    assert "ts" in entry
+
+
+def test_record_change_appends(config_dir):
+    from utils.plugin_history import record_change
+
+    record_change(config_dir, "inst", {"a": 1}, {"a": 2})
+    record_change(config_dir, "inst", {"a": 2}, {"a": 3})
+
+    hist_file = os.path.join(config_dir, "plugin_history", "inst.jsonl")
+    with open(hist_file) as fh:
+        lines = [ln.strip() for ln in fh if ln.strip()]
+    assert len(lines) == 2
+
+
+def test_get_history_returns_newest_first(config_dir):
+    from utils.plugin_history import get_history, record_change
+
+    for i in range(5):
+        record_change(config_dir, "inst", {"v": i}, {"v": i + 1})
+
+    history = get_history(config_dir, "inst", limit=10)
+    assert len(history) == 5
+    # Newest-first: last recorded change should appear first
+    assert history[0]["after"] == {"v": 5}
+    assert history[-1]["after"] == {"v": 1}
+
+
+def test_get_history_respects_limit(config_dir):
+    from utils.plugin_history import get_history, record_change
+
+    for i in range(10):
+        record_change(config_dir, "inst", {"v": i}, {"v": i + 1})
+
+    history = get_history(config_dir, "inst", limit=3)
+    assert len(history) == 3
+    # Most-recent 3 should be returned
+    assert history[0]["after"] == {"v": 10}
+
+
+def test_get_history_returns_empty_for_missing_instance(config_dir):
+    from utils.plugin_history import get_history
+
+    result = get_history(config_dir, "no_such_instance")
+    assert result == []
+
+
+def test_truncation_at_max_entries(config_dir):
+    """Writing more than MAX_ENTRIES records should drop the oldest."""
+    from utils.plugin_history import MAX_ENTRIES, get_history, record_change
+
+    total = MAX_ENTRIES + 10
+    for i in range(total):
+        record_change(config_dir, "inst", {"v": i}, {"v": i + 1})
+
+    # File should contain exactly MAX_ENTRIES lines
+    hist_file = os.path.join(config_dir, "plugin_history", "inst.jsonl")
+    with open(hist_file) as fh:
+        lines = [ln.strip() for ln in fh if ln.strip()]
+    assert len(lines) == MAX_ENTRIES
+
+    # The newest entry must be the very last recorded
+    history = get_history(config_dir, "inst", limit=1)
+    assert history[0]["after"] == {"v": total}
+
+    # The oldest retained entry should be the (total - MAX_ENTRIES + 1)-th change
+    all_history = get_history(config_dir, "inst", limit=MAX_ENTRIES)
+    assert len(all_history) == MAX_ENTRIES
+    # Oldest retained: index -1 (newest-first order), after value = total - MAX_ENTRIES + 1
+    assert all_history[-1]["after"] == {"v": total - MAX_ENTRIES + 1}
+
+
+def test_compute_diff_added(config_dir):
+    from utils.plugin_history import compute_diff
+
+    diff = compute_diff({}, {"new_key": "value"})
+    assert diff["added"] == {"new_key": "value"}
+    assert diff["removed"] == {}
+    assert diff["changed"] == {}
+
+
+def test_compute_diff_removed():
+    from utils.plugin_history import compute_diff
+
+    diff = compute_diff({"old_key": "value"}, {})
+    assert diff["added"] == {}
+    assert diff["removed"] == {"old_key": "value"}
+    assert diff["changed"] == {}
+
+
+def test_compute_diff_changed():
+    from utils.plugin_history import compute_diff
+
+    diff = compute_diff({"k": "before"}, {"k": "after"})
+    assert diff["added"] == {}
+    assert diff["removed"] == {}
+    assert diff["changed"] == {"k": {"before": "before", "after": "after"}}
+
+
+def test_compute_diff_no_change():
+    from utils.plugin_history import compute_diff
+
+    diff = compute_diff({"k": "same"}, {"k": "same"})
+    assert diff == {"added": {}, "removed": {}, "changed": {}}
+
+
+def test_compute_diff_mixed():
+    from utils.plugin_history import compute_diff
+
+    before = {"a": 1, "b": 2, "c": 3}
+    after = {"a": 10, "b": 2, "d": 4}
+    diff = compute_diff(before, after)
+    assert diff["added"] == {"d": 4}
+    assert diff["removed"] == {"c": 3}
+    assert diff["changed"] == {"a": {"before": 1, "after": 10}}
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests (use flask_app fixture from conftest.py)
+# ---------------------------------------------------------------------------
+
+
+def _add_plugin_instance(flask_app, instance_name: str):
+    """Helper: add a plugin instance to the Default playlist via the app config."""
+    device_config = flask_app.config["DEVICE_CONFIG"]
+    pm = device_config.get_playlist_manager()
+    default = pm.get_playlist("Default")
+    if default is None:
+        pm.add_playlist("Default")
+        default = pm.get_playlist("Default")
+    default.add_plugin(
+        {
+            "plugin_id": "clock",
+            "refresh": {"interval": 3600},
+            "plugin_settings": {"color": "white"},
+            "name": instance_name,
+        }
+    )
+    device_config.write_config()
+
+
+def _write_history(flask_app, instance_name: str, entries: int = 3):
+    """Write *entries* history records for *instance_name* via the utility."""
+    import os
+
+    from utils.plugin_history import record_change
+
+    device_config = flask_app.config["DEVICE_CONFIG"]
+    config_dir = os.path.dirname(device_config.config_file)
+    for i in range(entries):
+        record_change(
+            config_dir,
+            instance_name,
+            {"color": f"color_{i}"},
+            {"color": f"color_{i + 1}"},
+        )
+
+
+def test_history_endpoint_returns_json(flask_app):
+    client = flask_app.test_client()
+    instance_name = "clock_test"
+    _add_plugin_instance(flask_app, instance_name)
+    _write_history(flask_app, instance_name, entries=3)
+
+    resp = client.get(f"/api/plugins/instance/{instance_name}/history")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["instance"] == instance_name
+    assert isinstance(data["history"], list)
+    assert len(data["history"]) == 3
+
+
+def test_history_endpoint_limit_param(flask_app):
+    client = flask_app.test_client()
+    instance_name = "clock_limited"
+    _add_plugin_instance(flask_app, instance_name)
+    _write_history(flask_app, instance_name, entries=5)
+
+    resp = client.get(f"/api/plugins/instance/{instance_name}/history?limit=2")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["history"]) == 2
+
+
+def test_history_endpoint_404_for_unknown_instance(flask_app):
+    client = flask_app.test_client()
+    resp = client.get("/api/plugins/instance/no_such_plugin/history")
+    assert resp.status_code == 404
+
+
+def test_diff_endpoint_returns_correct_diff(flask_app):
+    client = flask_app.test_client()
+    instance_name = "clock_diff"
+    _add_plugin_instance(flask_app, instance_name)
+    _write_history(flask_app, instance_name, entries=2)
+
+    resp = client.get(f"/api/plugins/instance/{instance_name}/diff")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["instance"] == instance_name
+    assert "diff" in data
+    assert "changed" in data["diff"]
+    assert "from_ts" in data
+    assert "to_ts" in data
+
+
+def test_diff_endpoint_404_not_enough_history(flask_app):
+    client = flask_app.test_client()
+    instance_name = "clock_onehist"
+    _add_plugin_instance(flask_app, instance_name)
+    _write_history(flask_app, instance_name, entries=1)
+
+    resp = client.get(f"/api/plugins/instance/{instance_name}/diff")
+    assert resp.status_code == 404
+
+
+def test_diff_endpoint_404_for_unknown_instance(flask_app):
+    client = flask_app.test_client()
+    resp = client.get("/api/plugins/instance/ghost_instance/diff")
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../etc/passwd",
+        "foo/bar",
+        "foo\\bar",
+        "foo..bar",
+        "../secret",
+        ".hidden",
+    ],
+)
+def test_path_traversal_returns_400(flask_app, bad_name):
+    client = flask_app.test_client()
+    # URL-encode slashes so Flask doesn't route them as path separators
+    encoded = urllib.parse.quote(bad_name, safe="")
+    for endpoint in ("history", "diff"):
+        resp = client.get(f"/api/plugins/instance/{encoded}/{endpoint}")
+        assert resp.status_code in (
+            400,
+            404,
+        ), f"Expected 400/404 for name={bad_name!r} endpoint={endpoint}, got {resp.status_code}"
+
+
+def test_safe_name_with_slashes_gives_400(flask_app):
+    """Instance names containing slashes must be rejected."""
+    client = flask_app.test_client()
+    resp = client.get("/api/plugins/instance/foo%2Fbar/history")
+    assert resp.status_code in (400, 404)


### PR DESCRIPTION
## Summary

- Adds `src/utils/plugin_history.py`: `record_change`, `get_history`, `compute_diff` utilities with per-instance JSONL logs capped at 100 entries (atomic writes via temp file)
- Adds `src/blueprints/plugin_history_bp.py`: two new API endpoints:
  - `GET /api/plugins/instance/<name>/history?limit=N` — newest-first list of recent config changes
  - `GET /api/plugins/instance/<name>/diff` — diff between the two most-recent history entries
- Hooks `record_change` into `update_plugin_instance` and `_save_plugin_settings_common` in `plugin.py` (fail-safe: logs warning, never blocks save)
- Registers blueprint in `blueprints_registry.py` and `conftest.py`
- Sanitizes instance name — rejects path traversal, slashes, dots

## Test plan

- [x] 24 unit + integration tests in `tests/test_plugin_history.py`
- [x] `record_change` appends correctly and truncates at 100 entries
- [x] `get_history` returns newest-first and respects limit
- [x] `compute_diff` correctly reports added/removed/changed keys
- [x] GET /history endpoint returns JSON with correct entries
- [x] GET /diff returns correct diff between latest two entries
- [x] Path traversal names (`../etc/passwd`, `foo/bar`, etc.) return 400/404
- [x] Ruff ✅  Black ✅  Full suite: 2889 passed (2 pre-existing failures unrelated to this PR)

Closes JTN-479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin instance configurations are now tracked with timestamped change history, allowing you to see what changed and when.
  * New API endpoints enable retrieving plugin configuration change history and computing diffs to compare configuration versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->