### PR TITLE
fix: enable zramswap on Bullseye/Bookworm/Trixie (JTN-528)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -345,7 +345,7 @@ get_ip_address() {
   echo "$ip_address"
 }
 
-# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixe
+# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie
 get_os_version() {
   lsb_release -sr
 }
@@ -388,12 +388,15 @@ if [[ -n "$WS_TYPE" ]]; then
 fi
 enable_interfaces
 install_debian_dependencies
-# check OS version for Bookworm to setup zramswap
-if [[ $(get_os_version) = "12" ]] ; then
-  echo "OS version is Bookworm - setting up zramswap"
+# Setup zramswap on any modern Pi OS that ships zram-tools (Bullseye/Bookworm/Trixie).
+# This is critical on low-RAM boards like the Pi Zero 2 W (512 MB) — without
+# zramswap, pip install of numpy/Pillow/playwright will OOM during the install step.
+os_version=$(get_os_version)
+if [[ "$os_version" =~ ^(11|12|13)$ ]] ; then
+  echo "OS version is $os_version (Bullseye/Bookworm/Trixie) - setting up zramswap"
   setup_zramswap_service
 else
-  echo "OS version is not Bookworm - skipping zramswap setup."
+  echo "OS version is $os_version - skipping zramswap setup (zram-tools not available on this release)."
 fi
 setup_earlyoom_service
 configure_journal_size

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -108,6 +108,24 @@ class TestInstallScript:
     def test_install_builds_css(self):
         assert "build_css" in self.content
 
+    def test_install_enables_zramswap_on_bookworm_and_trixie(self):
+        # JTN-528: zramswap must be enabled on Bullseye/Bookworm/Trixie so the
+        # Pi Zero 2 W (512 MB RAM) doesn't OOM during pip install. The previous
+        # check only matched Bookworm (12) exactly, leaving Trixie users broken.
+        assert "os_version=$(get_os_version)" in self.content
+        assert '[[ "$os_version" =~ ^(11|12|13)$ ]]' in self.content
+        assert "setup_zramswap_service" in self.content
+        # The skip branch should still exist for unknown future releases.
+        assert "skipping zramswap setup" in self.content
+
+    def test_install_os_version_comment_lists_correct_codenames(self):
+        # The comment near get_os_version should list 11/12/13 with correct
+        # codenames — including the 'Trixie' typo fix from JTN-528.
+        assert "11=Bullseye" in self.content
+        assert "12=Bookworm" in self.content
+        assert "13=Trixie" in self.content
+        assert "Trixe" not in self.content  # typo guard
+
 
 # ---- update.sh ----
 


### PR DESCRIPTION
## Summary
- `install/install.sh` only enabled zramswap when `lsb_release -sr` returned exactly `12` (Bookworm). The default Pi OS image as of `2025-12-04` is now **Trixie** (Debian 13), so fresh installs on a Pi Zero 2 W silently skipped zramswap setup and would OOM during the pip install step.
- Extend the check to match Bullseye (11), Bookworm (12), and Trixie (13). zram-tools is available across all of these.
- Fix the `Trixe` typo in the `get_os_version` comment.

## Why this matters
The Pi Zero 2 W (512 MB RAM) is the canonical small-RAM target. Without zramswap, `pip install` of numpy / Pillow / playwright will OOM during the install step. earlyoom (which the script does enable on all versions) helps trigger faster but cannot prevent the failure — it'll start killing pip mid-install.

Found while preparing a fresh SD card for a Pi Zero 2 W. Without this fix, **v0.28.0 is not installable on the current default Pi OS image on a Pi Zero 2 W.**

## Changes
- `install/install.sh:391-401`: regex check `^(11|12|13)$` instead of strict equality with `"12"`. Echo also now reports the actual OS version.
- `install/install.sh:348`: comment typo `Trixe` → `Trixie`.
- `tests/unit/test_install_scripts.py`: 2 new structural tests.

## Test plan
- [x] `pytest tests/unit/test_install_scripts.py` — 29 passed
- [x] `bash -n install/install.sh` — syntax OK
- [x] `black --check tests/unit/test_install_scripts.py`
- [x] Manually verified `[[ "12" =~ ^(11|12|13)$ ]]` and `[[ "13" =~ ... ]]` both match; `"14"` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded zramswap service compatibility to support more Debian versions (11, 12, and 13).
  * Enhanced installation script messaging for setup and skip scenarios.

* **Tests**
  * Added unit tests to validate OS detection and service setup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->