### PR TITLE
feat: expand mutmut paths_to_mutate to full directories (JTN-508)

### DIFF
--- a/docs/mutation_testing.md
+++ b/docs/mutation_testing.md
@@ -19,14 +19,18 @@ second opinion on test quality independent of coverage metrics.
 
 ## Which files are currently in scope?
 
-The initial scope is intentionally small to keep nightly run times reasonable.
-See `pyproject.toml` → `[tool.mutmut]` → `paths_to_mutate`:
+As of JTN-508 the scope was expanded from three individual files to four full
+directories. See `pyproject.toml` → `[tool.mutmut]` → `paths_to_mutate`:
 
-| File | Reason chosen |
+| Path | Reason chosen |
 |------|--------------|
-| `src/utils/http_utils.py` | Core HTTP helpers used by every plugin |
-| `src/utils/image_serving.py` | Image pipeline; subtle bugs here are hard to spot |
-| `src/refresh_task/task.py` | Refresh coordinator; scheduling logic is regression-prone |
+| `src/app_setup/` | Application bootstrap and middleware helpers |
+| `src/blueprints/` | All Flask blueprint route handlers |
+| `src/utils/` | All shared utilities (HTTP, image, security, i18n, etc.) |
+| `src/refresh_task/` | Refresh coordinator; scheduling logic is regression-prone |
+
+Any surviving mutations found by the nightly run against these expanded paths
+should be triaged as described in the follow-up issue linked to JTN-508.
 
 ## How to run locally
 

--- a/docs/mutation_testing.md
+++ b/docs/mutation_testing.md
@@ -68,17 +68,17 @@ mutmut unapply
 
 ## How to expand scope
 
-1. Add the file path to `paths_to_mutate` in `pyproject.toml`:
+1. Add the directory (or file, if intentionally narrow) path to `paths_to_mutate` in `pyproject.toml`:
 
    ```toml
    [tool.mutmut]
-   paths_to_mutate = "src/utils/http_utils.py,src/utils/image_serving.py,src/refresh_task/task.py,src/utils/new_module.py"
+   paths_to_mutate = "src/app_setup/,src/blueprints/,src/utils/,src/refresh_task/,src/new_area/"
    ```
 
 2. Add the new path to `EXPECTED_FILES` in `tests/test_mutmut_config.py` so the
    config test keeps it honest.
 
-3. Open a PR with the change. The nightly job will pick up the new file on its
+3. Open a PR with the change. The nightly job will pick up the new path on its
    next Sunday run.
 
 ## CI schedule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ combine-as-imports = true
 known-first-party = ["src"]
 
 [tool.mutmut]
-paths_to_mutate = "src/utils/http_utils.py,src/utils/image_serving.py,src/refresh_task/task.py"
+paths_to_mutate = "src/app_setup/,src/blueprints/,src/utils/,src/refresh_task/"
 tests_dir = "tests/"
 runner = "python -m pytest tests/ -x --tb=no -q"
 dict_synonyms = ""

--- a/tests/test_mutmut_config.py
+++ b/tests/test_mutmut_config.py
@@ -10,9 +10,10 @@ from pathlib import Path
 PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 EXPECTED_FILES = [
-    "src/utils/http_utils.py",
-    "src/utils/image_serving.py",
-    "src/refresh_task/task.py",
+    "src/app_setup/",
+    "src/blueprints/",
+    "src/utils/",
+    "src/refresh_task/",
 ]
 
 

--- a/tests/test_mutmut_config.py
+++ b/tests/test_mutmut_config.py
@@ -42,8 +42,9 @@ class TestMutmutConfig:
     def test_expected_files_in_scope(self):
         cfg = _load_mutmut_config()
         paths = cfg.get("paths_to_mutate", "")
+        configured = {p.strip() for p in paths.split(",") if p.strip()}
         for expected in EXPECTED_FILES:
-            assert expected in paths, (
+            assert expected in configured, (
                 f"{expected} is not in paths_to_mutate — "
                 "do not remove files from mutation scope without a deliberate decision"
             )
@@ -69,3 +70,7 @@ class TestMutmutConfig:
                 f"Mutation scope references {rel_path} but file does not exist. "
                 "Either create the file or remove it from paths_to_mutate."
             )
+            if rel_path.endswith("/"):
+                assert full.is_dir(), f"{rel_path} should be a directory path"
+            else:
+                assert full.is_file(), f"{rel_path} should be a file path"


### PR DESCRIPTION
## Summary

- Expands `[tool.mutmut]` `paths_to_mutate` in `pyproject.toml` from 3 individual files to 4 full directories (`src/app_setup/`, `src/blueprints/`, `src/utils/`, `src/refresh_task/`), covering ~95% of application logic instead of ~5%.
- Updates `tests/test_mutmut_config.py` `EXPECTED_FILES` to match the new directory-level entries so the config guard test stays green.
- Updates `docs/mutation_testing.md` with a 2-line note on the expanded scope and triage guidance.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `paths_to_mutate` expanded to 4 directory paths |
| `tests/test_mutmut_config.py` | `EXPECTED_FILES` updated to directory paths |
| `docs/mutation_testing.md` | Scope table updated; triage note added |

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync involved

## Compatibility/Release Checklist

- [x] `pytest` passes (3120 passed, 2 pre-existing failures in `test_plugin_registry.py` unrelated to this PR)
- [x] `scripts/lint.sh` passes (mypy advisory only)
- [x] No breaking API route/path changes
- [x] No new files created — config and docs only

## Testing

- `tests/test_mutmut_config.py` — all 7 tests pass, including `test_expected_files_in_scope` and `test_scoped_files_exist_on_disk`
- Full pytest run: 3120 passed

## Follow-up

Triage of surviving mutants on the expanded path set is tracked in **JTN-595**: [[follow-up JTN-508] Triage mutmut survivors on expanded paths_to_mutate](https://linear.app/jtn0123/issue/JTN-595/follow-up-jtn-508-triage-mutmut-survivors-on-expanded-paths-to-mutate)

The nightly `mutation-nightly` job runs every Sunday at 03:00 UTC. **Do NOT run `mutmut run` on the expanded set as part of this PR** — it takes hours and triage is a deliberate follow-up.

Closes JTN-508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded mutation testing configuration scope from three specific source files to four full directories.

* **Tests**
  * Updated mutation testing assertions and test expectations to align with expanded scope.

* **Documentation**
  * Updated mutation testing documentation to reflect expanded testing scope and triage requirements for surviving mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->