### PR TITLE
fix: add OOMScoreAdjust=500 to inkypi.service to preserve sshd during OOM (JTN-601)

### DIFF
--- a/install/inkypi.service
+++ b/install/inkypi.service
@@ -18,6 +18,10 @@ StandardError=journal
 CPUQuota=40%
 MemoryHigh=250M
 MemoryMax=350M
+# JTN-601: Prefer inkypi as OOM victim over sshd/systemd-journald so we can
+# still SSH in during memory crunch. Positive value makes the kernel more
+# likely to kill inkypi first. See install/inkypi.service history.
+OOMScoreAdjust=500
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -44,6 +44,28 @@ class TestSystemdService:
         assert "MemoryHigh=250M" in self.content
         assert "MemoryMax=350M" in self.content
 
+    def test_service_oom_score_adjust_prefers_inkypi_as_victim(self):
+        # JTN-601: During memory crunch on Pi Zero 2 W, earlyoom was killing
+        # sshd and making the Pi unreachable. Positive OOMScoreAdjust makes
+        # inkypi the preferred OOM victim so we can still SSH in to debug.
+        # Value MUST be positive (+500); a negative value would protect
+        # inkypi and sacrifice sshd — the opposite of what we want.
+        assert "OOMScoreAdjust=500" in self.content
+
+        # The directive must live in the [Service] section, not [Unit] or
+        # [Install]. Parse the section boundaries and verify placement.
+        service_start = self.content.index("[Service]")
+        install_start = self.content.index("[Install]", service_start)
+        oom_pos = self.content.index("OOMScoreAdjust=500")
+        assert (
+            service_start < oom_pos < install_start
+        ), "OOMScoreAdjust=500 must be inside the [Service] section"
+
+        # Guard against someone accidentally re-introducing the wrong sign.
+        # The issue title originally said -500 which would protect inkypi
+        # and get sshd killed — exactly the opposite of what we want.
+        assert "OOMScoreAdjust=-500" not in self.content
+
     def test_service_watchdog(self):
         assert "WatchdogSec=120" in self.content
 


### PR DESCRIPTION
## Summary

- Adds `OOMScoreAdjust=500` to `install/inkypi.service` `[Service]` section so the kernel/earlyoom picks inkypi over sshd during memory crunch on the Pi Zero 2 W.
- Adds a unit test in `tests/unit/test_install_scripts.py` asserting the directive is present, lives in `[Service]`, and guards against the wrong sign (`-500`) being reintroduced.

## Why +500 (not -500)?

The Linear issue title says `-500` but the body explicitly corrects this. sshd and systemd-journald run with a default OOMScoreAdjust of -500 or -1000, meaning they're *harder* to kill. Setting inkypi to **+500** makes it **more** likely to be killed, preserving the debug toolchain (SSH) so Justin can still get into the Pi when it's thrashing. A negative value would do the opposite — protect inkypi and sacrifice sshd.

Observed on 2026-04-10 on a real Pi Zero 2 W: during install-time memory thrash, SSH banner exchange timed out because sshd couldn't fork a user shell. Hard power cycle was required. This PR is the debugging escape hatch.

## Test plan

- [x] `scripts/lint.sh` (ruff + black + shellcheck) — passing
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/unit/test_install_scripts.py` — 52 passed
- [ ] Manual verification on real Pi Zero 2 W: `systemctl show inkypi.service -p OOMScoreAdjust` returns `500`
- [ ] Manual OOM test: memory hog + inkypi, confirm earlyoom picks inkypi first (not sshd)

Fixes JTN-601.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated service configuration to adjust Out-Of-Memory victim selection priority during memory pressure events.

* **Tests**
  * Added validation test to ensure service configuration includes proper memory management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->