### PR TITLE
fix: install hardening + Pi Zero 2 W docs (JTN-534/537/538)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,9 @@ phosphor-icons/
 
 # Backup files
 *.bak*
+# Pre-restore safety backups created by scripts/restore_config.py — should
+# live next to the config they protect, not in the repo working tree (JTN-538)
+.pre-restore-*.tar.gz
 
 # Local benchmark database
 src/benchmarks.db

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,3 +31,38 @@
 </p>
 
 4. Click Yes to apply OS customization options and confirm
+
+## Pi Zero 2 W setup notes
+
+The Pi Zero 2 W is the cheapest officially-supported InkyPi target board, but its 512 MB of RAM and slow SD card I/O mean a few things are worth knowing up front.
+
+### OS choice
+
+As of `2025-12-04`, the **default Pi OS image is now Trixie (Debian 13)**. InkyPi v0.28.1+ supports it natively — earlier versions had a regression where `zramswap` was silently skipped on Trixie, causing OOMs during pip install on a Pi Zero 2 W (see JTN-528).
+
+If you're flashing a Bookworm image instead (e.g. for compatibility with an older e-ink driver), use the `Raspberry Pi OS (Legacy, 64-bit) Lite` option in Imager — that's the renamed Bookworm channel since the Trixie cutover.
+
+### `arm_64bit=1` requirement
+
+The 2025-12-04 Trixie image sets `arm_64bit=1` explicitly in `/boot/firmware/config.txt`. Older Bookworm images may not. If you're upgrading an existing Pi from Bullseye/Bookworm and using a 64-bit kernel, double-check this line is present — without it, the 64-bit `kernel8.img` won't boot on the Zero 2 W.
+
+### First-boot install time
+
+A fresh `install.sh` run on a Pi Zero 2 W takes **roughly 15 minutes** end-to-end. The bottleneck is `pip install` building wheels for `numpy`, `Pillow`, and `playwright` on a single Cortex-A53 core. Don't kill the install or assume it's hung — `htop` will show `pip` consuming one core. zramswap (auto-enabled by `install.sh` on Bullseye/Bookworm/Trixie) is critical here; without it the build OOMs.
+
+### Watching the install via cloud-init
+
+If you're driving an unattended install via cloud-init (e.g. via a `runcmd:` block in `user-data`), redirect the install output so you can watch it after the Pi boots:
+
+```yaml
+runcmd:
+- sudo -u <your-user> git clone --branch v0.28.1 --depth 1 https://github.com/jtn0123/InkyPi.git /home/<your-user>/InkyPi
+- chown -R <your-user>:<your-user> /home/<your-user>/InkyPi
+- bash -c 'cd /home/<your-user>/InkyPi/install && ./install.sh > /var/log/inkypi-install.log 2>&1 && touch /var/log/inkypi-install.done || touch /var/log/inkypi-install.failed'
+```
+
+Then SSH in and `tail -f /var/log/inkypi-install.log`. Check for `/var/log/inkypi-install.done` or `/var/log/inkypi-install.failed` to know when it's done.
+
+### Pi Zero W vs Pi Zero 2 W
+
+The "[Known Issues during Pi Zero W Installation](./troubleshooting.md#known-issues-during-pi-zero-w-installation)" section in the troubleshooting guide refers to the **original** 32-bit Pi Zero W, not the Pi Zero 2 W. The Zero 2 W is much more capable (4× Cortex-A53, ARMv8) and doesn't hit the same pip install issues — provided zramswap is enabled, which is automatic on InkyPi v0.28.1+.

--- a/install/install.sh
+++ b/install/install.sh
@@ -226,14 +226,16 @@ configure_journal_size() {
 create_venv(){
   echo "Creating python virtual environment. "
   python3 -m venv "$VENV_PATH"
-  "$VENV_PATH/bin/python" -m pip install --upgrade pip setuptools wheel > /dev/null
-  "$VENV_PATH/bin/python" -m pip install -r "$PIP_REQUIREMENTS_FILE" -qq > /dev/null &
+  # JTN-534: pass --retries 5 --timeout 60 to survive flaky Wi-Fi on a Pi Zero 2 W.
+  # pip's default retries=5 already; explicit so a future change to pip default doesn't bite us.
+  "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 --upgrade pip setuptools wheel > /dev/null
+  "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 -r "$PIP_REQUIREMENTS_FILE" -qq > /dev/null &
   show_loader "\tInstalling python dependencies. "
 
   # do additional dependencies for Waveshare support.
   if [[ -n "$WS_TYPE" ]]; then
     echo "Adding additional dependencies for waveshare to the python virtual environment. "
-    "$VENV_PATH/bin/python" -m pip install -r "$WS_REQUIREMENTS_FILE" > ws_pip_install.log &
+    "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 -r "$WS_REQUIREMENTS_FILE" > ws_pip_install.log &
     show_loader "\tInstalling additional Waveshare python dependencies. "
   fi
 
@@ -412,7 +414,13 @@ fi
 install_app_service
 
 echo "Update JS and CSS files"
-bash "$SCRIPT_DIR/update_vendors.sh" > /dev/null
+# JTN-534: previously the exit code from update_vendors.sh was discarded — a
+# transient curl write error during vendor download silently produced a
+# half-installed CSS/JS bundle. Fail loudly instead so the user knows.
+if ! bash "$SCRIPT_DIR/update_vendors.sh"; then
+  echo_error "ERROR: Vendor JS/CSS download failed. Check network connectivity and re-run."
+  exit 1
+fi
 
 echo "Building minified CSS bundle"
 if ! "$VENV_PATH/bin/python" "$SCRIPT_DIR/../scripts/build_css.py" --minify; then

--- a/install/update_vendors.sh
+++ b/install/update_vendors.sh
@@ -21,10 +21,15 @@ declare -a VENDORS=(
 for vendor in "${VENDORS[@]}"; do
   IFS='|' read -r name url output <<< "$vendor"
   echo "Updating $name..."
-  if curl -fsSL --retry 3 --connect-timeout 10 --max-time 60 "$url" -o "$output"; then
+  # JTN-534: --retry-all-errors retries write errors too (curl exit 23) which
+  # bit us during the JTN-528 sim run. --retry-delay 2 spaces retries to avoid
+  # hammering the CDN under flaky connectivity.
+  if curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+      --connect-timeout 10 --max-time 120 "$url" -o "$output"; then
     echo "  ✓ Downloaded to $output"
   else
-    echo "  ✗ Failed to download $name" >&2
+    rc=$?
+    echo "  ✗ Failed to download $name (curl exit $rc)" >&2
     exit 1
   fi
 done

--- a/scripts/restore_config.py
+++ b/scripts/restore_config.py
@@ -52,8 +52,16 @@ def _read_manifest(tar: tarfile.TarFile) -> dict:
     return json.loads(fobj.read().decode("utf-8"))
 
 
-def _pre_restore_backup(config_dir: str, instances_dir: str) -> str:
-    """Create a safety backup of current state before overwriting."""
+def _pre_restore_backup(
+    config_dir: str, instances_dir: str, output_dir: str | None = None
+) -> str:
+    """Create a safety backup of current state before overwriting.
+
+    The backup is written into *output_dir* (or the parent of *config_dir* if
+    not given) so it stays alongside the data it's protecting and never leaks
+    into a random working directory. Tests can pass a tmp_path here to keep
+    artifacts contained (JTN-538).
+    """
     # Import inline so the module stays self-contained
     scripts_dir = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, scripts_dir)
@@ -63,7 +71,9 @@ def _pre_restore_backup(config_dir: str, instances_dir: str) -> str:
         sys.path.pop(0)
 
     ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-    output = os.path.abspath(f".pre-restore-{ts}.tar.gz")
+    target_dir = output_dir or os.path.dirname(os.path.abspath(config_dir))
+    os.makedirs(target_dir, exist_ok=True)
+    output = os.path.join(target_dir, f".pre-restore-{ts}.tar.gz")
     history_dir = os.path.join(os.path.dirname(instances_dir), "history")
     backup_config.run_backup(
         output=output,

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -286,7 +286,7 @@ class TestRestoreConfig:
     def test_restore_creates_pre_restore_safety_backup(
         self, backup_mod, restore_mod, tmp_path, monkeypatch
     ):
-        """restore --yes should create a .pre-restore-*.tar.gz in cwd."""
+        """restore --yes should create a .pre-restore-*.tar.gz next to the config."""
         src = tmp_path / "src"
         src.mkdir()
         config_dir = _make_config_dir(src)
@@ -303,8 +303,12 @@ class TestRestoreConfig:
         safety_outputs: list[str] = []
         original_pre_restore = restore_mod._pre_restore_backup
 
-        def capture_pre_restore(config_dir, instances_dir):
-            result = original_pre_restore(config_dir, instances_dir)
+        # JTN-538: pin the safety backup output dir to tmp_path so the
+        # .pre-restore-*.tar.gz never leaks into the repo working tree.
+        def capture_pre_restore(config_dir, instances_dir, output_dir=None):
+            result = original_pre_restore(
+                config_dir, instances_dir, output_dir=str(tmp_path)
+            )
             safety_outputs.append(result)
             return result
 


### PR DESCRIPTION
## Summary
Three small install-path improvements identified during the JTN-528 verification work and grouped into one PR. All children of epic JTN-529.

### JTN-534 — Install network resilience
- `install/install.sh`: pass `--retries 5 --timeout 60` to pip install (3 call sites)
- `install/install.sh`: actually check `update_vendors.sh` exit code instead of swallowing it via `> /dev/null`. Previously a transient curl write error silently produced a half-installed CSS/JS bundle.
- `install/update_vendors.sh`: `--retry-all-errors` + `--retry-delay 2` so transient curl write errors (exit 23, hit during the JTN-528 sim run on a flaky CDN) actually retry.

### JTN-538 — Backup test cwd leak
- `scripts/restore_config.py`: `_pre_restore_backup()` takes an optional `output_dir` arg, defaulting to the parent of `config_dir` (next to the data it protects, instead of whatever random cwd the test happened to run from).
- `tests/test_backup_restore.py`: test now pins the safety backup to `tmp_path`.
- `.gitignore`: belt-and-suspenders ignore for `.pre-restore-*.tar.gz`.

### JTN-537 — Pi Zero 2 W setup notes
- New section in `docs/installation.md` covering: Trixie as default Pi OS, `arm_64bit=1` requirement, ~15 min first-boot install time, cloud-init install log location, Zero W vs Zero 2 W disambiguation.

## Test plan
- [x] `pytest tests/test_backup_restore.py tests/unit/test_install_scripts.py` — 41 passed
- [x] `bash -n install/install.sh install/update_vendors.sh` — syntax OK
- [x] `black --check`, `ruff check` clean on touched Python files
- [x] Verified no `.pre-restore-*.tar.gz` files leak after running affected tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)