### PR TITLE
docs: add Architecture Decision Records (JTN-522)

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# ADR-NNNN: Short Title
+
+**Status:** Proposed | Accepted | Superseded by ADR-XXXX
+
+## Context
+
+What is the background? What forces, constraints, or requirements led to this decision? Keep it to 2-4 sentences.
+
+## Decision
+
+What did we decide to do? State it clearly and directly.
+
+## Consequences
+
+### Positive
+- ...
+
+### Negative
+- ...
+
+## Alternatives considered
+
+- **Alternative A** — why it was not chosen
+- **Alternative B** — why it was not chosen

--- a/docs/adr/0001-subprocess-plugin-isolation.md
+++ b/docs/adr/0001-subprocess-plugin-isolation.md
@@ -1,0 +1,29 @@
+# ADR-0001: Subprocess isolation for plugin execution
+
+**Status:** Accepted
+
+## Context
+
+InkyPi plugins are third-party or user-written code that fetch external data and render images. A buggy plugin can leak memory, spin indefinitely, open file handles, or crash the interpreter. The refresh loop runs inside the same process as the Flask web server, so an uncaught exception or OOM kill in a plugin would bring down the web UI too. On a Pi Zero 2 W (512 MB RAM, no swap by default), unbounded memory growth from a single plugin is a real operational concern.
+
+## Decision
+
+Each plugin invocation is run in a separate child process via Python's `multiprocessing` module (see `src/refresh_task/worker.py`). On Linux (the production target) the `forkserver` start method is preferred because it spawns children from a lean server process rather than duplicating the parent's full heap on every `fork()`. The child serialises its result (PNG bytes + optional metadata) onto a `multiprocessing.Queue` and exits; the parent reads the queue and re-raises any exception as a structured error. The `_get_mp_context()` helper in `worker.py` encapsulates the platform-specific method selection (line 14-24).
+
+## Consequences
+
+### Positive
+- A crashing or OOM-killed plugin cannot take down the web UI.
+- Memory leaks are bounded to a single refresh cycle — the child process is reclaimed by the OS on exit.
+- The circuit breaker in `_update_plugin_health` (task.py) can track consecutive failures and pause a plugin without affecting others.
+
+### Negative
+- Subprocess spawn is slower than a direct function call; on a Pi Zero 2 W `forkserver` adds ~200-400 ms of overhead per refresh.
+- Plugin objects must be picklable (or reconstructed from config) to cross the process boundary — `Config` implements `__getstate__`/`__setstate__` for this reason (`src/config.py` lines 90-104).
+- Debugging is harder because tracebacks must be serialised as strings and re-raised in the parent.
+
+## Alternatives considered
+
+- **Run plugins in threads** — simpler and faster, but a crashing plugin or GIL-bypassing C extension can corrupt shared state, and memory leaks accumulate in the main process indefinitely.
+- **Run plugins in the same thread** — fastest, but any unhandled exception kills the refresh loop.
+- **Docker/sandbox per plugin** — complete isolation, but far too heavyweight for a Pi Zero 2 W.

--- a/docs/adr/0002-http-cache-strategy.md
+++ b/docs/adr/0002-http-cache-strategy.md
@@ -1,0 +1,30 @@
+# ADR-0002: Custom in-process HTTP cache with TTL
+
+**Status:** Accepted
+
+## Context
+
+Plugins call external APIs (weather, news, NASA APOD, Unsplash, etc.) on every refresh cycle. With a 5-minute refresh interval a single plugin can make ~288 API calls per day — often far beyond free-tier quotas. On a Pi Zero 2 W, each outbound HTTPS request also adds meaningful latency and power draw. An off-the-shelf solution such as `requests-cache` would work, but it introduces a SQLite or filesystem dependency and requires per-plugin opt-in. The project already avoids SQLite as a runtime dependency (see ADR-0004); adding it only for response caching seemed disproportionate.
+
+## Decision
+
+A custom `HTTPCache` class lives in `src/utils/http_cache.py`. It is an `OrderedDict`-backed, thread-safe, TTL+LRU store keyed on the full request URL (including query string). The helper `http_get()` in `src/utils/http_utils.py` wraps `requests.get()` and is the single call site all plugins use. Cache entries honour the server's `Cache-Control: max-age` when present; the default TTL is 300 s (overridable via `INKYPI_HTTP_CACHE_TTL_S`). LRU eviction was added in commit `6bc5ce7` (JTN-299) after the initial implementation allowed unbounded growth.
+
+## Consequences
+
+### Positive
+- No new runtime dependencies — pure Python, no SQLite.
+- Plugins benefit automatically without any code changes; `http_get()` is already the conventional call.
+- Cache is scoped to the process lifetime; no stale entries survive a service restart.
+- Statistics (`hits`, `misses`, `hit_rate`) are exposed for monitoring.
+
+### Negative
+- Cache is lost on restart — a cold start always fetches live data.
+- The cache is in-process only; if InkyPi is run as multiple workers behind a load balancer (not the current deployment model), each worker has its own cache.
+- Cache-key logic is URL-only; `POST` bodies or custom headers are not keyed, but plugins only use `GET`.
+
+## Alternatives considered
+
+- **`requests-cache`** — mature library, but brings a SQLite/filesystem backend that conflicts with the project's no-database stance and requires explicit integration per plugin.
+- **No cache / rely on ETags** — not all external APIs send `ETag`; even conditional requests consume quota on many services.
+- **Redis** — overkill for a single-Pi deployment.

--- a/docs/adr/0003-playlist-scheduling.md
+++ b/docs/adr/0003-playlist-scheduling.md
@@ -1,0 +1,37 @@
+# ADR-0003: Playlist scheduling — time windows, priority, and cycle interval
+
+**Status:** Accepted
+
+## Context
+
+Users want different content at different times of day: a clock overnight, news in the morning, weather in the afternoon. They also want to cycle through multiple plugins within a time window at a configurable rate. The scheduling model must be simple enough for a non-technical user to configure via the web UI, and it must work without a persistent scheduler process or database.
+
+## Decision
+
+Scheduling is encoded in three orthogonal axes, all stored in `device.json` and evaluated on every refresh tick:
+
+1. **Time window** (`start_time` / `end_time` on `Playlist`): a playlist is only eligible when the current wall-clock time falls inside `[start_time, end_time)`. Times are `HH:MM` strings; `24:00` is the canonical end-of-day sentinel. Evaluated by `Playlist.is_active()` in `src/model.py` (line 282).
+
+2. **Priority** (`Playlist.get_priority()`): when multiple playlists are active at the same time (overlapping windows), the one with the numerically lowest priority value wins. `PlaylistManager.determine_active_playlist()` sorts active playlists by priority and picks `[0]` (model.py line 173).
+
+3. **Cycle interval** (`plugin_cycle_interval_seconds` on the device config, defaulting to 3600 s): the refresh task's `_wait_for_trigger()` sleeps for this duration between ticks. Per-plugin `refresh_interval` (stored on `PluginInstance`) allows individual plugins to declare a minimum cadence independently of the playlist cycle; `PlaylistManager.should_refresh()` checks elapsed time against the interval (model.py line 233).
+
+Within an active playlist, plugins cycle round-robin via `Playlist.get_next_eligible_plugin()`, skipping plugins that fail `is_show_eligible()` (e.g., circuit-broken plugins).
+
+## Consequences
+
+### Positive
+- No external cron or scheduler needed — evaluation is pure in-memory arithmetic on every tick.
+- Priority + time windows covers the common "morning briefing / overnight clock" pattern with no special-case logic.
+- Round-robin within a playlist gives equal share of screen time without requiring the user to set explicit durations.
+
+### Negative
+- Overlapping time windows with equal priority are non-deterministic (sort is not stable across restarts) — users must assign distinct priorities if they want predictable overlap resolution.
+- The cycle interval is global; giving one playlist a faster cadence than another requires separate priority + time window configuration rather than a per-playlist interval setting.
+- Midnight-spanning windows (`start > end`, e.g., 22:00–06:00) are supported by `is_active()` but not surfaced clearly in the UI, which can confuse users.
+
+## Alternatives considered
+
+- **cron expressions per plugin** — more flexible, but far harder to expose in a web UI aimed at non-technical users; also requires a persistent scheduler.
+- **Fixed time slots per plugin** — simpler for users to reason about, but inflexible and requires the user to account for plugin run time.
+- **Event-driven (sunrise/sunset)** — requested as a future feature; not implemented because it requires a location-aware time source and adds complexity outside the initial scope.

--- a/docs/adr/0004-json-config-store.md
+++ b/docs/adr/0004-json-config-store.md
@@ -1,0 +1,31 @@
+# ADR-0004: JSON file as the sole config and state store
+
+**Status:** Accepted
+
+## Context
+
+InkyPi needs to persist device settings, playlist definitions, plugin instance configurations, and the last-refresh metadata across restarts. The deployment target is a single Raspberry Pi Zero 2 W running a systemd service. There is no multi-user, multi-process write contention beyond the one Flask worker and one background refresh thread. Simplicity of installation and inspectability of stored data are high priorities.
+
+## Decision
+
+All persistent state lives in a single `device.json` file (or `device_dev.json` in dev mode). The `Config` class in `src/config.py` is the sole reader and writer. Writes use a write-then-atomic-rename pattern (`Config.write_config()`) to prevent partial writes corrupting the file. Concurrent read/write access within the process is serialised by a `threading.RLock` (`_config_lock`). Schema validation runs on startup via `src/utils/config_schema.py` (added in commit `86f9cfc`, JTN-335). An mtime-based read cache was added in commit `cdbbc81` (JTN-519) to avoid re-parsing JSON on every route handler invocation.
+
+## Consequences
+
+### Positive
+- Zero runtime database dependency — no SQLite, PostgreSQL, or Redis needed on the Pi.
+- The file is human-readable and editable with any text editor; easy to inspect, back up, and restore (`src/config` CLI — JTN-336).
+- Installation is a single `pip install` + file copy; no `CREATE TABLE` migrations.
+- Plugin instance export/import (JTN-448) is trivially serialisable as JSON.
+
+### Negative
+- Not suitable for high write frequency; heavy playlist cycling writes the whole file on every tick. In practice, writes are infrequent (once per refresh, default 1 h).
+- A process crash mid-write could corrupt the file; the atomic-rename mitigates this but does not eliminate all edge cases on FAT32/SD cards.
+- As the number of plugins and history entries grows, the file grows with them; no built-in compaction.
+- Multi-instance deployments (e.g., two Pis sharing a config) are not supported — each device owns its own file.
+
+## Alternatives considered
+
+- **SQLite** — richer query support and transaction safety, but adds a native-library dependency and requires schema migrations. The Pi Zero 2 W's SD card I/O characteristics also make SQLite's WAL mode less attractive.
+- **Redis / key-value store** — overkill for a device that runs one Flask process; adds a daemon to manage.
+- **Environment variables only** — suitable for secrets (handled via `.env` + `python-dotenv`) but not for structured nested config.

--- a/docs/adr/0005-waitress-vs-gunicorn.md
+++ b/docs/adr/0005-waitress-vs-gunicorn.md
@@ -1,0 +1,33 @@
+# ADR-0005: Waitress as the production WSGI server
+
+**Status:** Accepted
+
+## Context
+
+InkyPi needs a production-grade WSGI server to replace Flask's built-in development server. The two most common choices in the Python ecosystem are Waitress and Gunicorn. The application runs a background `RefreshTask` thread that was started in the same process as the Flask app (`src/inkypi.py` line 370). Gunicorn's pre-fork worker model would fork the process after the refresh thread is already running, which is undefined behaviour in Python — threads do not survive `fork()` safely, and the forked workers would each hold a copy of the thread object pointing at state owned by the parent.
+
+## Decision
+
+Waitress (`waitress==3.0.2`, listed in `install/requirements.txt`) is used as the WSGI server. The entry point in `src/inkypi.py` calls `waitress.serve(created_app, host="0.0.0.0", port=PORT, threads=4)`. The thread count was raised from 1 to 4 in commit `90c44c2` (fix #142) after profiling showed single-threaded Waitress blocking on concurrent requests during manual plugin refreshes.
+
+Waitress is a pure-Python, multi-threaded server that runs in the same process as the application. There is no forking — the refresh thread, config lock, and event bus are all shared safely with the WSGI threads via the existing `threading.RLock`.
+
+## Consequences
+
+### Positive
+- No `fork()`-after-thread hazard; the refresh task and Flask workers share a single process with proper locking.
+- Pure-Python install — no C extensions, no `libpython` headers required on the Pi.
+- Works on Windows (useful for contributors developing on Windows without WSL).
+- Thread count is a simple integer tunable via code or env; no worker process management.
+
+### Negative
+- Waitress is multi-threaded but single-process; it cannot use multiple CPU cores the way Gunicorn with multiple worker processes can. On a Pi Zero 2 W (single-core effective throughput) this is not a concern.
+- Waitress does not support HTTP/2 or WebSockets natively; SSE for progress events is handled by Flask's streaming response, which works within the threading model.
+- Slightly less battle-tested at high concurrency compared to Gunicorn + gevent; acceptable for a single-Pi deployment with at most a handful of simultaneous browser tabs.
+
+## Alternatives considered
+
+- **Gunicorn with sync workers** — incompatible with the in-process refresh thread; forking after thread start is unsafe.
+- **Gunicorn with `--preload` disabled and gevent workers** — would require converting the entire codebase to async-compatible patterns.
+- **uWSGI** — C extension, heavier deployment footprint, thread model has the same forking caveats as Gunicorn.
+- **Flask dev server** — used in `--dev` mode only; explicitly not suitable for production.

--- a/docs/adr/0006-webp-on-the-fly-encoding.md
+++ b/docs/adr/0006-webp-on-the-fly-encoding.md
@@ -1,0 +1,30 @@
+# ADR-0006: WebP encoding on request rather than at generation time
+
+**Status:** Accepted
+
+## Context
+
+E-ink display images are generated as `PIL.Image` objects and saved to disk as PNG files (`current_image.png`, `processed_image.png`, per-plugin PNGs in `static/images/plugins/`). These PNGs are served to the browser dashboard on every page load and history view. PNG is lossless but large; a 600×448 display image is typically 200-400 KB as PNG but 30-60 KB as WebP (quality 85). The web UI loads dozens of history thumbnails, so the bandwidth difference is noticeable especially when the Pi is accessed over Wi-Fi. The question was: encode to WebP when the plugin generates the image, or at request time?
+
+## Decision
+
+WebP is encoded on-the-fly at request time in `src/utils/image_serving.py`. The `maybe_serve_webp()` function checks the `Accept` request header; browsers that advertise `image/webp` receive a WebP-encoded response, others receive the original PNG via `flask.send_from_directory`. Encoding is done with Pillow (`PIL.Image.save(..., format="WEBP", quality=85, method=4)`). An `lru_cache(maxsize=32)` keyed on `(path, mtime, size)` means repeated requests within a server session are served from memory without re-encoding (added in commit `7923b91`, JTN-302).
+
+## Consequences
+
+### Positive
+- PNGs remain on disk as the canonical source of truth — display drivers, history export, and backup/restore all work with unmodified files regardless of browser capability.
+- No storage duplication: there is no parallel `.webp` file to keep in sync or clean up.
+- The `lru_cache` makes the per-request overhead negligible for the small number of images in the history view (maxsize=32 covers the dashboard thumbnail grid).
+- Graceful degradation: old browsers or non-browser clients continue to receive PNG with no code changes.
+
+### Negative
+- First request for a large history image incurs a Pillow encode operation — measurable (~20-50 ms) on Pi Zero 2 W but within acceptable latency for a dashboard page load.
+- The in-process `lru_cache` is lost on restart; a cold-start page load re-encodes all visible images.
+- The 32-entry cache is sufficient for the current history thumbnail count but would need tuning if the history page grows significantly.
+
+## Alternatives considered
+
+- **Pre-encode to WebP at generation time** — eliminates the per-request latency but doubles disk usage (PNG + WebP per image) and complicates the history cleanup logic.
+- **Store WebP only, not PNG** — would break display drivers (Inky/Waveshare libraries expect PIL.Image or PNG), history export, and backup/restore which all depend on PNG.
+- **Serve PNG always** — simplest, but adds 5-10x more bytes per image over the wire on every dashboard load; noticeable on the local Wi-Fi link to a Pi.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records
+
+This directory captures significant architectural decisions made in the InkyPi project. Each record (ADR) explains the context that drove a decision, what was decided, its trade-offs, and the alternatives that were considered but rejected.
+
+Template: [0000-template.md](0000-template.md)
+
+When to file a new ADR: when you make a choice that is non-obvious, hard to reverse, or likely to be re-litigated by a future contributor. Good candidates are library choices, concurrency models, persistence strategies, and protocol decisions.
+
+---
+
+| # | Title | Status | Summary |
+|---|-------|--------|---------|
+| [0001](0001-subprocess-plugin-isolation.md) | Subprocess isolation for plugin execution | Accepted | Each plugin runs in a child process so a crash or memory leak cannot bring down the web server. |
+| [0002](0002-http-cache-strategy.md) | Custom in-process HTTP cache with TTL | Accepted | A bespoke TTL+LRU cache in `http_utils.py` reduces external API calls without adding a SQLite or Redis dependency. |
+| [0003](0003-playlist-scheduling.md) | Playlist scheduling — time windows, priority, and cycle interval | Accepted | Three orthogonal axes (time window, priority, cycle interval) cover the common multi-playlist use case with pure in-memory evaluation. |
+| [0004](0004-json-config-store.md) | JSON file as the sole config and state store | Accepted | A single `device.json` file keeps the deployment dependency-free and human-readable on a Pi. |
+| [0005](0005-waitress-vs-gunicorn.md) | Waitress as the production WSGI server | Accepted | Waitress is single-process/multi-thread, avoiding fork-after-thread hazards that would break the in-process refresh task. |
+| [0006](0006-webp-on-the-fly-encoding.md) | WebP encoding on request rather than at generation time | Accepted | Images are encoded to WebP at serve time with an LRU cache; PNGs remain the on-disk canonical format for drivers and exports. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 A high-level map of how requests flow through the app and how the refresh loop drives the e-ink display.
 
+## Architecture Decision Records
+
+Non-obvious design choices are documented as Architecture Decision Records (ADRs) in [`docs/adr/`](adr/README.md). Each ADR records the context, the decision, its trade-offs, and the alternatives that were considered. File a new ADR whenever you make a choice that is hard to reverse, likely to be re-litigated, or not obvious from reading the code alone.
+
 ## Overview
 
 InkyPi is a Flask web app + a background refresh task that runs in the same process. The web UI lets the user configure plugins and assemble them into playlists; the refresh task picks the next plugin from the playlist on a schedule, runs it, and pushes the resulting image to the display.


### PR DESCRIPTION
## Summary

- Creates `docs/adr/` with a template and index, plus 6 ADRs grounded in actual code and commit history
- Covers: subprocess plugin isolation, HTTP cache strategy, playlist scheduling, JSON config store, Waitress vs Gunicorn, WebP on-the-fly encoding
- Links the ADR index from `docs/architecture.md`

Closes JTN-522

> Note: A follow-up note in CONTRIBUTING.md about when to file ADRs should be added as part of JTN-510 (sibling PR that owns CONTRIBUTING.md).

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [x] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI

## Testing

- Pure documentation change — no source code modified, no new tests needed
- `scripts/lint.sh` passes (ruff + black unaffected; mypy advisory only)
- pytest count unchanged from baseline (3102 passing)

## ADRs written

| ADR | Topic |
|-----|-------|
| 0001 | Subprocess isolation — forkserver child process per plugin tick |
| 0002 | HTTP cache — custom TTL+LRU in `http_utils.py` instead of `requests-cache` |
| 0003 | Playlist scheduling — time windows + priority + cycle interval |
| 0004 | JSON config store — single `device.json`, no SQLite |
| 0005 | Waitress vs Gunicorn — single-process model avoids fork-after-thread hazard |
| 0006 | WebP on-the-fly encoding — encode at request time, PNG as canonical on-disk format |