### PR TITLE
fix: skip zram-tools when OS already provides zram swap (JTN-569)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -201,6 +201,12 @@ install_debian_dependencies() {
 }
 
 setup_zramswap_service() {
+  # If the OS already provides zram swap (e.g. Pi OS Trixie preinstalls zram-swap),
+  # skip zram-tools — they fight over /dev/zram0 and cause mkswap to fail.
+  if grep -q "^/dev/zram" /proc/swaps 2>/dev/null; then
+    echo "zram swap already active (likely from preinstalled zram-swap package) — skipping zram-tools install."
+    return 0
+  fi
   echo "Enabling and starting zramswap service."
   sudo apt-get install -y zram-tools > /dev/null
   echo -e "ALGO=zstd\nPERCENT=60" | sudo tee /etc/default/zramswap > /dev/null

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -112,9 +112,17 @@ class TestInstallScript:
         # JTN-569: Pi OS Trixie preinstalls zram-swap which configures /dev/zram0 at
         # boot. Installing zram-tools on top fights over /dev/zram0 and makes
         # `systemctl start zramswap` exit 1. The guard must run before apt-get.
-        assert 'grep -q "^/dev/zram" /proc/swaps' in self.content
+        guard = 'grep -q "^/dev/zram" /proc/swaps'
+        apt_install = "apt-get install -y zram-tools"
+        assert guard in self.content
         assert "skipping zram-tools install" in self.content
         assert "return 0" in self.content
+
+        fn_start = self.content.index("setup_zramswap_service() {")
+        guard_pos = self.content.index(guard, fn_start)
+        return_pos = self.content.index("return 0", fn_start)
+        apt_pos = self.content.index(apt_install, fn_start)
+        assert guard_pos < return_pos < apt_pos
 
     def test_install_enables_zramswap_on_bookworm_and_trixie(self):
         # JTN-528: zramswap must be enabled on Bullseye/Bookworm/Trixie so the

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -108,6 +108,14 @@ class TestInstallScript:
     def test_install_builds_css(self):
         assert "build_css" in self.content
 
+    def test_install_skips_zramtools_when_zram_swap_already_active(self):
+        # JTN-569: Pi OS Trixie preinstalls zram-swap which configures /dev/zram0 at
+        # boot. Installing zram-tools on top fights over /dev/zram0 and makes
+        # `systemctl start zramswap` exit 1. The guard must run before apt-get.
+        assert 'grep -q "^/dev/zram" /proc/swaps' in self.content
+        assert "skipping zram-tools install" in self.content
+        assert "return 0" in self.content
+
     def test_install_enables_zramswap_on_bookworm_and_trixie(self):
         # JTN-528: zramswap must be enabled on Bullseye/Bookworm/Trixie so the
         # Pi Zero 2 W (512 MB RAM) doesn't OOM during pip install. The previous


### PR DESCRIPTION
## Summary

- On Pi OS Trixie, the preinstalled `zram-swap` package configures `/dev/zram0` at boot automatically.
- Installing `zram-tools` on top causes `mkswap` to fail with "is mounted; will not make swapspace", and `systemctl start zramswap` exits 1.
- Added a `/proc/swaps` guard at the top of `setup_zramswap_service()` that exits early when zram swap is already active, preventing the conflict.
- The existing OS-version check (Bullseye/Bookworm/Trixie) still runs for systems that do NOT have zram swap pre-configured.

## Changes

- `install/install.sh`: Added `grep -q "^/dev/zram" /proc/swaps` early-return guard in `setup_zramswap_service()`
- `tests/unit/test_install_scripts.py`: Added `test_install_skips_zramtools_when_zram_swap_already_active` to assert the guard is present in the script

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync needed (this is a new fix)

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Scripts pass `scripts/lint.sh` (ruff + black pass; shellcheck runs in CI)

## Testing

- `tests/unit/test_install_scripts.py` — 30 tests all pass locally
- New test `test_install_skips_zramtools_when_zram_swap_already_active` validates the guard

Closes JTN-569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation process now detects existing zram swap configuration and skips redundant installation steps.

* **Tests**
  * Added test coverage for zram swap installation guard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->