### PR TITLE
fix: api-keys placeholder clobbers real keys + Save button below fold (JTN-598, JTN-599)

### DIFF
--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -281,8 +281,14 @@ def save_api_keys():
             # U+2022 BLACK CIRCLE placeholder. Historically the form pre-filled the
             # value attribute with literal bullet characters to fake a mask; if a
             # stale page (or anything else) POSTs that string back, we must not
-            # overwrite the real key with bullets.
-            if set(value) <= {"\u2022"}:
+            # overwrite the real key with bullets. Strip whitespace first so we
+            # also catch values like "  ••••  " that a stale client could send.
+            stripped = value.strip()
+            if not stripped:
+                # Whitespace-only input is treated the same as empty — keep
+                # the existing key unchanged.
+                continue
+            if set(stripped) <= {"\u2022"}:
                 _mod.logger.warning(
                     "Rejected save_api_keys value for %s: value is only U+2022 "
                     "placeholder characters (likely a stale cached page or a "

--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -264,6 +264,7 @@ def save_api_keys():
     try:
         form_data = request.form.to_dict()
         updated = []
+        skipped_placeholder = []
         for key in (
             "OPEN_AI_SECRET",
             "OPEN_WEATHER_MAP_SECRET",
@@ -273,12 +274,29 @@ def save_api_keys():
             "GOOGLE_AI_SECRET",
         ):
             value = form_data.get(key)
-            if value:
-                device_config.set_env_key(key, value)
-                updated.append(key)
-        return jsonify(
-            {"success": True, "message": "API keys saved.", "updated": updated}
-        )
+            if not value:
+                # Empty field means "leave current key unchanged" (JTN-598).
+                continue
+            # Defense-in-depth against JTN-598: reject any value that is solely the
+            # U+2022 BLACK CIRCLE placeholder. Historically the form pre-filled the
+            # value attribute with literal bullet characters to fake a mask; if a
+            # stale page (or anything else) POSTs that string back, we must not
+            # overwrite the real key with bullets.
+            if set(value) <= {"\u2022"}:
+                _mod.logger.warning(
+                    "Rejected save_api_keys value for %s: value is only U+2022 "
+                    "placeholder characters (likely a stale cached page or a "
+                    "client that appended to the legacy bullet pre-fill).",
+                    key,
+                )
+                skipped_placeholder.append(key)
+                continue
+            device_config.set_env_key(key, value)
+            updated.append(key)
+        response = {"success": True, "message": "API keys saved.", "updated": updated}
+        if skipped_placeholder:
+            response["skipped_placeholder"] = skipped_placeholder
+        return jsonify(response)
     except Exception:
         _mod.logger.exception("Error saving API keys")
         return json_internal_error(

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -25,14 +25,6 @@
       if (providerChip && config.mode === "managed") providerChip.textContent = "6 providers";
     }
 
-    function clearField(inputId) {
-      const input = document.getElementById(inputId);
-      if (!input) return;
-      input.value = "";
-      markDirty();
-      input.focus();
-    }
-
     function updateConfiguredStatus(updatedKeys) {
       updatedKeys.forEach((key) => {
         const mapping = {
@@ -53,39 +45,25 @@
         const statusElement = document.getElementById(statusId);
         const inputElement = document.getElementById(inputId);
         const value = inputElement ? inputElement.value : "";
-        if (statusElement && value && value !== config.maskPlaceholder) {
+        if (statusElement && value) {
           statusElement.textContent = "";
           const strong1 = document.createElement("strong");
           strong1.textContent = "Status:";
           statusElement.appendChild(strong1);
-          statusElement.appendChild(document.createTextNode(` Configured (${config.maskPlaceholder})`));
-          inputElement.value = config.maskPlaceholder;
-          addDeleteAndClearButtons(sectionId, key);
-        } else if (statusElement && value === "") {
-          statusElement.textContent = "";
-          const strong2 = document.createElement("strong");
-          strong2.textContent = "Status:";
-          statusElement.appendChild(strong2);
-          statusElement.appendChild(document.createTextNode(" Not configured"));
-          removeDeleteAndClearButtons(sectionId);
+          statusElement.appendChild(document.createTextNode(" Configured"));
+          // Clear the input and update its placeholder so subsequent edits start from empty
+          // rather than appending to the prior entry.
+          inputElement.value = "";
+          inputElement.placeholder = "(leave blank to keep current)";
+          addDeleteButton(sectionId, key);
         }
       });
       updateManagedSummary();
     }
 
-    function addDeleteAndClearButtons(sectionId, keyName) {
+    function addDeleteButton(sectionId, keyName) {
       const formGroup = document.querySelector(`#${sectionId}-status`)?.parentElement;
-      const inputContainer = formGroup?.querySelector(".input-container");
-      if (!formGroup || !inputContainer) return;
-      if (!inputContainer.querySelector(".clear-button")) {
-        const clearButton = document.createElement("button");
-        clearButton.type = "button";
-        clearButton.className = "clear-button";
-        clearButton.dataset.apiAction = "clear-field";
-        clearButton.dataset.inputId = `${sectionId}-input`;
-        clearButton.textContent = "×";
-        inputContainer.appendChild(clearButton);
-      }
+      if (!formGroup) return;
       if (!formGroup.querySelector(".delete-button")) {
         const deleteButton = document.createElement("button");
         deleteButton.type = "button";
@@ -97,10 +75,8 @@
       }
     }
 
-    function removeDeleteAndClearButtons(sectionId) {
+    function removeDeleteButton(sectionId) {
       const formGroup = document.querySelector(`#${sectionId}-status`)?.parentElement;
-      const inputContainer = formGroup?.querySelector(".input-container");
-      inputContainer?.querySelector(".clear-button")?.remove();
       formGroup?.querySelector(".delete-button")?.remove();
     }
 
@@ -184,8 +160,11 @@
         statusElement.appendChild(strong3);
         statusElement.appendChild(document.createTextNode(" Not configured"));
       }
-      if (inputElement) inputElement.value = "";
-      removeDeleteAndClearButtons(sectionId);
+      if (inputElement) {
+        inputElement.value = "";
+        inputElement.placeholder = "Enter API key";
+      }
+      removeDeleteButton(sectionId);
       updateManagedSummary();
     }
 
@@ -416,9 +395,7 @@
         const actionEl = event.target.closest("[data-api-action]");
         if (!actionEl) return;
         const action = actionEl.dataset.apiAction;
-        if (action === "clear-field") {
-          clearField(actionEl.dataset.inputId);
-        } else if (action === "delete-key") {
+        if (action === "delete-key") {
           deleteKey(actionEl.dataset.keyName);
         } else if (action === "delete-row") {
           deleteRow(actionEl);
@@ -433,7 +410,6 @@
     Object.assign(globalThis, {
       addPreset,
       addRow,
-      clearField,
       deleteKey,
       deleteRow,
       saveKeys,

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -1,4 +1,41 @@
 (function () {
+  // Module-scoped DOM helpers for the delete button inside a managed API key
+  // card. Hoisted out of `createApiKeysPage` because they don't close over any
+  // state (SonarCloud javascript:S7721).
+  function addDeleteButton(sectionId, keyName) {
+    // The Delete button lives inside `.api-key-actions` (the input row), NOT
+    // `.api-key-card-head` (which holds the label + status). Walk up to the
+    // card and then into the actions container so new buttons land next to
+    // the input rather than next to the status line.
+    const card = document
+      .getElementById(`${sectionId}-status`)
+      ?.closest(".api-key-card");
+    const actions = card?.querySelector(".api-key-actions");
+    if (!actions) return;
+    if (
+      !actions.querySelector('.delete-button[data-api-action="delete-key"]')
+    ) {
+      const deleteButton = document.createElement("button");
+      deleteButton.type = "button";
+      deleteButton.className = "header-button delete-button delete-button-danger";
+      deleteButton.dataset.apiAction = "delete-key";
+      deleteButton.dataset.keyName = keyName;
+      deleteButton.textContent = "Delete";
+      actions.appendChild(deleteButton);
+    }
+  }
+
+  function removeDeleteButton(sectionId) {
+    const card = document
+      .getElementById(`${sectionId}-status`)
+      ?.closest(".api-key-card");
+    card
+      ?.querySelector(
+        '.api-key-actions .delete-button[data-api-action="delete-key"]'
+      )
+      ?.remove();
+  }
+
   function createApiKeysPage(config) {
     // Dirty-tracking state: true when any field has changed since last save/load.
     let _isDirty = false;
@@ -61,38 +98,41 @@
       updateManagedSummary();
     }
 
-    function addDeleteButton(sectionId, keyName) {
-      // The Delete button lives inside `.api-key-actions` (the input row), NOT
-      // `.api-key-card-head` (which holds the label + status). Walk up to the
-      // card and then into the actions container so new buttons land next to
-      // the input rather than next to the status line.
-      const card = document
-        .getElementById(`${sectionId}-status`)
-        ?.closest(".api-key-card");
-      const actions = card?.querySelector(".api-key-actions");
-      if (!actions) return;
-      if (
-        !actions.querySelector('.delete-button[data-api-action="delete-key"]')
-      ) {
-        const deleteButton = document.createElement("button");
-        deleteButton.type = "button";
-        deleteButton.className = "header-button delete-button delete-button-danger";
-        deleteButton.dataset.apiAction = "delete-key";
-        deleteButton.dataset.keyName = keyName;
-        deleteButton.textContent = "Delete";
-        actions.appendChild(deleteButton);
+    // Extracted to keep saveManagedKeys below the cognitive-complexity
+    // threshold (SonarCloud javascript:S3776). Shows the appropriate modal
+    // for a successful resp.ok response and refreshes the configured-status
+    // UI for keys that were actually written.
+    function handleManagedSaveSuccess(result) {
+      const skipped = Array.isArray(result.skipped_placeholder)
+        ? result.skipped_placeholder
+        : [];
+      if (skipped.length > 0) {
+        // Some values were rejected as bullet-character placeholders
+        // (JTN-598). Tell the user which ones so they can retype if they
+        // actually wanted to update those keys.
+        showResponseModal(
+          "failure",
+          `Saved with warnings. Skipped placeholder-only values for: ${skipped.join(
+            ", "
+          )}. Type a real key and save again to update these.`
+        );
+      } else {
+        showResponseModal("success", `Success! ${result.message}`);
+      }
+      if (result.updated && result.updated.length > 0) {
+        updateConfiguredStatus(result.updated);
       }
     }
 
-    function removeDeleteButton(sectionId) {
-      const card = document
-        .getElementById(`${sectionId}-status`)
-        ?.closest(".api-key-card");
-      card
-        ?.querySelector(
-          '.api-key-actions .delete-button[data-api-action="delete-key"]'
-        )
-        ?.remove();
+    function finalizeSaveButton(saveBtn, savedOk) {
+      if (!saveBtn) return;
+      saveBtn.textContent = "Save";
+      if (savedOk) {
+        markClean();
+      } else {
+        // Re-enable so user can retry
+        saveBtn.disabled = false;
+      }
     }
 
     async function saveManagedKeys() {
@@ -109,38 +149,14 @@
         const result = await resp.json();
         if (resp.ok) {
           savedOk = true;
-          const skipped = Array.isArray(result.skipped_placeholder)
-            ? result.skipped_placeholder
-            : [];
-          if (skipped.length > 0) {
-            // Some values were rejected as bullet-character placeholders
-            // (JTN-598). Tell the user which ones so they can retype if they
-            // actually wanted to update those keys.
-            showResponseModal(
-              "failure",
-              `Saved with warnings. Skipped placeholder-only values for: ${skipped.join(
-                ", "
-              )}. Type a real key and save again to update these.`
-            );
-          } else {
-            showResponseModal("success", `Success! ${result.message}`);
-          }
-          if (result.updated && result.updated.length > 0) {
-            updateConfiguredStatus(result.updated);
-          }
+          handleManagedSaveSuccess(result);
         } else {
           showResponseModal("failure", `Error! ${result.error}`);
         }
       } catch (e) {
         showResponseModal("failure", "Failed to save keys. Please try again.");
       } finally {
-        if (saveBtn) { saveBtn.textContent = "Save"; }
-        if (savedOk) {
-          markClean();
-        } else {
-          // Re-enable so user can retry
-          if (saveBtn) saveBtn.disabled = false;
-        }
+        finalizeSaveButton(saveBtn, savedOk);
       }
     }
 
@@ -349,12 +365,7 @@
       } catch (error) {
         showResponseModal("failure", "Failed to save API keys");
       } finally {
-        if (saveBtn) { saveBtn.textContent = "Save"; }
-        if (savedOk) {
-          markClean();
-        } else {
-          if (saveBtn) saveBtn.disabled = false;
-        }
+        finalizeSaveButton(saveBtn, savedOk);
       }
     }
 

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -62,22 +62,37 @@
     }
 
     function addDeleteButton(sectionId, keyName) {
-      const formGroup = document.querySelector(`#${sectionId}-status`)?.parentElement;
-      if (!formGroup) return;
-      if (!formGroup.querySelector(".delete-button")) {
+      // The Delete button lives inside `.api-key-actions` (the input row), NOT
+      // `.api-key-card-head` (which holds the label + status). Walk up to the
+      // card and then into the actions container so new buttons land next to
+      // the input rather than next to the status line.
+      const card = document
+        .getElementById(`${sectionId}-status`)
+        ?.closest(".api-key-card");
+      const actions = card?.querySelector(".api-key-actions");
+      if (!actions) return;
+      if (
+        !actions.querySelector('.delete-button[data-api-action="delete-key"]')
+      ) {
         const deleteButton = document.createElement("button");
         deleteButton.type = "button";
         deleteButton.className = "header-button delete-button delete-button-danger";
         deleteButton.dataset.apiAction = "delete-key";
         deleteButton.dataset.keyName = keyName;
         deleteButton.textContent = "Delete";
-        formGroup.appendChild(deleteButton);
+        actions.appendChild(deleteButton);
       }
     }
 
     function removeDeleteButton(sectionId) {
-      const formGroup = document.querySelector(`#${sectionId}-status`)?.parentElement;
-      formGroup?.querySelector(".delete-button")?.remove();
+      const card = document
+        .getElementById(`${sectionId}-status`)
+        ?.closest(".api-key-card");
+      card
+        ?.querySelector(
+          '.api-key-actions .delete-button[data-api-action="delete-key"]'
+        )
+        ?.remove();
     }
 
     async function saveManagedKeys() {
@@ -94,7 +109,22 @@
         const result = await resp.json();
         if (resp.ok) {
           savedOk = true;
-          showResponseModal("success", `Success! ${result.message}`);
+          const skipped = Array.isArray(result.skipped_placeholder)
+            ? result.skipped_placeholder
+            : [];
+          if (skipped.length > 0) {
+            // Some values were rejected as bullet-character placeholders
+            // (JTN-598). Tell the user which ones so they can retype if they
+            // actually wanted to update those keys.
+            showResponseModal(
+              "failure",
+              `Saved with warnings. Skipped placeholder-only values for: ${skipped.join(
+                ", "
+              )}. Type a real key and save again to update these.`
+            );
+          } else {
+            showResponseModal("success", `Success! ${result.message}`);
+          }
           if (result.updated && result.updated.length > 0) {
             updateConfiguredStatus(result.updated);
           }

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -6427,6 +6427,23 @@ body.modal-open {
     }
 }
 
+/* ── Short laptop viewports (JTN-572 / JTN-599) ──
+   On common laptop screens shorter than ~860px (1280×800, 1366×768, 1280×768),
+   the Save button at the bottom of /settings and /settings/api-keys sits below
+   the fold, and there is no visible scroll affordance to reveal it. Pin the
+   buttons container to the bottom of the viewport so the primary action is
+   always one click away regardless of scroll position. */
+@media (max-height: 860px) {
+    .settings-panel > .buttons-container,
+    .api-keys-frame .buttons-container {
+        position: sticky;
+        bottom: 8px;
+        z-index: 6;
+        padding-top: 8px;
+        background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--bg) 94%, transparent) 22%);
+    }
+}
+
 /* ── Print styles ── */
 @media print {
   /* Hide non-essential chrome */

--- a/src/static/styles/partials/_responsive.css
+++ b/src/static/styles/partials/_responsive.css
@@ -1069,3 +1069,20 @@
         max-height: 90vh;
     }
 }
+
+/* ── Short laptop viewports (JTN-572 / JTN-599) ──
+   On common laptop screens shorter than ~860px (1280×800, 1366×768, 1280×768),
+   the Save button at the bottom of /settings and /settings/api-keys sits below
+   the fold, and there is no visible scroll affordance to reveal it. Pin the
+   buttons container to the bottom of the viewport so the primary action is
+   always one click away regardless of scroll position. */
+@media (max-height: 860px) {
+    .settings-panel > .buttons-container,
+    .api-keys-frame .buttons-container {
+        position: sticky;
+        bottom: 8px;
+        z-index: 6;
+        padding-top: 8px;
+        background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--bg) 94%, transparent) 22%);
+    }
+}

--- a/src/templates/api_keys.html
+++ b/src/templates/api_keys.html
@@ -39,7 +39,7 @@
         {{ breadcrumb([{'label': 'Home', 'url': url_for('main.main_page')}, {'label': 'Settings', 'url': url_for('settings.settings_page')}, {'label': 'API Keys'}]) }}
         <div class="page-intro">
             <div class="page-intro-body">
-                <p class="page-subtitle">Store service credentials in one place. Existing values stay masked so you can update only the keys that changed.</p>
+                <p class="page-subtitle">Store service credentials in one place. Configured fields start blank — leave a field blank to keep its current key, or type to replace it.</p>
             </div>
             <div class="page-summary">
                 <span id="providerCountSummary" class="status-chip info">{{ key_summary.provider_count }} providers</span>
@@ -92,7 +92,7 @@
             <span class="info-banner-icon">{{ icon('info', 'icon-image') | safe }}</span>
             <span class="info-banner-text">
                 API keys are stored in the <code>.env</code> file on the device.
-                Existing values remain masked. Some plugins may require a restart after changes.
+                Leave an input blank to keep the existing key. Some plugins may require a restart after changes.
             </span>
         </div>
 
@@ -106,7 +106,6 @@
     <script>
         window.__INKYPI_API_KEYS_BOOT__ = {
             deleteManagedUrl: {{ url_for('settings.delete_api_key') | tojson }},
-            maskPlaceholder: {{ '••••••••••••••••••••••••••••••••' | tojson }},
             mode: {{ api_keys_mode | default('managed') | tojson }},
             saveGenericUrl: {{ url_for('apikeys.save_apikeys') | tojson }},
             saveManagedUrl: {{ url_for('settings.save_api_keys') | tojson }},

--- a/src/templates/macros/api_key_card.html
+++ b/src/templates/macros/api_key_card.html
@@ -17,8 +17,7 @@
         {% if api_key_plugins and api_key_plugins.get(key_name) %}<div class="api-key-usage">Used by: {{ api_key_plugins[key_name] | join(', ') }}</div>{% endif %}
     </div>
     <div class="input-container api-key-actions">
-        <input type="password" id="{{ input_id }}" name="{{ key_name }}" placeholder="{{ placeholder }}" class="form-input" value="{{ '••••••••••••••••••••••••••••••••' if masked[key_name] else '' }}">
-        {% if masked[key_name] %}<button type="button" class="clear-button" data-api-action="clear-field" data-input-id="{{ input_id }}" aria-label="Clear {{ label }} key" title="Clear input field — save to confirm">×</button>{% endif %}
+        <input type="password" id="{{ input_id }}" name="{{ key_name }}" placeholder="{{ '(leave blank to keep current)' if masked[key_name] else placeholder }}" class="form-input" value="" autocomplete="off" spellcheck="false">
         {% if masked[key_name] %}<button type="button" class="header-button delete-button delete-button-danger" data-api-action="delete-key" data-key-name="{{ key_name }}" aria-label="Delete {{ label }} key permanently" title="Permanently remove key from .env">Delete</button>{% endif %}
     </div>
 </div>

--- a/tests/integration/test_api_keys_pages_more.py
+++ b/tests/integration/test_api_keys_pages_more.py
@@ -72,15 +72,19 @@ def test_managed_unconfigured_provider_has_empty_input(client):
     ), "Unsplash input should have an empty value when no key is configured"
 
 
-def test_managed_configured_provider_clear_button_has_title(client, device_config_dev):
-    """JTN-215: clear button has a tooltip explaining it only clears the input field."""
+def test_managed_configured_provider_has_no_clear_button(client, device_config_dev):
+    """JTN-598: The Clear input button was removed because inputs now start empty
+    (no literal bullet-character pre-fill). There's nothing to clear, so the
+    button itself was removed to avoid confusing users. This test ensures the
+    removal sticks."""
     device_config_dev.set_env_key("NASA_SECRET", "nasa-test-value")
 
     resp = client.get("/settings/api-keys")
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
 
-    assert 'title="Clear input field \u2014 save to confirm"' in html
+    assert "clear-button" not in html
+    assert 'data-api-action="clear-field"' not in html
 
 
 def test_managed_configured_provider_delete_button_has_title(client, device_config_dev):

--- a/tests/integration/test_api_keys_routes.py
+++ b/tests/integration/test_api_keys_routes.py
@@ -31,7 +31,8 @@ def test_save_api_keys_and_read_back(client, monkeypatch, tmp_path):
     # Dynamically import config.py
     src_dir = Path(__file__).resolve().parents[2] / "src"
     spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     config_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config_mod)
     cfg = config_mod.Config()
@@ -43,7 +44,8 @@ def test_save_api_keys_empty_value_preserves_existing(client, monkeypatch, tmp_p
     monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
     src_dir = Path(__file__).resolve().parents[2] / "src"
     spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     config_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config_mod)
     cfg = config_mod.Config()
@@ -67,7 +69,8 @@ def test_save_api_keys_bullet_placeholder_preserves_existing(
     monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
     src_dir = Path(__file__).resolve().parents[2] / "src"
     spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     config_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config_mod)
     cfg = config_mod.Config()
@@ -129,6 +132,62 @@ def test_api_keys_page_configured_fields_have_leave_blank_placeholder(
     assert "enter unsplash" in unsplash_input.group(0).lower()
 
 
+def test_save_api_keys_whitespace_padded_bullets_are_rejected(
+    client, monkeypatch, tmp_path
+):
+    """JTN-598 (CodeRabbit follow-up): the bullet-placeholder rejection must
+    also catch values where leading/trailing whitespace has been added by a
+    client (e.g. '  ••••  '). Otherwise a stale page could send a whitespace-
+    padded bullet string and bypass the defense-in-depth check."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
+    assert spec
+    assert spec.loader
+    config_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_mod)
+    cfg = config_mod.Config()
+    cfg.set_env_key("OPEN_AI_SECRET", "real-key-should-not-be-clobbered")
+
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={"OPEN_AI_SECRET": "  " + "\u2022" * 16 + "  "},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "OPEN_AI_SECRET" not in body["updated"]
+    assert body["skipped_placeholder"] == ["OPEN_AI_SECRET"]
+    assert cfg.load_env_key("OPEN_AI_SECRET") == "real-key-should-not-be-clobbered"
+
+
+def test_save_api_keys_whitespace_only_is_treated_as_unchanged(
+    client, monkeypatch, tmp_path
+):
+    """JTN-598 (CodeRabbit follow-up): a whitespace-only submission must be
+    treated the same as empty (leave current key unchanged), not saved as a
+    whitespace string."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
+    assert spec
+    assert spec.loader
+    config_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_mod)
+    cfg = config_mod.Config()
+    cfg.set_env_key("OPEN_AI_SECRET", "real-key-preserved")
+
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={"OPEN_AI_SECRET": "   \t  "},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "OPEN_AI_SECRET" not in body["updated"]
+    # Whitespace-only is "empty/unchanged", not "rejected as placeholder".
+    assert "skipped_placeholder" not in body
+    assert cfg.load_env_key("OPEN_AI_SECRET") == "real-key-preserved"
+
+
 def test_save_api_keys_mixed_bullet_and_real_chars_is_accepted(
     client, monkeypatch, tmp_path
 ):
@@ -139,7 +198,8 @@ def test_save_api_keys_mixed_bullet_and_real_chars_is_accepted(
     monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
     src_dir = Path(__file__).resolve().parents[2] / "src"
     spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     config_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config_mod)
     cfg = config_mod.Config()
@@ -180,7 +240,8 @@ def test_save_api_keys_partial_placeholder_reject(client, monkeypatch, tmp_path)
     monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
     src_dir = Path(__file__).resolve().parents[2] / "src"
     spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     config_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config_mod)
     cfg = config_mod.Config()
@@ -256,7 +317,7 @@ def test_api_keys_template_no_longer_references_bullet_placeholder():
 
 def test_api_keys_responsive_css_has_short_viewport_sticky_rule():
     """JTN-599: the Save button must be sticky on short laptop viewports
-    (max-height ≤ 860px covers 1280×800, 1366×768, 1280×768). Static check
+    (max-height ≤ 860px covers 1280x800, 1366x768, 1280x768). Static check
     against accidental deletion of the media query."""
     css_path = (
         Path(__file__).resolve().parents[2]
@@ -281,7 +342,8 @@ def test_delete_api_key(client, monkeypatch, tmp_path):
     # Prime .env
     src_dir = Path(__file__).resolve().parents[2] / "src"
     spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
-    assert spec and spec.loader
+    assert spec
+    assert spec.loader
     config_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(config_mod)
     cfg = config_mod.Config()

--- a/tests/integration/test_api_keys_routes.py
+++ b/tests/integration/test_api_keys_routes.py
@@ -38,6 +38,244 @@ def test_save_api_keys_and_read_back(client, monkeypatch, tmp_path):
     assert cfg.load_env_key("NASA_SECRET") == "route-test-123"
 
 
+def test_save_api_keys_empty_value_preserves_existing(client, monkeypatch, tmp_path):
+    """JTN-598: an empty posted value must not overwrite the existing .env entry."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
+    assert spec and spec.loader
+    config_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_mod)
+    cfg = config_mod.Config()
+    cfg.set_env_key("OPEN_AI_SECRET", "real-openai-key-abc123")
+
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={"OPEN_AI_SECRET": "", "NASA_SECRET": ""},
+    )
+    assert resp.status_code == 200
+    # Real key must still be intact — empty value means "leave unchanged".
+    assert cfg.load_env_key("OPEN_AI_SECRET") == "real-openai-key-abc123"
+    assert "OPEN_AI_SECRET" not in resp.get_json()["updated"]
+
+
+def test_save_api_keys_bullet_placeholder_preserves_existing(
+    client, monkeypatch, tmp_path
+):
+    """JTN-598: a value of pure U+2022 characters (the legacy placeholder) must
+    not overwrite the existing key — even from a stale cached page."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
+    assert spec and spec.loader
+    config_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_mod)
+    cfg = config_mod.Config()
+    cfg.set_env_key("OPEN_AI_SECRET", "real-openai-key-abc123")
+
+    bullet_placeholder = "\u2022" * 32
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={"OPEN_AI_SECRET": bullet_placeholder},
+    )
+    assert resp.status_code == 200
+    # Real key must still be intact — bullet placeholder must be rejected.
+    assert cfg.load_env_key("OPEN_AI_SECRET") == "real-openai-key-abc123"
+    body = resp.get_json()
+    assert "OPEN_AI_SECRET" not in body["updated"]
+    assert body.get("skipped_placeholder") == ["OPEN_AI_SECRET"]
+
+
+def test_api_keys_page_does_not_prefill_bullets_in_value_attribute(
+    client, device_config_dev
+):
+    """JTN-598: the server-rendered page must not include literal U+2022 chars
+    in any <input value=...>. Pre-filling with bullets is the root cause of the
+    data-destruction bug."""
+    device_config_dev.set_env_key("OPEN_AI_SECRET", "test-key-for-prefill-check")
+    resp = client.get("/settings/api-keys")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    # No literal U+2022 chars should appear inside any value="..." attribute.
+    # (They may appear elsewhere on the page — e.g., status line text — that's
+    # fine; the bug is specifically about input value attributes being
+    # editable form data.)
+    import re
+
+    for match in re.finditer(r'value="([^"]*)"', body):
+        assert "\u2022" not in match.group(1), (
+            f"Found U+2022 bullet chars in a value= attribute: {match.group(1)!r}. "
+            "This is the JTN-598 data-destruction regression."
+        )
+
+
+def test_api_keys_page_configured_fields_have_leave_blank_placeholder(
+    client, device_config_dev
+):
+    """JTN-598: a configured provider's input should render with a placeholder
+    telling the user that leaving it blank keeps the existing key — instead of
+    the generic 'Enter <provider> API key' placeholder used for unconfigured."""
+    device_config_dev.set_env_key("NASA_SECRET", "nasa-test-key")
+    resp = client.get("/settings/api-keys")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    import re
+
+    nasa_input = re.search(r'<input[^>]*id="nasa-input"[^>]*>', body)
+    assert nasa_input is not None, "NASA input must be rendered"
+    assert "leave blank to keep current" in nasa_input.group(0).lower()
+    unsplash_input = re.search(r'<input[^>]*id="unsplash-input"[^>]*>', body)
+    assert unsplash_input is not None, "Unsplash input must be rendered"
+    assert "enter unsplash" in unsplash_input.group(0).lower()
+
+
+def test_save_api_keys_mixed_bullet_and_real_chars_is_accepted(
+    client, monkeypatch, tmp_path
+):
+    """JTN-598: the rejection rule only fires when the value is **solely** U+2022
+    characters. A value like 'abc•••' is a legitimate (if oddly-chosen) password
+    and must be saved normally — we must not silently drop real keys that
+    happen to contain bullet chars."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
+    assert spec and spec.loader
+    config_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_mod)
+    cfg = config_mod.Config()
+
+    mixed_value = "abc" + "\u2022" * 3  # "abc•••"
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={"OPEN_AI_SECRET": mixed_value},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "OPEN_AI_SECRET" in body["updated"]
+    assert "skipped_placeholder" not in body
+    assert cfg.load_env_key("OPEN_AI_SECRET") == mixed_value
+
+
+def test_save_api_keys_normal_response_omits_skipped_placeholder_field(
+    client, monkeypatch, tmp_path
+):
+    """JTN-598: the new `skipped_placeholder` field should only appear in the
+    response when at least one value was actually skipped. A clean save should
+    have the same response shape as before the fix (forward compatibility)."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={"NASA_SECRET": "real-normal-key"},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["success"] is True
+    assert "NASA_SECRET" in body["updated"]
+    assert "skipped_placeholder" not in body
+
+
+def test_save_api_keys_partial_placeholder_reject(client, monkeypatch, tmp_path):
+    """JTN-598: posting a mix of real + bullet values should save the real ones
+    and skip the bullet ones, and the response must name the skipped keys."""
+    monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    spec = importlib.util.spec_from_file_location("config", str(src_dir / "config.py"))
+    assert spec and spec.loader
+    config_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(config_mod)
+    cfg = config_mod.Config()
+    cfg.set_env_key("OPEN_AI_SECRET", "preexisting-openai-key")
+
+    resp = client.post(
+        "/settings/save_api_keys",
+        data={
+            "OPEN_AI_SECRET": "\u2022" * 32,  # bullet placeholder → rejected
+            "NASA_SECRET": "new-nasa-real-key",  # real → saved
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["updated"] == ["NASA_SECRET"]
+    assert body["skipped_placeholder"] == ["OPEN_AI_SECRET"]
+    # Critical assertion: the real existing OpenAI key must still be intact.
+    assert cfg.load_env_key("OPEN_AI_SECRET") == "preexisting-openai-key"
+    assert cfg.load_env_key("NASA_SECRET") == "new-nasa-real-key"
+
+
+def test_api_keys_js_no_longer_references_mask_placeholder():
+    """JTN-598: after the fix, api_keys_page.js should no longer reference
+    `maskPlaceholder` anywhere — the constant was removed and the function that
+    used it (`updateConfiguredStatus`) should clear the field instead of
+    re-filling it with bullets. Static check against accidental re-introduction."""
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "api_keys_page.js"
+    )
+    content = js_path.read_text(encoding="utf-8")
+    assert "maskPlaceholder" not in content, (
+        "api_keys_page.js must not reference `maskPlaceholder` after JTN-598. "
+        "The bullet-character placeholder was the root cause of the data-"
+        "destruction bug — any re-introduction would re-open the hole."
+    )
+    assert "\u2022\u2022\u2022\u2022" not in content, (
+        "api_keys_page.js must not contain a bullet-character placeholder "
+        "sequence. See JTN-598."
+    )
+
+
+def test_api_keys_template_no_longer_references_bullet_placeholder():
+    """JTN-598: the api_keys.html template and api_key_card.html macro must
+    not contain the literal bullet sequence. Static check against regression."""
+    template_path = (
+        Path(__file__).resolve().parents[2] / "src" / "templates" / "api_keys.html"
+    )
+    macro_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "templates"
+        / "macros"
+        / "api_key_card.html"
+    )
+    for path in (template_path, macro_path):
+        content = path.read_text(encoding="utf-8")
+        assert "\u2022\u2022\u2022\u2022" not in content, (
+            f"{path.name} must not contain a bullet-character placeholder "
+            "sequence. See JTN-598 — pre-filling value= with bullets causes "
+            "data destruction."
+        )
+    # Macro must still render the input, just with an empty value.
+    macro_content = macro_path.read_text(encoding="utf-8")
+    assert 'value=""' in macro_content, (
+        "api_key_card.html macro must render inputs with an empty value= so "
+        "the user can cleanly type a new key without appending to a placeholder."
+    )
+
+
+def test_api_keys_responsive_css_has_short_viewport_sticky_rule():
+    """JTN-599: the Save button must be sticky on short laptop viewports
+    (max-height ≤ 860px covers 1280×800, 1366×768, 1280×768). Static check
+    against accidental deletion of the media query."""
+    css_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "styles"
+        / "partials"
+        / "_responsive.css"
+    )
+    content = css_path.read_text(encoding="utf-8")
+    # Must include the max-height: 860px media query scoped at .api-keys-frame.
+    assert "max-height: 860px" in content, (
+        "JTN-599: _responsive.css must define a @media (max-height: 860px) "
+        "rule to pin the Save button on short laptop screens."
+    )
+    # And the api-keys-frame selector must appear inside a sticky rule.
+    assert ".api-keys-frame .buttons-container" in content
+
+
 def test_delete_api_key(client, monkeypatch, tmp_path):
     monkeypatch.setenv("PROJECT_DIR", str(tmp_path))
     # Prime .env


### PR DESCRIPTION
## Summary

- **JTN-598 (Urgent — data destruction):** `/settings/api-keys` server-rendered each configured secret input with 32 literal U+2022 BLACK CIRCLE characters in the `value=` attribute as a faux password mask. Because they were real text, any user who clicked into a field and typed/pasted appended to the bullets; on Save, the form POSTed `••••…•••<user text>` (or just 32 bullets) to `/settings/save_api_keys`, which wrote it verbatim — silently destroying the real key. Fixed by rendering `value=""` + placeholder "(leave blank to keep current)", plus defense-in-depth in the backend to reject any pure-bullet value.
- **JTN-599 (Medium — fold issue):** Save button sat at y≈769 regardless of viewport, putting it below the fold on 1280×768 / 1366×768 / 1280×800 (common laptops). `elementFromPoint(btn.center)` returned `null` so even real mouse clicks missed. Fixed with a new `@media (max-height: 860px)` sticky rule that pins the buttons container to the viewport bottom; same rule also covers the settings panel (closes the sister issue JTN-572).
- JTN-598 is a regression of JTN-382 — JTN-382's fix switched `type=text`→`type=password` but left the literal-bullet `value=` pre-fill in place.

## Test plan

- [x] `tests/integration/test_api_keys_routes.py`: **+10** regression tests covering the full matrix:
  - [x] Empty value preserves existing key (the "leave blank" contract)
  - [x] Pure-bullet value rejected, existing key preserved, response includes `skipped_placeholder`
  - [x] Mixed real + pure-bullet request: real ones save, bullets rejected, response is shaped correctly
  - [x] Partial-bullet content ("abc•••") saves normally — rejection is pure-placeholder only
  - [x] Normal successful save omits `skipped_placeholder` from response (forward compat)
  - [x] Rendered HTML contains no U+2022 chars in any `value="..."` attribute
  - [x] Configured fields render "(leave blank to keep current)", unconfigured render "Enter <provider> API key"
  - [x] Static: `api_keys_page.js` no longer references `maskPlaceholder` or any 4+ bullet sequence
  - [x] Static: `api_keys.html` + `api_key_card.html` contain no bullet sequence; macro still renders `value=""`
  - [x] Static: `_responsive.css` has `@media (max-height: 860px)` rule scoped to `.api-keys-frame .buttons-container`
- [x] `tests/integration/test_api_keys_pages_more.py`: replaced the JTN-215 clear-button-tooltip test with a JTN-598 test asserting the clear button is removed entirely (there's nothing to clear now that fields start blank).
- [x] Full suite: **3336 passed**, 2 pre-existing `pyenv` failures in `test_plugin_registry` unrelated to this change.
- [x] `scripts/lint.sh`: ruff / black / shellcheck / mypy-strict all green.
- [ ] Manual browser verification at 1280×768 on `/settings/api-keys` after merge.

Closes JTN-598
Closes JTN-599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Action buttons now remain accessible on shorter screens with sticky positioning.

* **Bug Fixes**
  * API keys consisting only of placeholder characters are now properly rejected to prevent accidental overwrites.

* **UI Changes**
  * Removed the "clear field" button for a simplified API key input workflow.
  * Updated help text to clarify that leaving fields blank preserves existing keys.
  * Changed placeholder text for configured keys to indicate the "leave blank to keep current" behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->