### PR TITLE
fix: add aria-labelledby to image preview lightbox modal (JTN-467)

### DIFF
--- a/src/static/scripts/lightbox.js
+++ b/src/static/scripts/lightbox.js
@@ -76,10 +76,16 @@
       modal.className = 'modal image-modal';
       modal.setAttribute('role', 'dialog');
       modal.setAttribute('aria-modal', 'true');
-      modal.setAttribute('aria-label', 'Image preview');
+      modal.setAttribute('aria-labelledby', 'imagePreviewTitle');
       modal.style.display = 'none';
       const content = document.createElement('div');
       content.className = 'modal-content';
+
+      const heading = document.createElement('h2');
+      heading.id = 'imagePreviewTitle';
+      heading.className = 'sr-only';
+      heading.textContent = 'Image preview';
+      content.appendChild(heading);
 
       const close = document.createElement('button');
       close.className = 'close-button';

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -329,6 +329,7 @@
     <!-- Image preview (lightbox) for plugin page -->
     <div id="imagePreviewModal" class="modal image-modal" role="dialog" aria-modal="true" aria-labelledby="imagePreviewTitle" hidden>
         <div class="modal-content">
+            <h2 id="imagePreviewTitle" class="sr-only">Image preview</h2>
             <button class="close-button" type="button" data-lightbox-close aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
             <img id="imagePreviewImg" alt="Large preview" class="lightbox-preview-image"/>
         </div>

--- a/tests/static/test_image_preview_modal_a11y.py
+++ b/tests/static/test_image_preview_modal_a11y.py
@@ -1,0 +1,73 @@
+# pyright: reportMissingImports=false
+"""Accessibility tests for the image preview lightbox modal (JTN-467).
+
+Ensures the modal has a proper aria-labelledby attribute pointing to an
+existing element, satisfying WCAG 2.1 SC 4.1.2 (Name, Role, Value).
+"""
+
+import re
+from pathlib import Path
+
+_TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "src" / "templates"
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "src" / "static" / "scripts"
+
+
+def test_plugin_html_image_preview_modal_has_aria_labelledby():
+    """plugin.html must have aria-labelledby on #imagePreviewModal."""
+    content = (_TEMPLATES_DIR / "plugin.html").read_text(encoding="utf-8")
+    assert (
+        'aria-labelledby="imagePreviewTitle"' in content
+    ), "#imagePreviewModal in plugin.html must have aria-labelledby='imagePreviewTitle'"
+
+
+def test_plugin_html_image_preview_modal_labelledby_target_exists():
+    """The id referenced by aria-labelledby must exist inside the modal in plugin.html."""
+    content = (_TEMPLATES_DIR / "plugin.html").read_text(encoding="utf-8")
+    # Find the modal block
+    modal_start = content.find('id="imagePreviewModal"')
+    assert modal_start != -1, "#imagePreviewModal not found in plugin.html"
+    # Find the end of the modal div (closing tag after modal-content)
+    modal_end = content.find("</div>", content.find("</div>", modal_start) + 1) + len(
+        "</div>"
+    )
+    modal_block = content[modal_start:modal_end]
+    assert (
+        'id="imagePreviewTitle"' in modal_block
+    ), "Element with id='imagePreviewTitle' must exist inside #imagePreviewModal in plugin.html"
+
+
+def test_lightbox_js_dynamic_modal_uses_aria_labelledby():
+    """lightbox.js must use aria-labelledby (not just aria-label) on the dynamically created modal."""
+    content = (_SCRIPTS_DIR / "lightbox.js").read_text(encoding="utf-8")
+    assert (
+        "aria-labelledby" in content
+    ), "lightbox.js must set aria-labelledby on the dynamically-created modal"
+    assert (
+        "imagePreviewTitle" in content
+    ), "lightbox.js must reference 'imagePreviewTitle' for aria-labelledby"
+
+
+def test_lightbox_js_dynamic_modal_creates_heading_element():
+    """lightbox.js must create an h2 heading with id='imagePreviewTitle' for screen readers."""
+    content = (_SCRIPTS_DIR / "lightbox.js").read_text(encoding="utf-8")
+    assert re.search(
+        r"createElement\(['\"]h2['\"]\)", content
+    ), "lightbox.js must create an h2 element for the accessible modal name"
+    assert (
+        "heading.id = 'imagePreviewTitle'" in content
+    ), "lightbox.js must set heading.id = 'imagePreviewTitle'"
+
+
+def test_plugin_page_rendered_modal_has_aria_labelledby(client):
+    """Rendered plugin page must contain the modal with aria-labelledby and the target id."""
+    resp = client.get("/plugin/clock")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert (
+        'aria-labelledby="imagePreviewTitle"' in html
+    ), "Rendered plugin page must have aria-labelledby='imagePreviewTitle' on #imagePreviewModal"
+
+    assert (
+        'id="imagePreviewTitle"' in html
+    ), "Rendered plugin page must contain an element with id='imagePreviewTitle'"


### PR DESCRIPTION
## Summary

- Fixes missing/broken `aria-labelledby` on `#imagePreviewModal` so screen readers announce the dialog name (WCAG 2.1 SC 4.1.2)
- **plugin.html**: Added `<h2 id="imagePreviewTitle" class="sr-only">Image preview</h2>` inside the pre-rendered modal (the `aria-labelledby` attribute was already present but the target element did not exist)
- **lightbox.js**: Updated `ensureModal()` to create the same `<h2>` heading and use `aria-labelledby="imagePreviewTitle"` instead of the previous `aria-label="Image preview"` (affects dashboard, history, and playlist pages where the modal is created dynamically)

## Test plan

- [x] `test_plugin_html_image_preview_modal_has_aria_labelledby` — static check that attribute is present in template
- [x] `test_plugin_html_image_preview_modal_labelledby_target_exists` — static check that target `id` exists inside the modal in template
- [x] `test_lightbox_js_dynamic_modal_uses_aria_labelledby` — JS script uses `aria-labelledby`
- [x] `test_lightbox_js_dynamic_modal_creates_heading_element` — JS creates `<h2 id="imagePreviewTitle">`
- [x] `test_plugin_page_rendered_modal_has_aria_labelledby` — Flask client renders plugin page with both attribute and target id present

Closes JTN-467

🤖 Generated with [Claude Code](https://claude.com/claude-code)