### PR TITLE
fix: wait for NTP clock sync before install (JTN-592)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,6 +63,12 @@ runcmd:
 
 Then SSH in and `tail -f /var/log/inkypi-install.log`. Check for `/var/log/inkypi-install.done` or `/var/log/inkypi-install.failed` to know when it's done.
 
+### NTP clock sync on first boot
+
+The Pi Zero 2 W has no RTC battery. On boot, the system clock starts at the last `fake-hwclock` value, which can be months out of date if the Pi has been off for a while. Running `pip install` or `apt-get` before NTP syncs can cause TLS certificate validation failures ("certificate is not yet valid") because the system clock predates the server's SSL cert `notBefore` date.
+
+As of the version that resolves [JTN-592](https://linear.app/jtn0123/issue/JTN-592), `install.sh` now waits up to 60 seconds for `systemd-timesyncd` to confirm NTP sync via `timedatectl show -p NTPSynchronized` before starting any package installs. If your Pi is connected to a network with NTP access, the clock typically syncs within 5–10 seconds of boot. If the clock does not sync within 60 seconds (e.g. on an offline network), install will proceed with a warning — TLS errors may still occur in that case, and you can set the clock manually with `sudo date -u -s 'YYYY-MM-DD HH:MM:SS'`.
+
 ### Pi Zero W vs Pi Zero 2 W
 
 The "[Known Issues during Pi Zero W Installation](./troubleshooting.md#known-issues-during-pi-zero-w-installation)" section in the troubleshooting guide refers to the **original** 32-bit Pi Zero W, not the Pi Zero 2 W. The Zero 2 W is much more capable (4× Cortex-A53, ARMv8) and doesn't hit the same pip install issues — provided zramswap is enabled, which is automatic on InkyPi v0.28.1+.

--- a/install/install.sh
+++ b/install/install.sh
@@ -385,6 +385,29 @@ ask_for_reboot() {
   fi
 }
 
+# Wait for NTP sync before proceeding with network-dependent installs.
+# Pi Zero 2 W has no RTC battery; on boot, the clock starts at the last
+# fake-hwclock value (potentially months out of date). Running pip/apt before
+# NTP syncs can cause TLS cert validation failures. See JTN-592.
+wait_for_clock() {
+  if ! command -v timedatectl >/dev/null 2>&1; then
+    echo "timedatectl not available — skipping NTP sync wait."
+    return 0
+  fi
+  echo "Waiting for system clock to sync via NTP (max 60s)..."
+  for i in $(seq 1 60); do
+    if timedatectl show -p NTPSynchronized --value 2>/dev/null | grep -q yes; then
+      echo "✓ Clock synced (took ${i}s)."
+      return 0
+    fi
+    sleep 1
+  done
+  echo "WARNING: Clock did not sync within 60s. TLS errors during pip install may occur."
+  echo "         Current time: $(date -u). If this is wrong, set it manually with:"
+  echo "         sudo date -u -s 'YYYY-MM-DD HH:MM:SS'"
+  return 0  # don't block install on timeout — warn only
+}
+
 # check if we have an argument for WS display support.  Parameter is not required
 # to maintain default INKY display support.
 parse_arguments "$@"
@@ -395,6 +418,7 @@ if [[ -n "$WS_TYPE" ]]; then
   fetch_waveshare_driver
 fi
 enable_interfaces
+wait_for_clock                # JTN-592: defer until NTP sync to avoid TLS failures
 install_debian_dependencies
 # Setup zramswap on any modern Pi OS that ships zram-tools (Bullseye/Bookworm/Trixie).
 # This is critical on low-RAM boards like the Pi Zero 2 W (512 MB) — without

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -135,6 +135,59 @@ class TestInstallScript:
         # The skip branch should still exist for unknown future releases.
         assert "skipping zramswap setup" in self.content
 
+    def test_install_waits_for_clock(self):
+        # JTN-592: wait_for_clock function must be defined in install.sh
+        assert "wait_for_clock() {" in self.content
+
+    def test_install_calls_wait_for_clock_before_apt(self):
+        # JTN-592: wait_for_clock must be called before install_debian_dependencies
+        lines = self.content.splitlines()
+        wait_line = None
+        apt_line = None
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            is_call = stripped.startswith("wait_for_clock") and "() {" not in line
+            if is_call and wait_line is None:
+                wait_line = i
+            if stripped == "install_debian_dependencies":
+                apt_line = i
+        assert wait_line is not None, "wait_for_clock call not found in install.sh"
+        assert (
+            apt_line is not None
+        ), "install_debian_dependencies call not found in install.sh"
+        assert wait_line < apt_line, (
+            f"wait_for_clock (line {wait_line}) must come before "
+            f"install_debian_dependencies (line {apt_line})"
+        )
+
+    def test_wait_for_clock_uses_timedatectl(self):
+        # JTN-592: the function must reference timedatectl to check NTP sync
+        assert "timedatectl show -p NTPSynchronized" in self.content
+
+    def test_wait_for_clock_warns_but_does_not_fail_on_timeout(self):
+        # JTN-592: on timeout the function must return 0, not exit 1
+        # Find the function body between wait_for_clock() { and the closing }
+        lines = self.content.splitlines()
+        in_func = False
+        depth = 0
+        func_lines = []
+        for line in lines:
+            if "wait_for_clock() {" in line:
+                in_func = True
+                depth = 1
+                func_lines.append(line)
+                continue
+            if in_func:
+                func_lines.append(line)
+                depth += line.count("{") - line.count("}")
+                if depth <= 0:
+                    break
+        func_body = "\n".join(func_lines)
+        # Must not have an exit (non-zero) after the loop
+        assert "exit 1" not in func_body, "wait_for_clock must not exit 1 on timeout"
+        # Must have return 0 after the timeout warning (don't block install)
+        assert "return 0" in func_body
+
     def test_install_os_version_comment_lists_correct_codenames(self):
         # The comment near get_os_version should list 11/12/13 with correct
         # codenames — including the 'Trixie' typo fix from JTN-528.


### PR DESCRIPTION
## Summary

- **Bug**: Pi Zero 2 W has no RTC battery. On boot, the system clock starts at the last `fake-hwclock` value — which can be months out of date. Observed on a real Pi on 2026-04-10: cloud-init logs were timestamped `2025-12-05` (~4-month skew).
- **Impact**: Running `pip install` or `apt-get` before NTP syncs can fail with TLS certificate validation errors ("certificate is not yet valid") because the stale clock predates the server's SSL cert `notBefore` date.
- **Fix**: Added `wait_for_clock()` to `install/install.sh` that polls `timedatectl show -p NTPSynchronized` for up to 60 seconds before package installs begin. On timeout it warns and proceeds — it does **not** block the install (supports offline/airgapped setups). Called after `enable_interfaces` and before `install_debian_dependencies`.

## Test plan

- [x] `bash -n install/install.sh` passes (syntax check)
- [x] 4 new tests in `TestInstallScript`: `test_install_waits_for_clock`, `test_install_calls_wait_for_clock_before_apt`, `test_wait_for_clock_uses_timedatectl`, `test_wait_for_clock_warns_but_does_not_fail_on_timeout`
- [x] All 35 tests in `test_install_scripts.py` pass
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck all green)
- [x] Pi Zero 2 W section in `docs/installation.md` updated with NTP sync note

Fixes [JTN-592](https://linear.app/jtn0123/issue/JTN-592/pi-zero-2-w-rtc-clock-skew-can-break-pip-tls-during-install-defer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)