### PR TITLE
fix: allow underscores/hyphens in playlist instance names (JTN-471)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -26,6 +26,7 @@ playlist_bp = Blueprint("playlist", __name__)
 
 _PLAYLIST_NAME_MAX_LEN = 64
 _PLAYLIST_NAME_RE = re.compile(r"^[\w\s\-]+$", re.UNICODE)
+_INSTANCE_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]+$")
 
 # Shared string constants to avoid duplication
 _CODE_VALIDATION = "validation_error"
@@ -304,12 +305,9 @@ def add_plugin():
                 code=_CODE_VALIDATION,
                 details={"field": "instance_name"},
             )
-        if not all(
-            char.isalpha() or char.isspace() or char.isnumeric()
-            for char in instance_name
-        ):
+        if not _INSTANCE_NAME_RE.match(instance_name):
             return json_error(
-                "Instance name can only contain alphanumeric characters and spaces",
+                "Instance name can only contain letters, numbers, spaces, underscores, and hyphens",
                 status=422,
                 code=_CODE_VALIDATION,
                 details={"field": "instance_name"},

--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -12,6 +12,14 @@
       if (instanceError) instanceError.textContent = "Instance name is required";
       return false;
     }
+    if (!/^[A-Za-z0-9 _-]+$/.test(name)) {
+      if (instanceInput) {
+        instanceInput.setAttribute("aria-invalid", "true");
+        instanceInput.focus();
+      }
+      if (instanceError) instanceError.textContent = "Instance name can only contain letters, numbers, spaces, underscores, and hyphens";
+      return false;
+    }
     if (instanceInput) instanceInput.setAttribute("aria-invalid", "false");
     if (instanceError) instanceError.textContent = "";
     return true;

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -296,7 +296,7 @@
                 </div>
                 <div class="form-group">
                     <label for="instance" class="form-label">Instance Name:</label>
-                    <input type="text" id="instance" name="instance_name" placeholder="Enter instance name" required class="form-input" aria-required="true" aria-invalid="false" aria-describedby="instance-error">
+                    <input type="text" id="instance" name="instance_name" placeholder="Enter instance name" required pattern="[A-Za-z0-9 _-]+" title="Letters, numbers, spaces, underscores, and hyphens only" class="form-input" aria-required="true" aria-invalid="false" aria-describedby="instance-error">
                     <span id="instance-error" class="validation-message" role="alert"></span>
                 </div>
                 <div class="form-group">

--- a/tests/integration/test_playlist_more.py
+++ b/tests/integration/test_playlist_more.py
@@ -31,7 +31,7 @@ def test_add_plugin_validation_errors(client):
         "refresh_settings": json.dumps(
             {
                 "playlist": "Default",
-                "instance_name": "Bad-Name",  # hyphen not allowed
+                "instance_name": "bad/name",  # slash not allowed
                 "refreshType": "interval",
                 "unit": "minute",
                 "interval": 5,
@@ -40,7 +40,9 @@ def test_add_plugin_validation_errors(client):
     }
     r1 = client.post("/add_plugin", data=bad_name)
     assert r1.status_code == 422
-    assert "alphanumeric characters and spaces" in r1.get_json().get("error", "")
+    assert "letters, numbers, spaces, underscores, and hyphens" in r1.get_json().get(
+        "error", ""
+    )
 
     missing_type = {
         "plugin_id": "clock",
@@ -55,6 +57,69 @@ def test_add_plugin_validation_errors(client):
     r2 = client.post("/add_plugin", data=missing_type)
     assert r2.status_code == 422
     assert "Refresh type is required" in r2.get_json().get("error", "")
+
+
+def _add_plugin_with_instance(client, instance_name):
+    """Helper: attempt to add a clock plugin with the given instance name."""
+    payload = {
+        "plugin_id": "clock",
+        "refresh_settings": json.dumps(
+            {
+                "playlist": "Default",
+                "instance_name": instance_name,
+                "refreshType": "interval",
+                "unit": "minute",
+                "interval": 10,
+            }
+        ),
+    }
+    return client.post("/add_plugin", data=payload)
+
+
+def test_instance_name_allows_underscore(client):
+    """JTN-471: underscore should be accepted in instance names."""
+    resp = _add_plugin_with_instance(client, "weather_home")
+    assert resp.status_code == 200
+    assert resp.get_json().get("success") is True
+
+
+def test_instance_name_allows_hyphen(client):
+    """JTN-471: hyphen should be accepted in instance names."""
+    resp = _add_plugin_with_instance(client, "my-plugin")
+    assert resp.status_code == 200
+    assert resp.get_json().get("success") is True
+
+
+def test_instance_name_allows_plain(client):
+    """JTN-471: plain alphanumeric name should be accepted."""
+    resp = _add_plugin_with_instance(client, "plain")
+    assert resp.status_code == 200
+    assert resp.get_json().get("success") is True
+
+
+def test_instance_name_rejects_slash(client):
+    """JTN-471: slash must be rejected to prevent path traversal."""
+    resp = _add_plugin_with_instance(client, "foo/bar")
+    assert resp.status_code == 422
+    assert "letters, numbers, spaces, underscores, and hyphens" in resp.get_json().get(
+        "error", ""
+    )
+
+
+def test_instance_name_rejects_dotdot(client):
+    """JTN-471: ../etc traversal attempt must be rejected."""
+    resp = _add_plugin_with_instance(client, "../etc")
+    assert resp.status_code == 422
+    assert "letters, numbers, spaces, underscores, and hyphens" in resp.get_json().get(
+        "error", ""
+    )
+
+
+def test_instance_name_rejects_empty(client):
+    """JTN-471: empty instance name must be rejected."""
+    resp = _add_plugin_with_instance(client, "")
+    assert resp.status_code == 422
+    assert "required" in resp.get_json().get("error", "").lower()
 
 
 def test_create_playlist_error_paths(client):

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -451,7 +451,7 @@ class TestAddPlugin:
             data={"plugin_id": "weather", "refresh_settings": refresh_settings},
         )
         assert resp.status_code == 422
-        assert "alphanumeric" in resp.get_json()["error"]
+        assert "letters, numbers, spaces, underscores, and hyphens" in resp.get_json()["error"]
 
     def test_missing_refresh_type(self, client, device_config_dev):
         _create_playlist(client, "NoRefType", "08:00", "12:00")

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -451,7 +451,10 @@ class TestAddPlugin:
             data={"plugin_id": "weather", "refresh_settings": refresh_settings},
         )
         assert resp.status_code == 422
-        assert "letters, numbers, spaces, underscores, and hyphens" in resp.get_json()["error"]
+        assert (
+            "letters, numbers, spaces, underscores, and hyphens"
+            in resp.get_json()["error"]
+        )
 
     def test_missing_refresh_type(self, client, device_config_dev):
         _create_playlist(client, "NoRefType", "08:00", "12:00")


### PR DESCRIPTION
## Summary

- Instance name validation in `POST /add_plugin` now accepts `[A-Za-z0-9 _-]+` instead of alphanumeric+spaces only
- Fixes the contradiction where the system auto-generates `weather_saved_settings`-style names but rejected user-typed underscores
- Frontend JS (`plugin_page.js`) and the HTML `<input pattern>` attribute updated for immediate client-side feedback with a matching error message
- Error message updated to "letters, numbers, spaces, underscores, and hyphens" (was "alphanumeric characters and spaces")
- Slashes, dots, and all other path-unsafe characters remain rejected

## Test plan

- [x] `weather_home` — accepted (underscore)
- [x] `my-plugin` — accepted (hyphen)
- [x] `plain` — accepted (alphanum)
- [x] `foo/bar` — rejected 422
- [x] `../etc` — rejected 422
- [x] empty string — rejected 422
- [x] 6 new integration tests added to `tests/integration/test_playlist_more.py`
- [x] Lint passes (`scripts/lint.sh`)
- [x] All tests pass (2988 passed, 2 pre-existing env failures unrelated to this change)

Closes JTN-471

🤖 Generated with [Claude Code](https://claude.com/claude-code)