### PR TITLE
fix(settings): enforce HTML5 validation before Save submit (JTN-350)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -119,6 +119,12 @@
     // Dirty-state tracking for the Save button
     let _formSnapshot = null;
 
+    function isFormValid() {
+      const form = document.querySelector(".settings-form");
+      if (!form || typeof form.checkValidity !== "function") return true;
+      return form.checkValidity();
+    }
+
     function checkDirty() {
       const saveBtn = document.getElementById("saveSettingsBtn");
       if (!saveBtn || !_formSnapshot) return;
@@ -128,7 +134,11 @@
       for (const key of allKeys) {
         if (_formSnapshot[key] !== current[key]) { dirty = true; break; }
       }
-      saveBtn.disabled = !dirty;
+      // JTN-350: Save must be enabled only when the form is BOTH dirty AND
+      // satisfies all HTML5 constraints (required, min, max, etc.). This
+      // prevents users from clicking Save with `deviceName` empty or
+      // `interval=-5` and only learning about the problem from server toasts.
+      saveBtn.disabled = !(dirty && isFormValid());
     }
 
     async function appendGeoData(formData) {
@@ -153,6 +163,18 @@
     async function handleAction() {
       const form = document.querySelector(".settings-form");
       const saveBtn = document.getElementById("saveSettingsBtn");
+      // JTN-350: Always enforce HTML5 constraint validation before contacting
+      // the server. Even if the Save button slipped through the disabled
+      // gate (e.g. dispatched programmatically), reportValidity() shows the
+      // browser's native :invalid popup and focuses the first invalid field.
+      if (form && typeof form.checkValidity === "function" && !form.checkValidity()) {
+        if (typeof form.reportValidity === "function") form.reportValidity();
+        const firstInvalid = form.querySelector(":invalid");
+        if (firstInvalid && typeof firstInvalid.focus === "function") {
+          firstInvalid.focus();
+        }
+        return;
+      }
       if (saveBtn?.disabled) {
         showResponseModal("success", "No changes to save.");
         return;

--- a/tests/static/test_settings_save_validation.py
+++ b/tests/static/test_settings_save_validation.py
@@ -1,0 +1,107 @@
+"""Tests for HTML5 client-side validation enforcement on the Settings Save button (JTN-350).
+
+Background
+----------
+Before the fix, ``settings_page.js`` only checked dirty-state in ``checkDirty``
+and ``handleAction`` shipped the form to the server without ever calling
+``form.checkValidity()``. Users could clear ``deviceName`` (a ``required``
+field) or set ``interval=-5`` (which has ``min="1"``) and the only feedback
+they received was a server-side error toast — never the browser's native
+HTML5 validation popup.
+
+These static-analysis tests pin the fix in place by verifying that:
+
+1. ``checkDirty`` calls ``checkValidity`` (or its helper) so the button
+   remains disabled while the form is invalid.
+2. ``handleAction`` calls ``checkValidity`` and ``reportValidity`` to trigger
+   the native browser balloon and bail out before contacting the server.
+3. The ``settings.html`` template still declares the HTML5 constraints that
+   the JS now enforces (regression guard for the inputs the bug exercised).
+"""
+
+from pathlib import Path
+
+JS_PATH = Path("src/static/scripts/settings_page.js")
+HTML_PATH = Path("src/templates/settings.html")
+
+
+def _read_js() -> str:
+    return JS_PATH.read_text()
+
+
+def _read_html() -> str:
+    return HTML_PATH.read_text()
+
+
+def test_check_dirty_enforces_form_validity():
+    """JTN-350: Save must stay disabled while ``form.checkValidity()`` is false.
+
+    The dirty-check is the gate that enables the Save button as the user
+    edits the form. After JTN-350 it must also require validity, otherwise
+    the button enables on the first keystroke even when ``deviceName`` is
+    blank or ``interval`` is negative.
+    """
+    js = _read_js()
+    # The fix introduces an isFormValid helper that wraps form.checkValidity().
+    assert "isFormValid" in js, "Expected an isFormValid helper guarding Save"
+    assert "form.checkValidity()" in js, (
+        "checkDirty must consult form.checkValidity() so the Save button "
+        "stays disabled while the form violates HTML5 constraints"
+    )
+    # And the disabled assignment must combine dirty AND validity.
+    assert "dirty && isFormValid()" in js, (
+        "Save button must be enabled only when the form is BOTH dirty and "
+        "valid; otherwise users can still click Save with bad input"
+    )
+
+
+def test_handle_action_calls_report_validity_before_submit():
+    """JTN-350: handleAction must trigger the browser's native popup on click.
+
+    Even when the disabled gate is bypassed (e.g. by programmatic click),
+    handleAction must call reportValidity() to show the native :invalid
+    balloon and return early before fetching the save endpoint.
+    """
+    js = _read_js()
+    assert "form.reportValidity()" in js, (
+        "handleAction must call form.reportValidity() so users see the "
+        "native HTML5 validation popup on Save click"
+    )
+    # The reportValidity call must precede the fetch — verify ordering.
+    report_idx = js.find("form.reportValidity()")
+    fetch_idx = js.find("config.saveSettingsUrl")
+    assert report_idx != -1 and fetch_idx != -1
+    assert report_idx < fetch_idx, (
+        "reportValidity must run BEFORE the save fetch so the server is "
+        "never contacted with invalid form data"
+    )
+
+
+def test_handle_action_focuses_first_invalid_field():
+    """The first ``:invalid`` field should receive focus when Save is blocked."""
+    js = _read_js()
+    assert ":invalid" in js, (
+        "handleAction should query for ':invalid' to focus the first "
+        "invalid field after blocking submission"
+    )
+
+
+def test_settings_form_declares_required_constraints():
+    """Regression guard: the constraints the JS now enforces must still exist.
+
+    If a future refactor strips ``required`` from ``deviceName`` or ``min="1"``
+    from ``interval``, the JS gate becomes a no-op and JTN-350 silently
+    regresses. Pin the constraints here so that change is forced to be
+    deliberate.
+    """
+    html = _read_html()
+    # deviceName must remain required
+    assert 'id="deviceName"' in html
+    assert 'name="deviceName"' in html
+    device_line = next(line for line in html.splitlines() if 'id="deviceName"' in line)
+    assert "required" in device_line, "deviceName must remain required"
+
+    # interval must remain required with min="1"
+    interval_line = next(line for line in html.splitlines() if 'id="interval"' in line)
+    assert "required" in interval_line, "interval must remain required"
+    assert 'min="1"' in interval_line, 'interval must keep min="1"'


### PR DESCRIPTION
## Summary

Fixes [JTN-350](https://linear.app/jtn0123/issue/JTN-350): Settings Save button bypassed HTML5 client-side validation.

- **`checkDirty` now requires BOTH dirty state AND `form.checkValidity()`** so the Save button stays disabled the moment any constraint (e.g. empty `deviceName`, `interval=-5`) is violated. The existing input/change listeners already re-run the gate on every keystroke.
- **`handleAction` now calls `form.checkValidity()` and `form.reportValidity()` before posting**, so the browser's native `:invalid` balloon fires and the first invalid field receives focus. This is a defense in depth in case the disabled gate is bypassed (e.g. programmatic click).
- Static-analysis test pins the helper, the validity gate, the `reportValidity` call ordering, and the underlying HTML5 constraints on `deviceName` / `interval`.

Frontend-only fix; no backend changes.

## Test plan

- [x] `scripts/lint.sh` clean (ruff + black + shellcheck)
- [x] `pytest tests/static/test_settings_save_validation.py` (4 new tests pass)
- [x] `pytest tests/static/test_settings_interval_display.py` (regression guard)
- [x] `pytest tests/ -k settings` — 490 passed, 0 failed
- [ ] Manual: clear `deviceName` → Save stays disabled; click programmatically → native popup fires
- [ ] Manual: set `interval=-5` → Save stays disabled; popup fires on bypass