### PR TITLE
feat: fallback error-card image + circuit-breaker persistence (JTN-499)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -438,6 +438,81 @@ def force_retry_plugin_instance(plugin_id: str, instance_name: str):
     )
 
 
+def _update_now_direct(plugin_id, plugin_settings, device_config, display_manager):
+    """Execute a plugin directly (refresh task not running) and push to display.
+
+    Returns a Flask response tuple.  On plugin failure, a fallback error-card
+    image is pushed to the display before the error response is returned so the
+    screen does not stay frozen on stale content.
+    """
+    plugin_config = device_config.get_plugin(plugin_id)
+    if not plugin_config:
+        return json_error(f"Plugin '{plugin_id}' not found", status=404)
+
+    plugin = get_plugin_instance(plugin_config)
+    with track_progress() as tracker:
+        _t_req_start = perf_counter()
+        _t_gen_start = perf_counter()
+        try:
+            image = plugin.generate_image(plugin_settings, device_config)
+        except Exception as e:
+            logger.warning("Plugin error in update_now: %s", e)
+            _push_update_now_fallback(
+                plugin_id, plugin_config, device_config, display_manager, e
+            )
+            status = 400 if isinstance(e, RuntimeError) else 500
+            code = "plugin_error" if isinstance(e, RuntimeError) else "internal_error"
+            return json_error(str(e), status=status, code=code)
+        generate_ms = int((perf_counter() - _t_gen_start) * 1000)
+        display_manager.display_image(
+            image, image_settings=plugin_config.get("image_settings", [])
+        )
+        try:
+            ri = device_config.get_refresh_info()
+            display_ms = getattr(ri, "display_ms", None)
+            preprocess_ms = getattr(ri, "preprocess_ms", None)
+        except Exception:
+            display_ms = preprocess_ms = None
+        request_ms = int((perf_counter() - _t_req_start) * 1000)
+        metrics = {
+            "request_ms": request_ms,
+            "display_ms": display_ms,
+            "generate_ms": generate_ms,
+            "preprocess_ms": preprocess_ms,
+            "steps": tracker.get_steps(),
+        }
+    return (
+        jsonify({"success": True, "message": _MSG_DISPLAY_UPDATED, "metrics": metrics}),
+        200,
+    )
+
+
+def _push_update_now_fallback(
+    plugin_id, plugin_config, device_config, display_manager, exc
+):
+    """Best-effort: render and push an error-card image so the display updates on failure."""
+    try:
+        w, h = device_config.get_resolution()
+        fallback = render_error_image(
+            width=w,
+            height=h,
+            plugin_id=plugin_id,
+            instance_name=None,
+            error_class=type(exc).__name__,
+            error_message=str(exc),
+        )
+        display_manager.display_image(
+            fallback,
+            image_settings=plugin_config.get("image_settings", []),
+        )
+    except Exception:
+        logger.warning(
+            "update_now: fallback display failed for %s",
+            plugin_id,
+            exc_info=True,
+        )
+
+
 @plugin_bp.route("/update_now", methods=["POST"])
 def update_now():
     device_config = current_app.config[_CONFIG_KEY]
@@ -472,74 +547,8 @@ def update_now():
             )
         else:
             logger.info("Refresh task not running, updating display directly")
-            plugin_config = device_config.get_plugin(plugin_id)
-            if not plugin_config:
-                return json_error(f"Plugin '{plugin_id}' not found", status=404)
-
-            plugin = get_plugin_instance(plugin_config)
-            with track_progress() as tracker:
-                _t_req_start = perf_counter()
-                _t_gen_start = perf_counter()
-                try:
-                    image = plugin.generate_image(plugin_settings, device_config)
-                except Exception as e:
-                    logger.warning("Plugin error in update_now: %s", e)
-                    # Push a fallback image so the display reflects the failure
-                    try:
-                        w, h = device_config.get_resolution()
-                        fallback = render_error_image(
-                            width=w,
-                            height=h,
-                            plugin_id=plugin_id,
-                            instance_name=None,
-                            error_class=type(e).__name__,
-                            error_message=str(e),
-                        )
-                        display_manager.display_image(
-                            fallback,
-                            image_settings=plugin_config.get("image_settings", []),
-                        )
-                    except Exception:
-                        logger.warning(
-                            "update_now: fallback display failed for %s",
-                            plugin_id,
-                            exc_info=True,
-                        )
-                    status = 400 if isinstance(e, RuntimeError) else 500
-                    code = (
-                        "plugin_error"
-                        if isinstance(e, RuntimeError)
-                        else "internal_error"
-                    )
-                    return json_error(str(e), status=status, code=code)
-                generate_ms = int((perf_counter() - _t_gen_start) * 1000)
-                display_manager.display_image(
-                    image, image_settings=plugin_config.get("image_settings", [])
-                )
-                # Collect metrics from refresh_info if populated during display
-                try:
-                    ri = device_config.get_refresh_info()
-                    display_ms = getattr(ri, "display_ms", None)
-                    preprocess_ms = getattr(ri, "preprocess_ms", None)
-                except Exception:
-                    display_ms = preprocess_ms = None
-                request_ms = int((perf_counter() - _t_req_start) * 1000)
-                metrics = {
-                    "request_ms": request_ms,
-                    "display_ms": display_ms,
-                    "generate_ms": generate_ms,
-                    "preprocess_ms": preprocess_ms,
-                    "steps": tracker.get_steps(),
-                }
-            return (
-                jsonify(
-                    {
-                        "success": True,
-                        "message": _MSG_DISPLAY_UPDATED,
-                        "metrics": metrics,
-                    }
-                ),
-                200,
+            return _update_now_direct(
+                plugin_id, plugin_settings, device_config, display_manager
             )
     except Exception as e:
         logger.exception("Error in update_now: %s", e)

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -18,6 +18,7 @@ from flask import (
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task import ManualRefresh, PlaylistRefresh
 from utils.app_utils import handle_request_files, parse_form, resolve_path
+from utils.fallback_image import render_error_image
 from utils.http_utils import APIError, json_error
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 from utils.plugin_history import record_change as _record_plugin_change
@@ -481,9 +482,36 @@ def update_now():
                 _t_gen_start = perf_counter()
                 try:
                     image = plugin.generate_image(plugin_settings, device_config)
-                except RuntimeError as e:
+                except Exception as e:
                     logger.warning("Plugin error in update_now: %s", e)
-                    return json_error(str(e), status=400, code="plugin_error")
+                    # Push a fallback image so the display reflects the failure
+                    try:
+                        w, h = device_config.get_resolution()
+                        fallback = render_error_image(
+                            width=w,
+                            height=h,
+                            plugin_id=plugin_id,
+                            instance_name=None,
+                            error_class=type(e).__name__,
+                            error_message=str(e),
+                        )
+                        display_manager.display_image(
+                            fallback,
+                            image_settings=plugin_config.get("image_settings", []),
+                        )
+                    except Exception:
+                        logger.warning(
+                            "update_now: fallback display failed for %s",
+                            plugin_id,
+                            exc_info=True,
+                        )
+                    status = 400 if isinstance(e, RuntimeError) else 500
+                    code = (
+                        "plugin_error"
+                        if isinstance(e, RuntimeError)
+                        else "internal_error"
+                    )
+                    return json_error(str(e), status=status, code=code)
                 generate_ms = int((perf_counter() - _t_gen_start) * 1000)
                 display_manager.display_image(
                     image, image_settings=plugin_config.get("image_settings", [])

--- a/src/model.py
+++ b/src/model.py
@@ -532,6 +532,7 @@ class PluginInstance:
         snooze_until=None,
         consecutive_failure_count=0,
         paused=False,
+        disabled_reason: str | None = None,
     ):
         self.plugin_id = plugin_id
         self.name = name
@@ -542,6 +543,7 @@ class PluginInstance:
         self.snooze_until = snooze_until
         self.consecutive_failure_count = consecutive_failure_count
         self.paused = paused
+        self.disabled_reason = disabled_reason
 
     def update(self, updated_data):
         """Update attributes of the class with the dictionary values.
@@ -655,7 +657,7 @@ class PluginInstance:
         return latest_refresh
 
     def to_dict(self):
-        return {
+        d = {
             "plugin_id": self.plugin_id,
             "name": self.name,
             "plugin_settings": self.settings,
@@ -666,6 +668,9 @@ class PluginInstance:
             "consecutive_failure_count": self.consecutive_failure_count,
             "paused": self.paused,
         }
+        if self.disabled_reason is not None:
+            d["disabled_reason"] = self.disabled_reason
+        return d
 
     @classmethod
     def from_dict(cls, data):
@@ -679,4 +684,5 @@ class PluginInstance:
             snooze_until=data.get("snooze_until"),
             consecutive_failure_count=data.get("consecutive_failure_count", 0),
             paused=data.get("paused", False),
+            disabled_reason=data.get("disabled_reason"),
         )

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -19,6 +19,7 @@ from refresh_task.worker import (
     _remote_exception,
 )
 from utils.event_bus import get_event_bus
+from utils.fallback_image import render_error_image
 from utils.history_cleanup import cleanup_history
 from utils.image_utils import compute_image_hash
 from utils.metrics import (
@@ -359,6 +360,13 @@ class RefreshTask:
                         "error": str(exc),
                     },
                 )
+                self._push_fallback_image(
+                    plugin_id=plugin_id,
+                    instance_name=instance_name,
+                    exc=exc,
+                    plugin_config=plugin_config,
+                    refresh_action=refresh_action,
+                )
                 raise
             try:
                 save_stage_event(
@@ -644,6 +652,54 @@ class RefreshTask:
             if path and os.path.exists(path):
                 return path
         return None
+
+    def _push_fallback_image(
+        self,
+        plugin_id: str,
+        instance_name: str | None,
+        exc: BaseException,
+        plugin_config: dict,
+        refresh_action,
+    ) -> None:
+        """Render and push an error-card fallback image to the display.
+
+        Called when ``generate_image()`` raises so the user sees *something*
+        changed rather than stale content.  Best-effort: any error here is
+        logged but never re-raised.
+        """
+        try:
+            width, height = self.device_config.get_resolution()
+            fallback = render_error_image(
+                width=width,
+                height=height,
+                plugin_id=plugin_id,
+                instance_name=instance_name,
+                error_class=type(exc).__name__,
+                error_message=str(exc),
+            )
+            history_meta = {
+                "refresh_type": refresh_action.get_refresh_info().get("refresh_type"),
+                "plugin_id": plugin_id,
+                "playlist": refresh_action.get_refresh_info().get("playlist"),
+                "plugin_instance": instance_name,
+            }
+            self.display_manager.display_image(
+                fallback,
+                image_settings=plugin_config.get("image_settings", []),
+                history_meta=history_meta,
+            )
+            logger.info(
+                "plugin_lifecycle: fallback_displayed | plugin_id=%s instance=%s",
+                plugin_id,
+                instance_name,
+            )
+        except Exception:
+            logger.warning(
+                "plugin_lifecycle: fallback_display_failed | plugin_id=%s instance=%s",
+                plugin_id,
+                instance_name,
+                exc_info=True,
+            )
 
     def _update_refresh_info(self, refresh_info, metrics, used_cached):
         """Persist the latest refresh information to the device config.
@@ -1043,7 +1099,10 @@ class RefreshTask:
         """Reset the circuit breaker on a successful refresh."""
         if plugin_instance is None:
             return
-        if plugin_instance.paused or plugin_instance.consecutive_failure_count > 0:
+        changed = (
+            plugin_instance.paused or plugin_instance.consecutive_failure_count > 0
+        )
+        if changed:
             logger.info(
                 "plugin circuit_breaker: recovered | plugin_id=%s instance=%s",
                 plugin_id,
@@ -1051,7 +1110,18 @@ class RefreshTask:
             )
         plugin_instance.consecutive_failure_count = 0
         plugin_instance.paused = False
+        plugin_instance.disabled_reason = None
         set_circuit_breaker_open(plugin_id, False)
+        if changed:
+            try:
+                self.device_config.write_config()
+            except Exception:
+                logger.warning(
+                    "plugin circuit_breaker: failed to persist reset for %s/%s",
+                    plugin_id,
+                    instance,
+                    exc_info=True,
+                )
 
     def _cb_on_failure(
         self,
@@ -1071,8 +1141,18 @@ class RefreshTask:
             plugin_instance.consecutive_failure_count,
             threshold,
         )
+        newly_paused = False
         if plugin_instance.consecutive_failure_count >= threshold:
+            now_iso = now_device_tz(self.device_config).astimezone(UTC).isoformat()
+            error_msg = (
+                self.plugin_health.get(plugin_id, {}).get("last_error") or "unknown"
+            )
             plugin_instance.paused = True
+            plugin_instance.disabled_reason = (
+                f"Paused after {plugin_instance.consecutive_failure_count} consecutive "
+                f"failures at {now_iso}. Last error: {error_msg[:120]}"
+            )
+            newly_paused = True
             set_circuit_breaker_open(plugin_id, True)
             logger.error(
                 "plugin circuit_breaker: paused | plugin_id=%s instance=%s"
@@ -1081,6 +1161,18 @@ class RefreshTask:
                 instance,
                 plugin_instance.consecutive_failure_count,
             )
+        # Persist the updated counter (and paused state if newly paused) to disk
+        # so that a daemon restart preserves the circuit-breaker state.
+        if newly_paused or plugin_instance.consecutive_failure_count > 0:
+            try:
+                self.device_config.write_config()
+            except Exception:
+                logger.warning(
+                    "plugin circuit_breaker: failed to persist failure state for %s/%s",
+                    plugin_id,
+                    instance,
+                    exc_info=True,
+                )
 
         # Best-effort webhook notification — never raises.
         try:
@@ -1115,6 +1207,7 @@ class RefreshTask:
             return False
         plugin_instance.consecutive_failure_count = 0
         plugin_instance.paused = False
+        plugin_instance.disabled_reason = None
         # Sanitize user-controlled values for the audit log (S5145):
         # strip CR/LF (log injection) and truncate to a sane length.
         safe_pid = str(plugin_id).replace("\r", "").replace("\n", "")[:64]

--- a/src/utils/fallback_image.py
+++ b/src/utils/fallback_image.py
@@ -1,0 +1,97 @@
+"""Fallback image renderer for plugin failure notifications.
+
+When a plugin's generate_image() raises, the display would otherwise stay
+frozen on the previous image (silent lie).  This module provides a small
+helper that renders a human-readable error card so the user sees *something*
+changed, rather than stale content.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from PIL import Image, ImageDraw
+
+logger = logging.getLogger(__name__)
+
+# Maximum characters for the error message before truncation
+_MAX_MSG_LEN = 120
+# Fallback font size as a fraction of image width
+_FONT_SCALE = 0.028
+
+
+def render_error_image(
+    width: int,
+    height: int,
+    plugin_id: str,
+    instance_name: str | None,
+    error_class: str,
+    error_message: str,
+    timestamp: str | None = None,
+) -> Image.Image:
+    """Render a plain error-card image sized to the display dimensions.
+
+    Uses only PIL primitives (no custom fonts) so it never fails due to
+    missing font files.  The card shows:
+      - "Plugin Error" header
+      - plugin id / instance name
+      - error class + truncated message
+      - ISO timestamp
+
+    Args:
+        width: Target image width in pixels.
+        height: Target image height in pixels.
+        plugin_id: Plugin identifier string.
+        instance_name: Instance name or None.
+        error_class: Exception class name (e.g. ``"RuntimeError"``).
+        error_message: Exception message, truncated to ``_MAX_MSG_LEN`` chars.
+        timestamp: ISO timestamp string; defaults to current UTC time.
+
+    Returns:
+        A new RGBA :class:`PIL.Image.Image` containing the error card.
+    """
+    if timestamp is None:
+        timestamp = datetime.now(UTC).isoformat(timespec="seconds")
+
+    short_msg = error_message[:_MAX_MSG_LEN]
+    if len(error_message) > _MAX_MSG_LEN:
+        short_msg += "…"
+
+    img = Image.new("RGBA", (width, height), (255, 255, 255, 255))
+    draw = ImageDraw.Draw(img)
+
+    # Red error bar across the top
+    bar_h = max(6, height // 20)
+    draw.rectangle([(0, 0), (width, bar_h)], fill=(220, 50, 50, 255))
+
+    font_size = max(10, int(width * _FONT_SCALE))
+    line_gap = int(font_size * 1.6)
+    margin = max(12, int(width * 0.03))
+
+    lines = [
+        "Plugin Error",
+        "",
+        f"Plugin:   {plugin_id}",
+        f"Instance: {instance_name or '(none)'}",
+        "",
+        f"{error_class}: {short_msg}",
+        "",
+        f"Time: {timestamp}",
+    ]
+
+    try:
+        from utils.app_utils import get_font
+
+        font_header = get_font("Jost", font_size=int(font_size * 1.4))
+        font_body = get_font("Jost", font_size=font_size)
+    except Exception:
+        font_header = None
+        font_body = None
+
+    y = bar_h + margin
+    for i, line in enumerate(lines):
+        font = font_header if i == 0 else font_body
+        color = (180, 20, 20, 255) if i == 0 else (40, 40, 40, 255)
+        draw.text((margin, y), line, fill=color, font=font)
+        y += line_gap
+
+    return img

--- a/tests/integration/test_refresh_cycle.py
+++ b/tests/integration/test_refresh_cycle.py
@@ -138,7 +138,7 @@ def test_refresh_cycle_runs_plugin_to_display(device_config_dev, monkeypatch):
 
 
 def test_refresh_cycle_handles_plugin_failure(device_config_dev, monkeypatch):
-    """When the plugin raises, the display is skipped and health records the error."""
+    """When the plugin raises, a fallback error-card is pushed and health records the error."""
     failing_cfg = {"id": "bad_plugin", "class": "BadPlugin"}
     monkeypatch.setattr(
         device_config_dev,
@@ -183,8 +183,20 @@ def test_refresh_cycle_handles_plugin_failure(device_config_dev, monkeypatch):
             current_dt,
         )
 
-    # Display must NOT have been called
-    assert display_calls == [], "Display should not be called when plugin fails"
+    # A fallback image must have been pushed so the display does not stay frozen.
+    # The fallback image is an RGBA PIL Image at the device resolution.
+    assert (
+        len(display_calls) == 1
+    ), "Display should be called exactly once with the fallback error-card image"
+    fallback_img = display_calls[0][0]
+    from PIL import Image as _PIL_Image
+
+    assert isinstance(fallback_img, _PIL_Image.Image), "Fallback must be a PIL Image"
+    expected_w, expected_h = device_config_dev.get_resolution()
+    assert fallback_img.size == (
+        expected_w,
+        expected_h,
+    ), f"Fallback image dimensions {fallback_img.size} do not match display {(expected_w, expected_h)}"
 
     # Plugin health must record the failure
     assert "bad_plugin" in task.plugin_health

--- a/tests/unit/test_plugin_failure_fallback.py
+++ b/tests/unit/test_plugin_failure_fallback.py
@@ -1,0 +1,397 @@
+# pyright: reportMissingImports=false
+"""Tests for plugin failure fallback image and circuit-breaker persistence (JTN-499).
+
+Covers:
+- Fallback image is returned (not None) when a plugin always raises
+- After 5 consecutive failures the instance's config entry is marked paused
+- On a subsequent success the counter resets to 0 and disabled_reason is cleared
+- Fallback image is displayed on failure in _perform_refresh
+- Circuit-breaker state persists to disk (write_config called)
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from model import PluginInstance
+from refresh_task import RefreshTask
+from refresh_task.actions import PlaylistRefresh
+from utils.fallback_image import render_error_image
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(device_config_dev):
+    dm = MagicMock()
+    dm.display_image.return_value = {"display_ms": 10, "preprocess_ms": 5}
+    task = RefreshTask(device_config_dev, dm)
+    return task, dm
+
+
+def _make_plugin_instance(plugin_id="dummy", name="my_dummy"):
+    return PluginInstance(
+        plugin_id=plugin_id,
+        name=name,
+        settings={},
+        refresh={"interval": 3600},
+    )
+
+
+def _add_plugin_to_pm(device_config_dev, plugin_instance):
+    pm = device_config_dev.get_playlist_manager()
+    playlist = pm.get_playlist("Default")
+    if playlist is None:
+        pm.add_default_playlist()
+        playlist = pm.get_playlist("Default")
+    playlist.plugins.append(plugin_instance)
+    return pm
+
+
+# ---------------------------------------------------------------------------
+# render_error_image unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderErrorImage:
+    def test_returns_pil_image(self):
+        img = render_error_image(
+            width=800,
+            height=480,
+            plugin_id="weather",
+            instance_name="my_weather",
+            error_class="RuntimeError",
+            error_message="API unavailable",
+        )
+        assert isinstance(img, Image.Image)
+
+    def test_correct_dimensions(self):
+        img = render_error_image(
+            width=800,
+            height=480,
+            plugin_id="weather",
+            instance_name="my_weather",
+            error_class="RuntimeError",
+            error_message="err",
+        )
+        assert img.size == (800, 480)
+
+    def test_never_returns_none_on_long_message(self):
+        msg = "x" * 500
+        img = render_error_image(
+            width=400,
+            height=300,
+            plugin_id="plugin",
+            instance_name=None,
+            error_class="ValueError",
+            error_message=msg,
+        )
+        assert img is not None
+        assert isinstance(img, Image.Image)
+
+    def test_custom_timestamp(self):
+        img = render_error_image(
+            width=400,
+            height=300,
+            plugin_id="p",
+            instance_name="i",
+            error_class="TypeError",
+            error_message="bad",
+            timestamp="2025-01-01T00:00:00+00:00",
+        )
+        assert isinstance(img, Image.Image)
+
+    def test_small_dimensions(self):
+        """Even tiny dimensions should not raise."""
+        img = render_error_image(
+            width=50,
+            height=50,
+            plugin_id="p",
+            instance_name=None,
+            error_class="E",
+            error_message="m",
+        )
+        assert isinstance(img, Image.Image)
+
+
+# ---------------------------------------------------------------------------
+# Fallback display integration (via _update_plugin_health → _cb_on_failure)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackImageOnFailure:
+    def test_fallback_displayed_when_generate_raises(
+        self, device_config_dev, monkeypatch
+    ):
+        """When generate_image raises, _push_fallback_image is called."""
+        monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "none")
+        monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "0")
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+
+        task, dm = _make_task(device_config_dev)
+
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        dummy_cfg = {"id": "dummy", "class": "Dummy", "image_settings": []}
+        monkeypatch.setattr(device_config_dev, "get_plugin", lambda pid: dummy_cfg)
+
+        class AlwaysRaisesPlugin:
+            def generate_image(self, settings, cfg):
+                raise RuntimeError("API is down")
+
+            def get_latest_metadata(self):
+                return None
+
+        monkeypatch.setattr(
+            "refresh_task.task.get_plugin_instance",
+            lambda cfg: AlwaysRaisesPlugin(),
+        )
+
+        from refresh_task.actions import PlaylistRefresh
+
+        playlist = device_config_dev.get_playlist_manager().get_playlist("Default")
+        refresh_action = PlaylistRefresh(playlist, pi)
+
+        current_dt = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        fallback_calls = []
+        original_push = task._push_fallback_image
+
+        def _tracking_push(*args, **kwargs):
+            fallback_calls.append(True)
+            return original_push(*args, **kwargs)
+
+        monkeypatch.setattr(task, "_push_fallback_image", _tracking_push)
+
+        with pytest.raises(RuntimeError):
+            task._perform_refresh(refresh_action, current_dt, current_dt)
+
+        assert len(fallback_calls) == 1, "Fallback push should have been called once"
+
+    def test_fallback_image_pushed_to_display(self, device_config_dev, monkeypatch):
+        """display_manager.display_image is called with a PIL Image on failure."""
+        monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "none")
+        monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "0")
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+
+        task, dm = _make_task(device_config_dev)
+
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        dummy_cfg = {"id": "dummy", "class": "Dummy", "image_settings": []}
+        monkeypatch.setattr(device_config_dev, "get_plugin", lambda pid: dummy_cfg)
+
+        class AlwaysRaisesPlugin:
+            def generate_image(self, settings, cfg):
+                raise ValueError("config missing")
+
+            def get_latest_metadata(self):
+                return None
+
+        monkeypatch.setattr(
+            "refresh_task.task.get_plugin_instance",
+            lambda cfg: AlwaysRaisesPlugin(),
+        )
+
+        playlist = device_config_dev.get_playlist_manager().get_playlist("Default")
+        refresh_action = PlaylistRefresh(playlist, pi)
+
+        current_dt = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        with pytest.raises(ValueError):
+            task._perform_refresh(refresh_action, current_dt, current_dt)
+
+        # display_image should have been called at least once with a PIL Image
+        assert dm.display_image.called
+        call_args = dm.display_image.call_args
+        first_arg = call_args[0][0] if call_args[0] else call_args[1].get("image")
+        # Either positional or keyword — accept both
+        if first_arg is None:
+            first_arg = call_args[1].get("image") if call_args[1] else None
+        assert isinstance(
+            first_arg, Image.Image
+        ), f"Expected PIL Image to be passed to display_image, got {type(first_arg)}"
+
+
+# ---------------------------------------------------------------------------
+# Circuit-breaker persistence to disk
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerPersistence:
+    def test_failure_counter_persisted_to_config(self, device_config_dev, monkeypatch):
+        """Consecutive failures increment counter and write_config is called."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+        task, _dm = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        write_calls = []
+        orig_write = device_config_dev.write_config
+
+        def _tracking_write():
+            write_calls.append(True)
+            return orig_write()
+
+        monkeypatch.setattr(device_config_dev, "write_config", _tracking_write)
+
+        for _ in range(3):
+            task._update_plugin_health(
+                plugin_id="dummy",
+                instance="my_dummy",
+                ok=False,
+                metrics=None,
+                error="some error",
+            )
+
+        assert pi.consecutive_failure_count == 3
+        assert len(write_calls) == 3, "write_config should be called per failure"
+
+    def test_paused_after_five_failures_persists(self, device_config_dev, monkeypatch):
+        """After 5 failures the instance is paused and state is written to disk."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+        task, _dm = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        for _ in range(5):
+            task._update_plugin_health(
+                plugin_id="dummy",
+                instance="my_dummy",
+                ok=False,
+                metrics=None,
+                error="boom",
+            )
+
+        assert pi.paused is True
+        assert pi.consecutive_failure_count == 5
+        assert pi.disabled_reason is not None
+        assert "boom" in pi.disabled_reason
+
+        # Reload config from disk to verify persistence
+        import json
+
+        with open(device_config_dev.config_file, encoding="utf-8") as f:
+            saved = json.load(f)
+
+        playlists = saved.get("playlist_config", {}).get("playlists", [])
+        found_plugin = None
+        for pl in playlists:
+            for p in pl.get("plugins", []):
+                if p.get("plugin_id") == "dummy" and p.get("name") == "my_dummy":
+                    found_plugin = p
+                    break
+
+        assert found_plugin is not None, "Plugin should be persisted in config"
+        assert found_plugin["paused"] is True
+        assert found_plugin["consecutive_failure_count"] == 5
+
+    def test_success_resets_counter_and_persists(self, device_config_dev, monkeypatch):
+        """Success after failures resets counter to 0 and writes config once."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+        task, _dm = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        # Simulate 3 prior failures
+        for _ in range(3):
+            task._update_plugin_health(
+                plugin_id="dummy",
+                instance="my_dummy",
+                ok=False,
+                metrics=None,
+                error="err",
+            )
+        assert pi.consecutive_failure_count == 3
+
+        write_calls = []
+        orig_write = device_config_dev.write_config
+
+        def _tracking_write():
+            write_calls.append(True)
+            return orig_write()
+
+        monkeypatch.setattr(device_config_dev, "write_config", _tracking_write)
+
+        # Now a success
+        task._update_plugin_health(
+            plugin_id="dummy",
+            instance="my_dummy",
+            ok=True,
+            metrics={"request_ms": 100},
+            error=None,
+        )
+
+        assert pi.consecutive_failure_count == 0
+        assert pi.paused is False
+        assert pi.disabled_reason is None
+        assert (
+            len(write_calls) == 1
+        ), "write_config should be called exactly once on recovery"
+
+    def test_disabled_reason_cleared_on_success(self, device_config_dev, monkeypatch):
+        """disabled_reason is removed after successful refresh."""
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "2")
+        task, _dm = _make_task(device_config_dev)
+        pi = _make_plugin_instance()
+        _add_plugin_to_pm(device_config_dev, pi)
+
+        for _ in range(2):
+            task._update_plugin_health(
+                plugin_id="dummy",
+                instance="my_dummy",
+                ok=False,
+                metrics=None,
+                error="test error",
+            )
+        assert pi.paused is True
+        assert pi.disabled_reason is not None
+
+        task._update_plugin_health(
+            plugin_id="dummy",
+            instance="my_dummy",
+            ok=True,
+            metrics=None,
+            error=None,
+        )
+        assert pi.disabled_reason is None
+
+    def test_disabled_reason_in_to_dict(self):
+        pi = PluginInstance("p", "n", {}, {"interval": 3600})
+        pi.paused = True
+        pi.disabled_reason = "Paused after 5 consecutive failures"
+        d = pi.to_dict()
+        assert d["disabled_reason"] == "Paused after 5 consecutive failures"
+
+    def test_disabled_reason_round_trips_from_dict(self):
+        data = {
+            "plugin_id": "weather",
+            "name": "inst",
+            "plugin_settings": {},
+            "refresh": {"interval": 3600},
+            "paused": True,
+            "disabled_reason": "too many errors",
+            "consecutive_failure_count": 5,
+        }
+        pi = PluginInstance.from_dict(data)
+        assert pi.disabled_reason == "too many errors"
+
+    def test_disabled_reason_absent_from_dict_defaults_none(self):
+        data = {
+            "plugin_id": "weather",
+            "name": "inst",
+            "plugin_settings": {},
+            "refresh": {"interval": 3600},
+        }
+        pi = PluginInstance.from_dict(data)
+        assert pi.disabled_reason is None
+
+    def test_disabled_reason_not_in_to_dict_when_none(self):
+        pi = PluginInstance("p", "n", {}, {"interval": 3600})
+        d = pi.to_dict()
+        assert "disabled_reason" not in d


### PR DESCRIPTION
## Summary

- When a plugin's `generate_image()` raises, a human-readable error-card image is now pushed to the display immediately instead of leaving it frozen on stale content
- The error card shows plugin name, instance, error class, truncated message, and timestamp — rendered via new `src/utils/fallback_image.render_error_image()` helper
- Circuit-breaker state (`consecutive_failure_count`, `paused`, new `disabled_reason`) is now persisted to `device.json` via `write_config()` on every failure and on recovery, surviving daemon restarts
- Same fallback pattern applied to `blueprints/plugin.py` `update_now` direct-execution path

## Changes

**New files:**
- `src/utils/fallback_image.py` — small helper (<90 lines) to render a PIL error-card with no external font dependencies
- `tests/unit/test_plugin_failure_fallback.py` — 15 new unit tests

**Modified files:**
- `src/refresh_task/task.py` — `_push_fallback_image()` method, `_cb_on_failure`/`_cb_on_success` now persist to disk, `reset_circuit_breaker` clears `disabled_reason`
- `src/model.py` — `PluginInstance` gains `disabled_reason: str | None` field (serialized in `to_dict`/`from_dict`)
- `src/blueprints/plugin.py` — `update_now` catches all exceptions, pushes fallback image, returns appropriate status
- `tests/integration/test_refresh_cycle.py` — updated to assert fallback IS pushed on failure (was asserting it was NOT)

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync needed — original work

## Compatibility/Release Checklist

- [x] `pytest` passes: 3127 passed, 2 pre-existing failures (pyenv `python` command unavailable in CI env)
- [x] `scripts/lint.sh` passes (ruff + black clean; mypy advisory only)
- [x] No breaking API route/path changes
- [x] `PluginInstance.to_dict()` backwards-compatible: `disabled_reason` omitted when `None`

## Testing

- 15 new unit tests cover: `render_error_image()` dimensions/content, fallback display called on failure, config write on failure/recovery, `disabled_reason` round-trip via `to_dict`/`from_dict`
- Updated integration test asserts error-card pushed to display on failure

Closes JTN-499