### PR TITLE
fix: add shellcheck to lint.sh and OS codename parity test (JTN-531)

### DIFF
--- a/scripts/compare_icons.py
+++ b/scripts/compare_icons.py
@@ -347,13 +347,19 @@ def main():
         html.append(f"<td style='font-size:12px;color:#555'>{newp2}</td>")
         html.append(f"<td style='font-size:12px;color:#555'>{newp3}</td>")
         html.append(
-            f"<td>{(f'<a href=\'{ghA}\' target=\'_blank\'>GitHub</a>') if ghA else '—'}</td>"
+            "<td>"
+            + (f"<a href='{ghA}' target='_blank'>GitHub</a>" if ghA else "—")
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<a href=\'{ghB}\' target=\'_blank\'>GitHub</a>') if ghB else '—'}</td>"
+            "<td>"
+            + (f"<a href='{ghB}' target='_blank'>GitHub</a>" if ghB else "—")
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<a href=\'{ghC}\' target=\'_blank\'>GitHub</a>') if ghC else '—'}</td>"
+            "<td>"
+            + (f"<a href='{ghC}' target='_blank'>GitHub</a>" if ghC else "—")
+            + "</td>"
         )
         html.append("</tr>")
 
@@ -392,13 +398,31 @@ def main():
             f"<td>{label} <div style='color:#555;font-size:12px'>{key}</div></td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{u1}\'><br><img class=\'thumb-lg\' src=\'{u1}\'>') if u1 else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{u1}'><br><img class='thumb-lg' src='{u1}'>"
+                if u1
+                else "—"
+            )
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{u2}\'><br><img class=\'thumb-lg\' src=\'{u2}\'>') if u2 else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{u2}'><br><img class='thumb-lg' src='{u2}'>"
+                if u2
+                else "—"
+            )
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{u3}\'><br><img class=\'thumb-lg\' src=\'{u3}\'>') if u3 else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{u3}'><br><img class='thumb-lg' src='{u3}'>"
+                if u3
+                else "—"
+            )
+            + "</td>"
         )
         html.append(f"<td style='font-size:12px;color:#555'>{p1}</td>")
         html.append(f"<td style='font-size:12px;color:#555'>{p2}</td>")
@@ -424,16 +448,40 @@ def main():
             f"<td>{label} <div style='color:#555;font-size:12px'>{key}</div></td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{curu2}\'><br><img class=\'thumb-lg\' src=\'{curu2}\'>') if curu2 else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{curu2}'><br><img class='thumb-lg' src='{curu2}'>"
+                if curu2
+                else "—"
+            )
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{u1m}\'><br><img class=\'thumb-lg\' src=\'{u1m}\'>') if u1m else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{u1m}'><br><img class='thumb-lg' src='{u1m}'>"
+                if u1m
+                else "—"
+            )
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{u2m}\'><br><img class=\'thumb-lg\' src=\'{u2m}\'>') if u2m else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{u2m}'><br><img class='thumb-lg' src='{u2m}'>"
+                if u2m
+                else "—"
+            )
+            + "</td>"
         )
         html.append(
-            f"<td>{(f'<img class=\'thumb-sm\' src=\'{u3m}\'><br><img class=\'thumb-lg\' src=\'{u3m}\'>') if u3m else '—'}</td>"
+            "<td>"
+            + (
+                f"<img class='thumb-sm' src='{u3m}'><br><img class='thumb-lg' src='{u3m}'>"
+                if u3m
+                else "—"
+            )
+            + "</td>"
         )
         html.append(f"<td style='font-size:12px;color:#555'>{p1m}</td>")
         html.append(f"<td style='font-size:12px;color:#555'>{p2m}</td>")

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,6 +15,7 @@ fi
 RUFF_EXIT=0
 BLACK_EXIT=0
 MYPY_EXIT=0
+SHELLCHECK_EXIT=0
 
 echo "Running Ruff linter..."
 ruff check src tests scripts
@@ -43,13 +44,62 @@ else
     echo "✅ mypy type check passed"
 fi
 
+# Shell scripts that run on user devices — must pass shellcheck.
+SHELLCHECK_FILES=(
+    install/install.sh
+    install/uninstall.sh
+    install/update.sh
+    install/do_update.sh
+    scripts/dev.sh
+    scripts/dev_update.sh
+    scripts/format.sh
+    scripts/lint.sh
+    scripts/logs.sh
+    scripts/test.sh
+    scripts/test_profile.sh
+    scripts/venv.sh
+    scripts/web_only.sh
+    scripts/check_licenses.sh
+    scripts/preflash_validate.sh
+)
+
+# Filter to files that actually exist (guard against future renames).
+EXISTING_SHELLCHECK_FILES=()
+for f in "${SHELLCHECK_FILES[@]}"; do
+    [[ -f "$f" ]] && EXISTING_SHELLCHECK_FILES+=("$f")
+done
+
+echo "Running shellcheck..."
+if command -v shellcheck > /dev/null 2>&1; then
+    if [[ ${#EXISTING_SHELLCHECK_FILES[@]} -gt 0 ]]; then
+        shellcheck --severity=warning "${EXISTING_SHELLCHECK_FILES[@]}"
+        SHELLCHECK_EXIT=$?
+    else
+        echo "No shell script files found to check."
+    fi
+    if [ $SHELLCHECK_EXIT -ne 0 ]; then
+        echo "❌ shellcheck found issues (exit code: $SHELLCHECK_EXIT)"
+    else
+        echo "✅ shellcheck passed"
+    fi
+else
+    # In CI the binary must be present; locally we skip with a warning.
+    if [[ -n "${CI:-}" ]]; then
+        echo "❌ shellcheck not found — install it in the CI image."
+        SHELLCHECK_EXIT=1
+    else
+        echo "⚠️  shellcheck not found — skipping (install via: brew install shellcheck / apt install shellcheck)"
+    fi
+fi
+
 # Report summary — mypy is non-blocking (advisory only) until existing
-# type errors are resolved.  Ruff and Black are blocking.
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ]; then
+# type errors are resolved.  Ruff, Black, and shellcheck are blocking.
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     echo ""
     echo "❌ Some checks failed:"
     [ $RUFF_EXIT -ne 0 ] && echo "  - Ruff: $RUFF_EXIT"
     [ $BLACK_EXIT -ne 0 ] && echo "  - Black: $BLACK_EXIT"
+    [ $SHELLCHECK_EXIT -ne 0 ] && echo "  - shellcheck: $SHELLCHECK_EXIT"
     echo ""
     echo "Post-run actions will continue..."
 else
@@ -58,7 +108,7 @@ else
 fi
 [ $MYPY_EXIT -ne 0 ] && echo "⚠️  mypy issues remain (non-blocking)"
 
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ]; then
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     exit 1
 fi
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -44,30 +44,11 @@ else
     echo "✅ mypy type check passed"
 fi
 
-# Shell scripts that run on user devices — must pass shellcheck.
-SHELLCHECK_FILES=(
-    install/install.sh
-    install/uninstall.sh
-    install/update.sh
-    install/do_update.sh
-    scripts/dev.sh
-    scripts/dev_update.sh
-    scripts/format.sh
-    scripts/lint.sh
-    scripts/logs.sh
-    scripts/test.sh
-    scripts/test_profile.sh
-    scripts/venv.sh
-    scripts/web_only.sh
-    scripts/check_licenses.sh
-    scripts/preflash_validate.sh
-)
-
-# Filter to files that actually exist (guard against future renames).
-EXISTING_SHELLCHECK_FILES=()
-for f in "${SHELLCHECK_FILES[@]}"; do
-    [[ -f "$f" ]] && EXISTING_SHELLCHECK_FILES+=("$f")
-done
+# Shell scripts under install/ and scripts/ — must pass shellcheck.
+# Dynamic discovery ensures new scripts are covered automatically.
+shopt -s nullglob
+EXISTING_SHELLCHECK_FILES=(install/*.sh scripts/*.sh)
+shopt -u nullglob
 
 echo "Running shellcheck..."
 if command -v shellcheck > /dev/null 2>&1; then

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1,6 +1,7 @@
 # pyright: reportMissingImports=false
 """Structural validation of install/setup scripts — no shell execution."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -125,6 +126,49 @@ class TestInstallScript:
         assert "12=Bookworm" in self.content
         assert "13=Trixie" in self.content
         assert "Trixe" not in self.content  # typo guard
+
+    def test_zramswap_regex_matches_codename_comment_parity(self):
+        # JTN-531: The codename comment near get_os_version() and the version
+        # regex in the zramswap branch must list the same integer keys.
+        # If someone adds 14=Forky to one without updating the other this test
+        # will catch it.
+
+        # Parse "# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie"
+        # Capture every "<digit(s)>=<Codename>" pair from the comment line
+        # immediately above the get_os_version() function definition.
+        comment_versions = set()
+        lines = self.content.splitlines()
+        for i, line in enumerate(lines):
+            if "get_os_version" in line and line.strip().startswith("get_os_version"):
+                # Search backwards for the nearest preceding comment line with
+                # version=Codename pairs (at most 5 lines back).
+                for j in range(max(0, i - 5), i):
+                    if "#" in lines[j]:
+                        for m in re.finditer(r"(\d+)\s*=\s*[A-Za-z]+", lines[j]):
+                            comment_versions.add(int(m.group(1)))
+
+        # Parse the regex alternation in the zramswap if-branch:
+        # [[ "$os_version" =~ ^(11|12|13)$ ]]
+        regex_versions = set()
+        for line in self.content.splitlines():
+            m = re.search(r"\^\(([0-9|]+)\)\$", line)
+            if m:
+                for part in m.group(1).split("|"):
+                    if part.strip().isdigit():
+                        regex_versions.add(int(part.strip()))
+
+        assert (
+            comment_versions
+        ), "Could not parse any version numbers from the get_os_version comment in install.sh"
+        assert (
+            regex_versions
+        ), "Could not parse any version numbers from the zramswap regex in install.sh"
+        assert comment_versions == regex_versions, (
+            f"Codename comment versions {sorted(comment_versions)} do not match "
+            f"zramswap regex versions {sorted(regex_versions)}. "
+            "Update both the comment near get_os_version() and the regex in the "
+            "zramswap branch when adding a new Debian release."
+        )
 
 
 # ---- update.sh ----


### PR DESCRIPTION
## Summary

- Add `shellcheck` as a blocking lint step in `scripts/lint.sh`, covering `install/*.sh` and `scripts/*.sh`; gracefully skips locally when shellcheck is absent, fails in CI if missing
- Add `test_zramswap_regex_matches_codename_comment_parity` test to assert that the `get_os_version` comment and the zramswap regex always share the same Debian version integers — catching drift between the two without executing any shell
- Fix pre-existing ruff `invalid-syntax` errors in `scripts/compare_icons.py` (escaped quotes inside f-strings, Python <3.12 incompatible)

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync — this is an InkyPi-internal improvement

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (30/30 in test_install_scripts.py)
- [x] `scripts/lint.sh` passes (ruff ✅, black ✅, shellcheck ✅, mypy advisory)
- [x] No breaking API route/path changes
- [x] No new dependencies added

## Testing

- `tests/unit/test_install_scripts.py` — 30 tests pass, including new parity test
- Parity test verified: adding version to only the comment or only the regex causes the test to fail immediately
- shellcheck run locally against all target files — zero warnings at `--severity=warning`

Closes JTN-531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to build scripts and testing infrastructure to enhance development workflow and code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->