### PR TITLE
fix: display "Webcomic Name" (title case) in Daily Comic dropdown (JTN-386)

### DIFF
--- a/src/plugins/comic/comic.py
+++ b/src/plugins/comic/comic.py
@@ -6,7 +6,7 @@ from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import field, option, row, schema, section
 from utils.app_utils import get_font
 
-from .comic_parser import COMICS, get_panel
+from .comic_parser import COMIC_LABELS, COMICS, get_panel
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,10 @@ class Comic(BasePlugin):
                         "select",
                         label="Comic",
                         default="XKCD",
-                        options=[option(comic, comic) for comic in COMICS],
+                        options=[
+                            option(comic, COMIC_LABELS.get(comic, comic))
+                            for comic in COMICS
+                        ],
                     ),
                     field(
                         "fontSize",

--- a/src/plugins/comic/comic_parser.py
+++ b/src/plugins/comic/comic_parser.py
@@ -89,6 +89,11 @@ COMICS = {
     },
 }
 
+# Display labels for comics whose key differs from the official title.
+COMIC_LABELS = {
+    "webcomic name": "Webcomic Name",
+}
+
 
 def get_panel(comic_name):
     response = http_get(COMICS[comic_name]["feed"], timeout=20.0, use_cache=False)


### PR DESCRIPTION
## Summary

- The Daily Comic plugin dropdown showed `webcomic name` in lowercase, inconsistent with all other comic titles
- `Webcomic Name` is the official title of Alex Norris's webcomic
- The underlying dict key `"webcomic name"` is preserved for backward compatibility with existing device configs
- A `COMIC_LABELS` mapping in `comic_parser.py` provides the correct display label; `comic.py` uses `COMIC_LABELS.get(comic, comic)` to resolve it

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync needed — cosmetic label fix only

## Compatibility/Release Checklist

- [x] `pytest` passes (3,376 passing; 2 pre-existing pyenv failures unrelated to this change)
- [x] No breaking API route/path changes
- [x] No frontend asset changes

## Testing

- [x] Linting passes (`scripts/lint.sh` — ruff + black clean)
- [x] All existing tests pass
- [x] No new tests needed (label-only cosmetic change; no logic paths changed)

Closes JTN-386