### PR TITLE
ci: promote JTN-609 install crash-loop test to a mandatory CI gate (JTN-614)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,9 +638,40 @@ jobs:
           path: /tmp/inkypi-smoke-logs
           if-no-files-found: ignore
 
+  install-crash-loop-gate:
+    name: Install crash-loop regression gate
+    # JTN-614: runs the JTN-609 Docker-based regression gate that verifies
+    # JTN-600 (systemctl disable during install) and JTN-607 (install-in-progress
+    # lockfile) both prevent a mid-install crash from spawning a restart loop
+    # that would OOM a Pi Zero 2 W. The test auto-skips without Docker, so we
+    # set REQUIRE_INSTALL_CRASH_LOOP_TEST=1 to force it on CI.
+    needs: tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            install/requirements.txt
+            install/requirements-dev.txt
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r install/requirements.txt -r install/requirements-dev.txt
+      - name: Run install crash-loop regression gate
+        env:
+          REQUIRE_INSTALL_CRASH_LOOP_TEST: '1'
+          PYTHONPATH: src
+        run: |
+          pytest tests/integration/test_install_crash_loop.py -v
+
   ci-gate:
     name: CI gate (all checks pass)
-    needs: [lint, shellcheck, lockfile-drift, tests, sonarcloud, smoke, smoke-matrix, coverage-gate, security, browser-smoke, install-smoke-memcap]
+    needs: [lint, shellcheck, lockfile-drift, tests, sonarcloud, smoke, smoke-matrix, coverage-gate, security, browser-smoke, install-smoke-memcap, install-crash-loop-gate]
     # lockfile-drift is included in needs so the gate waits for it, but it is
     # treated as advisory (not listed in the required-success loop below) until
     # requirements.txt is regenerated. See JTN-597.
@@ -658,7 +689,7 @@ jobs:
           # Jobs that must be 'success'
           # lockfile-drift is advisory (continue-on-error); not in this list.
           # Add it here once requirements.txt is refreshed under the pinned Python version.
-          for job in lint shellcheck tests smoke smoke-matrix coverage-gate security browser-smoke install-smoke-memcap; do
+          for job in lint shellcheck tests smoke smoke-matrix coverage-gate security browser-smoke install-smoke-memcap install-crash-loop-gate; do
             result=$(echo "$results" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$job',{}).get('result','missing'))")
             if [ "$result" != "success" ]; then
               echo "Required job '$job' did not succeed (result: $result)"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -139,6 +139,8 @@ The gate runs in under 60 s on a developer laptop and asserts three invariants:
 
 If you are intentionally changing `install.sh`'s `stop_service()` function or `install/inkypi.service`'s `ExecStartPre` guard, expect this test to need updating — and be prepared to explain in the PR description how the Pi-thrash cascade (JTN-609 context) is still prevented.
 
+The gate runs automatically in CI via the `install-crash-loop-gate` job (see `.github/workflows/ci.yml`), which sets `REQUIRE_INSTALL_CRASH_LOOP_TEST=1` so the skip-without-Docker fallback is force-disabled. It is listed in the `ci-gate` required-success loop, so a regression will block merge (JTN-614).
+
 ---
 
 ### CI


### PR DESCRIPTION
## Summary

JTN-609 (PR #338, `4ec7921b`) landed `tests/integration/test_install_crash_loop.py` but left it auto-skipping on runners without Docker to avoid a merge conflict with JTN-608's parallel edits to `scripts/test_install_memcap.sh`. Both are now merged; this wires the crash-loop test in as a **blocking** CI gate.

## Changes

- **`.github/workflows/ci.yml`** — new `install-crash-loop-gate` job on `ubuntu-latest` with 10 min timeout. Sets `REQUIRE_INSTALL_CRASH_LOOP_TEST=1` so the test fails hard if Docker is missing instead of silently skipping. `needs: tests` (runs after the pytest matrix).
- **`ci-gate`** — added `install-crash-loop-gate` to `needs:` and to the required-success loop (line 661) alongside `install-smoke-memcap`. A regression that reverts JTN-600 or JTN-607 now blocks merge.
- **`docs/testing.md`** — documented the CI hookup in the existing "Pi thrash protection regression gate" section.

## Why this matters

The JTN-609 test runs a Docker container that installs `inkypi.service` verbatim, stubs the `ExecStart` to mimic `ModuleNotFoundError: flask`, creates the `/var/lib/inkypi/.install-in-progress` lockfile, and confirms systemd's `ExecStartPre` refuses to start the service. Per the JTN-609 agent's report, the test:

- Passes on clean main (`NRestarts=2`, `ExecMainPID=0`, stub marker absent).
- **Fails** under a synthetic JTN-607 revert (`ExecMainPID=132`, stub marker appears, test reports `FAIL: ExecStart ran while install-in-progress lockfile was present`).
- Completes in ~55s on a developer laptop; 10 min CI timeout is generous padding for container build + QEMU overhead.

## Test plan

- [ ] New `install-crash-loop-gate` job appears in this PR's CI status
- [ ] Job passes (confirms the test actually runs under `REQUIRE_INSTALL_CRASH_LOOP_TEST=1`)
- [ ] `CI gate (all checks pass)` stays green overall (both old and new required jobs succeed)
- [ ] `scripts/lint.sh` clean (ruff + black + shellcheck + mypy strict subset)

Closes JTN-614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)