### PR TITLE
fix: install-in-progress lockfile blocks mid-install service start (JTN-607)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,8 @@ If the service is running, this should output `Active: active (running)`:
 
 If the service is not running, check the logs for any errors or issues.
 
+If the journal shows `Install in progress — refusing to start` (JTN-607), an earlier `install.sh` run left the `/var/lib/inkypi/.install-in-progress` lockfile in place — rerun `install.sh` to let it complete and clear the lockfile, or manually remove it with `sudo rm /var/lib/inkypi/.install-in-progress` if you are certain no install is running.
+
 ## Debugging
 
 View the latest logs for the InkyPi service:

--- a/install/inkypi.service
+++ b/install/inkypi.service
@@ -8,6 +8,10 @@ Type=notify
 User=root
 RuntimeDirectory=inkypi
 WorkingDirectory=/run/inkypi
+# JTN-607: Defense-in-depth for JTN-600. If install.sh is running it creates
+# /var/lib/inkypi/.install-in-progress; refuse to start so systemd cannot
+# thrash the Pi with a start+crash+restart loop mid-install.
+ExecStartPre=/bin/bash -c '[ ! -f /var/lib/inkypi/.install-in-progress ] || (echo "Install in progress — refusing to start" && exit 1)'
 ExecStart=/usr/local/bin/inkypi run
 Restart=on-failure
 RestartSec=60

--- a/install/install.sh
+++ b/install/install.sh
@@ -32,6 +32,17 @@ SRC_PATH="$SCRIPT_DIR/../src"
 BINPATH="/usr/local/bin"
 VENV_PATH="$INSTALL_PATH/venv_$APPNAME"
 
+# JTN-607: Defense-in-depth for JTN-600. While install.sh is running, create
+# /var/lib/inkypi/.install-in-progress. inkypi.service's ExecStartPre refuses
+# to start if this file exists, so even if someone manually runs
+# `systemctl start inkypi.service` or systemd tries to auto-restart, the
+# service cannot thrash the Pi mid-install. The lockfile is removed once all
+# install steps succeed (see end of script). On failure exit the file is
+# deliberately left in place so the user MUST rerun install.sh (or manually
+# remove it) before the service can start.
+LOCKFILE_DIR="/var/lib/inkypi"
+LOCKFILE="$LOCKFILE_DIR/.install-in-progress"
+
 SERVICE_FILE="$APPNAME.service"
 SERVICE_FILE_SOURCE="$SCRIPT_DIR/$SERVICE_FILE"
 SERVICE_FILE_TARGET="/etc/systemd/system/$SERVICE_FILE"
@@ -448,6 +459,16 @@ wait_for_clock() {
 # to maintain default INKY display support.
 parse_arguments "$@"
 check_permissions
+
+# JTN-607: Create the install-in-progress lockfile. inkypi.service's
+# ExecStartPre refuses to start while this file exists (defense-in-depth for
+# JTN-600's systemctl disable). The lockfile is removed once all install
+# steps succeed (see near end of script); on failure exit it is left in place
+# so the user must rerun install.sh (or manually rm it) before the service
+# can start.
+mkdir -p "$LOCKFILE_DIR"
+touch "$LOCKFILE"
+
 stop_service
 # fetch the WS display driver if defined.
 if [[ -n "$WS_TYPE" ]]; then
@@ -500,5 +521,12 @@ if [ ! -f "$CSS_OUTPUT" ]; then
   exit 1
 fi
 echo_success "CSS bundle built."
+
+# JTN-607: All install steps succeeded — remove the install-in-progress
+# lockfile so the service is allowed to start. If install.sh exits early due
+# to a failure above, this line is never reached and the lockfile stays in
+# place, forcing the user to rerun install.sh (or manually rm the file)
+# before the service can start.
+rm -f "$LOCKFILE"
 
 ask_for_reboot

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -69,6 +69,38 @@ class TestSystemdService:
     def test_service_watchdog(self):
         assert "WatchdogSec=120" in self.content
 
+    def test_service_execstartpre_checks_install_lockfile(self):
+        # JTN-607: Defense-in-depth for JTN-600. If install.sh is running it
+        # creates /var/lib/inkypi/.install-in-progress; the service must
+        # refuse to start while the lockfile exists so systemd cannot thrash
+        # the Pi with a start+crash+restart loop mid-install.
+        assert "ExecStartPre=" in self.content, (
+            "inkypi.service must have an ExecStartPre directive that checks "
+            "the install-in-progress lockfile (JTN-607)"
+        )
+        assert "/var/lib/inkypi/.install-in-progress" in self.content, (
+            "ExecStartPre must reference the /var/lib/inkypi/.install-in-progress "
+            "lockfile path so the service refuses to start mid-install (JTN-607)"
+        )
+        # The directive must also produce a clear log message so operators
+        # can tell why the service failed to start.
+        assert "Install in progress" in self.content, (
+            "ExecStartPre must echo a clear 'Install in progress' message "
+            "so operators understand why the service refused to start"
+        )
+        # ExecStartPre must live in the [Service] section.
+        service_start = self.content.index("[Service]")
+        install_start = self.content.index("[Install]", service_start)
+        pre_pos = self.content.index("ExecStartPre=")
+        assert (
+            service_start < pre_pos < install_start
+        ), "ExecStartPre must be inside the [Service] section"
+        # And it must come before ExecStart so systemd runs the check first.
+        exec_start_pos = self.content.index("ExecStart=/usr/local/bin/inkypi")
+        assert (
+            pre_pos < exec_start_pos
+        ), "ExecStartPre must appear before ExecStart in the service file"
+
     def test_service_working_directory(self):
         assert "RuntimeDirectory=inkypi" in self.content
         assert "WorkingDirectory=/run/inkypi" in self.content
@@ -358,6 +390,85 @@ class TestInstallScript:
             "install_app_service() must call 'systemctl enable' to re-enable the "
             "service after stop_service() disabled it during the install window"
         )
+
+    def test_install_creates_lockfile_near_top(self):
+        # JTN-607: install.sh must create /var/lib/inkypi/.install-in-progress
+        # early in the main script body (after check_permissions) so any
+        # concurrent systemctl start attempt hits the ExecStartPre guard.
+        # Locate the call site — must appear after check_permissions and
+        # before the later install steps (install_debian_dependencies etc.).
+        assert (
+            "/var/lib/inkypi" in self.content
+        ), "install.sh must reference /var/lib/inkypi for the lockfile (JTN-607)"
+        assert (
+            ".install-in-progress" in self.content
+        ), "install.sh must reference the .install-in-progress lockfile (JTN-607)"
+
+        # The lockfile must be created (touch) in the main script body.
+        # Find the first 'touch "$LOCKFILE"' outside function definitions by
+        # searching after the last function closing brace before main flow.
+        main_start = self.content.index('parse_arguments "$@"')
+        main_body = self.content[main_start:]
+        assert (
+            'mkdir -p "$LOCKFILE_DIR"' in main_body
+        ), "install.sh main body must mkdir -p the lockfile directory (JTN-607)"
+        assert (
+            'touch "$LOCKFILE"' in main_body
+        ), "install.sh main body must touch the lockfile (JTN-607)"
+
+        # Ordering: touch must come after check_permissions (so we only create
+        # the lockfile once we know we're running as root) and before the
+        # heavy install steps.
+        check_pos = main_body.index("check_permissions")
+        touch_pos = main_body.index('touch "$LOCKFILE"')
+        install_deps_pos = main_body.index("install_debian_dependencies")
+        assert check_pos < touch_pos < install_deps_pos, (
+            'touch "$LOCKFILE" must run after check_permissions and before '
+            "install_debian_dependencies (JTN-607)"
+        )
+
+    def test_install_removes_lockfile_at_end_on_success(self):
+        # JTN-607: At the very end of install.sh, after every install step
+        # has succeeded, remove the lockfile so the service is allowed to
+        # start. The removal must come AFTER install_app_service and the CSS
+        # build so a failure in any earlier step leaves the lockfile in place.
+        main_start = self.content.index('parse_arguments "$@"')
+        main_body = self.content[main_start:]
+
+        assert (
+            'rm -f "$LOCKFILE"' in main_body
+        ), "install.sh must remove the lockfile on success (JTN-607)"
+
+        # Ordering: rm must come after install_app_service and after the CSS
+        # build so an earlier failure leaves the lockfile in place.
+        rm_pos = main_body.index('rm -f "$LOCKFILE"')
+        install_app_pos = main_body.index("install_app_service")
+        css_pos = main_body.index("CSS bundle built")
+        assert (
+            install_app_pos < rm_pos
+        ), 'rm -f "$LOCKFILE" must come after install_app_service (JTN-607)'
+        assert css_pos < rm_pos, (
+            'rm -f "$LOCKFILE" must come after the CSS bundle build step '
+            "so a CSS build failure leaves the lockfile in place (JTN-607)"
+        )
+
+    def test_install_lockfile_not_removed_by_error_trap(self):
+        # JTN-607: On failure exit, the lockfile must be LEFT in place so the
+        # user is forced to rerun install.sh (or manually rm the file) before
+        # the service can start. This means there must be NO trap that
+        # removes the lockfile on EXIT/ERR/INT/TERM — only the explicit
+        # rm -f at the end of a successful run.
+        trap_lines = [
+            line
+            for line in self.content.splitlines()
+            if line.strip().startswith("trap ")
+        ]
+        for line in trap_lines:
+            assert "$LOCKFILE" not in line and ".install-in-progress" not in line, (
+                "install.sh must NOT register a trap that removes the lockfile "
+                "on failure exit — leaving it in place forces the user to "
+                f"rerun install.sh before the service can start (JTN-607): {line!r}"
+            )
 
     def test_stop_service_disable_tolerates_already_disabled(self):
         # JTN-600: The disable call must not fail if the service is already


### PR DESCRIPTION
## Summary

Defense-in-depth for JTN-600 (the thrash cascade fix). JTN-600 made `install.sh` `systemctl disable inkypi.service` during install so systemd won't restart the service mid-install. This PR adds a second layer: an **install-in-progress lockfile** that the service's `ExecStartPre` checks. If the lockfile exists the service refuses to start — even if someone manually `systemctl start`s it or systemd decides to retry.

- `install.sh` creates `/var/lib/inkypi/.install-in-progress` after `check_permissions` and `rm -f`s it only after every install step has succeeded.
- `inkypi.service` gains an `ExecStartPre=/bin/bash -c '[ ! -f /var/lib/inkypi/.install-in-progress ] || (echo "Install in progress — refusing to start" && exit 1)'`.
- On failure the lockfile is **deliberately** left in place so the user must rerun `install.sh` (or manually `rm` the file) before the service can start.
- One-sentence note added to `docs/troubleshooting.md` explaining the recovery path.

This is additive; JTN-600's `systemctl disable` is unchanged.

## Changes

- `install/install.sh` — define `LOCKFILE` constants, `mkdir -p` + `touch` after `check_permissions`, `rm -f` right before `ask_for_reboot`.
- `install/inkypi.service` — add `ExecStartPre` lockfile guard in `[Service]`.
- `tests/unit/test_install_scripts.py` — four new structural tests:
  - `test_service_execstartpre_checks_install_lockfile` — ExecStartPre present, references the lockfile, in `[Service]`, before `ExecStart`.
  - `test_install_creates_lockfile_near_top` — main body `mkdir -p` + `touch` ordering (after `check_permissions`, before `install_debian_dependencies`).
  - `test_install_removes_lockfile_at_end_on_success` — `rm -f` ordering (after `install_app_service` and after CSS build).
  - `test_install_lockfile_not_removed_by_error_trap` — guards against anyone adding a trap that removes the lockfile on failure.
- `docs/troubleshooting.md` — one-sentence recovery note.

## Test plan

- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/unit/test_install_scripts.py -v` — 61 passed (4 new)
- [x] Full suite: 3376 passed, 2 pre-existing pyenv-env failures unrelated to this change
- [x] `bash -n install/install.sh` clean
- [x] `scripts/lint.sh` — ruff, black, shellcheck all pass (mypy advisory unchanged)

Closes JTN-607.