### PR TITLE
docs: cloud-init runcmd one-shot trap recovery (JTN-591)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,3 +66,94 @@ Then SSH in and `tail -f /var/log/inkypi-install.log`. Check for `/var/log/inkyp
 ### Pi Zero W vs Pi Zero 2 W
 
 The "[Known Issues during Pi Zero W Installation](./troubleshooting.md#known-issues-during-pi-zero-w-installation)" section in the troubleshooting guide refers to the **original** 32-bit Pi Zero W, not the Pi Zero 2 W. The Zero 2 W is much more capable (4× Cortex-A53, ARMv8) and doesn't hit the same pip install issues — provided zramswap is enabled, which is automatic on InkyPi v0.28.1+.
+
+## Re-editing user-data after first boot (cloud-init runcmd one-shot trap)
+
+> **Observed on a real Pi Zero 2 W on 2026-04-10 (JTN-591).** This section exists because it's a completely silent failure that is very hard to diagnose on your own.
+
+### What the trap looks like
+
+You flash an SD card with Pi Imager, boot the Pi (maybe Wi-Fi fails, or you just want to add InkyPi later), re-mount the card on your computer, add a `runcmd:` block to `/boot/firmware/user-data`, insert the card, and boot again. The Pi joins the network fine — but `runcmd` never ran. The cloned repo is missing. No `inkypi.service`. No install logs.
+
+### Why it happens
+
+cloud-init's `runcmd` is a **per-instance one-shot module**. On first boot, cloud-init records a unique instance ID (typically something like `rpi-imager-1772926083770`) in:
+
+```
+/var/lib/cloud/data/instance-id
+```
+
+On every subsequent boot of that same SD card, cloud-init compares the current instance ID against the recorded one. They match, so cloud-init considers this boot "already done" and **skips all per-instance modules — including `runcmd` — completely silently**. It will not log an error. It will not warn you. The rendered `runcmd` shell script at `/var/lib/cloud/instances/<id>/scripts/runcmd` is simply the one baked during first boot (which was empty if you hadn't added `runcmd:` yet).
+
+**This trap fires whenever:**
+1. You flash an SD card and boot the Pi at least once (even a failed Wi-Fi boot counts).
+2. You re-mount the SD card on your computer and add or change the `runcmd:` block in `user-data`.
+3. You boot the Pi again.
+
+### How to detect it
+
+SSH into the Pi and check these signals:
+
+```bash
+# Is the instance-id file present? (It will be if the Pi booted at least once.)
+cat /var/lib/cloud/data/instance-id
+
+# Is the rendered runcmd script empty or missing the InkyPi commands?
+cat /var/lib/cloud/instances/$(cat /var/lib/cloud/data/instance-id)/scripts/runcmd
+
+# Check cloud-init logs — you will NOT see any runcmd output if it was skipped.
+sudo journalctl -u cloud-init -n 100
+sudo cat /var/log/cloud-init-output.log
+```
+
+If `runcmd` lines are absent from the logs and the rendered script is empty, you've hit the trap.
+
+### How to recover — Option A (recommended)
+
+On the Pi (via SSH), reset cloud-init state and reboot:
+
+```bash
+sudo cloud-init clean --logs
+sudo reboot
+```
+
+After reboot, cloud-init will treat this as a fresh instance, regenerate the rendered `runcmd` script from the current `user-data`, and execute it. The InkyPi install will proceed normally.
+
+A convenience wrapper script is provided at `scripts/cloud_init_clean.sh` — you can copy it to the Pi and run it there.
+
+### How to recover — Option B (without SSH)
+
+If you cannot SSH into the Pi, you can reset the instance ID from your computer while the SD card is mounted:
+
+```bash
+# On your Mac/Linux machine, with the SD card mounted (adjust the mount path):
+sudo rm -rf /Volumes/bootfs/../rootfs/var/lib/cloud/instances/
+sudo rm -f  /Volumes/bootfs/../rootfs/var/lib/cloud/data/instance-id
+```
+
+On your next boot, cloud-init will create a new instance record and run `runcmd` from scratch.
+
+### How to recover — Option C (edit instance-id)
+
+Alternatively, you can force a new instance ID by editing the file before reboot:
+
+```bash
+# On the Pi via SSH:
+echo "fresh-instance-$(date +%s)" | sudo tee /var/lib/cloud/data/instance-id
+sudo reboot
+```
+
+cloud-init will see a new instance ID and re-run all per-instance modules.
+
+### Preventing the trap
+
+If you know you'll need to iterate on `user-data` before the install is final, add the following at the **top** of your `user-data` file so cloud-init always runs `runcmd` regardless of instance ID:
+
+```yaml
+#cloud-config
+# Force cloud-init to re-run per-instance modules on every boot.
+# Remove this line once the install is stable.
+always_rerun_modules: [runcmd]
+```
+
+> **Warning:** `always_rerun_modules: [runcmd]` makes `runcmd` run on *every* boot. Remove it once your install is confirmed working, or the install script will re-run each time the Pi reboots.

--- a/scripts/cloud_init_clean.sh
+++ b/scripts/cloud_init_clean.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/cloud_init_clean.sh
+# Resets cloud-init state so per-instance modules (runcmd, users, packages)
+# re-run on next boot. Use this when you've edited /boot/firmware/user-data
+# after the Pi has already booted at least once.
+#
+# JTN-591: see docs/installation.md for the full explanation.
+set -euo pipefail
+
+if ! command -v cloud-init >/dev/null 2>&1; then
+  echo "cloud-init is not installed on this system. Nothing to do."
+  exit 0
+fi
+
+echo "Resetting cloud-init state..."
+sudo cloud-init clean --logs
+echo
+echo "cloud-init state cleared."
+echo "  On next boot, cloud-init will re-process /boot/firmware/user-data"
+echo "  including any new runcmd entries."
+echo
+echo "To boot now, run: sudo reboot"

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -243,3 +243,72 @@ def test_service_exec_matches_cli_wrapper():
 
 def test_install_references_valid_config_base():
     assert (INSTALL_DIR / "config_base").is_dir()
+
+
+# ---- cloud_init_clean.sh (JTN-591) ----
+
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+DOCS_DIR = REPO_ROOT / "docs"
+
+
+class TestCloudInitCleanScript:
+    """Structural validation for the cloud-init cleanup helper (JTN-591)."""
+
+    def test_script_exists(self):
+        assert (SCRIPTS_DIR / "cloud_init_clean.sh").exists()
+
+    def test_script_is_executable(self):
+        import stat
+
+        path = SCRIPTS_DIR / "cloud_init_clean.sh"
+        mode = path.stat().st_mode
+        assert mode & stat.S_IXUSR, "cloud_init_clean.sh is not user-executable"
+
+    def test_script_syntax_valid(self):
+        import subprocess
+
+        result = subprocess.run(
+            ["bash", "-n", str(SCRIPTS_DIR / "cloud_init_clean.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"bash -n failed:\n{result.stderr}"
+
+    def test_script_has_set_euo_pipefail(self):
+        content = (SCRIPTS_DIR / "cloud_init_clean.sh").read_text()
+        assert "set -euo pipefail" in content
+
+    def test_script_checks_cloud_init_installed(self):
+        content = (SCRIPTS_DIR / "cloud_init_clean.sh").read_text()
+        assert "command -v cloud-init" in content
+
+    def test_script_calls_cloud_init_clean(self):
+        content = (SCRIPTS_DIR / "cloud_init_clean.sh").read_text()
+        assert "cloud-init clean" in content
+
+
+class TestInstallationDocCloudInit:
+    """Verify the cloud-init runcmd one-shot trap is documented (JTN-591)."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = (DOCS_DIR / "installation.md").read_text()
+
+    def test_cloud_init_re_edit_section_exists(self):
+        # The section header must mention both cloud-init and re-editing user-data.
+        assert "Re-editing user-data after first boot" in self.content
+
+    def test_documents_per_instance_one_shot_behaviour(self):
+        assert "per-instance" in self.content
+
+    def test_documents_instance_id_file_path(self):
+        assert "/var/lib/cloud/data/instance-id" in self.content
+
+    def test_documents_clean_logs_recovery_command(self):
+        assert "cloud-init clean --logs" in self.content
+
+    def test_documents_reboot_after_clean(self):
+        assert "sudo reboot" in self.content
+
+    def test_references_jtn_591(self):
+        assert "JTN-591" in self.content


### PR DESCRIPTION
## Summary

- Documents the silent cloud-init `runcmd` skip that occurs when re-mounting an SD card and editing `user-data` after the Pi has already booted at least once — observed on a real Pi Zero 2 W on **2026-04-10** (JTN-591).
- Explains the root cause: cloud-init is per-instance one-shot, keyed on `/var/lib/cloud/data/instance-id`, so any subsequent boot of the same SD card skips all per-instance modules including `runcmd` with no error output.
- Adds three recovery options (A: `cloud-init clean --logs && reboot`; B: delete instance files from mounted card; C: edit instance-id directly) plus a prevention tip (`always_rerun_modules`).
- Ships `scripts/cloud_init_clean.sh` as a convenience wrapper to run on the Pi when SSH is available.
- Adds structural tests in `tests/unit/test_install_scripts.py` covering: script exists, is executable, passes `bash -n`, uses `set -euo pipefail`, and the docs section is present with all required content.

## Linear

[JTN-591](https://linear.app/jtn0123/issue/JTN-591/document-cloud-init-runcmd-one-shot-trap-when-re-using-sd-cards)

## Test plan

- [ ] `bash -n scripts/cloud_init_clean.sh` passes
- [ ] `scripts/lint.sh` passes (ruff + black + shellcheck)
- [ ] `pytest tests/unit/test_install_scripts.py` — 43 tests pass
- [ ] Review the new "Re-editing user-data after first boot" section in `docs/installation.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)