### PR TITLE
ci: add arm64 install.sh end-to-end matrix (JTN-530)

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -1,0 +1,60 @@
+name: Install matrix (arm64 e2e)
+
+# JTN-530: Run install/install.sh end-to-end inside an arm64 Debian container
+# under a 512 MB memory cap for each supported Pi OS base (Bullseye, Bookworm,
+# Trixie). JTN-528 (a Trixie zramswap regression) went undetected for an entire
+# release cycle because no CI job exercised the install script on each base.
+# This matrix closes that gap.
+#
+# Wraps scripts/test_install_memcap.sh, which already accepts the codename as
+# its first positional argument and runs the same Phase 2/3/4 install + boot
+# probes used by the existing single-codename install-smoke-memcap job in
+# ci.yml.
+#
+# This workflow is intentionally a standalone advisory job for now — it is not
+# wired into the ci-gate `needs:` list. A follow-up ticket can promote it to
+# required once we've watched it run green for a few cycles. Each matrix cell
+# runs install.sh under arm64 QEMU emulation, which is slow (hence the 30 min
+# timeout per codename).
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-matrix:
+    name: install.sh e2e (${{ matrix.codename }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        codename: [bullseye, bookworm, trixie]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Run install smoke test (${{ matrix.codename }})
+        run: |
+          ./scripts/test_install_memcap.sh ${{ matrix.codename }}
+
+      - name: Upload container logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-matrix-${{ matrix.codename }}-logs
+          path: /tmp/inkypi-smoke-logs
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Adds a new `.github/workflows/install-matrix.yml` that runs `scripts/test_install_memcap.sh` against `bullseye`, `bookworm`, and `trixie` under arm64 QEMU emulation in a matrix.
- Closes the gap that let JTN-528 (Trixie zramswap regression) ship undetected: no CI job was exercising `install/install.sh` on each supported Pi OS base.
- Standalone advisory job for now (not wired into the `ci-gate` `needs:` list) so a slow QEMU run can't block PRs while we watch it stabilize. A follow-up ticket can promote it to required.

## Notes

- Wraps the existing `scripts/test_install_memcap.sh` (from JTN-536/JTN-608), which already accepts the codename as its first positional argument and runs the same Phase 2/3/4 install + boot probes used by the existing single-codename `install-smoke-memcap` job in `ci.yml`. No script changes were needed.
- Uses `docker/setup-qemu-action@v3` to enable arm64 emulation, mirroring the pattern in `build-wheelhouse.yml`.
- 30 min timeout per matrix cell because install.sh under QEMU is slow.
- `fail-fast: false` so a single codename failure doesn't mask the others.
- Uploads `/tmp/inkypi-smoke-logs` as an artifact on failure for triage.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/install-matrix.yml'))"`
- [x] `scripts/lint.sh` (ruff, black, shellcheck, mypy strict subset all green)
- [ ] Watch the matrix run after merge (the new workflow won't auto-run on this PR because it's a new file).

Linear: [JTN-530](https://linear.app/jtn0123/issue/JTN-530/add-arm64-installsh-end-to-end-ci-matrix-bullseyebookwormtrixie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)