### PR TITLE
feat: validate uploaded image magic bytes (JTN-514)

### DIFF
--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -224,6 +224,71 @@ _ALLOWED_FILE_EXTENSIONS = {
     "heic",
 }
 
+# Magic-byte signatures for image formats.  Each entry maps a normalised
+# extension (or set of equivalent extensions) to a list of byte-prefix
+# tuples that are valid for that format.  Only image extensions are listed
+# here; PDF is validated separately by downstream code.
+_IMAGE_MAGIC_SIGNATURES: dict[str, list[bytes]] = {
+    "png": [b"\x89PNG\r\n\x1a\n"],
+    "jpg": [b"\xff\xd8\xff"],
+    "jpeg": [b"\xff\xd8\xff"],
+    "gif": [b"GIF87a", b"GIF89a"],
+    "webp": [b"RIFF"],  # Full check: bytes[8:12] == b"WEBP" – done in validator
+    "bmp": [b"BM"],
+    # HEIF/HEIC/AVIF use ISO Base Media File Format; magic is at offset 4.
+    # We allow any ftyp box (offset 4–8 == b"ftyp") rather than enumerating
+    # every brand, then rely on PIL.verify() for deeper validation.
+    "heif": [],  # checked via PIL only
+    "heic": [],  # checked via PIL only
+    "avif": [],  # checked via PIL only
+}
+
+# Image extensions that require PIL verification after the magic-byte check.
+_IMAGE_EXTENSIONS: frozenset[str] = frozenset(
+    ext for ext in _ALLOWED_FILE_EXTENSIONS if ext != "pdf"
+)
+
+
+def _check_magic_bytes(content: bytes, extension: str) -> bool:
+    """Return True if *content* starts with a recognised magic signature for *extension*.
+
+    For formats without a simple prefix (heif/heic/avif) we defer entirely to
+    PIL.verify() and return True here so the caller proceeds to that check.
+
+    For WebP we additionally verify the "WEBP" brand at offset 8.
+    """
+    sigs = _IMAGE_MAGIC_SIGNATURES.get(extension)
+    if sigs is None:
+        # Unknown image extension — allow PIL to decide.
+        return True
+    if not sigs:
+        # Formats delegated entirely to PIL (heif/heic/avif).
+        return True
+    if not any(content.startswith(sig) for sig in sigs):
+        return False
+    # Extra check for WebP: the 4-byte brand field at offset 8 must be b"WEBP".
+    if extension == "webp":
+        return content[8:12] == b"WEBP"
+    return True
+
+
+def _validate_image_content(content: bytes, extension: str) -> None:
+    """Validate image content using magic bytes and PIL verification.
+
+    Raises ``RuntimeError`` with a user-safe message when the file is not a
+    valid image.  The caller is responsible for ensuring *content* is non-empty
+    before calling this function.
+    """
+    if not _check_magic_bytes(content, extension):
+        raise RuntimeError("Uploaded file is not a valid image")
+
+    # PIL verification: catches malformed files that pass the magic-byte check.
+    try:
+        with Image.open(BytesIO(content)) as img:
+            img.verify()
+    except Exception as exc:
+        raise RuntimeError("Uploaded file is not a valid image") from exc
+
 
 def _get_existing_file_location(key, form_data):
     """Return the existing file location(s) from form_data for the given key.
@@ -248,9 +313,14 @@ def _validate_and_read_file(file, file_name):
     if not extension or extension.lower() not in _ALLOWED_FILE_EXTENSIONS:
         return None, None
 
+    ext = extension.lower()
+
     content = file.read()
     if content is None:
         raise RuntimeError("Empty upload content")
+
+    if len(content) == 0:
+        raise RuntimeError("Uploaded file is not a valid image")
 
     max_upload_bytes_env = os.getenv("MAX_UPLOAD_BYTES")
     max_upload_bytes = (
@@ -260,7 +330,13 @@ def _validate_and_read_file(file, file_name):
         raise RuntimeError(
             f"Uploaded file exceeds size limit of {max_upload_bytes} bytes"
         )
-    return content, extension.lower()
+
+    # Validate magic bytes and PIL integrity for image uploads.
+    # PDFs are handled by downstream code; skip magic-byte check for them.
+    if ext in _IMAGE_EXTENSIONS:
+        _validate_image_content(content, ext)
+
+    return content, ext
 
 
 def _rewind_file_stream(file):

--- a/tests/unit/test_app_utils.py
+++ b/tests/unit/test_app_utils.py
@@ -391,7 +391,7 @@ def test_handle_request_files_empty_content(monkeypatch, tmp_path):
     f = FakeFile("empty.png", b"")
     files = FakeFiles([("file", f)])
 
-    with pytest.raises(RuntimeError, match="Invalid image upload"):
+    with pytest.raises(RuntimeError, match="not a valid image"):
         app_utils.handle_request_files(files)
 
 
@@ -477,5 +477,5 @@ def test_handle_request_files_invalid_jpeg_raises(monkeypatch, tmp_path):
     f = FakeFile("bad.jpg", b"not a real jpeg")
     files = FakeFiles([("file", f)])
 
-    with pytest.raises(RuntimeError, match="Invalid image upload"):
+    with pytest.raises(RuntimeError, match="not a valid image"):
         app_utils.handle_request_files(files)

--- a/tests/unit/test_image_upload_magic_bytes.py
+++ b/tests/unit/test_image_upload_magic_bytes.py
@@ -1,0 +1,258 @@
+"""Tests for magic-bytes validation in handle_request_files / _validate_and_read_file.
+
+JTN-514: Uploaded files must pass both a magic-byte check and PIL.verify()
+before being accepted, regardless of the file extension supplied by the client.
+"""
+
+from __future__ import annotations
+
+import os
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+import utils.app_utils as app_utils  # noqa: E402 (conftest adjusts sys.path)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeFile:
+    """Minimal file-like object accepted by _validate_and_read_file."""
+
+    def __init__(self, filename: str, content: bytes) -> None:
+        self.filename = filename
+        self._content = content
+        self._pos = 0
+
+        outer = self
+
+        class _Stream:
+            def seek(self, pos: int) -> None:
+                outer._pos = pos
+
+            def tell(self) -> int:
+                return outer._pos
+
+        self.stream = _Stream()
+
+    def read(self) -> bytes:
+        return self._content
+
+    def seek(self, pos: int) -> None:
+        self._pos = pos
+
+
+class _FakeFiles:
+    """Minimal multi-dict accepted by handle_request_files."""
+
+    def __init__(self, pairs: list[tuple[str, _FakeFile]]) -> None:
+        self._pairs = pairs
+
+    def keys(self) -> list[str]:
+        return [k for k, _ in self._pairs]
+
+    def items(self, multi: bool = False) -> list[tuple[str, _FakeFile]]:
+        return self._pairs
+
+
+def _make_valid_png() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (10, 10), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_valid_jpeg() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (10, 10), color=(0, 255, 0)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _make_valid_gif() -> bytes:
+    buf = BytesIO()
+    Image.new("P", (10, 10)).save(buf, format="GIF")
+    return buf.getvalue()
+
+
+def _make_valid_webp() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (10, 10), color=(0, 0, 255)).save(buf, format="WEBP")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for _validate_and_read_file
+# ---------------------------------------------------------------------------
+
+
+def test_valid_png_passes():
+    """A genuine PNG is accepted and content is returned."""
+    content = _make_valid_png()
+    f = _FakeFile("photo.png", content)
+    result_content, ext = app_utils._validate_and_read_file(f, "photo.png")
+    assert ext == "png"
+    assert result_content == content
+
+
+def test_valid_jpeg_passes():
+    """A genuine JPEG is accepted."""
+    content = _make_valid_jpeg()
+    f = _FakeFile("photo.jpg", content)
+    result_content, ext = app_utils._validate_and_read_file(f, "photo.jpg")
+    assert ext == "jpg"
+    assert result_content == content
+
+
+def test_valid_gif_passes():
+    """A genuine GIF is accepted."""
+    content = _make_valid_gif()
+    f = _FakeFile("anim.gif", content)
+    result_content, ext = app_utils._validate_and_read_file(f, "anim.gif")
+    assert ext == "gif"
+    assert result_content == content
+
+
+def test_valid_webp_passes():
+    """A genuine WebP is accepted."""
+    content = _make_valid_webp()
+    f = _FakeFile("img.webp", content)
+    result_content, ext = app_utils._validate_and_read_file(f, "img.webp")
+    assert ext == "webp"
+    assert result_content == content
+
+
+def test_text_file_renamed_to_png_rejected():
+    """A plain-text file renamed to .png is rejected with RuntimeError."""
+    content = b"Hello, world! This is definitely not an image."
+    f = _FakeFile("evil.png", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "evil.png")
+
+
+def test_random_binary_renamed_to_png_rejected():
+    """Random bytes with a .png extension are rejected."""
+    content = os.urandom(512)
+    f = _FakeFile("evil.png", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "evil.png")
+
+
+def test_empty_file_rejected():
+    """An empty file is rejected regardless of extension."""
+    f = _FakeFile("empty.png", b"")
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "empty.png")
+
+
+def test_truncated_png_header_rejected():
+    """Bytes that start with PNG magic but are not a valid PNG are rejected."""
+    content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20  # valid magic, corrupt body
+    f = _FakeFile("truncated.png", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "truncated.png")
+
+
+def test_jpeg_bytes_with_png_extension_rejected():
+    """JPEG content uploaded as .png must be rejected (magic mismatch)."""
+    content = _make_valid_jpeg()
+    f = _FakeFile("photo.png", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "photo.png")
+
+
+def test_png_bytes_with_jpeg_extension_rejected():
+    """PNG content uploaded as .jpg must be rejected (magic mismatch)."""
+    content = _make_valid_png()
+    f = _FakeFile("photo.jpg", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "photo.jpg")
+
+
+def test_exe_renamed_to_png_rejected():
+    """A Windows PE executable renamed to .png is rejected."""
+    # MZ header — the DOS stub of PE executables
+    content = b"MZ" + b"\x90" * 510
+    f = _FakeFile("malware.png", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils._validate_and_read_file(f, "malware.png")
+
+
+# ---------------------------------------------------------------------------
+# Integration via handle_request_files
+# ---------------------------------------------------------------------------
+
+
+def test_handle_request_files_accepts_valid_png(monkeypatch, tmp_path):
+    """handle_request_files saves valid images and returns the file path."""
+    monkeypatch.setattr(
+        app_utils,
+        "resolve_path",
+        lambda p: str(tmp_path / os.path.basename(p)),
+    )
+    os.makedirs(str(tmp_path / "saved"), exist_ok=True)
+
+    content = _make_valid_png()
+    f = _FakeFile("photo.png", content)
+    result = app_utils.handle_request_files(_FakeFiles([("imageFiles[]", f)]))
+    assert "imageFiles[]" in result
+    paths = result["imageFiles[]"]
+    assert isinstance(paths, list)
+    assert len(paths) == 1
+
+
+def test_handle_request_files_rejects_bad_magic(monkeypatch, tmp_path):
+    """handle_request_files propagates RuntimeError for files with bad magic."""
+    monkeypatch.setattr(
+        app_utils,
+        "resolve_path",
+        lambda p: str(tmp_path / os.path.basename(p)),
+    )
+
+    content = b"This is not an image at all."
+    f = _FakeFile("evil.png", content)
+    with pytest.raises(RuntimeError, match="not a valid image"):
+        app_utils.handle_request_files(_FakeFiles([("imageFiles[]", f)]))
+
+
+# ---------------------------------------------------------------------------
+# _check_magic_bytes unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_check_magic_bytes_png_valid():
+    assert app_utils._check_magic_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20, "png")
+
+
+def test_check_magic_bytes_png_invalid():
+    assert not app_utils._check_magic_bytes(b"NOTPNG", "png")
+
+
+def test_check_magic_bytes_jpeg_valid():
+    assert app_utils._check_magic_bytes(b"\xff\xd8\xff" + b"\x00" * 20, "jpg")
+
+
+def test_check_magic_bytes_gif87a_valid():
+    assert app_utils._check_magic_bytes(b"GIF87a" + b"\x00" * 20, "gif")
+
+
+def test_check_magic_bytes_gif89a_valid():
+    assert app_utils._check_magic_bytes(b"GIF89a" + b"\x00" * 20, "gif")
+
+
+def test_check_magic_bytes_webp_valid():
+    content = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 20
+    assert app_utils._check_magic_bytes(content, "webp")
+
+
+def test_check_magic_bytes_webp_invalid_brand():
+    content = b"RIFF" + b"\x00\x00\x00\x00" + b"AVI " + b"\x00" * 20
+    assert not app_utils._check_magic_bytes(content, "webp")
+
+
+def test_check_magic_bytes_heic_defers_to_pil():
+    """HEIF/HEIC/AVIF have no simple prefix — magic check always returns True."""
+    assert app_utils._check_magic_bytes(b"\x00" * 32, "heic")
+    assert app_utils._check_magic_bytes(b"\x00" * 32, "heif")
+    assert app_utils._check_magic_bytes(b"\x00" * 32, "avif")


### PR DESCRIPTION
## Summary
- Add magic-byte signature verification to `_validate_and_read_file` in `src/utils/app_utils.py` so files renamed to an image extension (e.g. `evil.exe → evil.png`) are rejected before reaching downstream PIL parsing.
- Hybrid approach: cheap prefix check against known PNG/JPEG/GIF/WebP/BMP signatures first, then `PIL.Image.open().verify()` for deeper validation; HEIF/HEIC/AVIF defer entirely to PIL.
- Empty files are now rejected with a clear 400-class `RuntimeError("Uploaded file is not a valid image")` message (S5145-safe — filename is never interpolated into the error).

## Test plan
- [x] 21 new tests in `tests/unit/test_image_upload_magic_bytes.py` covering: valid PNG/JPEG/GIF/WebP pass; text file renamed to .png rejected; random bytes renamed to .png rejected; empty file rejected; truncated PNG header rejected; cross-format extension mismatch rejected; Windows PE binary renamed to .png rejected; handle_request_files integration tests; `_check_magic_bytes` unit tests for each format.
- [x] Updated 2 existing tests in `test_app_utils.py` to match new error message.
- [x] `scripts/lint.sh` ruff + black clean.
- [x] Full test suite: 3004 passed (2 pre-existing pyenv environment failures unrelated to this change).

Closes JTN-514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)