### PR TITLE
fix: Escape closes #scheduleModal and focus moves into it on open (JTN-461, JTN-463)

### DIFF
--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -308,13 +308,23 @@
       } catch (e) { console.warn("Failed to refresh preview info:", e); }
     }
 
-    function openModal(modalId) {
+    // Track the element that triggered the most-recently opened modal so focus
+    // can be restored when the modal closes (WAI-ARIA best practice).
+    let _lastModalTrigger = null;
+
+    function openModal(modalId, triggerEl) {
       const modal = document.getElementById(modalId);
       if (!modal) return;
+      if (triggerEl) _lastModalTrigger = triggerEl;
       modal.hidden = false;
       modal.style.display = "flex";
       modal.classList.add("is-open");
       syncModalOpenState(ui);
+      // JTN-463: move focus into the modal on open
+      const focusable = modal.querySelector(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable) setTimeout(() => focusable.focus(), 0);
     }
 
     function closeModal(modalId) {
@@ -324,6 +334,11 @@
       modal.style.display = "none";
       modal.classList.remove("is-open");
       syncModalOpenState(ui);
+      // Restore focus to the trigger element (WAI-ARIA best practice)
+      if (_lastModalTrigger) {
+        try { _lastModalTrigger.focus(); } catch (_) {}
+        _lastModalTrigger = null;
+      }
     }
 
     function selectedFrame(element) {
@@ -558,6 +573,14 @@
           closeModal("scheduleModal");
         }
       });
+      // JTN-461: close #scheduleModal when Escape is pressed
+      document.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        const modal = document.getElementById("scheduleModal");
+        if (!modal || modal.hidden) return;
+        event.preventDefault();
+        closeModal("scheduleModal");
+      });
     }
 
     function setWorkflowMode(mode) {
@@ -604,7 +627,7 @@
         button.addEventListener("click", () => handleAction(button.dataset.pluginAction, button));
       });
       document.querySelectorAll("[data-open-modal]").forEach((button) => {
-        button.addEventListener("click", () => openModal(button.dataset.openModal));
+        button.addEventListener("click", () => openModal(button.dataset.openModal, button));
       });
       document.querySelectorAll("[data-close-modal]").forEach((button) => {
         button.addEventListener("click", () => closeModal(button.dataset.closeModal));

--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -336,7 +336,7 @@
       syncModalOpenState(ui);
       // Restore focus to the trigger element (WAI-ARIA best practice)
       if (_lastModalTrigger) {
-        try { _lastModalTrigger.focus(); } catch (_) {}
+        _lastModalTrigger.focus();
         _lastModalTrigger = null;
       }
     }
@@ -626,8 +626,9 @@
       document.querySelectorAll("[data-plugin-action]").forEach((button) => {
         button.addEventListener("click", () => handleAction(button.dataset.pluginAction, button));
       });
-      document.querySelectorAll("[data-open-modal]").forEach((button) => {
-        button.addEventListener("click", () => openModal(button.dataset.openModal, button));
+      document.addEventListener("click", (event) => {
+        const opener = event.target.closest("[data-open-modal]");
+        if (opener) openModal(opener.dataset.openModal, opener);
       });
       document.querySelectorAll("[data-close-modal]").forEach((button) => {
         button.addEventListener("click", () => closeModal(button.dataset.closeModal));

--- a/tests/static/test_modal_accessibility_guards.py
+++ b/tests/static/test_modal_accessibility_guards.py
@@ -33,3 +33,19 @@ def test_image_modal_script_handles_escape_and_null_container():
 
     assert "if (!imageContainer) return;" in content
     assert "e.key === 'Escape'" in content
+
+
+def test_plugin_page_schedule_modal_handles_escape():
+    """JTN-461: #scheduleModal closes on Escape key."""
+    content = _read_script("plugin_page.js")
+
+    assert 'event.key !== "Escape"' in content
+    assert "scheduleModal" in content
+
+
+def test_plugin_page_open_modal_focuses_first_focusable():
+    """JTN-463: openModal moves focus to first focusable element on open."""
+    content = _read_script("plugin_page.js")
+
+    assert "focusable.focus()" in content
+    assert "_lastModalTrigger" in content


### PR DESCRIPTION
## Summary

- **JTN-461**: `#scheduleModal` now closes when Escape is pressed — adds a `keydown` listener in `bindModalClose` that checks `modal.hidden` and calls `closeModal`, matching the pattern used by `playlistModal` and the history-page modals.
- **JTN-463**: `openModal` now moves focus to the first focusable element inside the modal on open (matching `setModalOpen` in `playlist.js`); trigger button is tracked in `_lastModalTrigger` and focus is restored to it when the modal closes (WAI-ARIA best practice).
- Two static regression tests added to `test_modal_accessibility_guards.py` to guard both fixes against regressions.

Closes JTN-461, JTN-463

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync — this is a new fix

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (2 pre-existing unrelated failures)
- [x] No breaking API route/path changes
- [x] No API changes — JS-only fix

## Testing

- All existing modal tests pass
- New tests: `test_plugin_page_schedule_modal_handles_escape`, `test_plugin_page_open_modal_focuses_first_focusable`