### PR TITLE
feat: Subresource Integrity hashes for vendored and CDN assets (JTN-478)

### DIFF
--- a/scripts/update_cdn_sri.py
+++ b/scripts/update_cdn_sri.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Update SRI hashes in cdn_manifest.json (JTN-478).
+
+Downloads each CDN asset listed in ``src/static/cdn_manifest.json``,
+computes its SHA-384 hash, and writes the updated hash back.
+
+Run this script manually whenever a CDN version is bumped:
+
+    python3 scripts/update_cdn_sri.py
+
+Optionally pass --dry-run to print the computed hashes without writing.
+
+Exit codes:
+  0  all hashes computed (and written if not dry-run)
+  1  one or more URLs failed to download
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "src" / "static" / "cdn_manifest.json"
+
+
+def compute_sri_from_url(url: str) -> str:
+    """Download *url* and return its ``sha384-<base64>`` SRI hash."""
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
+        data = resp.read()
+    digest = hashlib.sha384(data).digest()
+    return "sha384-" + base64.b64encode(digest).decode("ascii")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print computed hashes without writing the manifest",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=str(MANIFEST_PATH),
+        help="Path to cdn_manifest.json (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"ERROR: manifest not found: {manifest_path}", file=sys.stderr)
+        return 1
+
+    manifest: dict[str, dict] = json.loads(manifest_path.read_text(encoding="utf-8"))
+    errors: list[str] = []
+
+    for key, entry in manifest.items():
+        url = entry.get("url", "")
+        if not url:
+            print(f"  [{key}] SKIP — no url field")
+            continue
+        print(f"  [{key}] downloading {url} …", end=" ", flush=True)
+        try:
+            sri = compute_sri_from_url(url)
+            old = entry.get("integrity", "")
+            changed = sri != old
+            print(sri, "(changed)" if changed else "(unchanged)")
+            entry["integrity"] = sri
+        except Exception as exc:
+            print(f"ERROR: {exc}")
+            errors.append(key)
+
+    if errors:
+        print(f"\nFailed to update: {errors}", file=sys.stderr)
+
+    if not args.dry_run and not errors:
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nWritten to {manifest_path}")
+    elif args.dry_run:
+        print("\n[dry-run] manifest not written")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/blueprints/api_docs.py
+++ b/src/blueprints/api_docs.py
@@ -7,6 +7,8 @@ import os
 
 from flask import Blueprint, Response
 
+from utils.sri import cdn_sri
+
 api_docs_bp = Blueprint("api_docs", __name__)
 
 # Resolved at import time — always relative to this module's location.
@@ -14,30 +16,43 @@ _SPEC_PATH = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "static", "openapi.json")
 )
 
+_SWAGGER_CSS_URL = "https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css"
+_SWAGGER_JS_URL = "https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js"
+
 
 @api_docs_bp.route("/api/docs", methods=["GET"])
 def swagger_ui() -> Response:
     """Serve the Swagger UI HTML page pointing at /api/openapi.json."""
-    html = """<!DOCTYPE html>
+    css_integrity = cdn_sri("swagger-ui-css")
+    js_integrity = cdn_sri("swagger-ui-bundle")
+
+    css_integrity_attr = (
+        f' integrity="{css_integrity}" crossorigin="anonymous"' if css_integrity else ""
+    )
+    js_integrity_attr = (
+        f' integrity="{js_integrity}" crossorigin="anonymous"' if js_integrity else ""
+    )
+
+    html = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>InkyPi API Docs</title>
   <link rel="stylesheet"
-        href="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css" />
+        href="{_SWAGGER_CSS_URL}"{css_integrity_attr} />
 </head>
 <body>
   <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js"></script>
+  <script src="{_SWAGGER_JS_URL}"{js_integrity_attr}></script>
   <script>
-    SwaggerUIBundle({
+    SwaggerUIBundle({{
       url: "/api/openapi.json",
       dom_id: "#swagger-ui",
       presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
       layout: "BaseLayout",
       deepLinking: true
-    });
+    }});
   </script>
 </body>
 </html>"""

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -52,6 +52,7 @@ from refresh_task import RefreshTask
 from utils.app_utils import generate_startup_image, get_ip_address
 from utils.config_schema import ConfigValidationError
 from utils.i18n import init_i18n
+from utils.sri import init_sri
 
 # Re-exported for tests/unit/test_inkypi.py monkey-patches.
 __all__ = [
@@ -279,6 +280,7 @@ def create_app():
     init_i18n(app)
     register_blueprints(app)
     setup_asset_helpers(app)
+    init_sri(app)
     register_health_endpoints(app)
 
     @app.before_request

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -16,6 +16,7 @@ from utils.progress import (
     start_step,
     update_step,
 )
+from utils.sri import cdn_sri, sri_for
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,9 @@ class BasePlugin:
         self.env = Environment(
             loader=loader, autoescape=select_autoescape(["html", "xml"])
         )
+        # Register SRI helpers so plugin templates can use sri_for/cdn_sri
+        self.env.globals["sri_for"] = sri_for
+        self.env.globals["cdn_sri"] = cdn_sri
         # Enable template auto-reload for development convenience
         try:
             self.env.auto_reload = True

--- a/src/plugins/weather/render/weather_ny.html
+++ b/src/plugins/weather/render/weather_ny.html
@@ -88,7 +88,8 @@
   
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"
+        integrity="{{ cdn_sri('chart-js') }}" crossorigin="anonymous"></script>
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     const canvas = document.getElementById('hourlyTemperatureChart');

--- a/src/static/cdn_manifest.json
+++ b/src/static/cdn_manifest.json
@@ -1,0 +1,17 @@
+{
+  "swagger-ui-css": {
+    "url": "https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css",
+    "version": "5.17.14",
+    "integrity": "sha384-wxLW6kwyHktdDGr6Pv1zgm/VGJh99lfUbzSn6HNHBENZlCN7W602k9VkGdxuFvPn"
+  },
+  "swagger-ui-bundle": {
+    "url": "https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js",
+    "version": "5.17.14",
+    "integrity": "sha384-wmyclcVGX/WhUkdkATwhaK1X1JtiNrr2EoYJ+diV3vj4v6OC5yCeSu+yW13SYJep"
+  },
+  "chart-js": {
+    "url": "https://cdn.jsdelivr.net/npm/chart.js",
+    "version": "4.5.1",
+    "integrity": "sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+  }
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -21,7 +21,8 @@
     <script src="{{ url_for('static', filename='scripts/form_validator.js') }}" defer></script>
     <script src="{{ url_for('static', filename='scripts/response_modal.js') }}" defer></script>
     {% endif %}
-    <script src="{{ url_for('static', filename='vendor/htmx.min.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='vendor/htmx.min.js') }}" defer
+            integrity="{{ sri_for('vendor/htmx.min.js') }}" crossorigin="anonymous"></script>
     {% block head %}{% endblock %}
     <script>
       if ("serviceWorker" in navigator && (location.protocol === "https:" || location.hostname === "localhost" || location.hostname === "127.0.0.1")) {

--- a/src/utils/sri.py
+++ b/src/utils/sri.py
@@ -1,0 +1,142 @@
+"""Subresource Integrity (SRI) helpers for InkyPi (JTN-478).
+
+Provides:
+- ``compute_sri(file_path)`` — compute sha384-<base64> for an on-disk file
+- ``sri_for(static_rel_path)`` — Jinja-friendly; resolves relative to static/,
+  caches per process, returns "" + logs on error
+- ``cdn_sri(key)`` — looks up a pre-computed hash in cdn_manifest.json
+- ``init_sri(app)`` — registers ``sri_for`` and ``cdn_sri`` as Jinja globals
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+from pathlib import Path
+
+from flask import Flask
+
+logger = logging.getLogger(__name__)
+
+# Resolved at import time so the module can be used without a Flask context.
+_STATIC_ROOT = Path(__file__).resolve().parent.parent / "static"
+_CDN_MANIFEST_PATH = _STATIC_ROOT / "cdn_manifest.json"
+
+# Per-process caches — avoids recomputing hashes on every request.
+_sri_cache: dict[str, str] = {}
+_cdn_manifest_cache: dict[str, dict] | None = None
+_cdn_manifest_loaded: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+
+def compute_sri(file_path: str | Path) -> str:
+    """Return the ``sha384-<base64>`` SRI hash for *file_path*.
+
+    Raises ``FileNotFoundError`` if the file does not exist.
+    """
+    path = Path(file_path)
+    digest = hashlib.sha384(path.read_bytes()).digest()
+    b64 = base64.b64encode(digest).decode("ascii")
+    return f"sha384-{b64}"
+
+
+# ---------------------------------------------------------------------------
+# Jinja-friendly helpers with caching + graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def sri_for(static_rel_path: str) -> str:
+    """Return the SRI hash for a file relative to ``src/static/``.
+
+    Results are cached for the lifetime of the process.  Returns an empty
+    string (and logs a warning) if the file does not exist or cannot be read
+    so that a missing vendor file never crashes the page.
+    """
+    if static_rel_path in _sri_cache:
+        return _sri_cache[static_rel_path]
+
+    full_path = _STATIC_ROOT / static_rel_path
+    try:
+        result = compute_sri(full_path)
+    except FileNotFoundError:
+        logger.warning(
+            "sri_for: static asset not found, SRI will be omitted: %s", full_path
+        )
+        result = ""
+    except Exception as exc:
+        logger.warning("sri_for: could not compute SRI for %s: %s", full_path, exc)
+        result = ""
+
+    _sri_cache[static_rel_path] = result
+    return result
+
+
+def _load_cdn_manifest() -> dict[str, dict]:
+    """Return the CDN manifest dict, loading from disk on first call."""
+    global _cdn_manifest_cache, _cdn_manifest_loaded
+    if _cdn_manifest_loaded:
+        return _cdn_manifest_cache or {}
+    _cdn_manifest_loaded = True
+    if _CDN_MANIFEST_PATH.is_file():
+        try:
+            _cdn_manifest_cache = json.loads(
+                _CDN_MANIFEST_PATH.read_text(encoding="utf-8")
+            )
+            logger.debug("Loaded CDN manifest from %s", _CDN_MANIFEST_PATH)
+        except Exception as exc:
+            logger.warning("Failed to parse CDN manifest: %s", exc)
+            _cdn_manifest_cache = {}
+    else:
+        logger.debug("CDN manifest not found at %s", _CDN_MANIFEST_PATH)
+        _cdn_manifest_cache = {}
+    return _cdn_manifest_cache or {}
+
+
+def cdn_sri(key: str) -> str:
+    """Return the pre-computed SRI hash for CDN asset *key*.
+
+    The hash is read from ``src/static/cdn_manifest.json`` which is populated
+    by ``scripts/update_cdn_sri.py``.  Returns an empty string if the key is
+    absent so that missing entries never crash the page.
+    """
+    manifest = _load_cdn_manifest()
+    entry = manifest.get(key, {})
+    return entry.get("integrity", "")
+
+
+# ---------------------------------------------------------------------------
+# Flask integration
+# ---------------------------------------------------------------------------
+
+
+def init_sri(app: Flask) -> None:
+    """Register ``sri_for`` and ``cdn_sri`` as Jinja2 globals on *app*."""
+    app.jinja_env.globals["sri_for"] = sri_for
+    app.jinja_env.globals["cdn_sri"] = cdn_sri
+    logger.debug("SRI Jinja helpers registered")
+
+
+# ---------------------------------------------------------------------------
+# Test helpers (not part of the public API)
+# ---------------------------------------------------------------------------
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear all module-level caches.  For use in tests only."""
+    global _sri_cache, _cdn_manifest_cache, _cdn_manifest_loaded
+    _sri_cache = {}
+    _cdn_manifest_cache = None
+    _cdn_manifest_loaded = False
+
+
+def _override_cdn_manifest_path_for_tests(path: str | Path) -> None:
+    """Redirect CDN manifest reads to *path*.  For use in tests only."""
+    global _CDN_MANIFEST_PATH
+    _CDN_MANIFEST_PATH = Path(path)
+    _reset_cache_for_tests()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,7 @@ def flask_app(device_config_dev, monkeypatch):
         return {"csrf_token": _generate_csrf_token}
 
     from app_setup.http_metrics import setup_http_metrics
+    from utils.sri import init_sri
 
     # Register routes
     app.register_blueprint(main_bp)
@@ -321,6 +322,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(events_bp)
 
     setup_http_metrics(app)
+    init_sri(app)
 
     # Lightweight health endpoints for probes/CI
     @app.route("/healthz")

--- a/tests/test_sri.py
+++ b/tests/test_sri.py
@@ -1,0 +1,398 @@
+"""Tests for Subresource Integrity helpers (JTN-478).
+
+Covers:
+- compute_sri: returns sha384- prefix, is deterministic, differs with different content
+- sri_for: Jinja-friendly, cached, handles missing files gracefully
+- cdn_sri: reads cdn_manifest.json, returns empty string for unknown keys
+- init_sri: registers helpers as Jinja globals
+- cdn_manifest.json: valid JSON with expected keys
+- update_cdn_sri.py: computes correct hashes (uses responses/requests_mock)
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src"
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+CDN_MANIFEST_PATH = SRC_ROOT / "static" / "cdn_manifest.json"
+
+# Make src importable
+sys.path.insert(0, str(SRC_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sri(data: bytes) -> str:
+    """Compute expected sha384-<base64> for *data*."""
+    digest = hashlib.sha384(data).digest()
+    return "sha384-" + base64.b64encode(digest).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_sri
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSri:
+    def test_returns_sha384_prefix(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.js"
+        f.write_bytes(b"console.log('hello');")
+        from utils.sri import compute_sri
+
+        result = compute_sri(f)
+        assert result.startswith("sha384-"), f"Expected sha384- prefix, got: {result}"
+
+    def test_deterministic(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.js"
+        f.write_bytes(b"const x = 1;")
+        from utils.sri import compute_sri
+
+        assert compute_sri(f) == compute_sri(f)
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "a.js"
+        f2 = tmp_path / "b.js"
+        f1.write_bytes(b"const a = 1;")
+        f2.write_bytes(b"const b = 2;")
+        from utils.sri import compute_sri
+
+        assert compute_sri(f1) != compute_sri(f2)
+
+    def test_hash_matches_expected(self, tmp_path: Path) -> None:
+        data = b"hello world"
+        f = tmp_path / "file.txt"
+        f.write_bytes(data)
+        from utils.sri import compute_sri
+
+        expected = _make_sri(data)
+        assert compute_sri(f) == expected
+
+    def test_raises_on_missing_file(self, tmp_path: Path) -> None:
+        from utils.sri import compute_sri
+
+        with pytest.raises(FileNotFoundError):
+            compute_sri(tmp_path / "does_not_exist.js")
+
+
+# ---------------------------------------------------------------------------
+# Tests: sri_for (with cache reset between tests)
+# ---------------------------------------------------------------------------
+
+
+class TestSriFor:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        from utils import sri as sri_mod
+
+        sri_mod._reset_cache_for_tests()
+        # Redirect static root to a temp dir for each test
+        yield
+        sri_mod._reset_cache_for_tests()
+
+    def test_returns_sri_for_existing_file(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        data = b"htmx content"
+        f = tmp_path / "htmx.min.js"
+        f.write_bytes(data)
+        expected = _make_sri(data)
+
+        with patch.object(sri_mod, "_STATIC_ROOT", tmp_path):
+            result = sri_mod.sri_for("htmx.min.js")
+
+        assert result == expected
+
+    def test_returns_empty_string_for_missing_file(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        with patch.object(sri_mod, "_STATIC_ROOT", tmp_path):
+            result = sri_mod.sri_for("nonexistent.js")
+
+        assert result == ""
+
+    def test_missing_file_does_not_crash(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        # Should not raise
+        with patch.object(sri_mod, "_STATIC_ROOT", tmp_path):
+            sri_mod.sri_for("missing/path/file.js")
+
+    def test_cached_same_result(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        data = b"cached content"
+        f = tmp_path / "cached.js"
+        f.write_bytes(data)
+
+        with patch.object(sri_mod, "_STATIC_ROOT", tmp_path):
+            first = sri_mod.sri_for("cached.js")
+            second = sri_mod.sri_for("cached.js")
+
+        assert first == second
+
+    def test_caches_result_so_file_read_once(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        data = b"once only"
+        f = tmp_path / "once.js"
+        f.write_bytes(data)
+
+        with patch.object(sri_mod, "_STATIC_ROOT", tmp_path):
+            sri_mod.sri_for("once.js")
+            # Remove the file — cache should still serve old value
+            f.unlink()
+            result = sri_mod.sri_for("once.js")
+
+        assert result == _make_sri(data)
+
+    def test_sri_for_real_htmx_vendored(self) -> None:
+        """Sanity check: the actual vendored htmx.min.js produces a valid hash."""
+        from utils import sri as sri_mod
+
+        htmx_path = SRC_ROOT / "static" / "vendor" / "htmx.min.js"
+        if not htmx_path.is_file():
+            pytest.skip("htmx.min.js not present")
+
+        result = sri_mod.sri_for("vendor/htmx.min.js")
+        assert result.startswith("sha384-")
+        assert len(result) > 20
+
+
+# ---------------------------------------------------------------------------
+# Tests: cdn_sri
+# ---------------------------------------------------------------------------
+
+
+class TestCdnSri:
+    @pytest.fixture(autouse=True)
+    def reset_cdn_cache(self):
+        from utils import sri as sri_mod
+
+        sri_mod._reset_cache_for_tests()
+        yield
+        sri_mod._reset_cache_for_tests()
+
+    def test_returns_integrity_for_known_key(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        manifest = {
+            "swagger-ui-bundle": {
+                "url": "https://example.com/swagger.js",
+                "integrity": "sha384-abc123",
+            }
+        }
+        manifest_path = tmp_path / "cdn_manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        sri_mod._override_cdn_manifest_path_for_tests(manifest_path)
+        result = sri_mod.cdn_sri("swagger-ui-bundle")
+        assert result == "sha384-abc123"
+
+    def test_returns_empty_for_unknown_key(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        manifest = {}
+        manifest_path = tmp_path / "cdn_manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        sri_mod._override_cdn_manifest_path_for_tests(manifest_path)
+        result = sri_mod.cdn_sri("nonexistent-key")
+        assert result == ""
+
+    def test_returns_empty_when_manifest_missing(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        sri_mod._override_cdn_manifest_path_for_tests(tmp_path / "does_not_exist.json")
+        result = sri_mod.cdn_sri("any-key")
+        assert result == ""
+
+    def test_graceful_on_invalid_json(self, tmp_path: Path) -> None:
+        from utils import sri as sri_mod
+
+        bad_json = tmp_path / "cdn_manifest.json"
+        bad_json.write_text("NOT JSON", encoding="utf-8")
+
+        sri_mod._override_cdn_manifest_path_for_tests(bad_json)
+        # Should not raise
+        result = sri_mod.cdn_sri("any-key")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: init_sri registers Jinja globals
+# ---------------------------------------------------------------------------
+
+
+class TestInitSri:
+    def test_jinja_globals_registered(self, flask_app) -> None:
+        from utils.sri import init_sri
+
+        init_sri(flask_app)
+        assert "sri_for" in flask_app.jinja_env.globals
+        assert "cdn_sri" in flask_app.jinja_env.globals
+        assert callable(flask_app.jinja_env.globals["sri_for"])
+        assert callable(flask_app.jinja_env.globals["cdn_sri"])
+
+    def test_sri_for_renders_in_template(self, tmp_path: Path, flask_app) -> None:
+        """sri_for should render a valid sha384- string in a Jinja template."""
+        from utils import sri as sri_mod
+        from utils.sri import init_sri
+
+        data = b"var x = 1;"
+        f = tmp_path / "test.js"
+        f.write_bytes(data)
+        expected = _make_sri(data)
+
+        sri_mod._reset_cache_for_tests()
+        with patch.object(sri_mod, "_STATIC_ROOT", tmp_path):
+            init_sri(flask_app)
+            with flask_app.app_context():
+                rendered = flask_app.jinja_env.from_string(
+                    "{{ sri_for('test.js') }}"
+                ).render()
+
+        assert rendered == expected
+
+    def test_cdn_sri_renders_in_template(self, tmp_path: Path, flask_app) -> None:
+        from utils import sri as sri_mod
+        from utils.sri import init_sri
+
+        manifest = {
+            "my-lib": {
+                "url": "https://example.com/lib.js",
+                "integrity": "sha384-testvalue",
+            }
+        }
+        manifest_path = tmp_path / "cdn_manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        sri_mod._reset_cache_for_tests()
+        sri_mod._override_cdn_manifest_path_for_tests(manifest_path)
+        init_sri(flask_app)
+        with flask_app.app_context():
+            rendered = flask_app.jinja_env.from_string(
+                "{{ cdn_sri('my-lib') }}"
+            ).render()
+
+        assert rendered == "sha384-testvalue"
+
+
+# ---------------------------------------------------------------------------
+# Tests: cdn_manifest.json validity
+# ---------------------------------------------------------------------------
+
+
+class TestCdnManifest:
+    def test_manifest_is_valid_json(self) -> None:
+        assert (
+            CDN_MANIFEST_PATH.is_file()
+        ), f"cdn_manifest.json not found at {CDN_MANIFEST_PATH}"
+        manifest = json.loads(CDN_MANIFEST_PATH.read_text(encoding="utf-8"))
+        assert isinstance(manifest, dict)
+
+    def test_manifest_has_expected_keys(self) -> None:
+        manifest = json.loads(CDN_MANIFEST_PATH.read_text(encoding="utf-8"))
+        expected_keys = {"swagger-ui-css", "swagger-ui-bundle", "chart-js"}
+        for key in expected_keys:
+            assert key in manifest, f"cdn_manifest.json missing key: {key}"
+
+    def test_manifest_entries_have_required_fields(self) -> None:
+        manifest = json.loads(CDN_MANIFEST_PATH.read_text(encoding="utf-8"))
+        for key, entry in manifest.items():
+            assert "url" in entry, f"Entry '{key}' missing 'url'"
+            assert "integrity" in entry, f"Entry '{key}' missing 'integrity'"
+            assert entry["integrity"].startswith(
+                "sha384-"
+            ), f"Entry '{key}' integrity does not start with 'sha384-': {entry['integrity']}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_cdn_sri.py script
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCdnSriScript:
+    @pytest.fixture(autouse=True)
+    def patch_sys_path(self):
+        if str(SCRIPTS_ROOT) not in sys.path:
+            sys.path.insert(0, str(SCRIPTS_ROOT))
+        yield
+
+    def test_computes_correct_hash(self, tmp_path: Path) -> None:
+        """update_cdn_sri should download and write correct hashes."""
+        import update_cdn_sri as ucs
+
+        fake_data = b"fake cdn content"
+        expected_hash = _make_sri(fake_data)
+
+        manifest = {
+            "test-lib": {
+                "url": "https://cdn.example.com/test.js",
+                "version": "1.0.0",
+                "integrity": "sha384-old",
+            }
+        }
+        manifest_path = tmp_path / "cdn_manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        # Patch urllib.request.urlopen to return our fake data
+        import unittest.mock as mock
+
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = fake_data
+        fake_response.__enter__ = lambda s: s
+        fake_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            exit_code = ucs.main(["--manifest", str(manifest_path)])
+
+        assert exit_code == 0
+        updated = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert updated["test-lib"]["integrity"] == expected_hash
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        """--dry-run should compute but not write."""
+        import update_cdn_sri as ucs
+
+        original_integrity = "sha384-original"
+        manifest = {
+            "test-lib": {
+                "url": "https://cdn.example.com/test.js",
+                "integrity": original_integrity,
+            }
+        }
+        manifest_path = tmp_path / "cdn_manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        import unittest.mock as mock
+
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = b"new content"
+        fake_response.__enter__ = lambda s: s
+        fake_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch("urllib.request.urlopen", return_value=fake_response):
+            exit_code = ucs.main(["--dry-run", "--manifest", str(manifest_path)])
+
+        assert exit_code == 0
+        # File should be unchanged
+        still = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert still["test-lib"]["integrity"] == original_integrity
+
+    def test_missing_manifest_returns_error(self, tmp_path: Path) -> None:
+        import update_cdn_sri as ucs
+
+        exit_code = ucs.main(["--manifest", str(tmp_path / "nope.json")])
+        assert exit_code != 0


### PR DESCRIPTION
## Summary

- Adds `src/utils/sri.py` with `compute_sri()`, `sri_for()` (Jinja global, per-process cached), `cdn_sri()` (reads manifest, no network at boot), and `init_sri()` Flask wiring
- Adds `src/static/cdn_manifest.json` with pre-computed SHA-384 hashes for swagger-ui-css, swagger-ui-bundle, and chart-js CDN assets
- Adds `scripts/update_cdn_sri.py` to refresh CDN hashes when bumping a CDN version
- Injects `integrity` + `crossorigin="anonymous"` attrs on: htmx (vendored), swagger-ui CSS/JS, chart.js
- 24 tests covering hash computation, Jinja rendering, missing-file graceful degradation, cdn_manifest validation, and the update script

## Assets covered (4 total)
| Asset | Source | How |
|---|---|---|
| `htmx.min.js` | `src/static/vendor/` | `sri_for()` — computed from disk |
| `swagger-ui.css` | unpkg CDN | `cdn_sri()` — pre-computed in manifest |
| `swagger-ui-bundle.js` | unpkg CDN | `cdn_sri()` — pre-computed in manifest |
| `chart.js` | jsdelivr CDN | `cdn_sri()` — pre-computed in manifest |

## Test plan
- [x] `tests/test_sri.py` — 24 tests, all passing
- [x] Full suite: 2,889 passed, 2 pre-existing pyenv failures unrelated to this PR
- [x] Lint: ruff ✅ black ✅ mypy advisory (pre-existing)

Closes JTN-478

🤖 Generated with [Claude Code](https://claude.com/claude-code)