### PR TITLE
fix: reclaim /var/swap when zram is active (JTN-593)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -219,6 +219,33 @@ setup_earlyoom_service() {
   sudo systemctl enable --now earlyoom
 }
 
+maybe_disable_dphys_swapfile() {
+  # JTN-593: When zram is active, dphys-swapfile is dead weight on the SD card
+  # (Pi OS Trixie ships both — zram-swap preinstalled + dphys-swapfile preinstalled).
+  # Reclaim ~425MB from /var/swap and stop the dphys-swapfile service.
+  if ! grep -q "^/dev/zram" /proc/swaps 2>/dev/null; then
+    echo "zram swap not active — leaving dphys-swapfile alone."
+    return 0
+  fi
+  if [ ! -f /var/swap ] && ! systemctl list-unit-files dphys-swapfile.service >/dev/null 2>&1; then
+    echo "dphys-swapfile not present — nothing to clean up."
+    return 0
+  fi
+  echo "zram swap is active — disabling unused dphys-swapfile and reclaiming /var/swap..."
+  if systemctl is-active --quiet dphys-swapfile.service 2>/dev/null; then
+    sudo systemctl disable --now dphys-swapfile.service 2>/dev/null || true
+  fi
+  if command -v dphys-swapfile >/dev/null 2>&1; then
+    sudo dphys-swapfile swapoff 2>/dev/null || true
+    sudo dphys-swapfile uninstall 2>/dev/null || true
+  fi
+  if dpkg -l dphys-swapfile 2>/dev/null | grep -q "^ii"; then
+    sudo apt-get remove -y dphys-swapfile >/dev/null 2>&1 || true
+  fi
+  sudo rm -f /var/swap
+  echo "✓ Reclaimed dphys-swapfile space."
+}
+
 configure_journal_size() {
   local conf="/etc/systemd/journald.conf"
   if [ -f "$conf" ] && ! grep -q "^SystemMaxUse=" "$conf"; then
@@ -406,6 +433,7 @@ if [[ "$os_version" =~ ^(11|12|13)$ ]] ; then
 else
   echo "OS version is $os_version - skipping zramswap setup (zram-tools not available on this release)."
 fi
+maybe_disable_dphys_swapfile      # JTN-593: reclaim /var/swap when zram is active
 setup_earlyoom_service
 configure_journal_size
 install_src

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -186,6 +186,81 @@ class TestInstallScript:
             "zramswap branch when adding a new Debian release."
         )
 
+    def test_install_disables_dphys_swapfile_when_zram_active(self):
+        # JTN-593: maybe_disable_dphys_swapfile must be defined in install.sh
+        # so it can reclaim /var/swap (~425 MB) when zram is already active.
+        assert "maybe_disable_dphys_swapfile()" in self.content
+        assert "dphys-swapfile" in self.content
+
+    def test_install_calls_disable_dphys_after_zramswap(self):
+        # JTN-593: The call to maybe_disable_dphys_swapfile must appear AFTER
+        # the zramswap setup conditional and BEFORE setup_earlyoom_service so
+        # we never attempt to reclaim /var/swap before zram is guaranteed active.
+        zramswap_call = "setup_zramswap_service"
+        disable_call = "maybe_disable_dphys_swapfile"
+        earlyoom_call = "setup_earlyoom_service"
+
+        # Use the main script body (after function definitions) for ordering.
+        # Functions are defined before the main call site — find the call positions
+        # that occur after the last function definition closing brace.
+        fn_def_start = self.content.index("maybe_disable_dphys_swapfile() {")
+        fn_def_end = self.content.index("}", fn_def_start)
+
+        # All three calls must exist after the function definitions.
+        zram_pos = self.content.index(zramswap_call, fn_def_end)
+        disable_pos = self.content.index(disable_call, fn_def_end)
+        earlyoom_pos = self.content.index(earlyoom_call, fn_def_end)
+
+        assert zram_pos < disable_pos < earlyoom_pos, (
+            "maybe_disable_dphys_swapfile() call must appear after setup_zramswap_service "
+            "and before setup_earlyoom_service in install.sh"
+        )
+
+    def test_disable_dphys_only_runs_when_zram_active(self):
+        # JTN-593: The function must check /proc/swaps for /dev/zram BEFORE
+        # removing anything — it must be a no-op on systems without zram.
+        fn_start = self.content.index("maybe_disable_dphys_swapfile() {")
+        fn_end = self.content.index("\n}", fn_start)
+        fn_body = self.content[fn_start:fn_end]
+
+        zram_guard = 'grep -q "^/dev/zram" /proc/swaps'
+        rm_swap = "rm -f /var/swap"
+
+        assert zram_guard in fn_body, (
+            "maybe_disable_dphys_swapfile() must check /proc/swaps for /dev/zram "
+            "before removing /var/swap (safety guard for non-zram systems)"
+        )
+        assert rm_swap in fn_body, "Function should remove /var/swap"
+
+        guard_pos = fn_body.index(zram_guard)
+        rm_pos = fn_body.index(rm_swap)
+        assert (
+            guard_pos < rm_pos
+        ), "/dev/zram guard must appear before rm -f /var/swap in maybe_disable_dphys_swapfile()"
+
+    def test_disable_dphys_does_not_fail_if_package_missing(self):
+        # JTN-593: All dphys-swapfile commands must have || true guards so the
+        # function is safe on systems where the package is already gone.
+        fn_start = self.content.index("maybe_disable_dphys_swapfile() {")
+        fn_end = self.content.index("\n}", fn_start)
+        fn_body = self.content[fn_start:fn_end]
+
+        # Every line that calls dphys-swapfile binary commands should be guarded.
+        dphys_cmd_lines = [
+            line.strip()
+            for line in fn_body.splitlines()
+            if "dphys-swapfile" in line
+            and line.strip().startswith("sudo dphys-swapfile")
+        ]
+        assert (
+            dphys_cmd_lines
+        ), "Expected sudo dphys-swapfile command lines in the function"
+        for line in dphys_cmd_lines:
+            assert "|| true" in line, (
+                f"dphys-swapfile command must have '|| true' guard to avoid failures "
+                f"when package is missing: {line!r}"
+            )
+
 
 # ---- update.sh ----
 


### PR DESCRIPTION
## Summary

Pi OS Trixie ships **two swap setups simultaneously**:
- `zram-swap` preinstalled — creates `/dev/zram0` (active, priority 100, in `/proc/swaps`)
- `dphys-swapfile` preinstalled — creates `/var/swap` (~425 MB file on the SD card)

Because zram has higher priority, `/var/swap` is never used. But it sits on the SD card consuming ~425 MB (~3% of a 16 GB card) and causing confusion for anyone running `df -h`. Observed on a real Pi Zero 2 W running Pi OS Trixie after `install.sh` v0.28.1.

## Fix

Add `maybe_disable_dphys_swapfile()` to `install/install.sh`, called after the zramswap setup conditional and before `setup_earlyoom_service`:

- Checks `/proc/swaps` for `/dev/zram` first — **strict no-op on any system without zram active** (Bullseye systems using dphys-swapfile as their primary swap are unaffected)
- Disables the `dphys-swapfile.service` systemd unit
- Runs `dphys-swapfile swapoff` + `dphys-swapfile uninstall`
- Removes the `dphys-swapfile` package via apt
- Deletes `/var/swap` with `rm -f`
- All dphys-swapfile commands are guarded with `|| true` so the function is safe when the package is already removed

## Related

- Fixes [JTN-593](https://linear.app/jtn0123/issue/JTN-593)
- Related to JTN-569 (zram-tools vs zram-swap conflict) — both stem from Pi OS Trixie shipping zram infrastructure that collides with legacy swap tooling

## Test plan

- [ ] 4 new structural tests in `tests/unit/test_install_scripts.py`:
  - `test_install_disables_dphys_swapfile_when_zram_active` — function defined in install.sh
  - `test_install_calls_disable_dphys_after_zramswap` — call order: zramswap → disable_dphys → earlyoom
  - `test_disable_dphys_only_runs_when_zram_active` — `/proc/swaps` guard appears before `rm -f /var/swap`
  - `test_disable_dphys_does_not_fail_if_package_missing` — all `sudo dphys-swapfile` calls have `|| true`
- [ ] `bash -n install/install.sh` passes (syntax check)
- [ ] `scripts/lint.sh` passes (ruff + black + shellcheck)
- [ ] All 35 `test_install_scripts.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)