### PR TITLE
fix: reject non-http(s) URL schemes in screenshot plugin (JTN-456)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -335,7 +335,7 @@ def update_plugin_instance(instance_name: str):
                 status=404,
             )
 
-        # Validate required fields defined in the plugin schema
+        # Validate required fields and plugin-specific settings
         plugin_config = device_config.get_plugin(plugin_id)
         if plugin_config:
             try:
@@ -343,6 +343,9 @@ def update_plugin_instance(instance_name: str):
                 validation_error = _validate_required_fields(plugin, plugin_settings)
                 if validation_error:
                     return json_error(validation_error, status=400)
+                settings_error = plugin.validate_settings(plugin_settings)
+                if settings_error:
+                    return json_error(settings_error, status=400)
             except Exception:
                 logger.debug("Could not validate plugin schema for %s", plugin_id)
 
@@ -568,12 +571,15 @@ def _save_plugin_settings_common(
             status=404,
         )
 
-    # Validate required fields defined in the plugin schema
+    # Validate required fields and plugin-specific settings
     try:
         plugin = get_plugin_instance(plugin_config)
         validation_error = _validate_required_fields(plugin, plugin_settings)
         if validation_error:
             return json_error(validation_error, status=400)
+        settings_error = plugin.validate_settings(plugin_settings)
+        if settings_error:
+            return json_error(settings_error, status=400)
     except Exception:
         logger.debug("Could not validate plugin schema for %s", plugin_id)
 

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -132,6 +132,18 @@ class BasePlugin:
         except Exception:
             return self.to_file_url(path)
 
+    def validate_settings(self, settings: dict) -> str | None:
+        """Validate plugin-specific settings before they are persisted.
+
+        Plugins can override this to reject invalid settings at save time,
+        before ``generate_image`` is ever called.  Return a human-readable
+        error string to reject the save, or ``None`` to allow it.
+
+        The default implementation performs no validation and always returns
+        ``None``.
+        """
+        return None
+
     def build_settings_schema(self):
         """Return a declarative settings schema for shared rendering.
 

--- a/src/plugins/screenshot/screenshot.py
+++ b/src/plugins/screenshot/screenshot.py
@@ -9,14 +9,27 @@ logger = logging.getLogger(__name__)
 
 
 class Screenshot(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject non-http(s) URLs at save time to prevent unsafe values persisting."""
+        url = settings.get("url", "").strip()
+        if not url:
+            return "URL is required."
+        try:
+            validate_url(url)
+        except ValueError as e:
+            return f"Invalid URL: {e}"
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(
                 "Capture",
                 field(
                     "url",
+                    "url",
                     label="URL",
                     placeholder="https://example.com",
+                    pattern="https?://.*",
                     required=True,
                 ),
                 callout(
@@ -39,7 +52,8 @@ class Screenshot(BasePlugin):
 
         dimensions = self.get_oriented_dimensions(device_config)
 
-        logger.info(f"Taking screenshot of url: {url}")
+        safe_url = url.replace("\n", "").replace("\r", "")
+        logger.info("Taking screenshot of url: %s", safe_url)
 
         image = take_screenshot(url, dimensions, timeout_ms=40000)
 

--- a/src/templates/settings_schema.html
+++ b/src/templates/settings_schema.html
@@ -179,6 +179,7 @@
                 {% if field.step is defined %}step="{{ field.step }}"{% endif %}
                 {% if field.required %}required{% endif %}
                 {% if field.list %}list="{{ field.list.id }}"{% endif %}
+                {% if field.pattern %}pattern="{{ field.pattern }}"{% endif %}
             >
             {% if field.list %}
             <datalist id="{{ field.list.id }}">

--- a/tests/integration/test_screenshot_url_validation.py
+++ b/tests/integration/test_screenshot_url_validation.py
@@ -1,0 +1,207 @@
+# pyright: reportMissingImports=false
+"""Tests for screenshot plugin URL scheme validation at save time (JTN-456).
+
+The Screenshot plugin must reject non-http(s) URLs when settings are saved,
+not just when generate_image is called.  This prevents unsafe values (e.g.
+file:// or javascript:) from being persisted to device.json.
+"""
+
+# ---------------------------------------------------------------------------
+# /save_plugin_settings  (POST)
+# ---------------------------------------------------------------------------
+
+
+class TestSavePluginSettingsUrlValidation:
+    """Verify that /save_plugin_settings enforces URL scheme for screenshot."""
+
+    def test_javascript_url_rejected_on_save(self, client):
+        """javascript: URLs must be rejected at save time with HTTP 400."""
+        resp = client.post(
+            "/save_plugin_settings",
+            data={"plugin_id": "screenshot", "url": "javascript:alert(1)"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_file_url_rejected_on_save(self, client):
+        """file:// URLs must be rejected at save time with HTTP 400."""
+        resp = client.post(
+            "/save_plugin_settings",
+            data={"plugin_id": "screenshot", "url": "file:///etc/passwd"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_data_url_rejected_on_save(self, client):
+        """data: URLs must be rejected at save time with HTTP 400."""
+        resp = client.post(
+            "/save_plugin_settings",
+            data={"plugin_id": "screenshot", "url": "data:text/html,<h1>hi</h1>"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_ftp_url_rejected_on_save(self, client):
+        """ftp:// URLs must be rejected at save time with HTTP 400."""
+        resp = client.post(
+            "/save_plugin_settings",
+            data={"plugin_id": "screenshot", "url": "ftp://files.example.com/"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_http_url_accepted_on_save(self, client, monkeypatch):
+        """http:// URLs with a public hostname must be accepted (HTTP 200)."""
+        import socket
+
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+            ],
+        )
+        resp = client.post(
+            "/save_plugin_settings",
+            data={"plugin_id": "screenshot", "url": "http://example.com"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get("success") is True
+
+    def test_https_url_accepted_on_save(self, client, monkeypatch):
+        """https:// URLs with a public hostname must be accepted (HTTP 200)."""
+        import socket
+
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+            ],
+        )
+        resp = client.post(
+            "/save_plugin_settings",
+            data={"plugin_id": "screenshot", "url": "https://example.com"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get("success") is True
+
+
+# ---------------------------------------------------------------------------
+# /plugin/<plugin_id>/save  (POST alias)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveAliasUrlValidation:
+    """Verify the alias route /plugin/screenshot/save also enforces URL scheme."""
+
+    def test_javascript_url_rejected_via_alias(self, client):
+        """javascript: URL is rejected through the alias save route."""
+        resp = client.post(
+            "/plugin/screenshot/save",
+            data={"url": "javascript:alert(1)"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_file_url_rejected_via_alias(self, client):
+        """file:// URL is rejected through the alias save route."""
+        resp = client.post(
+            "/plugin/screenshot/save",
+            data={"url": "file:///etc/passwd"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_https_url_accepted_via_alias(self, client, monkeypatch):
+        """https:// URL is accepted through the alias save route."""
+        import socket
+
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+            ],
+        )
+        resp = client.post(
+            "/plugin/screenshot/save",
+            data={"url": "https://example.com"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get("success") is True
+
+
+# ---------------------------------------------------------------------------
+# /update_plugin_instance/<name>  (PUT)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateInstanceUrlValidation:
+    """Verify that updating an existing screenshot instance also validates URL."""
+
+    def _create_instance(self, device_config_dev, name="screenshot_test_instance"):
+        """Helper: create a screenshot plugin instance on the Default playlist."""
+        pm = device_config_dev.get_playlist_manager()
+        if not pm.get_playlist("Default"):
+            pm.add_playlist("Default")
+        playlist = pm.get_playlist("Default")
+        playlist.add_plugin(
+            {
+                "plugin_id": "screenshot",
+                "name": name,
+                "plugin_settings": {"url": "https://example.com"},
+                "refresh": {"interval": 3600},
+            }
+        )
+        device_config_dev.write_config()
+        return name
+
+    def test_update_rejects_javascript_url(self, client, device_config_dev):
+        """javascript: URL is rejected when updating an existing screenshot instance."""
+        name = self._create_instance(device_config_dev)
+        resp = client.put(
+            f"/update_plugin_instance/{name}",
+            data={"plugin_id": "screenshot", "url": "javascript:alert(1)"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "Invalid URL" in data.get("error", "")
+
+    def test_update_rejects_file_url(self, client, device_config_dev):
+        """file:// URL is rejected when updating an existing screenshot instance."""
+        name = self._create_instance(device_config_dev, "screenshot_file_test")
+        resp = client.put(
+            f"/update_plugin_instance/{name}",
+            data={"plugin_id": "screenshot", "url": "file:///etc/shadow"},
+        )
+        assert resp.status_code == 400
+
+    def test_update_accepts_https_url(self, client, device_config_dev, monkeypatch):
+        """https:// URL is accepted when updating an existing screenshot instance."""
+        import socket
+
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            lambda *a, **kw: [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+            ],
+        )
+        name = self._create_instance(device_config_dev, "screenshot_https_test")
+        resp = client.put(
+            f"/update_plugin_instance/{name}",
+            data={"plugin_id": "screenshot", "url": "https://example.com/page"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get("success") is True


### PR DESCRIPTION
## Summary

- **Security fix**: The Screenshot plugin's save endpoint accepted and persisted `javascript:`, `file://`, `data:`, and `ftp://` URLs without validation, allowing unsafe values to live in `device.json`.
- Added a `validate_settings` hook to `BasePlugin` (default returns `None`) and overrode it in `Screenshot` to run `validate_url` before settings are persisted — rejecting any non-http(s) scheme with HTTP 400.
- Wired the hook into `_save_plugin_settings_common` and `update_plugin_instance` so **all three save routes** enforce URL scheme validation.
- Added `type="url"` + `pattern="https?://.*"` to the screenshot URL field for client-side feedback (requires `settings_schema.html` pattern attribute support, also added).
- Sanitized URL in log message to prevent log injection (Sonar S5145).

## Changes

| File | Change |
|------|--------|
| `src/plugins/base_plugin/base_plugin.py` | Add `validate_settings` hook |
| `src/plugins/screenshot/screenshot.py` | Override `validate_settings`, fix log injection, add `type="url"` + `pattern` |
| `src/blueprints/plugin.py` | Call `validate_settings` in both save paths |
| `src/templates/settings_schema.html` | Render `pattern` attribute when set on a field |
| `tests/integration/test_screenshot_url_validation.py` | 12 new tests covering all save routes |

## Test plan

- [x] `javascript:alert(1)` rejected with 400 via all three save routes
- [x] `file:///etc/passwd` rejected with 400
- [x] `data:text/html,...` rejected with 400
- [x] `ftp://example.com` rejected with 400
- [x] `http://example.com` accepted (200)
- [x] `https://example.com` accepted (200)
- [x] All existing screenshot and security_utils tests continue to pass
- [x] Full test suite: 2995 passed (2 pre-existing env failures unrelated to this change)
- [x] `scripts/lint.sh` passes (ruff + black)

## Security impact

Fixes arbitrary local file disclosure path: previously `file:///etc/passwd` could be saved and picked up by the screenshot rendering pipeline, potentially exposing file contents via `/history`. Now rejected at the API boundary before persistence.

Closes JTN-456.