### PR TITLE
feat: enforce strict mypy on http_utils + security_utils (JTN-525)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,0 +1,59 @@
+# Type-Checking Strategy
+
+InkyPi uses [mypy](https://mypy.readthedocs.io/) for static type analysis.
+Rather than enabling strict mode everywhere at once, we follow an **incremental
+strict** path: a small "strict subset" is enforced as a CI blocker today, with
+more modules added over time as they stabilize.
+
+## Why incremental strict?
+
+Enabling `--strict` across the whole codebase in one shot would produce
+hundreds of errors and risk churn on actively-changing files.  An incremental
+approach lets us raise the quality bar module by module without blocking
+ongoing feature work.
+
+## Current strict subset (CI-blocking)
+
+| Module | Added |
+|---|---|
+| `src/utils/http_utils.py` | JTN-525 |
+| `src/utils/security_utils.py` | JTN-525 |
+
+`src/utils/http_cache.py` was deliberately deferred from the initial strict
+set because it was recently refactored (JTN-493) and is still settling.  It
+will be added in a follow-up once it stabilizes.
+
+## How to add a module to the strict subset
+
+1. **Run mypy strict on the module locally** and fix all errors:
+   ```bash
+   .venv/bin/python -m mypy --strict src/utils/your_module.py
+   ```
+2. **Add a per-module block to `mypy.ini`:**
+   ```ini
+   [mypy-src.utils.your_module]
+   strict = True
+   ```
+3. **Add the file to the blocking check in `scripts/lint.sh`:**
+   ```bash
+   mypy --strict src/utils/http_utils.py src/utils/security_utils.py src/utils/your_module.py
+   ```
+4. **Update the table above** with the module path and Linear issue reference.
+5. Open a PR — CI will enforce strictness from that point forward.
+
+## Advisory whole-codebase check
+
+`scripts/lint.sh` also runs `mypy src tests` (non-strict) over the entire
+codebase.  Failures there are printed with a `⚠️` warning but do **not** block
+the lint step.  This keeps visibility into type drift without blocking PRs on
+pre-existing issues.
+
+## Coding guidelines for typed modules
+
+- Avoid `Any` unless truly unavoidable; prefer `object` or a narrow union.
+- Prefer `collections.abc.Callable`, `Sequence`, `Mapping` over their
+  `typing` counterparts for argument types.
+- Use `cast()` sparingly — only when mypy cannot infer a type that you know is
+  correct (e.g. narrowing an untyped third-party return value).
+- Add `# type: ignore[<code>]` only as a last resort, always with a narrow
+  error code and an inline comment explaining why.

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -26,15 +26,20 @@ will be added in a follow-up once it stabilizes.
 ## How to add a module to the strict subset
 
 1. **Run mypy strict on the module locally** and fix all errors:
+
    ```bash
    .venv/bin/python -m mypy --strict src/utils/your_module.py
    ```
+
 2. **Add a per-module block to `mypy.ini`:**
+
    ```ini
-   [mypy-src.utils.your_module]
+   [mypy-utils.your_module]
    strict = True
    ```
+
 3. **Add the file to the blocking check in `scripts/lint.sh`:**
+
    ```bash
    mypy --strict src/utils/http_utils.py src/utils/security_utils.py src/utils/your_module.py
    ```

--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -21,6 +21,7 @@ requests-mock==1.12.1
 freezegun==1.5.1
 pytest-flask==1.3.0
 mypy==1.17.1
+types-requests==2.32.0.20241016
 black==26.3.1
 ruff==0.6.9
 jsonschema==4.23.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -43,3 +43,13 @@ strict_equality = True
 
 [mypy-jsonschema.*]
 ignore_missing_imports = True
+
+# ---- Strict subset ----
+# Modules listed here are held to --strict standards.
+# CI will fail if they regress. See docs/typing.md for how to expand this list.
+
+[mypy-src.utils.http_utils]
+strict = True
+
+[mypy-src.utils.security_utils]
+strict = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -48,8 +48,8 @@ ignore_missing_imports = True
 # Modules listed here are held to --strict standards.
 # CI will fail if they regress. See docs/typing.md for how to expand this list.
 
-[mypy-src.utils.http_utils]
+[mypy-utils.http_utils]
 strict = True
 
-[mypy-src.utils.security_utils]
+[mypy-utils.security_utils]
 strict = True

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,6 +15,7 @@ fi
 RUFF_EXIT=0
 BLACK_EXIT=0
 MYPY_EXIT=0
+MYPY_STRICT_EXIT=0
 SHELLCHECK_EXIT=0
 
 echo "Running Ruff linter..."
@@ -35,13 +36,24 @@ else
     echo "✅ Black formatting check passed"
 fi
 
-echo "Running mypy type checker..."
+echo "Running mypy type checker (advisory — whole codebase)..."
 mypy src tests
 MYPY_EXIT=$?
 if [ $MYPY_EXIT -ne 0 ]; then
-    echo "⚠️  mypy found type issues (exit code: $MYPY_EXIT) — non-blocking"
+    echo "⚠️  mypy: advisory only (except strict subset) — $MYPY_EXIT issue(s) found"
 else
-    echo "✅ mypy type check passed"
+    echo "✅ mypy advisory type check passed"
+fi
+
+echo "Running mypy strict check (blocking — strict subset only)..."
+# Strict subset: src/utils/http_utils.py and src/utils/security_utils.py
+# See docs/typing.md for how to add more modules to this list.
+mypy --strict src/utils/http_utils.py src/utils/security_utils.py
+MYPY_STRICT_EXIT=$?
+if [ $MYPY_STRICT_EXIT -ne 0 ]; then
+    echo "❌ mypy strict: http_utils + security_utils failed (exit code: $MYPY_STRICT_EXIT)"
+else
+    echo "✅ mypy strict: http_utils + security_utils clean"
 fi
 
 # Shell scripts under install/ and scripts/ — must pass shellcheck.
@@ -73,13 +85,14 @@ else
     fi
 fi
 
-# Report summary — mypy is non-blocking (advisory only) until existing
-# type errors are resolved.  Ruff, Black, and shellcheck are blocking.
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
+# Report summary — whole-codebase mypy is advisory only; the strict subset
+# (http_utils + security_utils) is blocking.  Ruff, Black, and shellcheck are blocking.
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     echo ""
     echo "❌ Some checks failed:"
     [ $RUFF_EXIT -ne 0 ] && echo "  - Ruff: $RUFF_EXIT"
     [ $BLACK_EXIT -ne 0 ] && echo "  - Black: $BLACK_EXIT"
+    [ $MYPY_STRICT_EXIT -ne 0 ] && echo "  - mypy strict subset: $MYPY_STRICT_EXIT"
     [ $SHELLCHECK_EXIT -ne 0 ] && echo "  - shellcheck: $SHELLCHECK_EXIT"
     echo ""
     echo "Post-run actions will continue..."
@@ -87,9 +100,9 @@ else
     echo ""
     echo "✅ All checks passed!"
 fi
-[ $MYPY_EXIT -ne 0 ] && echo "⚠️  mypy issues remain (non-blocking)"
+[ $MYPY_EXIT -ne 0 ] && echo "⚠️  mypy: advisory only (except strict subset) — issues remain (non-blocking)"
 
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     exit 1
 fi
 

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -4,10 +4,11 @@ import logging
 import os
 import threading
 from time import perf_counter
-from typing import Any
+from typing import Any, cast
 
 import requests
 from flask import Request, g, jsonify, request
+from flask.wrappers import Response as FlaskResponse
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -80,7 +81,7 @@ def json_error(
     status: int = 400,
     code: int | str | None = None,
     details: dict[str, Any] | None = None,
-):
+) -> tuple[FlaskResponse | dict[str, Any], int]:
     payload: dict[str, Any] = {"success": False, "error": message}
     if code is not None:
         payload["code"] = code
@@ -96,7 +97,9 @@ def json_error(
         return payload, status
 
 
-def json_success(message: str | None = None, status: int = 200, **payload: Any):
+def json_success(
+    message: str | None = None, status: int = 200, **payload: Any
+) -> tuple[FlaskResponse | dict[str, Any], int]:
     body: dict[str, Any] = {"success": True}
     if message is not None:
         body["message"] = message
@@ -116,7 +119,7 @@ def json_internal_error(
     status: int = 500,
     code: int | str | None = "internal_error",
     details: dict[str, Any] | None = None,
-):
+) -> tuple[FlaskResponse | dict[str, Any], int]:
     """Return a standardized internal error JSON while preserving existing error strings.
 
     - Keeps top-level error as a generic string for backward compatibility/tests
@@ -320,7 +323,7 @@ def http_get(
             from utils.http_cache import get_cache
 
             cache = get_cache()
-            cached_response = cache.get(url, params)
+            cached_response = cast(requests.Response, cache.get(url, params))
             if cached_response is not None:
                 return cached_response
         except Exception:


### PR DESCRIPTION
## Summary

- Add blocking `mypy --strict` CI check for a curated "strict subset" of modules: `src/utils/http_utils.py` and `src/utils/security_utils.py`
- Fix the 4 strict errors in `http_utils.py` (missing return types on `json_error`, `json_success`, `json_internal_error`; `no-any-return` on cache hit path)
- The whole-codebase `mypy src tests` run remains advisory (non-blocking) with a clear `⚠️` message
- Add `docs/typing.md` with the escalation plan: which modules are strict, how to add yours, why incremental strict is the chosen path

## Changes

- `mypy.ini` — per-module `strict = True` blocks for `src.utils.http_utils` and `src.utils.security_utils`
- `scripts/lint.sh` — new blocking strict-subset check; advisory whole-codebase run now prints `⚠️ mypy: advisory only (except strict subset)` on failure; both exit codes tracked separately
- `src/utils/http_utils.py` — type-only changes: return type annotations on the three `json_*` helpers (`tuple[FlaskResponse | dict[str, Any], int]`); `cast(requests.Response, ...)` on the cache hit return; import `FlaskResponse` and `cast`
- `docs/typing.md` — new file: strict module table, step-by-step guide to add a module, rationale for incremental approach

## Deliberate deferral

`src/utils/http_cache.py` was **intentionally excluded** from the starter set. It was recently refactored by JTN-493 (already merged) and is still a changing surface. It will join the strict set in a follow-up once it stabilizes.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a sync PR

## Compatibility/Release Checklist

- [x] `pytest` passes locally (3120 passed, 2 pre-existing failures unrelated to this PR)
- [x] `scripts/lint.sh` passes including new strict check
- [x] `mypy --strict src/utils/http_utils.py src/utils/security_utils.py` exits 0
- [x] No API route/path changes — type-only modifications
- [x] `docs/typing.md` added for new strict typing escalation plan

## Testing

- Verified `mypy --strict` exits 0 on both target files
- Confirmed existing test suite count unchanged (pre-existing failures in `test_plugin_registry.py` are unrelated to this PR)

Closes JTN-525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive typing documentation outlining static type-checking strategy and coding guidelines for maintainability.

* **Chores**
  * Enhanced lint workflow with strict type-checking validation for core utility modules.
  * Improved type annotations in utility functions to strengthen code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->