### PR TITLE
docs: add Google-style docstrings to private helpers (JTN-524)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,10 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 - `test:` — adding or updating tests
 - `chore:` — maintenance, dependencies, CI
 
+## Code Style
+
+Private helpers (`_*` functions) longer than ~5 lines or with non-obvious intent should have a docstring.
+
 ## PR Process
 
 1. Fork the repository

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -120,6 +120,13 @@ class RefreshTask:
 
     @staticmethod
     def _notify_watchdog():
+        """Send a WATCHDOG=1 keepalive notification to systemd, if available.
+
+        The ``cysystemd`` import is optional; when the library is absent or the
+        process is not running under systemd, this method is a no-op.  Errors
+        from the notification call are caught and logged rather than propagated,
+        so a watchdog hiccup never aborts the refresh loop.
+        """
         if _sd_notify:
             try:
                 _sd_notify("WATCHDOG=1")
@@ -128,6 +135,18 @@ class RefreshTask:
 
     @staticmethod
     def _complete_manual_request(manual_request, metrics=None, exception=None):
+        """Signal the waiting caller that a manual update request has finished.
+
+        Sets the ``done`` event on *manual_request* so the thread blocked in
+        :meth:`manual_update` can unblock and inspect the outcome.
+
+        Args:
+            manual_request: A :class:`ManualUpdateRequest` to complete, or
+                ``None`` (in which case this is a no-op).
+            metrics: Optional timing/steps dict to attach to the request.
+            exception: If set, the exception will be stored on the request so
+                the waiting caller can re-raise it.
+        """
         if manual_request is None:
             return
         if exception is not None:
@@ -637,6 +656,15 @@ class RefreshTask:
             logger.debug("Failed to save refresh benchmark event", exc_info=True)
 
     def _stale_display_path(self) -> str | None:
+        """Return the path to an existing display image file, or ``None``.
+
+        Checks ``processed_image_file`` first, then ``current_image_file``.
+        Used to detect whether the display currently shows stale content that
+        can be retained when a plugin refresh fails.
+
+        Returns:
+            An absolute path string if an image file exists, otherwise ``None``.
+        """
         for path in (
             getattr(self.device_config, "processed_image_file", None),
             getattr(self.device_config, "current_image_file", None),
@@ -834,6 +862,30 @@ class RefreshTask:
     def _execute_with_policy(
         self, refresh_action, plugin_config, current_dt: datetime, request_id=None
     ):
+        """Run a plugin with the configured retry and isolation policy.
+
+        Reads environment variables to determine the execution strategy:
+        - ``INKYPI_PLUGIN_ISOLATION``: ``"process"`` (default) spawns a
+          subprocess per attempt; ``"none"`` runs in-process via a worker thread.
+        - ``INKYPI_PLUGIN_RETRY_MAX``: Maximum number of retries (default 1).
+        - ``INKYPI_PLUGIN_RETRY_BACKOFF_MS``: Sleep between retries (default 500 ms).
+        - ``INKYPI_PLUGIN_TIMEOUT_S``: Per-attempt timeout in seconds (default 60).
+
+        Args:
+            refresh_action: The :class:`RefreshAction` describing what to run.
+            plugin_config: The raw plugin configuration dict from device.json.
+            current_dt: The current device-timezone datetime used by the plugin.
+            request_id: Optional correlation ID for logging and benchmarking.
+
+        Returns:
+            A ``(image, plugin_meta)`` tuple where *image* is a
+            ``PIL.Image.Image`` and *plugin_meta* is optional metadata from the
+            plugin.
+
+        Raises:
+            TimeoutError: If all attempts time out.
+            RuntimeError: If all attempts fail with an unrecoverable error.
+        """
         plugin_id = refresh_action.get_plugin_id()
         retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
         backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
@@ -991,6 +1043,20 @@ class RefreshTask:
         metrics: dict | None,
         error: str | None,
     ) -> None:
+        """Update the in-memory health entry for a plugin and trigger circuit-breaker logic.
+
+        Increments success or failure counters, stamps ``last_seen``, records
+        timing metrics, and delegates to :meth:`_cb_on_success` or
+        :meth:`_cb_on_failure` to manage the circuit-breaker state.
+
+        Args:
+            plugin_id: The unique plugin type identifier (e.g. ``"clock"``).
+            instance: The named plugin instance within the playlist, or ``None``
+                when the instance is unavailable.
+            ok: ``True`` if the refresh succeeded; ``False`` on failure.
+            metrics: Optional timing/steps dict to store on the health entry.
+            error: Human-readable error string to store when *ok* is ``False``.
+        """
         now_iso = now_device_tz(self.device_config).astimezone(UTC).isoformat()
         entry = self.plugin_health.get(plugin_id, {})
         entry.setdefault("success_count", 0)
@@ -1197,6 +1263,13 @@ class RefreshTask:
         return None, None
 
     def log_system_stats(self):
+        """Log a snapshot of CPU, memory, disk, swap, and network I/O metrics.
+
+        Uses ``psutil`` to gather system statistics.  If ``psutil`` is not
+        installed the method logs a warning and returns without raising.
+        Statistics are emitted at INFO level and include load averages where
+        the platform supports them.
+        """
         try:
             import psutil
         except Exception:

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -12,6 +12,16 @@ logger = logging.getLogger(__name__)
 
 
 def _get_mp_context():
+    """Return the best available multiprocessing start context for this platform.
+
+    Prefers ``forkserver`` on Linux (lower memory overhead on constrained
+    devices such as Pi Zero 2W) then ``fork``, falling back to the Python
+    default when neither is available.  ``forkserver`` requires all arguments
+    to be picklable, which is satisfied by the worker call site.
+
+    Returns:
+        A ``multiprocessing.context.BaseContext`` instance.
+    """
     # forkserver spawns children from a lean server process, reducing memory
     # on constrained devices like Pi Zero 2W. It requires picklable arguments,
     # so we only prefer it on Linux where the production target runs.
@@ -25,6 +35,19 @@ def _get_mp_context():
 
 
 def _restore_child_config(device_config):
+    """Re-initialise the Config singleton inside a subprocess from a serialised snapshot.
+
+    ``multiprocessing`` serialises ``device_config`` across the process
+    boundary.  The child process must reconstruct the singleton by setting the
+    class-level path attributes before calling ``Config()``.
+
+    Args:
+        device_config: A serialised snapshot of the parent's device config
+            object, carrying the file paths needed to rebuild the singleton.
+
+    Returns:
+        A new :class:`Config` instance initialised from the snapshot paths.
+    """
     from config import Config
 
     Config.config_file = device_config.config_file
@@ -36,6 +59,20 @@ def _restore_child_config(device_config):
 
 
 def _remote_exception(error_type: str, error_message: str) -> BaseException:
+    """Reconstruct an exception from its serialised type name and message.
+
+    Used to re-raise exceptions that were caught in a subprocess and
+    transported across the process boundary via a result queue.  Only a
+    fixed allow-list of exception types is supported; any unknown type
+    falls back to ``RuntimeError``.
+
+    Args:
+        error_type: The ``__class__.__name__`` of the original exception.
+        error_message: The string representation of the original exception.
+
+    Returns:
+        An instance of the matched (or fallback) exception class.
+    """
     exc_types = {
         "RuntimeError": RuntimeError,
         "ValueError": ValueError,
@@ -55,6 +92,23 @@ def _execute_refresh_attempt_worker(
     device_config,
     current_dt,
 ):
+    """Entry point for a plugin execution subprocess.
+
+    Intended to be the ``target`` of a ``multiprocessing.Process``.
+    Restores the config singleton in the child process, executes the refresh
+    action, serialises the resulting image to PNG bytes, and pushes a result
+    dict onto *result_queue*.  Any exception is caught and pushed as a
+    failure payload so the parent process can reconstruct it.
+
+    Args:
+        result_queue: A ``multiprocessing.Queue`` used to return exactly one
+            result dict to the parent process.
+        plugin_config: The raw plugin configuration dict from device.json.
+        refresh_action: The :class:`RefreshAction` describing what to run.
+        device_config: A serialised snapshot of the parent's device config,
+            used to restore the child Config singleton.
+        current_dt: The current device-timezone datetime passed to the plugin.
+    """
     try:
         child_config = _restore_child_config(device_config)
         plugin = get_plugin_instance(plugin_config)

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -79,6 +79,16 @@ def load_image_from_path(
 
 
 def get_image(image_url, timeout_seconds: float = 10.0):
+    """Fetch an image from a URL and return a PIL Image, or None on failure.
+
+    Args:
+        image_url: The URL of the image to fetch.
+        timeout_seconds: Request timeout in seconds (default 10).
+
+    Returns:
+        A ``PIL.Image.Image`` on success, or ``None`` if the request fails or
+        the response body cannot be decoded as an image.
+    """
     try:
         try:
             response = http_get(image_url, timeout=timeout_seconds)
@@ -143,6 +153,26 @@ def change_orientation(image, orientation, inverted: bool = False):
 
 
 def resize_image(image, desired_size, image_settings=None):
+    """Crop and resize an image to the desired dimensions while preserving aspect ratio.
+
+    The image is first cropped to match the target aspect ratio (centred by
+    default, or left-aligned when ``"keep-width"`` is present in
+    *image_settings*), then scaled to the exact *desired_size*.
+
+    Args:
+        image: A ``PIL.Image.Image`` to transform.
+        desired_size: A ``(width, height)`` tuple specifying the output
+            dimensions in pixels.
+        image_settings: An optional list of setting strings.  Passing
+            ``"keep-width"`` suppresses the horizontal centring crop so the
+            left edge of the original image is preserved.
+
+    Returns:
+        A new ``PIL.Image.Image`` resized to exactly *desired_size*.
+
+    Raises:
+        ValueError: If the image height or desired height is zero.
+    """
     img_width, img_height = image.size
     desired_width, desired_height = desired_size
     desired_width, desired_height = int(desired_width), int(desired_height)
@@ -183,7 +213,20 @@ def resize_image(image, desired_size, image_settings=None):
 
 
 def apply_image_enhancement(img, image_settings=None):
+    """Apply brightness, contrast, saturation, and sharpness adjustments to an image.
 
+    Each parameter defaults to ``1.0`` (no change) when absent from
+    *image_settings*.
+
+    Args:
+        img: A ``PIL.Image.Image`` to enhance.
+        image_settings: A dict with optional float keys ``"brightness"``,
+            ``"contrast"``, ``"saturation"``, and ``"sharpness"``.  Values
+            below 1.0 reduce the property; values above 1.0 increase it.
+
+    Returns:
+        The enhanced ``PIL.Image.Image``.
+    """
     if image_settings is None:
         image_settings = {}
 
@@ -203,6 +246,20 @@ def apply_image_enhancement(img, image_settings=None):
 
 
 def pad_image_blur(img: Image, dimensions: tuple[int, int]) -> Image:
+    """Fit an image into *dimensions* with a blurred letterbox background.
+
+    Creates a background by scaling the image to fill *dimensions* and
+    applying a ``BoxBlur``, then pastes a ``contain``-scaled version of the
+    original image centred on top.
+
+    Args:
+        img: A ``PIL.Image.Image`` to pad.
+        dimensions: The target ``(width, height)`` in pixels.
+
+    Returns:
+        A new ``PIL.Image.Image`` of exactly *dimensions* with the original
+        image centred on a blurred background.
+    """
     bkg = ImageOps.fit(img, dimensions)
     bkg = bkg.filter(ImageFilter.BoxBlur(8))
     img = ImageOps.contain(img, dimensions)
@@ -280,6 +337,21 @@ def _playwright_screenshot_html(
 
 
 def take_screenshot_html(html_str, dimensions, timeout_ms=None):
+    """Render an HTML string as an image by writing it to a temporary file.
+
+    Prefers Playwright for rendering (better local-asset support); falls back
+    to the headless browser subprocess path if Playwright is unavailable.
+
+    Args:
+        html_str: The HTML content to render.
+        dimensions: A ``(width, height)`` tuple specifying the viewport size
+            in pixels.
+        timeout_ms: Optional screenshot timeout in milliseconds passed to the
+            headless browser subprocess.
+
+    Returns:
+        A ``PIL.Image.Image`` of the rendered page, or ``None`` on failure.
+    """
     image = None
     html_file_path = None
     try:
@@ -360,6 +432,23 @@ def _find_browser_command(
 
 
 def take_screenshot(target, dimensions, timeout_ms=None):
+    """Capture a screenshot of *target* using a headless browser subprocess.
+
+    Iterates through known browser binaries (Chrome, Chromium) to find one
+    available on the system, launches it with ``--headless``, and reads the
+    resulting PNG back into a PIL Image.
+
+    Args:
+        target: A URL or ``file://`` path to render.
+        dimensions: A ``(width, height)`` tuple specifying the viewport size
+            in pixels.
+        timeout_ms: Optional screenshot timeout in milliseconds passed to the
+            browser via ``--timeout``.
+
+    Returns:
+        A ``PIL.Image.Image`` of the captured page, or ``None`` if no browser
+        is found or the subprocess fails.
+    """
     image = None
     img_file_path = None
     try:


### PR DESCRIPTION
## Summary

- Adds Google-style docstrings to private helpers longer than ~5 lines or with non-obvious intent across `src/utils/image_utils.py`, `src/refresh_task/task.py`, and `src/refresh_task/worker.py`
- `src/utils/image_serving.py` and `src/utils/output_validator.py` were audited; all helpers already had docstrings — no changes needed
- Adds a one-line docstring norm to `CONTRIBUTING.md` under a new "Code Style" section
- Ruff `D` rule enablement is deferred as a follow-up (enabling it now would surface many pre-existing violations)

## Changes

**`src/utils/image_utils.py`** — 6 docstrings added:
- `get_image` — fetch + decode from URL
- `resize_image` — aspect-ratio crop + scale
- `apply_image_enhancement` — brightness/contrast/saturation/sharpness pipeline
- `pad_image_blur` — blurred letterbox padding
- `take_screenshot_html` — HTML-string → PIL image via temp file
- `take_screenshot` — headless browser subprocess screenshot

**`src/refresh_task/task.py`** — 6 docstrings added:
- `_notify_watchdog` — systemd keepalive (optional no-op)
- `_complete_manual_request` — unblocks waiting manual-update caller
- `_stale_display_path` — finds existing display image for retain-on-failure
- `_update_plugin_health` — health counters + circuit-breaker dispatch
- `_execute_with_policy` — retry/isolation/timeout orchestration
- `log_system_stats` — psutil system metrics snapshot

**`src/refresh_task/worker.py`** — 4 docstrings added:
- `_get_mp_context` — best multiprocessing start method for platform
- `_restore_child_config` — Config singleton reconstruction in subprocess
- `_remote_exception` — deserialise cross-process exception
- `_execute_refresh_attempt_worker` — subprocess entry point

**`CONTRIBUTING.md`** — 1 line added under new "Code Style" section

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [x] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (3120 passing, 2 pre-existing failures unrelated to this PR)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI

## Testing

- Docstring-only changes; no logic modified
- `scripts/lint.sh` passes (ruff + black clean; mypy advisory non-blocking)
- 3120 tests passing; 2 pre-existing failures in `test_plugin_registry.py` unrelated to this PR

Closes JTN-524

Note: Enabling ruff `D` rules (pydocstyle enforcement) is explicitly out of scope for this PR — it would surface many pre-existing violations across the codebase. A follow-up issue should be filed to enable it incrementally.