### PR TITLE
fix: validate image_folder path exists on save (JTN-355)

### DIFF
--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -47,6 +47,24 @@ def list_files_in_folder(folder_path):
 
 
 class ImageFolder(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject missing/unreadable/empty folder paths at save time.
+
+        Without this, a bad ``folder_path`` persists in config and only
+        surfaces later when ``generate_image`` runs — far from where the
+        user can fix the typo. See JTN-355.
+        """
+        folder_path = (settings.get("folder_path") or "").strip()
+        if not folder_path:
+            return "Folder path is required."
+        if not os.path.isdir(folder_path):
+            return "Folder does not exist or is not readable."
+        if not os.access(folder_path, os.R_OK):
+            return "Folder is not readable."
+        if not list_files_in_folder(folder_path):
+            return "Folder contains no image files."
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/tests/integration/test_plugin_validation.py
+++ b/tests/integration/test_plugin_validation.py
@@ -14,11 +14,18 @@ def test_save_rejects_missing_required_fields(client):
     assert "Folder Path" in data.get("error", "")
 
 
-def test_save_accepts_valid_required_fields(client):
+def test_save_accepts_valid_required_fields(client, tmp_path):
     """Saving with all required fields filled should not return 400."""
+    from PIL import Image
+
+    folder = tmp_path / "test-images"
+    folder.mkdir()
+    # JTN-355: folder must actually exist and contain at least one image
+    Image.new("RGB", (8, 8), "white").save(folder / "sample.png")
+
     resp = client.post(
         "/save_plugin_settings",
-        data={"plugin_id": "image_folder", "folder_path": "/tmp/test-images"},
+        data={"plugin_id": "image_folder", "folder_path": str(folder)},
     )
     assert resp.status_code != 400
 
@@ -82,8 +89,17 @@ def test_update_instance_rejects_missing_required_fields(client, device_config_d
     assert "Required" in data.get("error", "")
 
 
-def test_update_instance_accepts_valid_required_fields(client, device_config_dev):
+def test_update_instance_accepts_valid_required_fields(
+    client, device_config_dev, tmp_path
+):
     """Updating an existing instance with valid required fields should succeed."""
+    from PIL import Image
+
+    # JTN-355: folder must actually exist and contain at least one image
+    new_folder = tmp_path / "new-path"
+    new_folder.mkdir()
+    Image.new("RGB", (8, 8), "white").save(new_folder / "sample.png")
+
     pm = device_config_dev.get_playlist_manager()
     if not pm.get_playlist("Default"):
         pm.add_playlist("Default")
@@ -92,7 +108,7 @@ def test_update_instance_accepts_valid_required_fields(client, device_config_dev
         {
             "plugin_id": "image_folder",
             "name": "valid_instance",
-            "plugin_settings": {"folder_path": "/tmp/old"},
+            "plugin_settings": {"folder_path": str(tmp_path / "old")},
             "refresh": {"interval": 300},
         }
     )
@@ -100,7 +116,7 @@ def test_update_instance_accepts_valid_required_fields(client, device_config_dev
 
     resp = client.put(
         "/update_plugin_instance/valid_instance",
-        data={"plugin_id": "image_folder", "folder_path": "/tmp/new-path"},
+        data={"plugin_id": "image_folder", "folder_path": str(new_folder)},
     )
     assert resp.status_code == 200
     data = resp.get_json()

--- a/tests/plugins/test_image_folder_validation.py
+++ b/tests/plugins/test_image_folder_validation.py
@@ -1,0 +1,169 @@
+# pyright: reportMissingImports=false
+"""JTN-355: validate_settings for the Image Folder plugin.
+
+The prior behavior silently accepted any ``folder_path`` at save time; bad
+values only surfaced later when ``generate_image`` ran at refresh time,
+making the failure hard to trace back to the save action.
+"""
+
+from PIL import Image
+
+
+def _make_img(path, size=(32, 24), color=(100, 150, 200)):
+    Image.new("RGB", size, color).save(path)
+
+
+def test_validate_settings_missing_path_returns_error():
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    err = plugin.validate_settings({})
+    assert err is not None
+    assert "required" in err.lower()
+
+
+def test_validate_settings_empty_path_returns_error():
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    err = plugin.validate_settings({"folder_path": ""})
+    assert err is not None
+    assert "required" in err.lower()
+
+
+def test_validate_settings_whitespace_path_returns_error():
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    err = plugin.validate_settings({"folder_path": "   "})
+    assert err is not None
+    assert "required" in err.lower()
+
+
+def test_validate_settings_nonexistent_path_returns_error(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    bogus = tmp_path / "does" / "not" / "exist"
+    err = plugin.validate_settings({"folder_path": str(bogus)})
+    assert err is not None
+    assert "exist" in err.lower() or "readable" in err.lower()
+
+
+def test_validate_settings_path_is_file_returns_error(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    # pass a file path, not a directory
+    f = tmp_path / "not_a_dir.txt"
+    f.write_text("hello")
+    err = plugin.validate_settings({"folder_path": str(f)})
+    assert err is not None
+    assert "exist" in err.lower() or "readable" in err.lower()
+
+
+def test_validate_settings_empty_folder_returns_error(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    err = plugin.validate_settings({"folder_path": str(empty)})
+    assert err is not None
+    assert "no image" in err.lower()
+
+
+def test_validate_settings_folder_with_only_non_images_returns_error(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    folder = tmp_path / "docs"
+    folder.mkdir()
+    (folder / "readme.txt").write_text("not an image")
+    (folder / "notes.md").write_text("also not an image")
+    err = plugin.validate_settings({"folder_path": str(folder)})
+    assert err is not None
+    assert "no image" in err.lower()
+
+
+def test_validate_settings_folder_with_one_png_returns_none(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    folder = tmp_path / "pics"
+    folder.mkdir()
+    _make_img(folder / "a.png")
+    assert plugin.validate_settings({"folder_path": str(folder)}) is None
+
+
+def test_validate_settings_folder_with_mixed_files_returns_none(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    folder = tmp_path / "mixed"
+    folder.mkdir()
+    (folder / "readme.txt").write_text("text file")
+    _make_img(folder / "photo.jpg")
+    assert plugin.validate_settings({"folder_path": str(folder)}) is None
+
+
+def test_validate_settings_nested_images_returns_none(tmp_path):
+    from plugins.image_folder.image_folder import ImageFolder
+
+    plugin = ImageFolder({"id": "image_folder"})
+    folder = tmp_path / "nested"
+    sub = folder / "subfolder"
+    sub.mkdir(parents=True)
+    _make_img(sub / "inner.png")
+    assert plugin.validate_settings({"folder_path": str(folder)}) is None
+
+
+def test_save_plugin_settings_rejects_missing_folder(client):
+    """JTN-355: POST /save_plugin_settings with bad path returns 4xx."""
+    data = {
+        "plugin_id": "image_folder",
+        "folder_path": "/definitely/not/a/real/path/for/jtn355",
+        "padImage": "false",
+        "backgroundOption": "blur",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    msg = body.get("error") or body.get("message") or ""
+    assert "exist" in msg.lower() or "readable" in msg.lower()
+
+
+def test_save_plugin_settings_rejects_empty_folder(client, tmp_path):
+    """JTN-355: POST /save_plugin_settings with an empty folder returns 4xx."""
+    empty = tmp_path / "empty_dir"
+    empty.mkdir()
+    data = {
+        "plugin_id": "image_folder",
+        "folder_path": str(empty),
+        "padImage": "false",
+        "backgroundOption": "blur",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    msg = body.get("error") or body.get("message") or ""
+    assert "no image" in msg.lower()
+
+
+def test_save_plugin_settings_accepts_folder_with_image(client, tmp_path):
+    """JTN-355: valid folder with at least one image saves successfully."""
+    folder = tmp_path / "valid_imgs"
+    folder.mkdir()
+    _make_img(folder / "one.png")
+    data = {
+        "plugin_id": "image_folder",
+        "folder_path": str(folder),
+        "padImage": "false",
+        "backgroundOption": "blur",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 200
+    body = resp.get_json() or {}
+    assert body.get("success") is True


### PR DESCRIPTION
## Summary
- Add `validate_settings()` to the Image Folder plugin so bad `folder_path` values are rejected at save time instead of silently persisting and failing later at refresh.
- Mirrors the pattern established by Weather (JTN-354) and Screenshot — the blueprint save flow already calls `plugin.validate_settings()`, so no blueprint changes are needed.

## Validation rules enforced
- Missing or empty `folder_path` -> "Folder path is required."
- Path is not a directory -> "Folder does not exist or is not readable."
- Directory exists but is not readable -> "Folder is not readable."
- Directory contains no supported image files -> "Folder contains no image files."

## Test plan
- [x] Unit: `validate_settings` with missing, empty, whitespace, non-existent, file-not-dir, empty-dir, non-image-only directories all return errors
- [x] Unit: folder with a single `.png`, folder with mixed files, nested-subdir images all return `None`
- [x] Integration: `POST /save_plugin_settings` with bad path -> 400; with empty folder -> 400; with a valid folder containing an image -> 200
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck; mypy strict subset clean)
- [x] All image_folder tests pass (18/18)

Fixes JTN-355.

Generated with [Claude Code](https://claude.com/claude-code)