### PR TITLE
fix: prevent open redirect in HTTPS upgrade middleware (JTN-317)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -55,6 +55,44 @@ Add an `auth` section to your device config:
 
 ---
 
+# HTTPS upgrade redirect
+
+InkyPi can transparently redirect plain HTTP requests to HTTPS via a
+`before_request` hook in the security middleware.
+
+## Enabling the redirect
+
+Set the following environment variables before starting InkyPi:
+
+```bash
+export INKYPI_FORCE_HTTPS=1
+# Optional — override the default allow-list of hostnames that may
+# appear in the redirect Location header. Comma-separated. Defaults to
+# "inkypi.local,localhost,127.0.0.1".
+export INKYPI_ALLOWED_HOSTS="inkypi.local,inkypi.example.com"
+```
+
+Requests arriving with `X-Forwarded-Proto: https` (e.g. behind a TLS-
+terminating reverse proxy) are treated as already-HTTPS and pass through
+unchanged. In `--dev` mode the redirect is always skipped regardless of
+`INKYPI_FORCE_HTTPS`.
+
+## Host allow-list (JTN-317)
+
+The redirect hook validates the inbound `Host` header against
+`INKYPI_ALLOWED_HOSTS` before building the new `Location`. Requests whose
+host is not in the allow-list receive a `400 Bad Request` instead of a
+redirect. This defends against open-redirect attacks (CodeQL rule
+`py/url-redirection`) where an attacker could previously spoof the
+`Host` header to have InkyPi emit `Location: https://evil.example/`.
+
+When the server is reached by a hostname that is not in the default
+allow-list (for example a custom mDNS name or a public DNS record), add
+it to `INKYPI_ALLOWED_HOSTS` — otherwise all HTTP traffic will be
+rejected with a 400.
+
+---
+
 # Read-only API Token (JTN-477)
 
 InkyPi supports an optional read-only bearer token for monitoring scripts and

--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -110,17 +110,36 @@ def setup_https_redirect(app: Flask, *, dev_mode: bool) -> None:
         ):
             return None
         # Defend against open-redirect via spoofed Host header (JTN-317,
-        # CodeQL py/url-redirection alert #52). We must never echo a
-        # caller-controlled hostname back in a Location header, so we
-        # validate ``request.host`` against an allow-list before using
-        # ``request.url`` to build the redirect target.
+        # CodeQL py/url-redirection alert #52). ``request.url`` is
+        # built from the client-supplied ``Host`` header, so using it
+        # directly in a ``Location`` header lets an attacker point the
+        # redirect at an arbitrary domain. Instead we:
+        #   1. Validate the request host against an allow-list.
+        #   2. Rebuild the redirect target from the allow-listed host
+        #      value (not the raw header) plus the request path.
         allowed_hosts = _load_allowed_hosts()
-        host = (request.host or "").split(":", 1)[0].lower()
-        if host not in allowed_hosts:
+        raw_host = request.host or ""
+        host_name, _sep, host_port = raw_host.partition(":")
+        host_name = host_name.lower()
+        if host_name not in allowed_hosts:
             abort(400, description="Invalid host")
-        # NOSONAR — the http:// literal is intentional: we are upgrading the
-        # request to https. SonarCloud rule S5332 is a false positive here.
-        url = request.url.replace("http://", "https://", 1)  # NOSONAR
+        # Rebuild the authority from the allow-listed host. Preserving
+        # the port lets ``localhost:5000`` → ``https://localhost:5000``
+        # still work for local development.
+        safe_authority = host_name
+        # ``request.host`` already ran through Werkzeug parsing, so
+        # the port (if present) is digits-only; still, guard it.
+        if host_port and host_port.isdigit():
+            safe_authority = f"{host_name}:{host_port}"
+        # Preserve path + query string. ``full_path`` always ends with
+        # a ``?`` even when there are no query args, so strip it.
+        path_and_query = request.full_path
+        if path_and_query.endswith("?"):
+            path_and_query = path_and_query[:-1]
+        # NOSONAR — the https:// literal is intentional: we are
+        # upgrading the request to https. SonarCloud rule S5332 is a
+        # false positive here.
+        url = f"https://{safe_authority}{path_and_query}"  # NOSONAR
         return redirect(url, code=301)
 
 

--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -15,7 +15,7 @@ import os
 import secrets
 from time import perf_counter
 
-from flask import Flask, g, make_response, redirect, request, session
+from flask import Flask, abort, g, make_response, redirect, request, session
 
 from config import Config
 from utils.http_utils import json_error
@@ -36,9 +36,30 @@ _MUTATE_MAX = 60  # requests per IP per window
 
 _TRUTHY = frozenset({"1", "true", "yes"})
 
+#: Default allow-list of hostnames that may appear in a redirect ``Location``
+#: header when upgrading HTTP to HTTPS. Operators can override this via the
+#: ``INKYPI_ALLOWED_HOSTS`` env var (comma-separated). Only requests whose
+#: ``Host`` header matches one of these entries are eligible for the HTTPS
+#: upgrade redirect — everything else is rejected with a 400 to prevent
+#: open-redirect attacks via spoofed ``Host`` headers (JTN-317, CodeQL
+#: ``py/url-redirection`` alert #52).
+_DEFAULT_ALLOWED_HOSTS = "inkypi.local,localhost,127.0.0.1"
+
 
 def _env_bool(name: str, default: str = "") -> bool:
     return os.getenv(name, default).strip().lower() in _TRUTHY
+
+
+def _load_allowed_hosts() -> frozenset[str]:
+    """Parse ``INKYPI_ALLOWED_HOSTS`` into a lowercase frozenset.
+
+    Read at request time (not import time) so tests and operators can
+    override the allow-list via environment variables without having to
+    reload the module. Hostnames are compared case-insensitively and
+    without any port suffix.
+    """
+    raw = os.getenv("INKYPI_ALLOWED_HOSTS") or _DEFAULT_ALLOWED_HOSTS
+    return frozenset(h.strip().lower() for h in raw.split(",") if h.strip())
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +109,15 @@ def setup_https_redirect(app: Flask, *, dev_mode: bool) -> None:
             or request.headers.get("X-Forwarded-Proto", "").lower() == "https"
         ):
             return None
+        # Defend against open-redirect via spoofed Host header (JTN-317,
+        # CodeQL py/url-redirection alert #52). We must never echo a
+        # caller-controlled hostname back in a Location header, so we
+        # validate ``request.host`` against an allow-list before using
+        # ``request.url`` to build the redirect target.
+        allowed_hosts = _load_allowed_hosts()
+        host = (request.host or "").split(":", 1)[0].lower()
+        if host not in allowed_hosts:
+            abort(400, description="Invalid host")
         # NOSONAR — the http:// literal is intentional: we are upgrading the
         # request to https. SonarCloud rule S5332 is a false positive here.
         url = request.url.replace("http://", "https://", 1)  # NOSONAR

--- a/tests/unit/test_security_middleware_https_redirect.py
+++ b/tests/unit/test_security_middleware_https_redirect.py
@@ -115,8 +115,7 @@ def test_allowed_host_still_redirects(monkeypatch):
     resp = client.get("/settings", headers={"Host": "localhost"})
 
     assert resp.status_code == 301
-    assert resp.location is not None
-    assert resp.location.startswith("https://localhost")
+    assert resp.location == "https://localhost/settings"
 
 
 def test_default_allowed_hosts_include_inkypi_local(monkeypatch):
@@ -131,8 +130,7 @@ def test_default_allowed_hosts_include_inkypi_local(monkeypatch):
     resp = client.get("/settings", headers={"Host": "inkypi.local"})
 
     assert resp.status_code == 301
-    assert resp.location is not None
-    assert resp.location.startswith("https://inkypi.local")
+    assert resp.location == "https://inkypi.local/settings"
 
 
 def test_x_forwarded_proto_https_bypass_still_works(monkeypatch):
@@ -171,12 +169,39 @@ def test_custom_allowed_hosts_env_var(monkeypatch):
     client = app.test_client()
     resp = client.get("/settings", headers={"Host": "mypi.example.com"})
     assert resp.status_code == 301
-    assert resp.location is not None
-    assert resp.location.startswith("https://mypi.example.com")
+    assert resp.location == "https://mypi.example.com/settings"
 
     # A host not in the custom allow-list is still rejected.
     resp2 = client.get("/settings", headers={"Host": "evil.example"})
     assert resp2.status_code == 400
+
+
+def test_redirect_preserves_path_and_query_string(monkeypatch):
+    """The upgrade redirect must preserve the original path and query string."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/settings?foo=bar&baz=1", headers={"Host": "localhost"})
+    assert resp.status_code == 301
+    assert resp.location == "https://localhost/settings?foo=bar&baz=1"
+
+
+def test_redirect_omits_trailing_question_mark_when_no_query(monkeypatch):
+    """A request with no query string must not end the Location in ``?``."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/", headers={"Host": "localhost"})
+    assert resp.status_code == 301
+    assert resp.location == "https://localhost/"
 
 
 def test_allowed_host_ignores_port_suffix(monkeypatch):
@@ -191,5 +216,4 @@ def test_allowed_host_ignores_port_suffix(monkeypatch):
     resp = client.get("/settings", headers={"Host": "localhost:5000"})
 
     assert resp.status_code == 301
-    assert resp.location is not None
-    assert resp.location.startswith("https://localhost:5000")
+    assert resp.location == "https://localhost:5000/settings"

--- a/tests/unit/test_security_middleware_https_redirect.py
+++ b/tests/unit/test_security_middleware_https_redirect.py
@@ -1,0 +1,195 @@
+# pyright: reportMissingImports=false
+"""Unit tests for the HTTPS upgrade middleware host allow-list (JTN-317).
+
+Regression tests for the open-redirect vulnerability in
+``setup_https_redirect`` flagged by CodeQL rule ``py/url-redirection``
+(alert #52). An attacker could previously force a redirect to an
+attacker-controlled domain by spoofing the ``Host`` header when
+``INKYPI_FORCE_HTTPS=1`` was set.
+
+These tests ensure that:
+
+* Requests with a host that is not in the allow-list are rejected
+  with HTTP 400, rather than being redirected to the spoofed host.
+* Requests with an allowed host are still redirected from
+  ``http://`` to ``https://`` (functionality preserved).
+* ``X-Forwarded-Proto: https`` still bypasses the redirect cleanly.
+* The allow-list is configurable via ``INKYPI_ALLOWED_HOSTS``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def _reload_inkypi(monkeypatch, env):
+    """Reload the inkypi module with a clean environment.
+
+    Mirrors the helper in ``tests/unit/test_inkypi.py`` but local to
+    this test file so the two stay independent.
+    """
+    for key in (
+        "INKYPI_ENV",
+        "FLASK_ENV",
+        "INKYPI_CONFIG_FILE",
+        "INKYPI_PORT",
+        "PORT",
+        "INKYPI_FORCE_HTTPS",
+        "INKYPI_ALLOWED_HOSTS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    monkeypatch.setattr(sys, "argv", ["inkypi.py"])
+
+    if "inkypi" in sys.modules:
+        del sys.modules["inkypi"]
+
+    import inkypi  # noqa: F401
+
+    mod = importlib.reload(sys.modules["inkypi"])
+    mod.main([])
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Open-redirect regression (JTN-317)
+# ---------------------------------------------------------------------------
+
+
+def test_spoofed_host_is_rejected_not_redirected(monkeypatch):
+    """A spoofed Host header must NOT produce a Location: https://evil.com/.
+
+    This is the core regression test for the CodeQL
+    py/url-redirection alert #52.
+    """
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/", headers={"Host": "evil.com"})
+
+    # Must NOT redirect to the attacker-controlled host.
+    assert resp.status_code != 301, (
+        f"Spoofed host was redirected (status {resp.status_code}, "
+        f"location {resp.location!r}) — open-redirect regression"
+    )
+    if resp.location is not None:
+        assert "evil.com" not in resp.location
+    # The defensive behaviour is a 400 Bad Request.
+    assert resp.status_code == 400
+
+
+def test_spoofed_host_with_port_is_rejected(monkeypatch):
+    """Host header including a port is still rejected when not allow-listed."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/", headers={"Host": "attacker.example:8080"})
+
+    assert resp.status_code == 400
+    if resp.location is not None:
+        assert "attacker.example" not in resp.location
+
+
+def test_allowed_host_still_redirects(monkeypatch):
+    """A request with an allow-listed host is still upgraded to HTTPS."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    # Flask's test client defaults Host to "localhost" which is
+    # in the default allow-list.
+    resp = client.get("/settings", headers={"Host": "localhost"})
+
+    assert resp.status_code == 301
+    assert resp.location is not None
+    assert resp.location.startswith("https://localhost")
+
+
+def test_default_allowed_hosts_include_inkypi_local(monkeypatch):
+    """``inkypi.local`` is in the default allow-list."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/settings", headers={"Host": "inkypi.local"})
+
+    assert resp.status_code == 301
+    assert resp.location is not None
+    assert resp.location.startswith("https://inkypi.local")
+
+
+def test_x_forwarded_proto_https_bypass_still_works(monkeypatch):
+    """TLS-terminating proxies using X-Forwarded-Proto: https are unaffected.
+
+    The allow-list check must only apply when we are actually going
+    to redirect; a request already coming in behind a TLS proxy
+    should pass through without a host lookup.
+    """
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get(
+        "/healthz",
+        headers={"X-Forwarded-Proto": "https", "Host": "whatever.example"},
+    )
+    assert resp.status_code == 200
+
+
+def test_custom_allowed_hosts_env_var(monkeypatch):
+    """INKYPI_ALLOWED_HOSTS lets operators add their own hostnames."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={
+            "INKYPI_FORCE_HTTPS": "1",
+            "INKYPI_ENV": "production",
+            "INKYPI_ALLOWED_HOSTS": "mypi.example.com,localhost",
+        },
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/settings", headers={"Host": "mypi.example.com"})
+    assert resp.status_code == 301
+    assert resp.location is not None
+    assert resp.location.startswith("https://mypi.example.com")
+
+    # A host not in the custom allow-list is still rejected.
+    resp2 = client.get("/settings", headers={"Host": "evil.example"})
+    assert resp2.status_code == 400
+
+
+def test_allowed_host_ignores_port_suffix(monkeypatch):
+    """``localhost:5000`` should count as the allow-listed ``localhost``."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/settings", headers={"Host": "localhost:5000"})
+
+    assert resp.status_code == 301
+    assert resp.location is not None
+    assert resp.location.startswith("https://localhost:5000")


### PR DESCRIPTION
## Summary

Fixes [JTN-317](https://linear.app/jtn0123/issue/JTN-317) — CodeQL `py/url-redirection` [alert #52](https://github.com/jtn0123/InkyPi/security/code-scanning/52).

The `_redirect_to_https` before_request hook in `src/app_setup/security_middleware.py` rebuilt the redirect URL from `request.url`, which echoes the caller-supplied `Host` header. With `INKYPI_FORCE_HTTPS=1`, a request with a spoofed `Host: evil.com` would produce `Location: https://evil.com/` — a classic open redirect.

- Validate `request.host` against an allow-list before emitting the redirect.
- Allow-list is configurable via the new `INKYPI_ALLOWED_HOSTS` env var (comma-separated), defaulting to `inkypi.local,localhost,127.0.0.1`.
- Unknown hosts abort 400 instead of being reflected in a `Location` header.
- `X-Forwarded-Proto: https` bypass is preserved (TLS proxies unaffected).
- `--dev` mode still skips the redirect entirely.

## Test plan

- [x] New `tests/unit/test_security_middleware_https_redirect.py` covers:
  - [x] Spoofed `Host: evil.com` returns 400 (regression for alert #52)
  - [x] Spoofed host with port returns 400
  - [x] Allow-listed host (`localhost`, `inkypi.local`) still 301-redirects to HTTPS
  - [x] `X-Forwarded-Proto: https` bypass still works with arbitrary Host
  - [x] Custom `INKYPI_ALLOWED_HOSTS` env var is honoured
  - [x] Allow-list comparison ignores port suffix (`localhost:5000` matches `localhost`)
- [x] Existing `test_inkypi.py` HTTPS redirect tests still pass
- [x] Full security test suite (94 tests) green
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck blocking)
- [x] Docs updated in `docs/auth.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)