### PR TITLE
fix: surface clock plugin preview errors + fix silent failure (JTN-341, JTN-318)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -407,6 +407,23 @@ def force_retry_plugin_instance(plugin_id: str, instance_name: str):
     )
 
 
+def _safe_display_image(display_manager, image, image_settings, history_meta):
+    """Invoke display_manager.display_image, tolerating older stubs without ``history_meta``.
+
+    Some test doubles monkeypatch ``display_image`` with a (image, image_settings)
+    signature.  We prefer to pass ``history_meta`` so the history sidecar records
+    the plugin_id — without it, /plugin_latest_image/<plugin_id> cannot find the
+    image and the "Latest from this plugin" card stays empty (JTN-341).
+    """
+    try:
+        return display_manager.display_image(
+            image, image_settings=image_settings, history_meta=history_meta
+        )
+    except TypeError:
+        # Legacy/test stub without the history_meta kwarg
+        return display_manager.display_image(image, image_settings=image_settings)
+
+
 def _update_now_direct(plugin_id, plugin_settings, device_config, display_manager):
     """Execute a plugin directly (refresh task not running) and push to display.
 
@@ -416,7 +433,9 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
     """
     plugin_config = device_config.get_plugin(plugin_id)
     if not plugin_config:
-        return json_error(f"Plugin '{plugin_id}' not found", status=404)
+        return json_error(
+            f"Plugin '{sanitize_response_value(plugin_id)}' not found", status=404
+        )
 
     plugin = get_plugin_instance(plugin_config)
     with track_progress() as tracker:
@@ -424,17 +443,46 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
         _t_gen_start = perf_counter()
         try:
             image = plugin.generate_image(plugin_settings, device_config)
-        except Exception as e:
-            logger.warning("Plugin error in update_now: %s", e)
+        except RuntimeError as e:
+            # RuntimeError is raised by plugins to signal a user-actionable
+            # failure (bad config, upstream API returned empty, etc.).  The
+            # message is explicitly authored by the plugin as user-facing copy
+            # and is safe to surface — plugins should never put secrets there.
+            logger.exception(
+                "Plugin %s failed to generate preview",
+                sanitize_log_field(plugin_id),
+            )
             _push_update_now_fallback(
                 plugin_id, plugin_config, device_config, display_manager, e
             )
-            status = 400 if isinstance(e, RuntimeError) else 500
-            code = "plugin_error" if isinstance(e, RuntimeError) else "internal_error"
-            return json_error(str(e), status=status, code=code)
+            return json_error(
+                sanitize_response_value(str(e)),
+                status=400,
+                code="plugin_error",
+            )
+        except Exception:
+            # Unexpected exceptions must not leak exception text to the client
+            # (JTN-318): could contain stack-traces, DB credentials, etc.
+            logger.exception(
+                "Unexpected error generating preview for plugin %s",
+                sanitize_log_field(plugin_id),
+            )
+            _push_update_now_fallback_from_current_exception(
+                plugin_id, plugin_config, device_config, display_manager
+            )
+            return json_error(_ERR_INTERNAL, status=500, code="internal_error")
         generate_ms = int((perf_counter() - _t_gen_start) * 1000)
-        display_manager.display_image(
-            image, image_settings=plugin_config.get("image_settings", [])
+        history_meta = {
+            "refresh_type": "Manual Update",
+            "plugin_id": plugin_id,
+            "playlist": None,
+            "plugin_instance": None,
+        }
+        _safe_display_image(
+            display_manager,
+            image,
+            plugin_config.get("image_settings", []),
+            history_meta,
         )
         try:
             ri = device_config.get_refresh_info()
@@ -470,16 +518,45 @@ def _push_update_now_fallback(
             error_class=type(exc).__name__,
             error_message=str(exc),
         )
-        display_manager.display_image(
+        _safe_display_image(
+            display_manager,
             fallback,
-            image_settings=plugin_config.get("image_settings", []),
+            plugin_config.get("image_settings", []),
+            {
+                "refresh_type": "Manual Update",
+                "plugin_id": plugin_id,
+                "playlist": None,
+                "plugin_instance": None,
+                "error_class": type(exc).__name__,
+            },
         )
     except Exception:
         logger.warning(
             "update_now: fallback display failed for %s",
-            plugin_id,
+            sanitize_log_field(plugin_id),
             exc_info=True,
         )
+
+
+def _push_update_now_fallback_from_current_exception(
+    plugin_id, plugin_config, device_config, display_manager
+):
+    """Variant of _push_update_now_fallback that uses the currently-raised exception.
+
+    Centralised so callers don't need to capture the exception into a local
+    variable (which would make it too tempting to embed the raw ``str(exc)``
+    in the JSON error response).  The exception text is still rendered on the
+    fallback image because that image is pushed to the e-paper screen, not
+    returned via HTTP.
+    """
+    import sys
+
+    exc = sys.exc_info()[1]
+    if exc is None:
+        return
+    _push_update_now_fallback(
+        plugin_id, plugin_config, device_config, display_manager, exc
+    )
 
 
 @plugin_bp.route("/update_now", methods=["POST"])

--- a/tests/integration/test_jtn_341_clock_preview.py
+++ b/tests/integration/test_jtn_341_clock_preview.py
@@ -1,0 +1,190 @@
+# pyright: reportMissingImports=false
+"""Regression tests for JTN-341 — Clock plugin Update Preview silent failure.
+
+Dogfooding on 2026-04-08 showed that clicking "Update Preview" on the Clock
+plugin settings page produced a 200 JSON response from ``/update_now`` but the
+"Latest from this plugin" card never populated because the image was saved to
+the history directory WITHOUT a ``plugin_id`` sidecar key — so
+``/plugin_latest_image/clock`` could never find it.
+
+These tests cover:
+
+1. End-to-end: the direct (refresh task not running) update_now code path
+   must save a history entry whose sidecar JSON contains the requested
+   ``plugin_id``, and ``/plugin_latest_image/<plugin_id>`` must return 200
+   with an image.
+2. Error handling: when plugin ``generate_image`` raises, the response must
+   be a 4xx/5xx with a SAFE user-facing message (no raw ``str(exc)`` leakage)
+   and ``logger.exception`` must be called so Sentry/Loki captures it.
+3. The fix must also cover JTN-318-style exception exposure in ``plugin.py``.
+"""
+
+import json
+import logging
+import os
+
+# ---------------------------------------------------------------------------
+# 1. End-to-end happy path for the clock preview
+# ---------------------------------------------------------------------------
+
+
+def test_clock_update_preview_populates_latest_plugin_image(
+    client, monkeypatch, flask_app, device_config_dev
+):
+    """Clock Update Preview must make /plugin_latest_image/clock serve an image.
+
+    Reproduces JTN-341: previously the direct update_now path called
+    display_manager.display_image without ``history_meta``, so the sidecar
+    JSON had no ``plugin_id`` and the lookup endpoint always 404'd.
+    """
+    from display.display_manager import DisplayManager
+
+    # Force the refresh task OFF so we take the _update_now_direct code path
+    flask_app.config["REFRESH_TASK"].running = False
+
+    # Use the REAL DisplayManager._save_history_entry so we exercise the sidecar
+    # write and the /plugin_latest_image lookup end-to-end.  Stub the actual
+    # display driver instead of stubbing display_image.
+    dm = flask_app.config["DISPLAY_MANAGER"]
+    monkeypatch.setattr(dm.display, "display_image", lambda *a, **kw: None)
+
+    # Ensure the real history dir is empty (test isolation)
+    history_dir = device_config_dev.history_image_dir
+    os.makedirs(history_dir, exist_ok=True)
+    for name in os.listdir(history_dir):
+        os.remove(os.path.join(history_dir, name))
+
+    # POST the default Clock settings — this is the same payload the
+    # /plugin/clock settings page submits on "Update Preview".
+    resp = client.post(
+        "/update_now",
+        data={
+            "plugin_id": "clock",
+            "selectedClockFace": "Gradient Clock",
+            "primaryColor": "#db3246",
+            "secondaryColor": "#000000",
+        },
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.json.get("success") is True
+
+    # The sidecar must contain plugin_id so /plugin_latest_image can find it
+    json_files = [n for n in os.listdir(history_dir) if n.endswith(".json")]
+    assert json_files, "No history sidecar written — JTN-341 regression"
+
+    with open(os.path.join(history_dir, json_files[0]), encoding="utf-8") as fh:
+        meta = json.load(fh)
+    assert (
+        meta.get("plugin_id") == "clock"
+    ), f"Sidecar missing plugin_id (JTN-341 regression): {meta}"
+
+    # /plugin_latest_image/clock must now serve the image (no more 404)
+    latest = client.get("/plugin_latest_image/clock")
+    assert latest.status_code == 200
+    assert latest.content_type.startswith("image/")
+    assert len(latest.get_data()) > 0
+
+    # Unknown plugin still 404s
+    assert client.get("/plugin_latest_image/nonexistent_xyz").status_code == 404
+
+    # Assert DisplayManager was not bypassed
+    assert isinstance(dm, DisplayManager)
+
+
+# ---------------------------------------------------------------------------
+# 2. Error handling — plugin RuntimeError surfaces safely to user
+# ---------------------------------------------------------------------------
+
+
+def test_clock_update_preview_runtime_error_returns_400_and_logs(
+    client, monkeypatch, flask_app, caplog
+):
+    """When generate_image raises RuntimeError, we must return a user-facing
+    4xx with a safe message AND call logger.exception so the failure is
+    captured in logs (JTN-318 pattern).
+    """
+    from plugins.plugin_registry import get_plugin_instance
+
+    plugin_authored_message = "Failed to display clock."
+
+    def boom(*args, **kwargs):
+        raise RuntimeError(plugin_authored_message)
+
+    # Patch both the cached instance (non-dev mode reuses it) and the class.
+    clock_inst = get_plugin_instance({"id": "clock", "class": "Clock"})
+    monkeypatch.setattr(clock_inst, "generate_image", boom, raising=False)
+
+    flask_app.config["REFRESH_TASK"].running = False
+
+    # Prevent the fallback error-card write from touching the real display
+    dm = flask_app.config["DISPLAY_MANAGER"]
+    monkeypatch.setattr(dm, "display_image", lambda *a, **kw: None, raising=True)
+
+    with caplog.at_level(logging.ERROR, logger="blueprints.plugin"):
+        resp = client.post(
+            "/update_now",
+            data={"plugin_id": "clock", "selectedClockFace": "Gradient Clock"},
+        )
+
+    # Must be a 4xx error, NOT a silent 200 (JTN-341)
+    assert resp.status_code == 400
+    body = resp.json or {}
+    assert body.get("success") is False
+    # Plugin-authored message (plugins raise RuntimeError with user-visible copy)
+    # must be surfaced.  This is the contract: silent success -> visible error.
+    assert plugin_authored_message in body.get("error", "")
+    assert body.get("code") == "plugin_error"
+
+    # logger.exception (JTN-318): stacktrace must be captured, and any record
+    # at ERROR level from blueprints.plugin with exc_info set satisfies this.
+    exception_records = [
+        rec
+        for rec in caplog.records
+        if rec.name == "blueprints.plugin"
+        and rec.levelno >= logging.ERROR
+        and rec.exc_info is not None
+    ]
+    assert exception_records, (
+        "Expected logger.exception call in blueprints.plugin, "
+        f"got: {[(r.name, r.levelname, r.message) for r in caplog.records]}"
+    )
+
+
+def test_clock_update_preview_unexpected_exception_returns_500_and_logs(
+    client, monkeypatch, flask_app, caplog
+):
+    """Unexpected (non-RuntimeError) exceptions must return 500 with a
+    generic message — never ``str(exc)`` — and must logger.exception.
+    """
+    from plugins.plugin_registry import get_plugin_instance
+
+    secret_marker = "SECRET_DB_CONNSTRING=postgres://u:p@internal"
+
+    def boom(*args, **kwargs):
+        raise ValueError(secret_marker)
+
+    clock_inst = get_plugin_instance({"id": "clock", "class": "Clock"})
+    monkeypatch.setattr(clock_inst, "generate_image", boom, raising=False)
+
+    flask_app.config["REFRESH_TASK"].running = False
+    dm = flask_app.config["DISPLAY_MANAGER"]
+    monkeypatch.setattr(dm, "display_image", lambda *a, **kw: None, raising=True)
+
+    with caplog.at_level(logging.ERROR, logger="blueprints.plugin"):
+        resp = client.post(
+            "/update_now",
+            data={"plugin_id": "clock", "selectedClockFace": "Gradient Clock"},
+        )
+
+    assert resp.status_code == 500
+    body = resp.json or {}
+    assert body.get("success") is False
+    # MUST NOT leak the raw exception text
+    assert secret_marker not in (body.get("error") or "")
+    assert secret_marker not in json.dumps(body)
+    assert body.get("code") == "internal_error"
+
+    # Must still logger.exception the failure
+    assert any(
+        "Unexpected error generating preview" in rec.message for rec in caplog.records
+    ), f"Expected logger.exception call, got: {[r.message for r in caplog.records]}"

--- a/tests/integration/test_refresh_task_interval.py
+++ b/tests/integration/test_refresh_task_interval.py
@@ -41,7 +41,7 @@ def test_interval_refresh_logic_without_thread(device_config_dev, monkeypatch):
     dm = DisplayManager(device_config_dev)
     calls = {"display": 0}
 
-    def fake_display_image(img, image_settings=None):
+    def fake_display_image(img, image_settings=None, history_meta=None):
         calls["display"] += 1
 
     monkeypatch.setattr(dm, "display_image", fake_display_image, raising=True)

--- a/tests/integration/test_update_now_happy.py
+++ b/tests/integration/test_update_now_happy.py
@@ -16,8 +16,9 @@ def test_update_now_happy_path(client, monkeypatch, flask_app):
     # Mock display
     called = {"displayed": False}
 
-    def fake_display_image(image, image_settings=None):
+    def fake_display_image(image, image_settings=None, history_meta=None):
         called["displayed"] = True
+        called["history_meta"] = history_meta
 
     display_manager = flask_app.config["DISPLAY_MANAGER"]
     monkeypatch.setattr(
@@ -40,3 +41,7 @@ def test_update_now_happy_path(client, monkeypatch, flask_app):
     assert resp.status_code == 200
     assert resp.json.get("success") is True
     assert called["displayed"] is True
+    # Regression for JTN-341: direct update_now path must pass history_meta
+    # containing plugin_id so /plugin_latest_image/<plugin_id> can find it.
+    assert called["history_meta"] is not None
+    assert called["history_meta"].get("plugin_id") == "ai_text"


### PR DESCRIPTION
## Summary

- **Root cause (JTN-341):** The direct \`_update_now_direct\` code path (used when the background refresh task is not running — dev/web-only mode, first request after boot, or worker crash) called \`display_manager.display_image()\` **without** the \`history_meta\` kwarg. As a result the history sidecar JSON was written with only \`refresh_time\` and no \`plugin_id\`. The \`/plugin_latest_image/<plugin_id>\` endpoint filters by \`meta.get("plugin_id") == plugin_id\`, so the lookup always 404'd and the "Latest from this plugin" card stayed empty — even though the image was generated and saved correctly.
- **Bonus JTN-318:** While in \`plugin.py\`, hardened exception exposure in \`_update_now_direct\`. Plugin-authored \`RuntimeError\` messages are preserved (plugins raise them specifically as user-facing copy, e.g. "NASA API Key not configured.") but now flow through \`sanitize_response_value\` and are logged via \`logger.exception\` instead of \`logger.warning\`. Unexpected exceptions no longer leak \`str(exc)\` to the HTTP response — they return a generic internal-error message with the full traceback captured by \`logger.exception\`.
- Likely resolves cluster **JTN-333, JTN-342-346, JTN-366-375** (same symptom across plugins; user to verify each).

## Reproduction (before fix)

1. \`SKIP_BROWSER=1 .venv/bin/python src/inkypi.py --dev --web-only\`
2. \`curl\` \`/plugin/clock\`, extract CSRF meta token
3. \`curl -X POST /update_now\` with default clock payload → **200 success**
4. \`curl /plugin_latest_image/clock\` → **404 Not Found** ❌
5. Sidecar JSON at \`src/static/images/history/display_*.json\` contains only \`{"refresh_time": "..."}\` — no \`plugin_id\`.

## Verification (after fix)

1. Same flow
2. \`/update_now\` → 200 success
3. \`/plugin_latest_image/clock\` → **200 OK, 92 KB PNG** ✅
4. Sidecar JSON now contains \`{"refresh_type": "Manual Update", "plugin_id": "clock", ...}\`

## Changes

- **\`src/blueprints/plugin.py\`**
  - \`_update_now_direct\` now builds \`history_meta\` and passes it via a new \`_safe_display_image\` helper (which tolerates older test stubs missing the kwarg).
  - Split RuntimeError and generic Exception branches: RuntimeError keeps the sanitized plugin-authored message, generic Exception returns \`_ERR_INTERNAL\` with \`code="internal_error"\`.
  - Both branches now call \`logger.exception\` (was \`logger.warning\`).
  - New helper \`_push_update_now_fallback_from_current_exception\` so callers don't need to capture the exception into a local variable (which would tempt embedding raw \`str(exc)\` in the response).
  - \`Plugin '{plugin_id}' not found\` now sanitized via \`sanitize_response_value\`.

- **New test file: \`tests/integration/test_jtn_341_clock_preview.py\`**
  - \`test_clock_update_preview_populates_latest_plugin_image\` — full end-to-end regression: REAL \`DisplayManager._save_history_entry\` is exercised; asserts sidecar has \`plugin_id=clock\` and \`/plugin_latest_image/clock\` returns an image.
  - \`test_clock_update_preview_runtime_error_returns_400_and_logs\` — asserts plugin-authored messages are preserved AND \`logger.exception\` is called.
  - \`test_clock_update_preview_unexpected_exception_returns_500_and_logs\` — asserts that a \`ValueError\` containing a secret marker is **never** echoed in the HTTP response, and the full stacktrace is captured by \`logger.exception\`.

- **\`tests/integration/test_update_now_happy.py\`** — asserts new \`history_meta\` contract (\`plugin_id\` flows through), and updated stub to accept the kwarg.
- **\`tests/integration/test_refresh_task_interval.py\`** — stub updated to accept \`history_meta=None\`.

## Test plan

- [x] \`scripts/lint.sh\` passes (ruff + black blocking; mypy advisory same as baseline)
- [x] Targeted tests pass: \`test_jtn_341_clock_preview.py\`, \`test_update_now_happy.py\`, \`test_plugin_update_now.py\`, \`test_api_json_errors.py\`, \`test_plugin_pages.py\`, \`test_refresh_task_interval.py\`, \`test_error_recovery.py\`, \`test_error_injection.py\`, \`test_clock.py\` (66 passed)
- [x] Full test suite: 3329 passed, 2 pre-existing failures unrelated to this change (\`test_plugin_registry.py\` needs pyenv \`python\` shim)
- [x] Manual dev-server verification: before fix → 404; after fix → 200 PNG

## Linear

- Fixes JTN-341
- Addresses JTN-318 exception-exposure patterns in \`plugin.py\`
- Likely resolves: JTN-333, JTN-342, JTN-343, JTN-344, JTN-345, JTN-346, JTN-366, JTN-367, JTN-368, JTN-369, JTN-370, JTN-371, JTN-372, JTN-373, JTN-374, JTN-375

🤖 Generated with [Claude Code](https://claude.com/claude-code)