### PR TITLE
fix: validate weather plugin latitude/longitude range (JTN-354)

### DIFF
--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -18,6 +18,31 @@ logger = logging.getLogger(__name__)
 
 
 class Weather(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject out-of-range latitude/longitude at save time.
+
+        Without this, the map widget's readonly inputs can still be bypassed by
+        a direct POST, and bad values persist until ``generate_image`` runs —
+        far from where the user can fix them.
+        """
+        lat_raw = settings.get("latitude")
+        lon_raw = settings.get("longitude")
+        if lat_raw in (None, "") or lon_raw in (None, ""):
+            return "Latitude and longitude are required."
+        try:
+            lat = float(lat_raw)
+        except (TypeError, ValueError):
+            return "Latitude must be a number between -90 and 90."
+        try:
+            lon = float(lon_raw)
+        except (TypeError, ValueError):
+            return "Longitude must be a number between -180 and 180."
+        if not -90.0 <= lat <= 90.0:
+            return "Latitude must be between -90 and 90."
+        if not -180.0 <= lon <= 180.0:
+            return "Longitude must be between -180 and 180."
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/src/templates/widgets/weather_map.html
+++ b/src/templates/widgets/weather_map.html
@@ -4,11 +4,11 @@
 <div class="inline-readonly-grid">
     <div class="form-group">
         <label for="latitude" class="form-label">Latitude</label>
-        <input readonly type="text" id="latitude" name="latitude" class="form-input" value="{{ plugin_settings.get('latitude', '') if plugin_settings else '' }}">
+        <input readonly required type="number" min="-90" max="90" step="any" id="latitude" name="latitude" class="form-input" value="{{ plugin_settings.get('latitude', '') if plugin_settings else '' }}">
     </div>
     <div class="form-group">
         <label for="longitude" class="form-label">Longitude</label>
-        <input readonly type="text" id="longitude" name="longitude" class="form-input" value="{{ plugin_settings.get('longitude', '') if plugin_settings else '' }}">
+        <input readonly required type="number" min="-180" max="180" step="any" id="longitude" name="longitude" class="form-input" value="{{ plugin_settings.get('longitude', '') if plugin_settings else '' }}">
     </div>
 </div>
 <button type="button" id="openMap" class="action-button compact">Select Location</button>

--- a/tests/plugins/test_weather_validation.py
+++ b/tests/plugins/test_weather_validation.py
@@ -143,6 +143,129 @@ def test_weather_invalid_coordinates_raises(device_config_dev):
         p.generate_image(settings, device_config_dev)
 
 
+def test_weather_validate_settings_rejects_out_of_range_latitude():
+    """JTN-354: validate_settings must reject latitudes outside [-90, 90]."""
+    from plugins.weather.weather import Weather
+
+    p = Weather({"id": "weather"})
+
+    for bad_lat in ("999.999", "91", "-91", "9999", "-90.0001", "90.0001"):
+        err = p.validate_settings({"latitude": bad_lat, "longitude": "-74.0"})
+        assert err is not None
+        assert "Latitude" in err
+
+
+def test_weather_validate_settings_rejects_out_of_range_longitude():
+    """JTN-354: validate_settings must reject longitudes outside [-180, 180]."""
+    from plugins.weather.weather import Weather
+
+    p = Weather({"id": "weather"})
+
+    for bad_lon in ("500", "181", "-181", "180.0001", "-180.0001"):
+        err = p.validate_settings({"latitude": "40.0", "longitude": bad_lon})
+        assert err is not None
+        assert "Longitude" in err
+
+
+def test_weather_validate_settings_rejects_non_numeric():
+    """JTN-354: validate_settings must reject non-numeric lat/lon."""
+    from plugins.weather.weather import Weather
+
+    p = Weather({"id": "weather"})
+
+    assert p.validate_settings({"latitude": "abc", "longitude": "-74.0"}) is not None
+    assert p.validate_settings({"latitude": "40.0", "longitude": "xyz"}) is not None
+
+
+def test_weather_validate_settings_rejects_missing_coordinates():
+    """JTN-354: validate_settings must reject missing/empty lat/lon."""
+    from plugins.weather.weather import Weather
+
+    p = Weather({"id": "weather"})
+
+    assert p.validate_settings({"longitude": "-74.0"}) is not None
+    assert p.validate_settings({"latitude": "40.0"}) is not None
+    assert p.validate_settings({"latitude": "", "longitude": ""}) is not None
+
+
+def test_weather_validate_settings_accepts_valid_coordinates():
+    """JTN-354: valid lat/lon at and inside bounds must pass validation."""
+    from plugins.weather.weather import Weather
+
+    p = Weather({"id": "weather"})
+
+    valid_cases = [
+        ("37.7749", "-122.4194"),  # San Francisco
+        ("0", "0"),
+        ("90", "180"),
+        ("-90", "-180"),
+        ("40.7128", "-74.0060"),  # New York
+    ]
+    for lat, lon in valid_cases:
+        assert p.validate_settings({"latitude": lat, "longitude": lon}) is None
+
+
+def test_weather_save_plugin_settings_rejects_out_of_range_latitude(client):
+    """JTN-354: POST to /save_plugin_settings with bad lat must return 400."""
+    data = {
+        "plugin_id": "weather",
+        "latitude": "999.999",
+        "longitude": "-74.0060",
+        "units": "imperial",
+        "weatherProvider": "OpenMeteo",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    assert "Latitude" in (body.get("error") or body.get("message") or "")
+
+
+def test_weather_save_plugin_settings_rejects_out_of_range_longitude(client):
+    """JTN-354: POST to /save_plugin_settings with bad lon must return 400."""
+    data = {
+        "plugin_id": "weather",
+        "latitude": "40.7128",
+        "longitude": "500",
+        "units": "imperial",
+        "weatherProvider": "OpenMeteo",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    assert "Longitude" in (body.get("error") or body.get("message") or "")
+
+
+def test_weather_save_plugin_settings_rejects_negative_out_of_range(client):
+    """JTN-354: lat=-91 must be rejected with 400."""
+    data = {
+        "plugin_id": "weather",
+        "latitude": "-91",
+        "longitude": "-74.0060",
+        "units": "imperial",
+        "weatherProvider": "OpenMeteo",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+
+
+def test_weather_plugin_settings_template_has_numeric_inputs(client):
+    """JTN-354: lat/lon inputs must be type=number with min/max constraints."""
+    resp = client.get("/plugin/weather")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    # Latitude constraints
+    assert 'id="latitude"' in html
+    assert 'type="number"' in html
+    assert 'min="-90"' in html
+    assert 'max="90"' in html
+    # Longitude constraints
+    assert 'id="longitude"' in html
+    assert 'min="-180"' in html
+    assert 'max="180"' in html
+
+
 def test_weather_invalid_units(device_config_dev):
     """Test weather plugin with invalid units."""
     from plugins.weather.weather import Weather


### PR DESCRIPTION
## Summary
- Add `Weather.validate_settings` to reject out-of-range latitude/longitude at save time (lat outside [-90, 90] or lon outside [-180, 180]), fixing the bug where bad values were persisted and only surfaced as opaque errors inside `generate_image`.
- Tighten the map widget inputs in `src/templates/widgets/weather_map.html` to `type="number"` with `min`/`max`/`step="any"`/`required`, giving the browser a semantic safety net even though the inputs remain readonly and are normally populated via the Leaflet map modal.
- Extend `tests/plugins/test_weather_validation.py` with unit tests for the new `validate_settings` paths and integration tests that POST to `/save_plugin_settings` to confirm 400 responses for out-of-range inputs, plus a Jinja-render assertion for the numeric input constraints.

## Issue
Fixes JTN-354 (from dogfood pass 2026-04-08). Repro was setting latitude to `999.999` on the Weather plugin page, clicking Save, and observing the value persist.

## Test plan
- [x] `scripts/lint.sh` clean (ruff + black blocking)
- [x] Targeted tests: `tests/plugins/test_weather_validation.py tests/plugins/test_weather_ui.py tests/unit/test_weather_plugin.py tests/plugins/test_weather.py tests/static/test_accessibility_labels_dialog.py` — 64 passed
- [x] Full suite: 3335 passed (two unrelated `test_plugin_registry.py` failures are pre-existing environmental pyenv issues, confirmed via `git stash`)

Generated with [Claude Code](https://claude.com/claude-code)