### PR TITLE
fix: default waitress threads to 2 for Pi Zero 2 W (JTN-603)

### DIFF
--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -91,6 +91,28 @@ logger = logging.getLogger(__name__)
 
 _TRUTHY = frozenset({"1", "true", "yes"})
 _DEFAULT_MAX_UPLOAD = 10 * 1024 * 1024
+_DEFAULT_WEB_THREADS = 2
+
+
+def _get_web_threads() -> int:
+    """Return the waitress thread count, env-configurable via INKYPI_WEB_THREADS.
+
+    Defaults to 2 (suitable for Pi Zero 2 W's 425 MB RAM). Users with more
+    headroom can set INKYPI_WEB_THREADS=4 or higher via a systemd drop-in.
+    """
+    raw = os.environ.get("INKYPI_WEB_THREADS")
+    if raw is None or raw == "":
+        return _DEFAULT_WEB_THREADS
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        logger.warning(
+            "Invalid INKYPI_WEB_THREADS=%r, falling back to default (%d)",
+            raw,
+            _DEFAULT_WEB_THREADS,
+        )
+        return _DEFAULT_WEB_THREADS
+    return max(1, value)
 
 
 def _env_bool(name: str, default: str = "") -> bool:
@@ -367,7 +389,9 @@ if __name__ == "__main__":
             if local_ip:
                 logger.info(f"Serving on http://{local_ip}:{PORT}")
 
-        serve(created_app, host="0.0.0.0", port=PORT, threads=4)
+        web_threads = _get_web_threads()
+        logger.info(f"waitress threads: {web_threads}")
+        serve(created_app, host="0.0.0.0", port=PORT, threads=web_threads)
     finally:
         refresh_task_obj = created_app.config.get("REFRESH_TASK")
         if refresh_task_obj is not None:

--- a/tests/unit/test_web_threads.py
+++ b/tests/unit/test_web_threads.py
@@ -1,0 +1,53 @@
+"""Tests for _get_web_threads() in src/inkypi.py (JTN-603)."""
+
+
+class TestGetWebThreads:
+    """Unit tests for _get_web_threads()."""
+
+    def _get(self):
+        """Import and return the _get_web_threads function."""
+        import inkypi
+
+        return inkypi._get_web_threads
+
+    def test_default_web_threads_is_2(self, monkeypatch):
+        """Unset env var returns the default of 2."""
+        monkeypatch.delenv("INKYPI_WEB_THREADS", raising=False)
+        fn = self._get()
+        assert fn() == 2
+
+    def test_env_override_to_4(self, monkeypatch):
+        """INKYPI_WEB_THREADS=4 returns 4."""
+        monkeypatch.setenv("INKYPI_WEB_THREADS", "4")
+        fn = self._get()
+        assert fn() == 4
+
+    def test_env_override_to_8(self, monkeypatch):
+        """INKYPI_WEB_THREADS=8 returns 8."""
+        monkeypatch.setenv("INKYPI_WEB_THREADS", "8")
+        fn = self._get()
+        assert fn() == 8
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        """Non-numeric value falls back to default (2) without crashing."""
+        monkeypatch.setenv("INKYPI_WEB_THREADS", "banana")
+        fn = self._get()
+        assert fn() == 2
+
+    def test_empty_env_uses_default(self, monkeypatch):
+        """Empty string falls back to default (2)."""
+        monkeypatch.setenv("INKYPI_WEB_THREADS", "")
+        fn = self._get()
+        assert fn() == 2
+
+    def test_zero_or_negative_clamped_to_1(self, monkeypatch):
+        """Zero is clamped to 1 via max(1, value)."""
+        monkeypatch.setenv("INKYPI_WEB_THREADS", "0")
+        fn = self._get()
+        assert fn() == 1
+
+    def test_negative_clamped_to_1(self, monkeypatch):
+        """Negative value is clamped to 1 via max(1, value)."""
+        monkeypatch.setenv("INKYPI_WEB_THREADS", "-5")
+        fn = self._get()
+        assert fn() == 1


### PR DESCRIPTION
## Summary

- **Problem**: `src/inkypi.py` hard-coded `threads=4` in the waitress `serve()` call. On a Pi Zero 2 W (425 MB RAM), 4 waitress worker threads consume ~100-150 MB of baseline RSS that InkyPi never needs — it's a single-user dashboard with no concurrent traffic.
- **Fix**: Replace hardcoded `4` with `_get_web_threads()` which defaults to `2`, saving ~50-100 MB idle RSS. The thread count is configurable at runtime via `INKYPI_WEB_THREADS` env var (e.g. `Environment=INKYPI_WEB_THREADS=8` in a systemd drop-in for users with beefier hardware).
- **Safety**: Invalid values (`INKYPI_WEB_THREADS=banana`) fall back gracefully to the default with a warning log. Zero/negative values are clamped to 1 via `max(1, value)`. The `--dev` mode is unaffected — it uses Flask's own dev server, not waitress.

## Test plan

- [x] `test_default_web_threads_is_2` — unset env var returns 2
- [x] `test_env_override_to_4` — `INKYPI_WEB_THREADS=4` returns 4
- [x] `test_env_override_to_8` — `INKYPI_WEB_THREADS=8` returns 8
- [x] `test_invalid_env_falls_back_to_default` — `INKYPI_WEB_THREADS=banana` returns 2 (no crash)
- [x] `test_empty_env_uses_default` — `INKYPI_WEB_THREADS=` returns 2
- [x] `test_zero_or_negative_clamped_to_1` — `INKYPI_WEB_THREADS=0` returns 1
- [x] `test_negative_clamped_to_1` — `INKYPI_WEB_THREADS=-5` returns 1

Closes [JTN-603](https://linear.app/jtn0123/issue/JTN-603/reduce-waitress-thread-count-to-2-on-low-ram-devices-100-mb-runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)