### PR TITLE
fix: add aria-pressed to logs panel toggle buttons (JTN-472)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -287,6 +287,7 @@
         btn.textContent = state.logsAutoScroll
           ? "Auto-Scroll: On"
           : "Auto-Scroll: Off";
+        btn.setAttribute("aria-pressed", String(state.logsAutoScroll));
       }
       ui.savePref?.("", prefKey("autoScroll"), state.logsAutoScroll);
     }
@@ -398,7 +399,10 @@
       const viewer = document.getElementById("logsViewer");
       const btn = document.getElementById("logsWrapBtn");
       if (viewer) viewer.style.whiteSpace = state.logsWrap ? "pre-wrap" : "pre";
-      if (btn) btn.textContent = state.logsWrap ? "Wrap: On" : "Wrap: Off";
+      if (btn) {
+        btn.textContent = state.logsWrap ? "Wrap: On" : "Wrap: Off";
+        btn.setAttribute("aria-pressed", String(state.logsWrap));
+      }
       ui.savePref?.("", prefKey("wrap"), state.logsWrap);
     }
 
@@ -708,9 +712,11 @@
         autoBtn.textContent = state.logsAutoScroll
           ? "Auto-Scroll: On"
           : "Auto-Scroll: Off";
+        autoBtn.setAttribute("aria-pressed", String(state.logsAutoScroll));
       }
       if (wrapBtn) {
         wrapBtn.textContent = state.logsWrap ? "Wrap: On" : "Wrap: Off";
+        wrapBtn.setAttribute("aria-pressed", String(state.logsWrap));
       }
       if (viewer) {
         viewer.style.whiteSpace = state.logsWrap ? "pre-wrap" : "pre";

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -337,8 +337,8 @@
                     <input id="logsMaxLines" type="number" min="50" value="500" class="form-input" />
                 </div>
                 <div class="logs-actions">
-                    <button id="logsAutoScrollBtn" class="header-button is-secondary" type="button">Auto-Scroll: On</button>
-                    <button id="logsWrapBtn" class="header-button is-secondary" type="button">Wrap: On</button>
+                    <button id="logsAutoScrollBtn" class="header-button is-secondary" type="button" aria-pressed="true">Auto-Scroll: On</button>
+                    <button id="logsWrapBtn" class="header-button is-secondary" type="button" aria-pressed="true">Wrap: On</button>
                     <button id="logsRefreshBtn" class="header-button is-secondary" type="button">Refresh</button>
                     <button id="logsCopyBtn" class="header-button is-secondary" type="button">Copy</button>
                     <button id="logsClearBtn" class="header-button is-dark" type="button">Clear</button>

--- a/tests/unit/test_aria_landmarks.py
+++ b/tests/unit/test_aria_landmarks.py
@@ -139,3 +139,41 @@ def test_skip_link_css_offscreen():
         ".skip-link must be positioned off-screen by default; "
         f"found block: {block!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# aria-pressed on logs panel toggle buttons (JTN-472)
+# ---------------------------------------------------------------------------
+
+
+def test_logs_panel_toggle_buttons_have_aria_pressed(client):
+    """Auto-Scroll and Wrap toggle buttons must expose aria-pressed (JTN-472)."""
+    html = _html(client, "/settings")
+    # logsAutoScrollBtn must have aria-pressed attribute
+    assert (
+        'id="logsAutoScrollBtn"' in html
+    ), "logsAutoScrollBtn not found in settings HTML"
+    assert 'id="logsWrapBtn"' in html, "logsWrapBtn not found in settings HTML"
+
+    # Both buttons must carry aria-pressed in the rendered HTML
+    import re
+
+    auto_scroll_match = re.search(
+        r'id="logsAutoScrollBtn"[^>]*aria-pressed="(true|false)"'
+        r'|aria-pressed="(true|false)"[^>]*id="logsAutoScrollBtn"',
+        html,
+    )
+    assert auto_scroll_match, (
+        "logsAutoScrollBtn is missing aria-pressed attribute; "
+        "toggle state must not be conveyed through text label alone (JTN-472)"
+    )
+
+    wrap_match = re.search(
+        r'id="logsWrapBtn"[^>]*aria-pressed="(true|false)"'
+        r'|aria-pressed="(true|false)"[^>]*id="logsWrapBtn"',
+        html,
+    )
+    assert wrap_match, (
+        "logsWrapBtn is missing aria-pressed attribute; "
+        "toggle state must not be conveyed through text label alone (JTN-472)"
+    )


### PR DESCRIPTION
## Summary
- Adds `aria-pressed="true"` initial state to the **Auto-Scroll** and **Wrap** toggle buttons in the Settings > Show Logs panel
- Updates `toggleLogsAutoScroll`, `toggleLogsWrap`, and `initializeLogsControls` in `settings_page.js` to call `setAttribute('aria-pressed', ...)` whenever the toggle state changes, keeping the ARIA attribute in sync with the actual state
- Adds a Flask-rendered HTML test (`test_logs_panel_toggle_buttons_have_aria_pressed`) that asserts both buttons carry `aria-pressed` in the rendered `/settings` page

## Test plan
- [ ] `test_logs_panel_toggle_buttons_have_aria_pressed` passes (verifies HTML has `aria-pressed` on both buttons)
- [ ] Screen reader (VoiceOver / NVDA) announces "pressed" / "not pressed" when toggling Auto-Scroll and Wrap buttons
- [ ] `scripts/lint.sh` passes (ruff + black clean)
- [ ] All pre-existing tests remain passing

Fixes JTN-472

🤖 Generated with [Claude Code](https://claude.com/claude-code)