### PR TITLE
fix: make skip link actually move focus to main (JTN-458)

### DIFF
--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}InkyPi - Page Not Found{% endblock %}
 {% block body %}
-    <main id="main-content" role="main" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
     <div class="frame">
         {% from 'macros/icons.html' import icon, theme_toggle %}
         <div class="app-header">

--- a/src/templates/api_keys.html
+++ b/src/templates/api_keys.html
@@ -6,7 +6,7 @@
 {% block body %}
     {% from 'macros/icons.html' import icon, theme_toggle, empty_state, breadcrumb %}
     {% from 'macros/api_key_card.html' import api_key_card %}
-    <main id="main-content" role="main" class="page-shell page-shell-management" data-page-shell="management">
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-management" data-page-shell="management">
     <div class="frame api-keys-frame">
         {% set key_summary = namespace(provider_count=(entries|length if entries is defined else 0), configured_count=0) %}
         {% if api_keys_mode == 'managed' %}

--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -5,7 +5,7 @@
     <script src="{{ url_for('static', filename='scripts/history_page.js') }}" defer></script>
 {% endblock %}
 {% block body %}
-    <main id="main-content" role="main" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
     <div class="frame">
         {% from 'macros/icons.html' import icon, theme_toggle, empty_state, breadcrumb %}
         <header class="app-header" role="banner">

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -44,7 +44,7 @@
         </div>
 
         <!-- Main content area -->
-        <main id="main-content" role="main" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
+        <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
             <div class="dashboard-hero">
                 <section class="dashboard-stage">
                     <div class="dashboard-stage-header">

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -21,7 +21,7 @@
 {% endblock %}
 {% block body %}
     {% from 'macros/icons.html' import icon, theme_toggle, empty_state, breadcrumb %}
-    <main id="main-content" role="main" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
     <div id="playlist-page-content">
     <div class="frame playlist-frame">
         <!-- Settings Header -->

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -30,7 +30,7 @@
     </script>
 {% endblock %}
 {% block body %}
-    <main id="main-content" role="main" class="page-shell page-shell-workflow" data-page-shell="workflow">
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-workflow" data-page-shell="workflow">
     <div class="frame workflow-frame">
         {% from 'macros/icons.html' import icon, theme_toggle, breadcrumb, PLUGIN_ICON_MAP %}
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -5,7 +5,7 @@
     <script src="{{ url_for('static', filename='scripts/settings_page.js') }}"></script>
 {% endblock %}
 {% block body %}
-    <main id="main-content" role="main" class="page-shell page-shell-management" data-page-shell="management">
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-management" data-page-shell="management">
     <div class="settings-grid">
     <div class="frame settings-panel">
         {% from 'macros/icons.html' import icon, theme_toggle, breadcrumb %}

--- a/tests/unit/test_aria_landmarks.py
+++ b/tests/unit/test_aria_landmarks.py
@@ -73,6 +73,32 @@ def test_all_pages_have_main_landmark(client, path):
     ), f"No <main id='main-content'> or role='main' with id='main-content' on {path}"
 
 
+@pytest.mark.parametrize("path", MAIN_PAGES)
+def test_main_element_has_tabindex_minus_one(client, path):
+    """<main id='main-content'> must have tabindex='-1' so skip link can move focus.
+
+    Without tabindex='-1', activating the skip link scrolls the viewport but does
+    not move keyboard focus, leaving the next Tab at the top of the page (JTN-458).
+    """
+    html = _html(client, path)
+    # The main element must contain both id="main-content" and tabindex="-1"
+    # as attributes on the same opening tag.
+    has_tabindex = bool(
+        re.search(
+            r'<main\b[^>]*\bid=["\']main-content["\'][^>]*\btabindex=["\']?-1["\']?',
+            html,
+        )
+        or re.search(
+            r'<main\b[^>]*\btabindex=["\']?-1["\']?[^>]*\bid=["\']main-content["\']',
+            html,
+        )
+    )
+    assert has_tabindex, (
+        f"<main id='main-content'> on {path} is missing tabindex='-1'. "
+        'Add tabindex="-1" so the skip link moves keyboard focus into main (JTN-458).'
+    )
+
+
 # ---------------------------------------------------------------------------
 # role="banner" / <header>
 # Plugin pages are out of scope for this PR (JTN-296 partial).


### PR DESCRIPTION
## Summary
- Adds `tabindex="-1"` to `<main id="main-content">` in all 7 page templates (inky, settings, playlist, history, api_keys, plugin, 404) so the browser can move keyboard focus programmatically when the skip link is activated
- Without this attribute, pressing the skip link scrolls the page but leaves `document.activeElement` as `<body>`, so the next Tab keystroke restarts from the page header rather than continuing inside `<main>`
- Adds a new parametrized pytest `test_main_element_has_tabindex_minus_one` covering all 6 main pages

## Test plan
- [x] `pytest tests/unit/test_aria_landmarks.py` — all 26 tests pass (including 6 new tabindex assertions)
- [x] `scripts/lint.sh` — ruff + black clean
- [x] Full test suite: 2989 passed, 2 pre-existing pyenv failures unrelated to this change

Closes JTN-458

🤖 Generated with [Claude Code](https://claude.com/claude-code)