### PR TITLE
fix: add OOMScoreAdjust=500 to inkypi.service for better OOM behavior (JTN-601)

### DIFF
--- a/install/inkypi.service
+++ b/install/inkypi.service
@@ -18,6 +18,9 @@ StandardError=journal
 CPUQuota=40%
 MemoryHigh=250M
 MemoryMax=350M
+# JTN-601: Prefer to kill inkypi over sshd/systemd during memory crunch
+# so we can still SSH in to debug. Default is 0; +500 raises the OOM score.
+OOMScoreAdjust=500
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -47,6 +47,33 @@ class TestSystemdService:
     def test_service_watchdog(self):
         assert "WatchdogSec=120" in self.content
 
+    def test_service_has_oom_score_adjust(self):
+        # JTN-601: inkypi must declare OOMScoreAdjust so the kernel prefers to
+        # kill it over sshd during memory pressure, keeping SSH accessible.
+        assert "OOMScoreAdjust=" in self.content
+
+    def test_service_oom_score_adjust_value(self):
+        # JTN-601: The value must be positive (>= 100) — a positive score makes
+        # inkypi MORE likely to be killed. A negative value would protect inkypi
+        # and sacrifice sshd, which is the opposite of our intent.
+        match = re.search(r"OOMScoreAdjust=(-?\d+)", self.content)
+        assert match is not None, "OOMScoreAdjust= line not found in inkypi.service"
+        value = int(match.group(1))
+        assert value >= 100, (
+            f"OOMScoreAdjust={value} is not positive enough — must be >= 100 "
+            "to reliably prefer inkypi over sshd as the OOM victim."
+        )
+
+    def test_service_oom_score_adjust_within_systemd_range(self):
+        # JTN-601: systemd only accepts -1000 to 1000; values outside that range
+        # cause systemd to reject the unit file entirely.
+        match = re.search(r"OOMScoreAdjust=(-?\d+)", self.content)
+        assert match is not None, "OOMScoreAdjust= line not found in inkypi.service"
+        value = int(match.group(1))
+        assert (
+            -1000 <= value <= 1000
+        ), f"OOMScoreAdjust={value} is outside the systemd-valid range [-1000, 1000]"
+
     def test_service_working_directory(self):
         assert "RuntimeDirectory=inkypi" in self.content
         assert "WorkingDirectory=/run/inkypi" in self.content


### PR DESCRIPTION
## Summary

- On a real Pi Zero 2 W (2026-04-10), SSH timed out during install-time memory thrash — earlyoom killed sshd instead of inkypi, making the Pi completely unreachable (hard power cycle required)
- Adds `OOMScoreAdjust=500` to the `[Service]` section of `install/inkypi.service`, making inkypi the preferred OOM victim over sshd/systemd
- Adds 3 unit tests guarding the value is present, positive (>= 100), and within systemd's valid range (-1000 to 1000)

## Why +500, not -500

| Process | OOMScoreAdjust | Effect |
|---------|---------------|--------|
| sshd | ~-500 | Harder to kill (protected) |
| systemd default | 0 | Neutral |
| inkypi (after this PR) | +500 | Preferred OOM victim |

A **negative** value would protect inkypi and sacrifice sshd — the opposite of what we want. A **positive** value makes inkypi more killable, preserving the SSH debug toolchain when memory is tight.

## Changes

- `install/inkypi.service`: Added `OOMScoreAdjust=500` after `MemoryMax=350M` with explaining comment
- `tests/unit/test_install_scripts.py`: Added 3 tests in `TestSystemdService`:
  - `test_service_has_oom_score_adjust` — asserts the key is present
  - `test_service_oom_score_adjust_value` — asserts value >= 100 (catches a sign-flip regression)
  - `test_service_oom_score_adjust_within_systemd_range` — asserts value in [-1000, 1000]

## Test plan

- [x] `SKIP_BROWSER=1 pytest tests/unit/test_install_scripts.py` — 54 passed
- [x] `scripts/lint.sh` — all checks passed (ruff, black, shellcheck, mypy strict)
- [ ] On Pi: `systemctl show inkypi.service -p OOMScoreAdjust` returns `OOMScoreAdjust=500`

## Linear

Closes [JTN-601](https://linear.app/jtn0123/issue/JTN-601)

🤖 Generated with [Claude Code](https://claude.com/claude-code)