### PR TITLE
ci: add per-PR startup memory diff comment (JTN-610)

### DIFF
--- a/.github/workflows/memory-diff.yml
+++ b/.github/workflows/memory-diff.yml
@@ -1,0 +1,152 @@
+# JTN-610: Per-PR memory diff comment.
+#
+# Posts an informational sticky comment on every pull request showing how
+# InkyPi's startup allocator breakdown changed versus the PR's base branch.
+# Uses memray when available, falls back to stdlib tracemalloc otherwise.
+#
+# This workflow is DELIBERATELY advisory — it never fails the PR. Hard RSS
+# budgets are a separate gate owned by JTN-608 (`install-smoke-memcap` in
+# ci.yml). Do NOT add failure conditions here.
+
+name: Memory diff
+
+on:
+  pull_request:
+    # Re-run on every push so the sticky comment updates in place.
+    types: [opened, synchronize, reopened]
+
+# Read-only contents but we need write access to pull-requests to post/update
+# the sticky comment. No other permissions are needed.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # Cancel superseded runs on the same PR so a force-push only keeps the
+  # latest memory comment in flight.
+  group: memory-diff-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  memory-diff:
+    name: Memory diff vs base
+    runs-on: ubuntu-latest
+    # Keep the whole job under ~3 min per the JTN-610 spec. Setup is the
+    # long pole; the two measurements themselves take ~5s each.
+    timeout-minutes: 8
+    # Never block the PR. This is an informational gate.
+    continue-on-error: true
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          # We need the base commit available locally so we can checkout the
+          # base tree into a side directory without a second clone.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: install/requirements-dev.txt
+
+      - name: Install runtime + dev deps
+        run: |
+          python -m pip install -U pip wheel
+          pip install -r install/requirements.txt -r install/requirements-dev.txt
+          # memray is optional — tolerate absence gracefully (JTN-610).
+          # Install explicitly so the preferred backend is available without
+          # forcing the lockfile regen onto this PR's critical path.
+          pip install 'memray>=1.10,<2' || true
+
+      - name: Measure PR branch startup
+        env:
+          PYTHONPATH: src
+          INKYPI_ENV: dev
+          INKYPI_NO_REFRESH: '1'
+        run: |
+          python scripts/memory_diff.py --output pr.json --backend auto
+          echo "--- pr.json summary ---"
+          python -c "import json; d=json.load(open('pr.json')); print('backend:', d['backend'], 'modules:', d['module_count'], 'rss:', d['total_rss_bytes'])"
+
+      - name: Checkout base branch into side worktree
+        run: |
+          # Stash the memory_diff helpers so the worktree still has them if
+          # the base branch predates this commit. The helpers are standalone
+          # scripts so this is safe.
+          mkdir -p /tmp/memdiff-scripts
+          cp scripts/memory_diff.py /tmp/memdiff-scripts/
+          cp scripts/format_memory_diff.py /tmp/memdiff-scripts/
+          git worktree add --detach /tmp/base-tree "origin/${{ github.base_ref }}"
+          if [ ! -f /tmp/base-tree/scripts/memory_diff.py ]; then
+            echo "Base branch does not have memory_diff.py yet — copying from PR"
+            cp /tmp/memdiff-scripts/memory_diff.py /tmp/base-tree/scripts/
+          fi
+
+      - name: Measure base branch startup
+        env:
+          PYTHONPATH: /tmp/base-tree/src
+          INKYPI_ENV: dev
+          INKYPI_NO_REFRESH: '1'
+        working-directory: /tmp/base-tree
+        run: |
+          python scripts/memory_diff.py --output "${{ github.workspace }}/base.json" --backend auto || {
+            echo "Base measurement failed — writing empty summary so the formatter can still run"
+            echo '{"backend":"unavailable","total_rss_bytes":0,"module_count":0,"allocators":[]}' > "${{ github.workspace }}/base.json"
+          }
+
+      - name: Format comment
+        run: |
+          python scripts/format_memory_diff.py \
+            --base base.json \
+            --pr pr.json \
+            --output comment.md
+          echo "--- comment preview ---"
+          cat comment.md
+
+      - name: Upload raw JSON as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-diff-json
+          path: |
+            base.json
+            pr.json
+            comment.md
+          if-no-files-found: warn
+
+      - name: Post sticky comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('comment.md', 'utf8');
+            // The sticky marker must match scripts/format_memory_diff.py::STICKY_MARKER.
+            const marker = '<!-- memory-diff:jtn-610 -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const prior = existing.find((c) => c.body && c.body.includes(marker));
+            if (prior) {
+              core.info(`Updating existing memory-diff comment #${prior.id}`);
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: prior.id,
+                body,
+              });
+            } else {
+              core.info('Posting new memory-diff comment');
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/memory-diff.yml
+++ b/.github/workflows/memory-diff.yml
@@ -66,7 +66,12 @@ jobs:
           INKYPI_ENV: dev
           INKYPI_NO_REFRESH: '1'
         run: |
-          python scripts/memory_diff.py --output pr.json --backend auto
+          # Soft-fail: if the helper crashes we still want the formatter to
+          # run and post a "backend unavailable" comment rather than bail.
+          python scripts/memory_diff.py --output pr.json --backend auto || {
+            echo "PR measurement failed — writing empty summary"
+            echo '{"backend":"unavailable","total_rss_bytes":0,"module_count":0,"allocators":[]}' > pr.json
+          }
           echo "--- pr.json summary ---"
           python -c "import json; d=json.load(open('pr.json')); print('backend:', d['backend'], 'modules:', d['module_count'], 'rss:', d['total_rss_bytes'])"
 

--- a/install/requirements-dev.in
+++ b/install/requirements-dev.in
@@ -60,3 +60,8 @@ pip-licenses>=5.0,<6
 
 # Mutation testing (optional — slow; run with: mutmut run)
 mutmut>=2.5,<3
+
+# Memory profiling for the per-PR memory diff comment (JTN-610). Linux-only
+# wheels; tracemalloc fallback is used on other platforms. Pinned to 1.x to
+# keep CLI flags stable.
+memray>=1.10,<2; sys_platform == "linux"

--- a/scripts/format_memory_diff.py
+++ b/scripts/format_memory_diff.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""JTN-610: Format a Markdown memory diff comment from two JSON summaries.
+
+Consumes two JSON files produced by ``scripts/memory_diff.py`` — one for the
+PR branch, one for the base branch — and renders a sticky-comment-friendly
+Markdown body suitable for posting via ``actions/github-script``.
+
+The output deliberately starts with a hidden HTML marker
+``<!-- memory-diff:jtn-610 -->`` so the workflow can find and overwrite the
+previous comment on every force-push instead of piling new comments onto
+the PR.
+
+Usage:
+    python scripts/format_memory_diff.py \
+        --base base.json --pr pr.json --output comment.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# The marker is the first line of the comment and is how github-script finds
+# the previous comment to overwrite. Do NOT change without also updating the
+# workflow that looks for it.
+STICKY_MARKER = "<!-- memory-diff:jtn-610 -->"
+
+# Delta (in bytes) above which we flag a row with a warning emoji. 1 MiB is a
+# reasonable "noticeable but not alarming" threshold on the Pi Zero 2 W
+# envelope (total budget is 200 MB idle).
+WARN_DELTA_BYTES = 1 * 1024 * 1024
+
+
+def _fmt_bytes(n: int) -> str:
+    """Render a byte count as a short human-friendly string."""
+    if n == 0:
+        return "0 B"
+    abs_n = abs(n)
+    if abs_n >= 1024 * 1024:
+        return f"{n / (1024 * 1024):.2f} MB"
+    if abs_n >= 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n} B"
+
+
+def _fmt_delta(delta: int) -> str:
+    """Render a signed delta with a leading sign so the column reads naturally."""
+    if delta == 0:
+        return "0"
+    sign = "+" if delta > 0 else ""
+    formatted = f"{sign}{_fmt_bytes(delta)}"
+    if abs(delta) >= WARN_DELTA_BYTES:
+        return f"**{formatted}** :warning:"
+    return formatted
+
+
+def _short_location(loc: str, max_len: int = 60) -> str:
+    """Shorten allocator location strings so the table stays readable.
+
+    memray and tracemalloc emit absolute paths; we keep only the last two
+    path components to avoid a comment that is 200 columns wide.
+    """
+    if not loc:
+        return "<unknown>"
+    # Drop runner-specific absolute path prefix, keep last 2 segments.
+    parts = loc.replace("\\", "/").split("/")
+    tail = "/".join(parts[-2:]) if len(parts) > 1 else parts[-1]
+    if len(tail) > max_len:
+        tail = "..." + tail[-(max_len - 3) :]
+    # Escape markdown pipe characters inside the location string so a
+    # filename containing a pipe cannot break the table rendering.
+    return tail.replace("|", "\\|")
+
+
+def _load(path: Path) -> dict:
+    """Load a JSON summary, returning an empty shell if the file is missing.
+
+    Missing files are tolerated so the formatter can still emit a helpful
+    comment on the very first run when the base-branch measurement hasn't
+    been produced yet (e.g. cache miss + setup flake).
+    """
+    if not path.exists():
+        return {
+            "backend": "unavailable",
+            "total_rss_bytes": 0,
+            "module_count": 0,
+            "allocators": [],
+        }
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        print(
+            f"format_memory_diff: failed to parse {path}: {exc}",
+            file=sys.stderr,
+        )
+        return {
+            "backend": "unavailable",
+            "total_rss_bytes": 0,
+            "module_count": 0,
+            "allocators": [],
+        }
+
+
+def _merge_allocators(base: list[dict], pr: list[dict]) -> list[dict]:
+    """Merge two allocator lists by location, producing union-sorted rows.
+
+    Returns a list of dicts with ``location``, ``base_bytes``, ``pr_bytes``,
+    and ``delta`` keyed fields, sorted by absolute delta descending so the
+    biggest regressors land at the top of the table.
+    """
+    index: dict[str, dict] = {}
+    for entry in base:
+        loc = str(entry.get("location", "<unknown>"))
+        index[loc] = {
+            "location": loc,
+            "base_bytes": int(entry.get("bytes", 0)),
+            "pr_bytes": 0,
+        }
+    for entry in pr:
+        loc = str(entry.get("location", "<unknown>"))
+        if loc in index:
+            index[loc]["pr_bytes"] = int(entry.get("bytes", 0))
+        else:
+            index[loc] = {
+                "location": loc,
+                "base_bytes": 0,
+                "pr_bytes": int(entry.get("bytes", 0)),
+            }
+    rows = list(index.values())
+    for row in rows:
+        row["delta"] = row["pr_bytes"] - row["base_bytes"]
+    rows.sort(key=lambda r: abs(r["delta"]), reverse=True)
+    return rows
+
+
+def format_comment(base: dict, pr: dict, top: int = 20) -> str:
+    """Build the full Markdown comment body.
+
+    The comment has three parts:
+
+    1. Header with the sticky marker + a summary line (total RSS delta,
+       module-count delta, which backend was used).
+    2. A collapsible details block containing the top-N allocator table.
+    3. A footer linking back to JTN-610 so reviewers know where to file
+       bugs about the gate itself.
+    """
+    base_backend = str(base.get("backend", "unavailable"))
+    pr_backend = str(pr.get("backend", "unavailable"))
+
+    base_rss = int(base.get("total_rss_bytes", 0) or 0)
+    pr_rss = int(pr.get("total_rss_bytes", 0) or 0)
+    rss_delta = pr_rss - base_rss
+
+    base_mods = int(base.get("module_count", 0) or 0)
+    pr_mods = int(pr.get("module_count", 0) or 0)
+    mod_delta = pr_mods - base_mods
+
+    rows = _merge_allocators(
+        list(base.get("allocators", [])),
+        list(pr.get("allocators", [])),
+    )[:top]
+
+    lines: list[str] = []
+    lines.append(STICKY_MARKER)
+    lines.append("## Memory diff vs base")
+    lines.append("")
+
+    if base_backend == "unavailable" and pr_backend == "unavailable":
+        lines.append(
+            ":information_source: Memory profiling is not yet available on this "
+            "runner — install `memray` or ensure `tracemalloc` is reachable."
+        )
+        lines.append("")
+        lines.append("<sub>JTN-610 · backend=unavailable</sub>")
+        return "\n".join(lines) + "\n"
+
+    # Summary row — mirrors the `| Total |` row from the issue sketch but
+    # lives in its own compact table so readers can grok the delta at a glance.
+    lines.append("| Metric | Base | PR | Delta |")
+    lines.append("|---|---|---|---|")
+    lines.append(
+        f"| Peak RSS | {_fmt_bytes(base_rss)} | {_fmt_bytes(pr_rss)} "
+        f"| {_fmt_delta(rss_delta)} |"
+    )
+    lines.append(
+        f"| `sys.modules` count | {base_mods} | {pr_mods} | "
+        f"{'+' if mod_delta > 0 else ''}{mod_delta} |"
+    )
+    lines.append("")
+
+    # Collapse the long allocator table by default so the PR conversation
+    # stays skimmable. GitHub renders <details> nicely in comments.
+    lines.append("<details>")
+    lines.append(f"<summary>Top {len(rows)} startup allocators</summary>")
+    lines.append("")
+    lines.append("| # | Location | Base | PR | Delta |")
+    lines.append("|---|---|---|---|---|")
+    if not rows:
+        lines.append("| — | _(no allocators sampled)_ | — | — | — |")
+    else:
+        for i, row in enumerate(rows, 1):
+            lines.append(
+                f"| {i} | `{_short_location(row['location'])}` "
+                f"| {_fmt_bytes(row['base_bytes'])} "
+                f"| {_fmt_bytes(row['pr_bytes'])} "
+                f"| {_fmt_delta(row['delta'])} |"
+            )
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    lines.append(
+        f"<sub>JTN-610 · backend=base:{base_backend}, pr:{pr_backend} · "
+        "informational only, does not block merge. Hard RSS budgets are enforced "
+        "separately by JTN-608.</sub>"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="Base-branch JSON summary")
+    parser.add_argument("--pr", required=True, help="PR-branch JSON summary")
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Path to write the Markdown comment to, or '-' for stdout.",
+    )
+    parser.add_argument("--top", type=int, default=20)
+    args = parser.parse_args(argv)
+
+    base = _load(Path(args.base))
+    pr = _load(Path(args.pr))
+    body = format_comment(base, pr, top=args.top)
+
+    if args.output == "-":
+        sys.stdout.write(body)
+    else:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/memory_diff.py
+++ b/scripts/memory_diff.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""JTN-610: Startup memory profile capture for the per-PR memory diff job.
+
+This helper is invoked twice by ``.github/workflows/memory-diff.yml`` — once
+against the PR branch and once against the base branch — to produce
+comparable JSON summaries of what an ``import inkypi`` actually allocates.
+
+Unlike ``scripts/test_install_memcap.sh`` (JTN-608, which samples RSS of the
+running service), this script profiles the *startup allocator breakdown* so
+a reviewer can see which modules grew at import time. It is deliberately
+orthogonal to the render-exercise RSS gate — JTN-613 tracks fixing that.
+
+Two backends are supported:
+
+* **memray** (preferred) — gives per-file allocation bytes and is much more
+  accurate for C-extension backed allocators like numpy / PIL.
+* **tracemalloc** (stdlib fallback) — always available, per-file aggregated
+  bytes. Used when ``memray`` is not installed (e.g. first-time setup before
+  the lockfile is regenerated).
+
+Output format (stable so ``format_memory_diff.py`` can parse both halves):
+
+    {
+      "backend": "memray" | "tracemalloc",
+      "total_rss_bytes": int,           # best-effort process RSS after import
+      "module_count": int,              # len(sys.modules) after import
+      "allocators": [
+        {"location": "<file>:<line or module>", "bytes": int},
+        ...
+      ]
+    }
+
+Usage:
+    python scripts/memory_diff.py --output pr.json
+    python scripts/memory_diff.py --backend tracemalloc --output base.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src"
+
+# Cap on how many allocators we surface in the diff comment. Matches the
+# acceptance criteria in JTN-610 ("top 20 allocators").
+TOP_N = 20
+
+
+def _startup_env() -> dict[str, str]:
+    """Environment for the child profiling subprocess.
+
+    Mirrors the setup used by ``tests/unit/test_lazy_imports.py`` so the
+    measurement reflects the same startup path that CI's lazy-import gate
+    checks. ``INKYPI_NO_REFRESH=1`` keeps plugin side-effects quiet.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_DIR)
+    env["INKYPI_ENV"] = "dev"
+    env["INKYPI_NO_REFRESH"] = "1"
+    env["PYTHONWARNINGS"] = "ignore"
+    return env
+
+
+def _read_rss_bytes() -> int:
+    """Best-effort RSS read — returns 0 when psutil/resource are unavailable."""
+    try:
+        import resource  # noqa: PLC0415 — stdlib, Linux/macOS only
+
+        rusage = resource.getrusage(resource.RUSAGE_SELF)
+        # Linux reports ru_maxrss in kilobytes; macOS reports in bytes.
+        if sys.platform == "darwin":
+            return int(rusage.ru_maxrss)
+        return int(rusage.ru_maxrss) * 1024
+    except Exception:
+        return 0
+
+
+def _run_tracemalloc() -> dict:
+    """Profile ``import inkypi`` using stdlib tracemalloc.
+
+    Runs in a subprocess so ``sys.modules`` starts empty and tracemalloc
+    captures every module-level allocation done during import.
+    """
+    code = textwrap.dedent("""
+        import json, sys, tracemalloc
+        tracemalloc.start()
+        import inkypi  # noqa: F401 — we only care about the import side effects
+        snapshot = tracemalloc.take_snapshot()
+        stats = snapshot.statistics("filename")
+        allocators = [
+            {"location": str(s.traceback[0]), "bytes": int(s.size)}
+            for s in stats[:100]
+        ]
+        # Best-effort RSS — tracemalloc size is the tracked Python heap, not RSS.
+        rss = 0
+        try:
+            import resource
+            r = resource.getrusage(resource.RUSAGE_SELF)
+            rss = r.ru_maxrss * (1 if sys.platform == "darwin" else 1024)
+        except Exception:
+            pass
+        print(json.dumps({
+            "backend": "tracemalloc",
+            "total_rss_bytes": rss,
+            "module_count": len(sys.modules),
+            "allocators": allocators,
+        }))
+        """)
+    proc = subprocess.run(  # noqa: S603 — trusted stdlib-only snippet
+        [sys.executable, "-c", code],
+        env=_startup_env(),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"tracemalloc probe failed (rc={proc.returncode}).\n"
+            f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
+        )
+    # The subprocess may emit warnings / log lines before the JSON; take the
+    # last non-empty line.
+    last = [line for line in proc.stdout.splitlines() if line.strip()][-1]
+    return json.loads(last)
+
+
+def _run_memray() -> dict:
+    """Profile ``import inkypi`` using memray.
+
+    We shell out to ``memray run`` so the capture file uses the same format
+    as ``memray stats`` expects, then parse ``memray stats --json``.
+    """
+    # Verify memray is actually importable before we try to use it.
+    try:
+        import memray  # noqa: F401,PLC0415
+    except ImportError as exc:
+        raise RuntimeError("memray backend requested but not installed") from exc
+
+    with tempfile.TemporaryDirectory() as tmp:
+        capture = Path(tmp) / "inkypi.bin"
+        # memray refuses to overwrite an existing file; pass -f to be safe.
+        run_cmd = [
+            sys.executable,
+            "-m",
+            "memray",
+            "run",
+            "-f",
+            "-o",
+            str(capture),
+            "-c",
+            "import inkypi",
+        ]
+        proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            run_cmd,
+            env=_startup_env(),
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "memray run failed.\n"
+                f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
+            )
+
+        stats_cmd = [
+            sys.executable,
+            "-m",
+            "memray",
+            "stats",
+            "--json",
+            str(capture),
+        ]
+        stats_proc = subprocess.run(  # noqa: S603 — fixed argv
+            stats_cmd,
+            env=_startup_env(),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if stats_proc.returncode != 0:
+            raise RuntimeError(
+                "memray stats failed.\n"
+                f"stdout:\n{stats_proc.stdout}\n\nstderr:\n{stats_proc.stderr}"
+            )
+
+        # memray stats --json shape: {"total_bytes_allocated": int,
+        #                              "top_locations_by_size": [...]}
+        # Field names vary across versions; handle both "top_locations_by_size"
+        # and "top_allocations_by_size".
+        raw = json.loads(stats_proc.stdout)
+        candidates = (
+            raw.get("top_locations_by_size")
+            or raw.get("top_allocations_by_size")
+            or raw.get("top_locations")
+            or []
+        )
+        allocators: list[dict] = []
+        for entry in candidates[:100]:
+            loc = (
+                entry.get("location")
+                or entry.get("file")
+                or entry.get("name")
+                or "<unknown>"
+            )
+            size = int(
+                entry.get("size") or entry.get("total_bytes") or entry.get("bytes") or 0
+            )
+            allocators.append({"location": str(loc), "bytes": size})
+
+    # Also count modules loaded after import to feed the summary row.
+    module_code = textwrap.dedent("""
+        import json, sys
+        import inkypi  # noqa: F401
+        print(json.dumps({"count": len(sys.modules)}))
+        """)
+    mod_proc = subprocess.run(  # noqa: S603 — fixed argv
+        [sys.executable, "-c", module_code],
+        env=_startup_env(),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    module_count = 0
+    if mod_proc.returncode == 0:
+        last = [line for line in mod_proc.stdout.splitlines() if line.strip()][-1]
+        module_count = int(json.loads(last)["count"])
+
+    return {
+        "backend": "memray",
+        "total_rss_bytes": _read_rss_bytes(),
+        "module_count": module_count,
+        "allocators": allocators,
+    }
+
+
+def _detect_backend(requested: str) -> str:
+    """Resolve the backend request, falling back gracefully.
+
+    ``auto`` prefers memray when importable, else tracemalloc. Explicit
+    ``memray`` / ``tracemalloc`` values are respected if available.
+    """
+    if requested == "tracemalloc":
+        return "tracemalloc"
+    if requested == "memray":
+        try:
+            import memray  # noqa: F401,PLC0415
+        except ImportError:
+            print(
+                "memory_diff: memray requested but not installed; "
+                "falling back to tracemalloc",
+                file=sys.stderr,
+            )
+            return "tracemalloc"
+        return "memray"
+    # auto
+    try:
+        import memray  # noqa: F401,PLC0415
+
+        return "memray"
+    except ImportError:
+        return "tracemalloc"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the JSON summary to.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "memray", "tracemalloc"),
+        default="auto",
+        help="Profiling backend. 'auto' uses memray when available.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=TOP_N,
+        help="Number of top allocators to keep in the output JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    backend = _detect_backend(args.backend)
+    print(f"memory_diff: using backend={backend}", file=sys.stderr)
+
+    result = _run_memray() if backend == "memray" else _run_tracemalloc()
+
+    # Trim to the top-N allocators by bytes before writing.
+    allocators = sorted(
+        result.get("allocators", []),
+        key=lambda a: int(a.get("bytes", 0)),
+        reverse=True,
+    )[: args.top]
+    result["allocators"] = allocators
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2))
+    print(
+        f"memory_diff: wrote {len(allocators)} allocators to {out_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/memory_diff.py
+++ b/scripts/memory_diff.py
@@ -136,12 +136,16 @@ def _run_tracemalloc() -> dict:
 def _run_memray() -> dict:
     """Profile ``import inkypi`` using memray.
 
-    We shell out to ``memray run`` so the capture file uses the same format
-    as ``memray stats`` expects, then parse ``memray stats --json``.
+    Runs ``memray run`` in a subprocess to produce a capture file, then
+    opens it with memray's Python API (``FileReader``) to aggregate
+    high-watermark allocations by source location. The CLI's ``stats``
+    subcommand emits a human-readable report to stdout (not JSON), so we
+    go straight to the API for a stable machine-readable result.
     """
     # Verify memray is actually importable before we try to use it.
     try:
         import memray  # noqa: F401,PLC0415
+        from memray import FileReader  # noqa: PLC0415
     except ImportError as exc:
         raise RuntimeError("memray backend requested but not installed") from exc
 
@@ -173,51 +177,41 @@ def _run_memray() -> dict:
                 f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
             )
 
-        stats_cmd = [
-            sys.executable,
-            "-m",
-            "memray",
-            "stats",
-            "--json",
-            str(capture),
-        ]
-        stats_proc = subprocess.run(  # noqa: S603 — fixed argv
-            stats_cmd,
-            env=_startup_env(),
-            capture_output=True,
-            text=True,
-            timeout=60,
-            check=False,
+        # Aggregate high-watermark allocations by source location using the
+        # FileReader API. ``get_high_watermark_allocation_records`` returns
+        # the set of allocations live at peak RSS — a better signal than
+        # total-ever-allocated because short-lived churn is excluded.
+        reader = FileReader(str(capture))
+        by_location: dict[str, int] = {}
+        records = reader.get_high_watermark_allocation_records(
+            merge_threads=True,
         )
-        if stats_proc.returncode != 0:
-            raise RuntimeError(
-                "memray stats failed.\n"
-                f"stdout:\n{stats_proc.stdout}\n\nstderr:\n{stats_proc.stderr}"
-            )
+        for rec in records:
+            size = int(getattr(rec, "size", 0) or 0)
+            if size <= 0:
+                continue
+            # Try Python-only stack first (always available on Python frames),
+            # then fall back to the hybrid/native stack if the allocation
+            # happened inside a C extension. Each yields (func, file, lineno)
+            # tuples from innermost frame outward.
+            loc = "<unknown>"
+            for stack_method in ("stack_trace", "hybrid_stack_trace"):
+                try:
+                    frames = list(getattr(rec, stack_method)())
+                except Exception:
+                    frames = []
+                if frames:
+                    _func, fname, lineno = frames[0]
+                    loc = f"{fname}:{lineno}"
+                    break
+            by_location[loc] = by_location.get(loc, 0) + size
 
-        # memray stats --json shape: {"total_bytes_allocated": int,
-        #                              "top_locations_by_size": [...]}
-        # Field names vary across versions; handle both "top_locations_by_size"
-        # and "top_allocations_by_size".
-        raw = json.loads(stats_proc.stdout)
-        candidates = (
-            raw.get("top_locations_by_size")
-            or raw.get("top_allocations_by_size")
-            or raw.get("top_locations")
-            or []
-        )
-        allocators: list[dict] = []
-        for entry in candidates[:100]:
-            loc = (
-                entry.get("location")
-                or entry.get("file")
-                or entry.get("name")
-                or "<unknown>"
-            )
-            size = int(
-                entry.get("size") or entry.get("total_bytes") or entry.get("bytes") or 0
-            )
-            allocators.append({"location": str(loc), "bytes": size})
+        allocators: list[dict] = [
+            {"location": loc, "bytes": total}
+            for loc, total in sorted(
+                by_location.items(), key=lambda kv: kv[1], reverse=True
+            )[:100]
+        ]
 
     # Also count modules loaded after import to feed the summary row.
     module_code = textwrap.dedent("""
@@ -298,7 +292,22 @@ def main(argv: list[str] | None = None) -> int:
     backend = _detect_backend(args.backend)
     print(f"memory_diff: using backend={backend}", file=sys.stderr)
 
-    result = _run_memray() if backend == "memray" else _run_tracemalloc()
+    # memray is preferred, but if it blows up (missing method, bad capture,
+    # container sandboxing quirks) we fall back to tracemalloc so the job
+    # still produces *a* comment instead of dying with a traceback. JTN-610
+    # specifically calls out "Tolerant of first-time setup".
+    if backend == "memray":
+        try:
+            result = _run_memray()
+        except Exception as exc:  # noqa: BLE001 — intentional broad fallback
+            print(
+                f"memory_diff: memray backend failed ({exc}); "
+                "falling back to tracemalloc",
+                file=sys.stderr,
+            )
+            result = _run_tracemalloc()
+    else:
+        result = _run_tracemalloc()
 
     # Trim to the top-N allocators by bytes before writing.
     allocators = sorted(

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1076,3 +1076,107 @@ class TestInstallationDocCloudInit:
 
     def test_references_jtn_591(self):
         assert "JTN-591" in self.content
+
+
+# ---- memory-diff workflow ----
+
+
+class TestMemoryDiffWorkflow:
+    """JTN-610: per-PR memory diff sticky comment."""
+
+    WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "memory-diff.yml"
+    SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        assert self.WORKFLOW_PATH.exists(), (
+            f"Expected memory-diff workflow at {self.WORKFLOW_PATH}. "
+            "See JTN-610 for the per-PR memory diff comment design."
+        )
+        self.content = self.WORKFLOW_PATH.read_text()
+
+    def test_workflow_runs_on_pull_requests(self):
+        # Every PR must get a memory diff comment — this is the whole point
+        # of JTN-610. Running on push or schedule instead would defeat the
+        # purpose.
+        assert "pull_request:" in self.content
+
+    def test_workflow_cancels_superseded_runs(self):
+        # A force-push should not stack memory-diff runs on top of each
+        # other; the concurrency group must cancel stale runs so we only
+        # ever post the freshest comment.
+        assert "concurrency:" in self.content
+        assert "cancel-in-progress: true" in self.content
+
+    def test_workflow_references_memray(self):
+        # The preferred backend per JTN-610 is memray. Even though the
+        # helper script falls back to tracemalloc, the workflow should
+        # install memray explicitly so the comment contains the richer
+        # per-allocator breakdown whenever possible.
+        assert "memray" in self.content
+
+    def test_workflow_is_non_blocking(self):
+        # Hard RSS budgets are JTN-608's job. This job must not fail the PR
+        # even when memory regresses — it is informational. Both the job
+        # and every step need to keep going on failure.
+        assert "continue-on-error: true" in self.content
+
+    def test_workflow_invokes_helper_scripts(self):
+        # The workflow must call both the capture helper and the formatter
+        # helper — bypassing them would drift the comment format away from
+        # what the unit tests exercise.
+        assert "scripts/memory_diff.py" in self.content
+        assert "scripts/format_memory_diff.py" in self.content
+
+    def test_workflow_posts_sticky_comment(self):
+        # Uses actions/github-script (or an equivalent sticky-comment
+        # action) and searches by the marker so force-pushes overwrite the
+        # existing comment instead of piling new ones onto the PR.
+        assert "github-script" in self.content or "comment-pull-request" in self.content
+        assert "memory-diff:jtn-610" in self.content
+
+    def test_workflow_grants_pr_write_permission(self):
+        # Posting/updating comments requires pull-requests: write. Without
+        # this the github-script step cannot create the sticky comment.
+        assert "pull-requests: write" in self.content
+
+    def test_workflow_checks_out_base_branch(self):
+        # The diff is only meaningful if we measure both sides — the
+        # workflow must explicitly checkout the base branch.
+        assert "github.base_ref" in self.content
+
+    def test_capture_helper_exists_and_is_valid_python(self):
+        # Structural check that the capture helper is present; we compile
+        # it to catch syntax errors introduced by future edits.
+        helper = self.SCRIPTS_DIR / "memory_diff.py"
+        assert helper.exists(), f"Missing {helper}"
+        compile(helper.read_text(), str(helper), "exec")
+
+    def test_formatter_helper_exists_and_is_valid_python(self):
+        helper = self.SCRIPTS_DIR / "format_memory_diff.py"
+        assert helper.exists(), f"Missing {helper}"
+        compile(helper.read_text(), str(helper), "exec")
+
+    def test_formatter_uses_stable_sticky_marker(self):
+        # The marker is the contract between the formatter and the
+        # workflow. If either side changes it without the other the
+        # sticky-comment overwrite logic silently regresses to spam mode.
+        formatter = (self.SCRIPTS_DIR / "format_memory_diff.py").read_text()
+        assert 'STICKY_MARKER = "<!-- memory-diff:jtn-610 -->"' in formatter
+
+    def test_capture_helper_supports_both_backends(self):
+        # memray is preferred but tracemalloc is the graceful fallback
+        # when memray is missing (JTN-610: tolerant of first-time setup).
+        capture = (self.SCRIPTS_DIR / "memory_diff.py").read_text()
+        assert "memray" in capture
+        assert "tracemalloc" in capture
+
+    def test_memray_listed_in_requirements_dev_in(self):
+        # The lockfile regen happens under JTN-597's advisory
+        # lockfile-drift check, but the .in file must be updated so the
+        # next regen picks up memray for future PRs.
+        content = (INSTALL_DIR / "requirements-dev.in").read_text()
+        assert "memray" in content, (
+            "memray must be declared in install/requirements-dev.in so the "
+            "memory-diff workflow can install it from the lockfile."
+        )


### PR DESCRIPTION
## Summary

Every PR now gets a sticky comment showing how its startup allocator breakdown compares to the base branch — an early-warning signal for slow memory creep that JTN-608's hard RSS budgets would only catch after cumulative damage.

- New `scripts/memory_diff.py` profiles `import inkypi` under **memray** (preferred) or stdlib **tracemalloc** (fallback) and emits a stable JSON summary with the top 20 allocators, peak RSS, and `sys.modules` count.
- New `scripts/format_memory_diff.py` diffs two JSON summaries and renders a collapsible Markdown table with a hidden sticky marker so force-pushes overwrite the existing comment instead of spamming new ones.
- New `.github/workflows/memory-diff.yml` runs on every `pull_request` (opened/synchronize/reopened), measures both branches via `git worktree add`, uploads raw JSON as an artifact, and posts/updates the sticky comment via `actions/github-script`. Marked `continue-on-error: true` so it **never blocks the PR** — JTN-608 owns the hard budgets.
- `install/requirements-dev.in` now declares `memray` (Linux only) so the next lockfile regen picks it up; CI installs it explicitly in the meantime.

## Why this is orthogonal to JTN-613

JTN-613 is an open follow-up to JTN-608 where the render-exercise RSS gate short-circuits on `--web-only`. This PR deliberately measures the **startup allocator breakdown** (what `import inkypi` allocates), not the render loop, so it's unaffected by that bug.

## Test plan

- [x] `scripts/lint.sh` passes (ruff + black clean)
- [x] `tests/unit/test_install_scripts.py::TestMemoryDiffWorkflow` — 13 new structural assertions covering workflow triggers, non-blocking posture, sticky marker contract, and helper script presence
- [x] Full test suite: `SKIP_BROWSER=1 pytest tests/` — 3475 passed (2 pre-existing failures in `test_plugin_registry.py` unrelated to this change, confirmed present on main)
- [x] `memory_diff.py` + `format_memory_diff.py` exercised locally via tracemalloc backend (memray not installed on macOS dev)
- [ ] The memory-diff workflow itself should show up on this PR within a few minutes of opening — dogfood target

Closes JTN-610.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>