### PR TITLE
fix: validate calendar URL + prevent empty row spam (JTN-357)

### DIFF
--- a/src/plugins/calendar/calendar.py
+++ b/src/plugins/calendar/calendar.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
 
 import icalendar
@@ -23,6 +24,34 @@ logger = logging.getLogger(__name__)
 
 
 class Calendar(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject non-URL ICS values at save time (JTN-357).
+
+        Each submitted calendar URL must parse to an http(s) scheme with a
+        non-empty host.  ``webcal://`` is also accepted because the runtime
+        rewrites it to https before fetching.  Empty URLs and invalid values
+        (e.g. ``not-a-url`` or ``javascript:alert(1)``) are rejected so the
+        user cannot persist junk rows from the settings form.
+        """
+        calendar_urls = settings.get("calendarURLs[]")
+        if not calendar_urls:
+            return "At least one calendar URL is required."
+
+        allowed_schemes = {"http", "https", "webcal"}
+        for raw in calendar_urls:
+            url = (raw or "").strip()
+            if not url:
+                return "Calendar URL is required."
+            try:
+                parsed = urlparse(url)
+            except ValueError:
+                return f"Calendar URL is not valid: {url!r}"
+            if parsed.scheme.lower() not in allowed_schemes:
+                return f"Calendar URL is not valid: {url!r}"
+            if not parsed.netloc:
+                return f"Calendar URL is not valid: {url!r}"
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -211,11 +211,13 @@
     const toolbar = document.createElement("div");
     toolbar.className = "dynamic-list-toolbar compact-repeater-toolbar";
     const urlInput = document.createElement("input");
-    urlInput.type = "text";
+    urlInput.type = "url";
     urlInput.name = "calendarURLs[]";
     urlInput.className = "form-input";
     urlInput.placeholder = "https://calendar.google.com/…/basic.ics";
     urlInput.required = true;
+    urlInput.setAttribute("aria-label", "Calendar URL");
+    urlInput.pattern = "https?://.+";
     urlInput.value = url || "";
     const removeBtn = document.createElement("button");
     removeBtn.type = "button";
@@ -312,6 +314,28 @@
     updateRepeaterEmptyState(list);
     syncRemoveButtonStates(list);
     addButton.addEventListener("click", () => {
+      // JTN-357: Refuse to append a new empty row while the previous row
+      // holds an empty or invalid value.  This prevents users from spamming
+      // empty/invalid rows into the form.
+      const items = list.querySelectorAll(".dynamic-list-item");
+      if (items.length > 0) {
+        const lastItem = items[items.length - 1];
+        const lastInput = lastItem.querySelector('input[name="calendarURLs[]"]');
+        if (lastInput) {
+          const value = (lastInput.value || "").trim();
+          if (!value || !lastInput.checkValidity()) {
+            lastInput.focus();
+            lastInput.reportValidity?.();
+            const message = value
+              ? "Fix the previous calendar URL before adding another."
+              : "Enter a calendar URL before adding another.";
+            if (typeof showError === "function") {
+              showError(message);
+            }
+            return;
+          }
+        }
+      }
       list.appendChild(createCalendarEntry("", "#007BFF"));
       updateRepeaterEmptyState(list);
       syncRemoveButtonStates(list);

--- a/src/templates/widgets/calendar_repeater.html
+++ b/src/templates/widgets/calendar_repeater.html
@@ -8,12 +8,13 @@
     <div class="dynamic-list-item compact-repeater compact-repeater-calendar">
         <div class="dynamic-list-toolbar compact-repeater-toolbar">
             <input
-                type="text"
+                type="url"
                 name="calendarURLs[]"
                 class="form-input"
                 placeholder="https://calendar.google.com/…/basic.ics"
                 value="{{ calendar_urls[idx] }}"
                 required
+                pattern="https?://.+"
                 aria-label="Calendar URL"
             >
             <button type="button" class="remove-btn icon-button" aria-label="Remove calendar">

--- a/tests/plugins/test_calendar_validation.py
+++ b/tests/plugins/test_calendar_validation.py
@@ -1,0 +1,151 @@
+# pyright: reportMissingImports=false
+"""JTN-357: Calendar plugin URL validation.
+
+The ICS URL field must reject non-URL values at save time (backend
+``validate_settings``) and the rendered settings template must use a
+``type="url"`` input so the browser enforces basic URL constraints client-side.
+"""
+
+
+def _plugin():
+    from plugins.calendar.calendar import Calendar
+
+    return Calendar({"id": "calendar"})
+
+
+def test_validate_settings_accepts_http_ics_url():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["http://example.com/cal.ics"],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is None
+
+
+def test_validate_settings_accepts_https_ics_url():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": [
+                "https://calendar.google.com/calendar/ical/abc/public/basic.ics"
+            ],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is None
+
+
+def test_validate_settings_accepts_webcal_url():
+    # The runtime rewrites webcal:// to https:// before fetching, so webcal
+    # should also be considered a valid persisted value.
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["webcal://example.com/cal.ics"],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is None
+
+
+def test_validate_settings_accepts_url_without_ics_extension():
+    # Some providers serve calendar files without an .ics extension.
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["https://example.com/calendar"],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is None
+
+
+def test_validate_settings_rejects_non_url_string():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["not-a-url"],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is not None
+    assert "not valid" in error.lower()
+    assert "not-a-url" in error
+
+
+def test_validate_settings_rejects_javascript_scheme():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["javascript:alert(1)"],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_file_scheme():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["file:///etc/passwd"],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_empty_url():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": [""],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is not None
+
+
+def test_validate_settings_rejects_whitespace_url():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": ["   "],
+            "calendarColors[]": ["#007BFF"],
+        }
+    )
+    assert error is not None
+
+
+def test_validate_settings_rejects_missing_urls_key():
+    error = _plugin().validate_settings({"calendarColors[]": ["#007BFF"]})
+    assert error is not None
+    assert "required" in error.lower()
+
+
+def test_validate_settings_rejects_when_any_row_invalid():
+    error = _plugin().validate_settings(
+        {
+            "calendarURLs[]": [
+                "https://example.com/cal.ics",
+                "bogus",
+            ],
+            "calendarColors[]": ["#007BFF", "#FF0000"],
+        }
+    )
+    assert error is not None
+    assert "bogus" in error
+
+
+def test_calendar_url_input_is_type_url_and_required(client):
+    """The calendar settings form renders a type=url input with required (JTN-357)."""
+    resp = client.get("/plugin/calendar")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'name="calendarURLs[]"' in html
+    assert 'type="url"' in html
+    # The input must be required so the browser blocks empty submissions.
+    # We check for the attribute on the calendarURLs[] input specifically by
+    # looking for a window containing both the name and the required attr.
+    import re
+
+    input_tag = re.search(r"<input[^>]*name=\"calendarURLs\[\]\"[^>]*>", html)
+    assert input_tag is not None, "calendarURLs[] input not found in rendered page"
+    tag = input_tag.group(0)
+    assert 'type="url"' in tag
+    assert "required" in tag


### PR DESCRIPTION
## Summary

Closes JTN-357. Repro: `/plugin/calendar` → type `not-a-url` → click Add Calendar. Previously, the bad string was accepted silently and Add Calendar appended a new empty row on top of it, so a user could spam empty/invalid rows indefinitely.

- **Template** (`src/templates/widgets/calendar_repeater.html`): switched the calendar URL input from `type="text"` to `type="url"` with a `https?://.+` pattern hint and `required`, so the browser enforces basic URL constraints before submit.
- **JS** (`src/static/scripts/plugin_schema.js`): `createCalendarEntry` mirrors the template (`type="url"`, pattern, required, aria-label). The Add Calendar click handler now refuses to append a new row while the last existing row is empty or fails `checkValidity()`, and surfaces a toast via `showError` + `reportValidity()` instead of using a browser dialog.
- **Backend** (`src/plugins/calendar/calendar.py`): new `validate_settings` override rejects non-http(s)/webcal URLs at save time via `urllib.parse.urlparse` (scheme + netloc check), so bad values can never be persisted even if the client-side guard is bypassed. `webcal://` is accepted because the runtime already rewrites it to https before fetching.
- **Tests** (`tests/plugins/test_calendar_validation.py`, 12 new tests): validates that http/https/webcal pass; `not-a-url`, empty, whitespace, `javascript:alert(1)`, `file:///etc/passwd`, and any-row-invalid cases are rejected; template render asserts the calendarURLs[] input is `type="url"` + `required`.

## Test plan

- [x] `scripts/lint.sh` — passes (ruff + black + shellcheck green; mypy advisory unchanged)
- [x] `pytest tests/plugins/test_calendar_validation.py tests/plugins/test_calendar.py tests/plugins/test_calendar_errors.py tests/unit/test_template_snapshots.py` — 70/70 pass
- [x] Full suite: 3442 passed, 2 pre-existing unrelated failures in `tests/unit/test_plugin_registry.py` (pyenv `python` command missing in local env; not touched by this PR)
- [ ] Manual smoke: visit `/plugin/calendar`, type `not-a-url`, click Add Calendar, confirm toast + focus on bad row + no new row appended

Fixes JTN-357.

Generated with Claude Code