### PR TITLE
fix: disable inkypi.service during install to prevent thrash loop (JTN-600)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -340,9 +340,13 @@ stop_service() {
     then
       /usr/bin/systemctl stop "$SERVICE_FILE" > /dev/null &
       show_loader "Stopping $APPNAME service"
-    else  
+    else
       echo_success "\t$SERVICE_FILE not running"
     fi
+    # JTN-600: DISABLE (not just stop) during install so systemd cannot
+    # restart the half-installed service and thrash the Pi. install_app_service
+    # re-enables it at the end of the install.
+    /usr/bin/systemctl disable "$SERVICE_FILE" 2>/dev/null || true
 }
 
 start_service() {

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -314,6 +314,46 @@ class TestInstallScript:
                 f"when package is missing: {line!r}"
             )
 
+    def test_install_disables_service_during_install(self):
+        # JTN-600: stop_service() must DISABLE (not just stop) the service so
+        # systemd cannot auto-restart the half-installed service during the ~15 min
+        # install window and cause a memory-thrash cascade on the Pi Zero 2 W.
+        fn_start = self.content.index("stop_service() {")
+        fn_end = self.content.index("\n}", fn_start)
+        fn_body = self.content[fn_start:fn_end]
+        assert 'systemctl disable "$SERVICE_FILE"' in fn_body, (
+            "stop_service() must call 'systemctl disable \"$SERVICE_FILE\"' to "
+            "prevent systemd from restarting the half-installed service"
+        )
+
+    def test_install_re_enables_service_at_end(self):
+        # JTN-600: Regression guard — install_app_service() must re-enable the
+        # service at the end of the install after stop_service() disabled it.
+        fn_start = self.content.index("install_app_service() {")
+        fn_end = self.content.index("\n}", fn_start)
+        fn_body = self.content[fn_start:fn_end]
+        assert "systemctl enable" in fn_body, (
+            "install_app_service() must call 'systemctl enable' to re-enable the "
+            "service after stop_service() disabled it during the install window"
+        )
+
+    def test_stop_service_disable_tolerates_already_disabled(self):
+        # JTN-600: The disable call must not fail if the service is already
+        # disabled (e.g. fresh install). Must use '|| true' or '2>/dev/null'.
+        fn_start = self.content.index("stop_service() {")
+        fn_end = self.content.index("\n}", fn_start)
+        fn_body = self.content[fn_start:fn_end]
+        # Find the disable line and confirm it has an error-tolerant fallback.
+        disable_lines = [
+            line.strip() for line in fn_body.splitlines() if "systemctl disable" in line
+        ]
+        assert disable_lines, "No 'systemctl disable' line found in stop_service()"
+        for line in disable_lines:
+            assert "|| true" in line or "2>/dev/null" in line, (
+                f"systemctl disable call must have '|| true' or '2>/dev/null' so "
+                f"it doesn't fail when the service is already disabled: {line!r}"
+            )
+
 
 # ---- update.sh ----
 


### PR DESCRIPTION
## Summary

- **Root cause**: `stop_service()` in `install/install.sh` only *stopped* the service, leaving it *enabled*. During the ~15 minute pip install window, systemd's `Restart=on-failure` timer could auto-restart the half-installed service, which immediately crashed with `ModuleNotFoundError: flask`, triggering another restart — and so on.
- **Real incident** (2026-04-10): During an in-place upgrade from v0.36.0 → v0.38.0 on a Pi Zero 2 W, this cascade caused 3+ dead Python interpreter processes to compete with pip's wheel builds (~300 MB peak), exhausting the 512 MB RAM. SSH banner exchange timed out and the Pi became completely unreachable, requiring a hard power cycle to recover.
- **Fix**: Add `systemctl disable "$SERVICE_FILE" 2>/dev/null || true` at the end of `stop_service()`. The service stays disabled during the entire install. `install_app_service()` already calls `systemctl enable` at the end, restoring the service to enabled state — no other changes needed.
- **3 structural tests** added to `tests/unit/test_install_scripts.py`:
  1. `test_install_disables_service_during_install` — asserts `systemctl disable "$SERVICE_FILE"` is in `stop_service()` body
  2. `test_install_re_enables_service_at_end` — regression guard that `systemctl enable` remains in `install_app_service()`
  3. `test_stop_service_disable_tolerates_already_disabled` — asserts the disable call has `|| true` or `2>/dev/null` so fresh installs don't fail

## Linear

Closes [JTN-600](https://linear.app/jtn0123/issue/JTN-600/urgent-installsh-must-disable-systemd-restart-loop-during-install)

## Test plan

- [x] `bash -n install/install.sh` passes (syntax check)
- [x] `scripts/lint.sh` — Ruff, Black, shellcheck all pass
- [x] `pytest tests/unit/test_install_scripts.py` — all 54 tests pass (3 new)
- [x] Full test suite: 3329 passed (2 pre-existing unrelated failures in test_plugin_registry.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)