### PR TITLE
feat: publish CycloneDX SBOM as release asset (JTN-517)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           cache: 'pip'
           cache-dependency-path: install/requirements.txt
 
-      - name: Install semantic-release
-        run: pip install python-semantic-release==9.21.1
+      - name: Install semantic-release and SBOM tools
+        run: pip install python-semantic-release==9.21.1 cyclonedx-bom
 
       - name: Semantic Release — version & publish
         env:
@@ -34,3 +34,30 @@ jobs:
         run: |
           semantic-release version
           semantic-release publish
+
+      - name: Generate SBOM
+        run: |
+          pip install -r install/requirements.txt
+          python -m venv .venv
+          .venv/bin/pip install -r install/requirements.txt
+          mkdir -p artifacts/security
+          python -m cyclonedx_py environment .venv/bin/python --of JSON \
+            -o artifacts/security/sbom.json
+
+      - name: Attach SBOM to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(cat VERSION)
+          TAG="v${VERSION}"
+          SBOM_FILE="inkypi-${TAG}-bom.json"
+          cp artifacts/security/sbom.json "${SBOM_FILE}"
+          # Only upload if the release exists (semantic-release may not bump on every push)
+          if gh release view "${TAG}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            gh release upload "${TAG}" "${SBOM_FILE}" \
+              --repo "${{ github.repository }}" \
+              --clobber
+            echo "Uploaded ${SBOM_FILE} to release ${TAG}"
+          else
+            echo "No release found for ${TAG}, skipping SBOM upload"
+          fi

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,57 @@
+# Security
+
+## Software Bill of Materials (SBOM)
+
+Every GitHub release includes a CycloneDX JSON SBOM attached as a release asset named
+`inkypi-vX.Y.Z-bom.json`. This file lists all Python packages bundled with that release
+so that security teams and auditors can inventory third-party dependencies.
+
+### Downloading the SBOM
+
+```bash
+# Replace vX.Y.Z with the release tag, e.g. v0.39.8
+gh release download vX.Y.Z --repo jtn0123/InkyPi --pattern 'inkypi-vX.Y.Z-bom.json'
+```
+
+Or download it directly from the GitHub releases page:
+`https://github.com/jtn0123/InkyPi/releases`
+
+### Validating the SBOM with cyclonedx-cli
+
+Install the [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli):
+
+```bash
+# macOS (Homebrew)
+brew install cyclonedx/cyclonedx/cyclonedx-cli
+
+# Or download a binary from:
+# https://github.com/CycloneDX/cyclonedx-cli/releases
+```
+
+Validate the SBOM is well-formed:
+
+```bash
+cyclonedx-cli validate --input-file inkypi-vX.Y.Z-bom.json --input-format json
+```
+
+Convert to other formats (e.g. SPDX):
+
+```bash
+cyclonedx-cli convert \
+  --input-file inkypi-vX.Y.Z-bom.json \
+  --input-format json \
+  --output-file inkypi-vX.Y.Z-bom.spdx \
+  --output-format spdxtag
+```
+
+### Checking for known vulnerabilities
+
+```bash
+pip install pip-audit
+pip-audit --sbom inkypi-vX.Y.Z-bom.json
+```
+
+## Security Reporting
+
+To report a vulnerability, please open a [GitHub Security Advisory](https://github.com/jtn0123/InkyPi/security/advisories/new)
+or email the maintainers directly rather than filing a public issue.


### PR DESCRIPTION
## Summary

- Attaches a CycloneDX JSON SBOM (`inkypi-vX.Y.Z-bom.json`) to every GitHub release so downstream users can audit dependencies of any specific version without relying on expiring CI artifacts
- Regenerates the SBOM during the release workflow (simpler and more reliable than pulling the 90-day-expiring CI artifact) using `cyclonedx-bom` against the release venv
- Adds `docs/security.md` explaining how to download and validate the SBOM with `cyclonedx-cli` and `pip-audit`
- Architectural choice: **regenerate-during-release** rather than download-from-CI — avoids artifact expiry issues and race conditions with the CI job

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync needed — this is a new feature

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (2 pre-existing failures unrelated to this PR)
- [x] No breaking API route/path changes
- [x] Docs added at `docs/security.md`

## Changes

- `.github/workflows/release.yml` — added SBOM generation + `gh release upload` step
- `docs/security.md` — new doc: how to download, validate, and use the SBOM

## Testing

- [x] Lint passes (`scripts/lint.sh`)
- [x] All tests pass except 2 pre-existing failures in `test_plugin_registry.py` (confirmed present on `main` before this PR)

Fixes JTN-517