### PR TITLE
feat: accessor + reset_for_tests() for utils singletons (JTN-493)

### DIFF
--- a/src/utils/http_cache.py
+++ b/src/utils/http_cache.py
@@ -438,6 +438,25 @@ def get_cache_stats() -> dict[str, Any]:
     return get_cache().get_stats()
 
 
+def get_http_cache() -> HTTPCache:
+    """Get or create the global HTTP cache instance.
+
+    Alias for :func:`get_cache` that follows the ``get_<resource>()`` naming
+    convention used by the other utils modules.
+    """
+    return get_cache()
+
+
+def reset_for_tests() -> None:
+    """Reset the global HTTP cache singleton (testing only).
+
+    Clears the singleton so the next call to ``get_cache()`` / ``get_http_cache()``
+    creates a fresh instance.  Call this from a pytest fixture to prevent cache
+    state from leaking between tests.
+    """
+    _reset_cache_for_tests()
+
+
 def _reset_cache_for_tests() -> None:
     """Reset the global cache (testing only)."""
     global _global_cache

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -71,7 +71,7 @@ def get_http_session() -> requests.Session:
     return _HTTP_SESSION
 
 
-def close_http_session():
+def close_http_session() -> None:
     """
     Close the shared HTTP session.
     Should be called on application shutdown.
@@ -82,4 +82,22 @@ def close_http_session():
         if _HTTP_SESSION is not None:
             logger.debug("Closing shared HTTP session")
             _HTTP_SESSION.close()
+            _HTTP_SESSION = None
+
+
+def reset_for_tests() -> None:
+    """Reset the shared HTTP session (testing only).
+
+    Closes any open session and clears the singleton so the next call to
+    ``get_http_session()`` creates a fresh instance.  Call this from a
+    pytest fixture to prevent session state from leaking between tests.
+    """
+    global _HTTP_SESSION
+
+    with _HTTP_SESSION_LOCK:
+        if _HTTP_SESSION is not None:
+            try:
+                _HTTP_SESSION.close()
+            except Exception:
+                pass
             _HTTP_SESSION = None

--- a/src/utils/i18n.py
+++ b/src/utils/i18n.py
@@ -79,6 +79,36 @@ def _load_locale(locale: str) -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
+def get_translations() -> dict[str, str]:
+    """Return the currently loaded translations mapping.
+
+    Provides controlled read access to the module-level ``_TRANSLATIONS``
+    dict so callers do not need to import the bare global directly.
+    """
+    return _TRANSLATIONS
+
+
+def get_active_locale() -> str:
+    """Return the currently active locale code (e.g. ``"en"``).
+
+    Provides controlled read access to the module-level ``_ACTIVE_LOCALE``
+    variable so callers do not need to import the bare global directly.
+    """
+    return _ACTIVE_LOCALE
+
+
+def reset_for_tests() -> None:
+    """Reset i18n state to defaults (testing only).
+
+    Resets ``_TRANSLATIONS`` to an empty dict and ``_ACTIVE_LOCALE`` to
+    ``"en"`` so that tests which call ``init_i18n()`` or inspect locale state
+    do not affect one another.
+    """
+    global _TRANSLATIONS, _ACTIVE_LOCALE
+    _TRANSLATIONS = {}
+    _ACTIVE_LOCALE = "en"
+
+
 def _(msg: str) -> str:
     """Return the localised form of *msg*, or *msg* itself if not found.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,26 @@ def mock_screenshot(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def reset_utils_singletons():
+    """Reset utils module-level singletons before each test.
+
+    Prevents HTTP session state, cache contents, and i18n locale state from
+    leaking across tests regardless of execution order.
+    """
+    from utils.http_cache import reset_for_tests as _reset_http_cache
+    from utils.http_client import reset_for_tests as _reset_http_session
+    from utils.i18n import reset_for_tests as _reset_i18n
+
+    _reset_http_session()
+    _reset_http_cache()
+    _reset_i18n()
+    yield
+    _reset_http_session()
+    _reset_http_cache()
+    _reset_i18n()
+
+
+@pytest.fixture(autouse=True)
 def reset_display_next_cooldown():
     """Reset the /display-next rate limiter between tests."""
     from blueprints.main import _reset_display_next_cooldown

--- a/tests/unit/test_http_cache.py
+++ b/tests/unit/test_http_cache.py
@@ -14,6 +14,8 @@ from utils.http_cache import (
     clear_cache,
     get_cache,
     get_cache_stats,
+    get_http_cache,
+    reset_for_tests,
 )
 
 
@@ -561,3 +563,28 @@ def test_existing_ttl_behavior_preserved(mock_response):
 
         mock_time.time.return_value = 2001.0
         assert c.get(url) is None
+
+
+def test_get_http_cache_returns_http_cache_instance():
+    """get_http_cache() returns an HTTPCache singleton."""
+    cache = get_http_cache()
+    assert isinstance(cache, HTTPCache)
+
+
+def test_get_http_cache_is_same_as_get_cache():
+    """get_http_cache() returns the same object as get_cache()."""
+    assert get_http_cache() is get_cache()
+
+
+def test_reset_for_tests_clears_singleton():
+    """reset_for_tests() resets the global cache so the next call creates a fresh instance."""
+    cache1 = get_http_cache()
+    reset_for_tests()
+    cache2 = get_http_cache()
+    assert cache2 is not cache1
+
+
+def test_reset_for_tests_when_none():
+    """reset_for_tests() is safe to call when the global cache is already None."""
+    reset_for_tests()  # clear first
+    reset_for_tests()  # must not raise

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 
 import utils.http_client as http_client_mod
-from utils.http_client import close_http_session, get_http_session
+from utils.http_client import close_http_session, get_http_session, reset_for_tests
 
 
 @pytest.fixture(autouse=True)
@@ -140,3 +140,21 @@ def test_atexit_registered():
         get_http_session()
         # atexit.register should have been called with close_http_session
         mock_register.assert_called_with(close_http_session)
+
+
+def test_reset_for_tests_closes_and_clears():
+    """reset_for_tests() closes any open session and resets singleton to None."""
+    session = get_http_session()
+    assert http_client_mod._HTTP_SESSION is not None
+    reset_for_tests()
+    assert http_client_mod._HTTP_SESSION is None
+    # Next call must create a fresh instance
+    new_session = get_http_session()
+    assert new_session is not session
+
+
+def test_reset_for_tests_when_none():
+    """reset_for_tests() is safe to call when no session exists."""
+    assert http_client_mod._HTTP_SESSION is None
+    reset_for_tests()  # must not raise
+    assert http_client_mod._HTTP_SESSION is None

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -1,0 +1,68 @@
+"""Tests for i18n module accessors and reset_for_tests()."""
+
+import pytest
+
+import utils.i18n as i18n_mod
+from utils.i18n import (
+    _,
+    get_active_locale,
+    get_translations,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_i18n():
+    """Ensure clean i18n state before and after each test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+def test_get_translations_returns_dict():
+    """get_translations() returns a dict."""
+    result = get_translations()
+    assert isinstance(result, dict)
+
+
+def test_get_active_locale_returns_default_en():
+    """get_active_locale() returns 'en' before any init_i18n() call."""
+    assert get_active_locale() == "en"
+
+
+def test_identity_translation():
+    """_() returns the key unchanged when no translations are loaded."""
+    assert _("Settings") == "Settings"
+    assert _("Hello World") == "Hello World"
+
+
+def test_get_translations_reflects_state():
+    """get_translations() reflects the current _TRANSLATIONS module global."""
+    assert get_translations() is i18n_mod._TRANSLATIONS
+
+
+def test_get_active_locale_reflects_state():
+    """get_active_locale() reflects the current _ACTIVE_LOCALE module global."""
+    assert get_active_locale() == i18n_mod._ACTIVE_LOCALE
+
+
+def test_reset_for_tests_clears_translations():
+    """reset_for_tests() resets _TRANSLATIONS to empty dict."""
+    i18n_mod._TRANSLATIONS = {"Hello": "Hola"}
+    reset_for_tests()
+    assert i18n_mod._TRANSLATIONS == {}
+
+
+def test_reset_for_tests_resets_locale():
+    """reset_for_tests() resets _ACTIVE_LOCALE to 'en'."""
+    i18n_mod._ACTIVE_LOCALE = "fr"
+    reset_for_tests()
+    assert i18n_mod._ACTIVE_LOCALE == "en"
+
+
+def test_reset_for_tests_idempotent():
+    """Calling reset_for_tests() twice does not raise."""
+    reset_for_tests()
+    reset_for_tests()
+    assert get_active_locale() == "en"
+    assert get_translations() == {}


### PR DESCRIPTION
## Summary

- Add `get_http_session()` / `reset_for_tests()` to `src/utils/http_client.py` — lazy-init singleton with test teardown
- Add `get_http_cache()` / `reset_for_tests()` to `src/utils/http_cache.py` — named accessor alias and public reset companion to the existing `_reset_cache_for_tests()`
- Add `get_translations()` / `get_active_locale()` / `reset_for_tests()` to `src/utils/i18n.py` — controlled read access to bare module globals and per-test reset
- Wire an `autouse=True` pytest fixture in `tests/conftest.py` that calls all three `reset_for_tests()` functions before and after each test, eliminating order-dependent pollution

## Changes

| File | What changed |
|---|---|
| `src/utils/http_client.py` | Added `reset_for_tests()` (closes session + nulls singleton) |
| `src/utils/http_cache.py` | Added `get_http_cache()` accessor alias + public `reset_for_tests()` wrapper |
| `src/utils/i18n.py` | Added `get_translations()`, `get_active_locale()`, `reset_for_tests()` |
| `tests/conftest.py` | Added `reset_utils_singletons` autouse fixture |

## Out of scope (intentional)

`src/inkypi.py` globals and `src/plugins/plugin_registry.py` are intentionally **not** touched in this PR — they require a larger Flask extension pattern refactor that would conflict with parallel in-flight work. A follow-up Linear issue will track that.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Testing

- [x] All existing tests pass (3112 passed, 2 pre-existing pyenv failures unrelated to this change)
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck clean; mypy advisory only)

Closes JTN-493