### PR TITLE
feat: set Content-Disposition on download endpoints (JTN-515)

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -174,6 +174,9 @@ def get_current_image():
         "%a, %d %b %Y %H:%M:%S GMT"
     )
     response.headers["Cache-Control"] = "no-cache"
+    response.headers["Content-Disposition"] = (
+        f'inline; filename="{os.path.basename(image_path)}"'
+    )
     return response
 
 

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -91,6 +91,8 @@ def _cacheable_send_file(path: str, ttl_env: str = "INKYPI_RENDER_CACHE_TTL_S"):
         ttl = 300
     ttl = max(0, ttl)
     resp.headers["Cache-Control"] = f"public, max-age={ttl}"
+    basename = os.path.basename(safe_path)
+    resp.headers["Content-Disposition"] = f'inline; filename="{basename}"'
     return resp
 
 
@@ -171,6 +173,8 @@ def image(plugin_id: str, filename: str):
     except Exception:
         ttl = 300
     resp.headers["Cache-Control"] = f"public, max-age={max(0, ttl)}"
+    basename = os.path.basename(filename)
+    resp.headers["Content-Disposition"] = f'inline; filename="{basename}"'
     return resp
 
 

--- a/src/blueprints/settings/_logs.py
+++ b/src/blueprints/settings/_logs.py
@@ -28,7 +28,7 @@ def download_logs():
         return Response(
             buffer.read(),
             mimetype="text/plain",
-            headers={"Content-Disposition": f"attachment; filename={filename}"},
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
 
     except Exception:

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -84,7 +84,9 @@ def maybe_serve_webp(
     if not _client_accepts_webp(accept_header):
         # send_from_directory performs path-traversal validation internally;
         # this is the recognized sanitization sink.
-        return send_from_directory(root_str, filename, mimetype="image/png")
+        resp = send_from_directory(root_str, filename, mimetype="image/png")
+        resp.headers["Content-Disposition"] = f'inline; filename="{filename}"'
+        return resp
 
     # For the WebP path we still need an absolute filesystem path. Re-use
     # send_from_directory's validation by calling it once to resolve, then
@@ -104,6 +106,7 @@ def maybe_serve_webp(
     response = Response(webp_bytes, mimetype="image/webp")
     response.headers["ETag"] = etag
     response.headers["Cache-Control"] = "no-cache"
+    response.headers["Content-Disposition"] = f'inline; filename="{filename}"'
     return response
 
 

--- a/tests/contracts/test_download_headers.py
+++ b/tests/contracts/test_download_headers.py
@@ -1,0 +1,171 @@
+"""Contract tests: Content-Disposition headers on download/image endpoints (JTN-515).
+
+Every route that sends file bytes must set an explicit Content-Disposition so
+browsers cannot apply MIME-sniffing or silently render files inline.
+
+Rules checked here:
+  - download_logs  -> attachment; filename="inkypi_<timestamp>.log"
+  - maybe_serve_webp PNG branch -> inline; filename="<name>.png"
+  - maybe_serve_webp WebP branch -> inline; filename="<name>.png"
+  - X-Content-Type-Options: nosniff set globally (spot-checked on download_logs)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+from PIL import Image
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+SRC_ABS = os.path.join(PROJECT_ROOT, "src")
+for _p in (PROJECT_ROOT, SRC_ABS):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_inline(cd: str) -> None:
+    """Assert Content-Disposition is inline with a properly quoted filename."""
+    assert cd.startswith("inline;"), f"Expected inline disposition, got: {cd!r}"
+    assert 'filename="' in cd, f"Filename not quoted in: {cd!r}"
+
+
+def _assert_attachment(cd: str) -> None:
+    """Assert Content-Disposition is attachment with a properly quoted filename."""
+    assert cd.startswith("attachment;"), f"Expected attachment disposition, got: {cd!r}"
+    assert 'filename="' in cd, f"Filename not quoted in: {cd!r}"
+
+
+# ---------------------------------------------------------------------------
+# download_logs — attachment disposition + quoted filename
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadLogsHeaders:
+    def test_attachment_disposition(self, client, monkeypatch):
+        """download_logs must return attachment with a properly quoted filename."""
+        import blueprints.settings as mod
+
+        monkeypatch.setattr(mod, "JOURNAL_AVAILABLE", False)
+        resp = client.get("/download-logs")
+        assert resp.status_code == 200
+        cd = resp.headers.get("Content-Disposition", "")
+        _assert_attachment(cd)
+
+    def test_filename_matches_pattern(self, client, monkeypatch):
+        """download_logs filename must match inkypi_YYYYMMDD-HHMMSS.log."""
+        import blueprints.settings as mod
+
+        monkeypatch.setattr(mod, "JOURNAL_AVAILABLE", False)
+        resp = client.get("/download-logs")
+        assert resp.status_code == 200
+        cd = resp.headers.get("Content-Disposition", "")
+        assert re.search(
+            r'filename="inkypi_\d{8}-\d{6}\.log"', cd
+        ), f"Unexpected filename in: {cd!r}"
+
+    def test_filename_has_safe_chars_only(self, client, monkeypatch):
+        """Filename in Content-Disposition must contain only safe characters."""
+        import blueprints.settings as mod
+
+        monkeypatch.setattr(mod, "JOURNAL_AVAILABLE", False)
+        resp = client.get("/download-logs")
+        assert resp.status_code == 200
+        cd = resp.headers.get("Content-Disposition", "")
+        m = re.search(r'filename="([^"]+)"', cd)
+        assert m, f"No quoted filename found in: {cd!r}"
+        fname = m.group(1)
+        assert re.fullmatch(
+            r"[a-zA-Z0-9._-]+", fname
+        ), f"Filename contains unsafe characters: {fname!r}"
+
+    def test_nosniff_header_present(self, client, monkeypatch):
+        """download_logs response must include X-Content-Type-Options: nosniff."""
+        import blueprints.settings as mod
+
+        monkeypatch.setattr(mod, "JOURNAL_AVAILABLE", False)
+        resp = client.get("/download-logs")
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+# ---------------------------------------------------------------------------
+# maybe_serve_webp — inline disposition on both code paths
+# ---------------------------------------------------------------------------
+
+
+def _make_png(tmp_path, name="test.png"):
+    p = tmp_path / name
+    img = Image.new("RGB", (4, 4), color=(10, 20, 30))
+    img.save(str(p), format="PNG")
+    return p
+
+
+class TestMaybeServeWebpHeaders:
+    def test_png_path_sets_inline_disposition(self, tmp_path):
+        """maybe_serve_webp PNG branch must set inline Content-Disposition."""
+        from flask import Flask
+
+        from utils.image_serving import maybe_serve_webp
+
+        _make_png(tmp_path)
+        app = Flask(__name__)
+        with app.test_request_context("/"):
+            resp = maybe_serve_webp(str(tmp_path), "test.png", accept_header=None)
+
+        cd = resp.headers.get("Content-Disposition", "")
+        _assert_inline(cd)
+        assert "test.png" in cd, f"Filename missing from: {cd!r}"
+
+    def test_webp_path_sets_inline_disposition(self, tmp_path):
+        """maybe_serve_webp WebP branch must set inline Content-Disposition."""
+        from flask import Flask
+
+        from utils.image_serving import maybe_serve_webp
+
+        _make_png(tmp_path)
+        app = Flask(__name__)
+        with app.test_request_context("/"):
+            resp = maybe_serve_webp(
+                str(tmp_path), "test.png", accept_header="image/webp"
+            )
+
+        cd = resp.headers.get("Content-Disposition", "")
+        _assert_inline(cd)
+        assert "test.png" in cd, f"Filename missing from: {cd!r}"
+
+    def test_png_filename_quoted(self, tmp_path):
+        """PNG branch filename must be double-quoted per RFC 6266."""
+        from flask import Flask
+
+        from utils.image_serving import maybe_serve_webp
+
+        _make_png(tmp_path, "my-image.png")
+        app = Flask(__name__)
+        with app.test_request_context("/"):
+            resp = maybe_serve_webp(str(tmp_path), "my-image.png", accept_header=None)
+
+        cd = resp.headers.get("Content-Disposition", "")
+        assert 'filename="my-image.png"' in cd, f"Expected quoted filename in: {cd!r}"
+
+    def test_webp_filename_quoted(self, tmp_path):
+        """WebP branch filename must be double-quoted per RFC 6266."""
+        from flask import Flask
+
+        from utils.image_serving import maybe_serve_webp
+
+        _make_png(tmp_path, "my-image.png")
+        app = Flask(__name__)
+        with app.test_request_context("/"):
+            resp = maybe_serve_webp(
+                str(tmp_path), "my-image.png", accept_header="image/webp"
+            )
+
+        cd = resp.headers.get("Content-Disposition", "")
+        assert 'filename="my-image.png"' in cd, f"Expected quoted filename in: {cd!r}"


### PR DESCRIPTION
## Summary

- Add `Content-Disposition: attachment; filename="inkypi_*.log"` to `download_logs` (was missing quotes around filename)
- Add `Content-Disposition: inline; filename="..."` to all image-serving routes: `_cacheable_send_file`, `/images/<plugin_id>/<filename>`, `maybe_serve_webp` (both PNG + WebP branches), and `get_current_image`
- `X-Content-Type-Options: nosniff` is already set globally by security middleware — no change needed per route

Fixes JTN-515 (Grade E3 — defense-in-depth).

## Test plan

- [x] `tests/contracts/test_download_headers.py` — new contract tests asserting attachment/inline disposition, quoted filenames, safe characters, and nosniff header
- [x] Existing tests in `test_settings_logs.py`, `test_settings_extra.py`, `test_image_serving.py` continue to pass
- [x] `scripts/lint.sh` clean (ruff + black)
- [x] 2991 tests pass (2 pre-existing failures unrelated to this PR: pyenv `python` not found in test env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)