### PR TITLE
fix: use type=password for existing API key value inputs (JTN-382)

### DIFF
--- a/src/templates/api_keys.html
+++ b/src/templates/api_keys.html
@@ -66,7 +66,7 @@
                     {% for entry in entries %}
                     <div class="apikey-row" data-existing="true">
                         <input type="text" class="apikey-key" value="{{ entry.key }}" placeholder="KEY_NAME" readonly aria-label="{{ entry.key }} key name">
-                        <input type="text" class="apikey-value masked" value="{{ entry.masked }}" placeholder="(unchanged)" readonly aria-label="{{ entry.key }} value">
+                        <input type="password" class="apikey-value" value="" placeholder="(unchanged)" readonly aria-label="{{ entry.key }} value, hidden">
                         <button type="button" class="btn-delete" data-api-action="delete-row" title="Delete" aria-label="Delete {{ entry.key }} API key">×</button>
                     </div>
                     {% endfor %}

--- a/tests/integration/test_api_keys_pages_more.py
+++ b/tests/integration/test_api_keys_pages_more.py
@@ -34,7 +34,8 @@ def test_generic_api_keys_list_inputs_have_aria_labels(client, monkeypatch, tmp_
     html = resp.get_data(as_text=True)
 
     assert 'aria-label="ANOTHER_KEY key name"' in html
-    assert 'aria-label="ANOTHER_KEY value"' in html
+    # JTN-382: value input is now type=password with ", hidden" suffix in aria-label
+    assert 'aria-label="ANOTHER_KEY value, hidden"' in html
 
 
 def test_managed_api_keys_card_delete_button_has_aria_label(client, device_config_dev):

--- a/tests/unit/test_template_snapshots.py
+++ b/tests/unit/test_template_snapshots.py
@@ -154,3 +154,38 @@ def test_calendar_url_input_has_aria_label(client):
     html = resp.get_data(as_text=True)
     assert 'name="calendarURLs[]"' in html
     assert 'aria-label="Calendar URL"' in html
+
+
+# ---------------------------------------------------------------------------
+# JTN-382: Existing-secret inputs must use type=password, not bullet chars
+# ---------------------------------------------------------------------------
+
+
+def test_api_keys_existing_row_uses_password_input(client):
+    """Existing-key rows render as type=password with empty value (JTN-382).
+
+    The old implementation used type=text with literal U+25CF bullet characters
+    as the value, which breaks screen readers, password managers, and copy-paste.
+    The fix renders type=password with value="" and placeholder="(unchanged)".
+    """
+    from unittest.mock import patch
+
+    fake_entries = [("MY_API_KEY", "supersecret")]
+
+    with patch("blueprints.apikeys.parse_env_file", return_value=fake_entries):
+        resp = client.get("/api-keys")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    # Must use type=password for the value column
+    assert 'type="password"' in html
+
+    # Must NOT contain the U+25CF bullet-character hack
+    assert "\u25cf" not in html.lower()
+
+    # The secret value itself must not appear in the HTML source
+    assert "supersecret" not in html
+
+    # The empty-value + placeholder pattern must be present
+    assert 'placeholder="(unchanged)"' in html


### PR DESCRIPTION
## Summary

- Replace `type="text"` inputs filled with literal U+25CF bullet characters with `type="password" value="" placeholder="(unchanged)"` for existing-secret rows in the generic API Keys list view
- Fixes screen reader output (was reading "black circle" 20 times), password manager recognition, and garbage copy-paste behavior
- Aria-label updated to include `, hidden` suffix to communicate masked state to assistive technology
- No functional behaviour change — the JS `saveGenericKeys` already treats an empty value as "keep existing" (`keepExisting: true`)

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [x] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (3376 passed, 2 pre-existing env failures unrelated to this change)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI — N/A (no new flags/endpoints)
- [x] **Frontend changes**: template-render test added verifying `type="password"`, absence of U+25CF, and `placeholder="(unchanged)"`

## Testing

- Updated `tests/integration/test_api_keys_pages_more.py` to expect new aria-label `"ANOTHER_KEY value, hidden"`
- Added `tests/unit/test_template_snapshots.py::test_api_keys_existing_row_uses_password_input` that:
  - Patches `parse_env_file` to inject a real entry
  - Asserts `type="password"` present
  - Asserts U+25CF bullet char absent
  - Asserts raw secret value not in HTML source
  - Asserts `placeholder="(unchanged)"` present

Fixes JTN-382.