### PR TITLE
docs: add pre-commit install subsection to development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,21 @@ devbox run dev # alternatively run `devbox shell` and then run `python src/inkyp
 
 **That's it!** Open http://localhost:8080 and start developing.
 
+### Install pre-commit hooks (recommended)
+
+After cloning, install the git hooks so linting runs automatically before each commit:
+
+```bash
+pre-commit install
+```
+
+On every `git commit` this runs: whitespace/YAML/merge-conflict checks, **ruff** (lint + format),
+**mypy** (type checks), **gitleaks** (secret scanning), and **conventional-commit** message
+validation. See [`.pre-commit-config.yaml`](../.pre-commit-config.yaml) for the full hook list.
+
+> **Bypass when needed:** `git commit --no-verify` skips the hooks locally, but CI enforces the
+> same checks — failures will surface there instead.
+
 ## What You Can Do
 
 - **Develop plugins** - Create new plugins without hardware (no Raspberry Pi, nor physical displays)


### PR DESCRIPTION
## Summary

- Adds a \"Install pre-commit hooks (recommended)\" subsection to the Setup section of `docs/development.md`
- Documents the `pre-commit install` command, which was previously only mentioned in CONTRIBUTING.md
- Lists the hooks that run (ruff lint+format, mypy, gitleaks, conventional-commit, plus basic file checks) pulled directly from `.pre-commit-config.yaml`
- Includes a bypass note: `git commit --no-verify` skips locally but CI still enforces

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync needed — doc-only change

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Docs updated (this IS the docs update)

## Testing

- [x] `scripts/lint.sh` passes (ruff + black green)
- [x] Doc-only change — no new logic to test

Closes JTN-527