### PR TITLE
fix: atomic config RMW — add Config.update_atomic (JTN-498)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -332,11 +332,16 @@ def add_plugin():
             "plugin_settings": plugin_settings,
             "name": instance_name,
         }
-        result = playlist_manager.add_plugin_to_playlist(playlist, plugin_dict)
-        if not result:
-            return json_error("Failed to add to playlist", status=500)
+        add_result: list[bool] = []
 
-        device_config.write_config()
+        def _do_add(cfg):
+            add_result.append(
+                playlist_manager.add_plugin_to_playlist(playlist, plugin_dict)
+            )
+
+        device_config.update_atomic(_do_add)
+        if not add_result or not add_result[0]:
+            return json_error("Failed to add to playlist", status=500)
     except Exception:
         return json_internal_error(
             "add plugin to playlist",
@@ -530,13 +535,18 @@ def create_playlist():
             # best-effort, fallback to allow
             pass
 
-        result = playlist_manager.add_playlist(
-            playlist_name, data.get("start_time"), data.get("end_time")
-        )
-        if not result:
-            return json_error("Failed to create playlist", status=500)
+        add_pl_result: list[bool] = []
 
-        device_config.write_config()
+        def _do_add_playlist(cfg):
+            add_pl_result.append(
+                playlist_manager.add_playlist(
+                    playlist_name, data.get("start_time"), data.get("end_time")
+                )
+            )
+
+        device_config.update_atomic(_do_add_playlist)
+        if not add_pl_result or not add_pl_result[0]:
+            return json_error("Failed to create playlist", status=500)
 
         warning = None
         if playlist_name != "Default":
@@ -606,13 +616,19 @@ def update_playlist(playlist_name):
     except Exception:
         pass
 
-    result = playlist_manager.update_playlist(
-        playlist_name, new_name, start_time, end_time
-    )
-    if not result:
+    upd_result: list[bool] = []
+
+    def _do_update_playlist(cfg):
+        upd_result.append(
+            playlist_manager.update_playlist(
+                playlist_name, new_name, start_time, end_time
+            )
+        )
+        _apply_cycle_override(playlist_manager, new_name, data.get("cycle_minutes"))
+
+    device_config.update_atomic(_do_update_playlist)
+    if not upd_result or not upd_result[0]:
         return json_error("Failed to update playlist", status=500)
-    _apply_cycle_override(playlist_manager, new_name, data.get("cycle_minutes"))
-    device_config.write_config()
 
     # Warn if the updated playlist overlaps with Default.
     warning = None
@@ -638,8 +654,9 @@ def delete_playlist(playlist_name):
     if not playlist:
         return json_error(f"Playlist '{playlist_name}' does not exist", status=400)
 
-    playlist_manager.delete_playlist(playlist_name)
-    device_config.write_config()
+    device_config.update_atomic(
+        lambda cfg: playlist_manager.delete_playlist(playlist_name)
+    )
 
     return json_success(f"Deleted playlist '{playlist_name}'!")
 
@@ -687,10 +704,15 @@ def reorder_plugins():
         if not playlist:
             return json_error(f"Playlist '{playlist_name}' not found", status=400)
 
-        if not playlist.reorder_plugins(ordered):
+        reorder_result: list[bool] = []
+
+        def _do_reorder(cfg):
+            reorder_result.append(playlist.reorder_plugins(ordered))
+
+        device_config.update_atomic(_do_reorder)
+        if not reorder_result or not reorder_result[0]:
             return json_error("Invalid order payload", status=400)
 
-        device_config.write_config()
         return json_success("Reordered plugins")
     except Exception:
         return json_internal_error(

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -253,6 +253,36 @@ def _compute_playlist_rotation_eta(pl, next_index, until_next_min, cycle_min, no
     return eta_for_pl
 
 
+def _validate_instance_name(raw_name):
+    """Validate and normalise an instance name.
+
+    Returns ``(name, error_response)``.  Exactly one will be non-None.
+    """
+    name = raw_name.strip() if raw_name else ""
+    if not name:
+        return None, json_error(
+            "Instance name is required",
+            status=422,
+            code=_CODE_VALIDATION,
+            details={"field": "instance_name"},
+        )
+    if len(name) > 64:
+        return None, json_error(
+            "Instance name must be 64 characters or fewer",
+            status=422,
+            code=_CODE_VALIDATION,
+            details={"field": "instance_name"},
+        )
+    if not _INSTANCE_NAME_RE.match(name):
+        return None, json_error(
+            "Instance name can only contain letters, numbers, spaces, underscores, and hyphens",
+            status=422,
+            code=_CODE_VALIDATION,
+            details={"field": "instance_name"},
+        )
+    return name, None
+
+
 @playlist_bp.route("/add_plugin", methods=["POST"])
 def add_plugin():
     device_config = current_app.config["DEVICE_CONFIG"]
@@ -282,7 +312,6 @@ def add_plugin():
             )
 
         playlist = refresh_settings.get("playlist")
-        instance_name = refresh_settings.get("instance_name")
         if not playlist:
             return json_error(
                 PLAYLIST_NAME_REQUIRED_ERROR,
@@ -290,28 +319,11 @@ def add_plugin():
                 code=_CODE_VALIDATION,
                 details={"field": "playlist"},
             )
-        instance_name = instance_name.strip() if instance_name else ""
-        if not instance_name:
-            return json_error(
-                "Instance name is required",
-                status=422,
-                code=_CODE_VALIDATION,
-                details={"field": "instance_name"},
-            )
-        if len(instance_name) > 64:
-            return json_error(
-                "Instance name must be 64 characters or fewer",
-                status=422,
-                code=_CODE_VALIDATION,
-                details={"field": "instance_name"},
-            )
-        if not _INSTANCE_NAME_RE.match(instance_name):
-            return json_error(
-                "Instance name can only contain letters, numbers, spaces, underscores, and hyphens",
-                status=422,
-                code=_CODE_VALIDATION,
-                details={"field": "instance_name"},
-            )
+        instance_name, name_err = _validate_instance_name(
+            refresh_settings.get("instance_name")
+        )
+        if name_err:
+            return name_err
 
         existing = playlist_manager.find_plugin(plugin_id, instance_name)
         if existing:

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -292,11 +292,14 @@ def delete_plugin_instance():
         existing = playlist.find_plugin(plugin_id, plugin_instance)
         plugin_settings = dict(existing.settings) if existing else {}
 
-        result = playlist.delete_plugin(plugin_id, plugin_instance)
-        if not result:
-            return json_error("Plugin instance not found", status=400)
+        del_result: list[bool] = []
 
-        device_config.write_config()
+        def _do_delete(cfg):
+            del_result.append(playlist.delete_plugin(plugin_id, plugin_instance))
+
+        device_config.update_atomic(_do_delete)
+        if not del_result or not del_result[0]:
+            return json_error("Plugin instance not found", status=400)
         _cleanup_plugin_resources(
             device_config, plugin_id, plugin_instance, plugin_settings
         )
@@ -354,8 +357,11 @@ def update_plugin_instance(instance_name: str):
                 logger.debug("Could not validate plugin schema for %s", plugin_id)
 
         before_settings = dict(plugin_instance.settings or {})
-        plugin_instance.settings = plugin_settings
-        device_config.write_config()
+
+        def _do_update_instance(cfg):
+            plugin_instance.settings = plugin_settings
+
+        device_config.update_atomic(_do_update_instance)
         config_dir = os.path.dirname(device_config.config_file)
         _record_plugin_change(
             config_dir, instance_name, before_settings, plugin_settings
@@ -594,24 +600,26 @@ def _save_plugin_settings_common(
         playlist = playlist_manager.get_playlist(default_playlist_name)
 
     instance_name = f"{plugin_id}_saved_settings"
-    existing_instance = playlist.find_plugin(plugin_id, instance_name)
     before_settings: dict = {}
-    if existing_instance:
-        before_settings = dict(existing_instance.settings or {})
-        existing_instance.settings = plugin_settings
-    else:
-        playlist.add_plugin(
-            {
-                _PLUGIN_ID: plugin_id,
-                "refresh": {"interval": 3600},
-                "plugin_settings": plugin_settings,
-                "name": instance_name,
-            }
-        )
 
-    # Preserve legacy failure surface for callers/tests that patch config mutation hooks.
-    device_config.update_value("playlist_config", playlist_manager.to_dict())
-    device_config.write_config()
+    def _do_save_settings(cfg):
+        nonlocal before_settings
+        inst = playlist.find_plugin(plugin_id, instance_name)
+        if inst:
+            before_settings = dict(inst.settings or {})
+            inst.settings = plugin_settings
+        else:
+            playlist.add_plugin(
+                {
+                    _PLUGIN_ID: plugin_id,
+                    "refresh": {"interval": 3600},
+                    "plugin_settings": plugin_settings,
+                    "name": instance_name,
+                }
+            )
+        cfg["playlist_config"] = playlist_manager.to_dict()
+
+    device_config.update_atomic(_do_save_settings)
     config_dir = os.path.dirname(device_config.config_file)
     _record_plugin_change(config_dir, instance_name, before_settings, plugin_settings)
     return (

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import threading
+from collections.abc import Callable
 from typing import Any
 
 from dotenv import load_dotenv, set_key, unset_key
@@ -442,6 +443,19 @@ class Config:
             self.config[key] = value
             if write:
                 self.write_config()
+
+    def update_atomic(self, update_fn: Callable[[dict], None]) -> None:
+        """Run update_fn(self._config) while holding the config lock and atomically write.
+
+        This ensures the full read-modify-write cycle is performed under the
+        config lock, preventing concurrent threads from clobbering each other's
+        changes.  Because ``_config_lock`` is a reentrant lock, methods that
+        already hold it (e.g. ``write_config``) are safe to call from within
+        ``update_fn``.
+        """
+        with self._config_lock:
+            update_fn(self.config)
+            self.write_config()
 
     def get_env_file_path(self):
         """Return absolute path to the .env file used for secrets.

--- a/tests/integration/test_api_json_errors.py
+++ b/tests/integration/test_api_json_errors.py
@@ -29,10 +29,10 @@ def test_save_plugin_settings_error_json(client, flask_app, monkeypatch):
     # Simulate a config write failure so endpoint returns JSON error
     dc = flask_app.config["DEVICE_CONFIG"]
 
-    def boom_update_value(*args, **kwargs):
+    def boom_update_atomic(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(dc, "update_value", boom_update_value, raising=True)
+    monkeypatch.setattr(dc, "update_atomic", boom_update_atomic, raising=True)
 
     resp = client.post(
         "/save_plugin_settings",

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -215,10 +215,10 @@ def test_update_now_exception_handling(client, flask_app, monkeypatch):
 
 def test_save_plugin_settings_exception_handling(client, flask_app, monkeypatch):
     dc = flask_app.config["DEVICE_CONFIG"]
-    # Make update_value raise to simulate config failure
+    # Make update_atomic raise to simulate config failure
     monkeypatch.setattr(
         dc,
-        "update_value",
+        "update_atomic",
         lambda *args, **kwargs: (_ for _ in ()).throw(Exception("test")),
     )
 

--- a/tests/unit/test_config_update_atomic.py
+++ b/tests/unit/test_config_update_atomic.py
@@ -1,0 +1,179 @@
+"""Regression tests for Config.update_atomic (JTN-498).
+
+Ensures that concurrent read-modify-write operations on the playlist are
+protected by the config lock so that no edits are silently dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+import pytest
+
+_MIN_CFG: dict[str, Any] = {
+    "name": "AtomicTest",
+    "display_type": "mock",
+    "resolution": [800, 480],
+    "orientation": "horizontal",
+    "plugin_cycle_interval_seconds": 300,
+    "image_settings": {
+        "saturation": 1.0,
+        "brightness": 1.0,
+        "sharpness": 1.0,
+        "contrast": 1.0,
+    },
+    "playlist_config": {"playlists": [], "active_playlist": ""},
+    "refresh_info": {
+        "refresh_time": None,
+        "image_hash": None,
+        "refresh_type": "Manual Update",
+        "plugin_id": "",
+    },
+}
+
+
+def _write_config_file(path: str, data: dict | None = None) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(data if data is not None else _MIN_CFG, fh)
+
+
+def _make_config(tmp_path, monkeypatch):
+    """Build a Config instance pointing at a fresh tmp_path device.json."""
+    # Ensure src/ is importable
+    src_dir = os.path.join(os.path.dirname(__file__), "..", "..", "src")
+    src_dir = os.path.abspath(src_dir)
+    if src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
+
+    import config as config_mod
+
+    config_file = tmp_path / "config" / "device.json"
+    _write_config_file(str(config_file))
+
+    monkeypatch.setattr(config_mod.Config, "config_file", str(config_file))
+    # Prevent directories from being created in the real src tree
+    monkeypatch.setattr(
+        config_mod.Config,
+        "current_image_file",
+        str(tmp_path / "images" / "current_image.png"),
+    )
+    monkeypatch.setattr(
+        config_mod.Config,
+        "processed_image_file",
+        str(tmp_path / "images" / "processed_image.png"),
+    )
+    monkeypatch.setattr(
+        config_mod.Config,
+        "plugin_image_dir",
+        str(tmp_path / "images" / "plugins"),
+    )
+    monkeypatch.setattr(
+        config_mod.Config,
+        "history_image_dir",
+        str(tmp_path / "images" / "history"),
+    )
+    return config_mod.Config()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for update_atomic itself
+# ---------------------------------------------------------------------------
+
+
+def test_update_atomic_applies_mutation(tmp_path, monkeypatch):
+    """update_atomic calls update_fn and persists the result."""
+    cfg = _make_config(tmp_path, monkeypatch)
+    cfg.update_atomic(lambda c: c.update({"extra_key": "hello"}))
+    assert cfg.config.get("extra_key") == "hello"
+
+
+def test_update_atomic_writes_to_disk(tmp_path, monkeypatch):
+    """update_atomic writes the config to disk after the mutation."""
+    cfg = _make_config(tmp_path, monkeypatch)
+    cfg.update_atomic(lambda c: c.update({"disk_test": True}))
+    with open(cfg.config_file) as fh:
+        on_disk = json.load(fh)
+    assert on_disk.get("disk_test") is True
+
+
+def test_update_atomic_exception_does_not_write(tmp_path, monkeypatch):
+    """If update_fn raises, write_config should not be reached."""
+    cfg = _make_config(tmp_path, monkeypatch)
+    original_hash = cfg._last_written_hash
+
+    def _bad_fn(c):
+        c["should_not_persist"] = "bad"
+        raise RuntimeError("intentional failure")
+
+    with pytest.raises(RuntimeError):
+        cfg.update_atomic(_bad_fn)
+
+    # The hash should still be None (no write happened)
+    assert cfg._last_written_hash == original_hash
+
+
+# ---------------------------------------------------------------------------
+# Concurrent regression test: N threads each add a distinct plugin instance
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_add_to_playlist_no_clobber(tmp_path, monkeypatch):
+    """Fire N threads each adding a different plugin instance via update_atomic.
+
+    All N instances must survive in the final config without any being silently
+    clobbered.
+    """
+    N = 20
+    cfg = _make_config(tmp_path, monkeypatch)
+    playlist_manager = cfg.playlist_manager
+
+    # Ensure the Default playlist exists
+    if not playlist_manager.get_playlist("Default"):
+        playlist_manager.add_playlist("Default")
+        cfg.write_config()
+
+    errors: list[Exception] = []
+
+    def _add_plugin(i: int) -> None:
+        plugin_dict = {
+            "plugin_id": "clock",
+            "name": f"instance_{i}",
+            "refresh": {"interval": 3600},
+            "plugin_settings": {},
+        }
+
+        def _do_add(c):
+            result = playlist_manager.add_plugin_to_playlist("Default", plugin_dict)
+            if not result:
+                raise RuntimeError(f"add_plugin_to_playlist failed for instance_{i}")
+
+        cfg.update_atomic(_do_add)
+
+    with ThreadPoolExecutor(max_workers=N) as executor:
+        futures = [executor.submit(_add_plugin, i) for i in range(N)]
+        for fut in as_completed(futures):
+            exc = fut.exception()
+            if exc is not None:
+                errors.append(exc)
+
+    assert not errors, f"Some threads raised: {errors}"
+
+    # Reload from disk to verify durability
+    with open(cfg.config_file) as fh:
+        on_disk = json.load(fh)
+
+    playlists = on_disk.get("playlist_config", {}).get("playlists", [])
+    default_pl = next((p for p in playlists if p.get("name") == "Default"), None)
+    assert default_pl is not None, "Default playlist missing from on-disk config"
+
+    plugin_names = {p["name"] for p in default_pl.get("plugins", [])}
+    expected = {f"instance_{i}" for i in range(N)}
+    assert plugin_names == expected, (
+        f"Missing plugins: {expected - plugin_names}; "
+        f"extra: {plugin_names - expected}"
+    )


### PR DESCRIPTION
## Summary
- Add `Config.update_atomic(update_fn)` that holds `_config_lock` across the full read → mutate → write cycle, preventing concurrent threads from silently clobbering each other's playlist edits (e.g. two concurrent `add_to_playlist` calls)
- Migrate key RMW callsites in `playlist.py` and `plugin.py` to use `update_atomic` instead of bare mutation + `write_config()`
- Add `from collections.abc import Callable` import for the type annotation
- Update two integration tests that mocked `update_value` to instead mock `update_atomic` (the new entry point)
- Add 20-thread concurrent regression test asserting all plugin additions survive without any being dropped

## Changes
**`src/config.py`** — Add `update_atomic(update_fn)` method with `_config_lock` held across mutation + write

**`src/blueprints/playlist.py`** — Migrate `add_plugin`, `create_playlist`, `update_playlist`, `delete_playlist`, `reorder_plugins` to `update_atomic`

**`src/blueprints/plugin.py`** — Migrate `delete_plugin_instance`, `update_plugin_instance`, `_save_plugin_settings_common` to `update_atomic`

**`tests/unit/test_config_update_atomic.py`** — New regression tests: unit tests for `update_atomic`, plus a 20-thread concurrency test

**`tests/integration/test_api_json_errors.py` / `test_plugin_routes.py`** — Update mocks from `update_value` → `update_atomic`

## Test plan
- [x] All existing tests pass (2 failed → 2 failed, same pre-existing failures; 3102 → 3106 passing)
- [x] 4 new tests added covering `update_atomic` including concurrent stress test
- [x] Linting passes (`scripts/lint.sh` — ruff + black clean, mypy advisory only)

Closes JTN-498