### PR TITLE
fix: clear stale error toasts and auto-dismiss (JTN-464)

### DIFF
--- a/src/static/scripts/response_modal.js
+++ b/src/static/scripts/response_modal.js
@@ -1,6 +1,7 @@
 // Enhanced toast notification system
 // Configurable timing defaults (ms).
 const TOAST_DURATION_MS = 5000;
+const TOAST_ERROR_DURATION_MS = 8000;
 const MODAL_AUTO_CLOSE_MS = 10000;
 const TOAST_FADE_MS = 300;
 
@@ -20,15 +21,32 @@ function ensureToastContainer() {
 
 const MAX_VISIBLE_TOASTS = 3;
 
+function dismissStaleErrors() {
+    const container = ensureToastContainer();
+    const existingErrors = Array.from(container.querySelectorAll('.toast.error'));
+    existingErrors.forEach(el => closeToast(el.id));
+}
+
 function showToast(status, message, duration = TOAST_DURATION_MS) {
     const container = ensureToastContainer();
     const toastId = `toast-${++toastCounter}`;
+
+    // When showing a new error, dismiss any previous error toasts first
+    // so stale validation messages don't stack up across save attempts.
+    if (status === 'error') {
+        dismissStaleErrors();
+    }
 
     // Enforce stack limit — remove oldest toasts beyond MAX_VISIBLE_TOASTS
     while (container.children.length >= MAX_VISIBLE_TOASTS) {
         const oldest = container.firstElementChild;
         if (oldest) oldest.remove();
     }
+
+    // Resolve effective duration: errors use TOAST_ERROR_DURATION_MS by default
+    const effectiveDuration = (status === 'error' && duration === TOAST_DURATION_MS)
+        ? TOAST_ERROR_DURATION_MS
+        : duration;
 
     const toast = document.createElement('div');
     toast.className = `toast ${status}`;
@@ -62,10 +80,10 @@ function showToast(status, message, duration = TOAST_DURATION_MS) {
     toast.appendChild(closeBtn);
 
     // Add countdown progress bar for auto-closing toasts
-    if (duration > 0 && status !== 'error') {
+    if (effectiveDuration > 0) {
         const progress = document.createElement('div');
         progress.className = 'toast-progress';
-        progress.style.animationDuration = `${duration}ms`;
+        progress.style.animationDuration = `${effectiveDuration}ms`;
         toast.appendChild(progress);
     }
 
@@ -76,9 +94,9 @@ function showToast(status, message, duration = TOAST_DURATION_MS) {
         toast.classList.add('show');
     });
 
-    // Auto-close after duration (skip for errors so users can read details)
-    if (duration > 0 && status !== 'error') {
-        setTimeout(() => closeToast(toastId), duration);
+    // Auto-close after effectiveDuration
+    if (effectiveDuration > 0) {
+        setTimeout(() => closeToast(toastId), effectiveDuration);
     }
 
     return toastId;

--- a/tests/static/test_js_api_contracts.py
+++ b/tests/static/test_js_api_contracts.py
@@ -163,6 +163,7 @@ def test_response_modal_script_exists(client):
     # Core functions
     for token in [
         "function ensureToastContainer()",
+        "function dismissStaleErrors()",
         "function showToast(status, message, duration = TOAST_DURATION_MS)",
         "function closeToast(toastId)",
         "function showResponseModal(status, message, useToast = true)",
@@ -175,6 +176,9 @@ def test_response_modal_script_exists(client):
         "function showInfo(message, duration)",
     ]:
         assert token in js
+
+    # Auto-dismiss constants
+    assert "TOAST_ERROR_DURATION_MS" in js
 
 
 def test_handle_json_response_presence(client):


### PR DESCRIPTION
## Summary

- When a new error toast is shown, any existing error toasts are dismissed first — stale validation messages no longer stack up across save attempts.
- Added `TOAST_ERROR_DURATION_MS = 8000` constant so error toasts auto-dismiss after 8 seconds instead of requiring a manual × click.
- Success/warning/info toast behaviour and the × close button are unchanged.

## Changes

- `src/static/scripts/response_modal.js` — added `dismissStaleErrors()` helper; call it at the top of `showToast` when `status === 'error'`; added `TOAST_ERROR_DURATION_MS` constant and unified the auto-dismiss path so errors also get the countdown progress bar and auto-close timer.
- `tests/static/test_js_api_contracts.py` — assert the new function and constant are present in the served JS.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a sync PR

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (3102 passed, 2 pre-existing unrelated failures)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract unchanged

## Testing

- All toast-related tests pass: `tests/static/test_js_api_contracts.py`, `tests/integration/test_modal_lifecycle_e2e.py`
- No CSS changes needed (no `build_css.py` run required)

Closes JTN-464