### PR TITLE
fix: validate NASA APOD date range (1995-06-16..today) (JTN-379)

### DIFF
--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -7,7 +7,7 @@ For the API key, set `NASA_SECRET={API_KEY}` in your .env file.
 
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from io import BytesIO
 from random import randint
 
@@ -19,8 +19,43 @@ from utils.http_client import get_http_session
 
 logger = logging.getLogger(__name__)
 
+# NASA's Astronomy Picture of the Day archive begins on 1995-06-16. Requesting
+# any date earlier than this — or any future date — returns a 404 from the
+# upstream API, so we reject such values at save time rather than letting the
+# bad config persist until ``generate_image`` runs.
+_APOD_MIN_DATE = date(1995, 6, 16)
+
 
 class Apod(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject out-of-range custom dates at save time (JTN-379).
+
+        The frontend ``<input type="date">`` enforces ``min``/``max``, but a
+        direct POST can still bypass it. Without server-side validation a bad
+        date persists with a success toast and only fails later when the
+        plugin tries to fetch a non-existent APOD from NASA.
+        """
+        if settings.get("randomizeApod") == "true":
+            # Random mode picks its own date — ignore customDate.
+            return None
+        custom_date_str = (settings.get("customDate") or "").strip()
+        if not custom_date_str:
+            # No custom date set — ``generate_image`` falls back to today.
+            return None
+        try:
+            parsed = date.fromisoformat(custom_date_str)
+        except ValueError:
+            return f"Invalid date format: {custom_date_str!r} (expected YYYY-MM-DD)"
+        today = date.today()
+        if parsed < _APOD_MIN_DATE:
+            return (
+                f"Date must be on or after {_APOD_MIN_DATE.isoformat()} "
+                "(NASA APOD archive start)."
+            )
+        if parsed > today:
+            return f"Date must be on or before today ({today.isoformat()})."
+        return None
+
     def build_settings_schema(self):
         today = datetime.today().strftime("%Y-%m-%d")
         return schema(
@@ -44,6 +79,12 @@ class Apod(BasePlugin):
                     "date",
                     label="Date",
                     default=today,
+                    min=_APOD_MIN_DATE.isoformat(),
+                    max=today,
+                    hint=(
+                        f"NASA APOD archive runs from {_APOD_MIN_DATE.isoformat()} "
+                        "to today."
+                    ),
                     visible_if={"field": "randomizeApod", "equals": "false"},
                 ),
             )

--- a/tests/plugins/test_apod_validation.py
+++ b/tests/plugins/test_apod_validation.py
@@ -1,0 +1,148 @@
+# pyright: reportMissingImports=false
+"""JTN-379: validate_settings + min/max date constraints for the APOD plugin.
+
+Prior behavior silently accepted any ``customDate`` (e.g. ``1900-01-01`` or
+``2099-12-31``), surfacing the failure later when the plugin tried to fetch a
+non-existent APOD from NASA's API. The archive begins on 1995-06-16 and
+obviously cannot return future dates, so we now reject out-of-range values at
+save time and constrain the date input client-side via ``min``/``max``.
+"""
+
+from datetime import date, timedelta
+
+
+def _make_plugin():
+    from plugins.apod.apod import Apod
+
+    return Apod({"id": "apod"})
+
+
+def test_validate_settings_empty_custom_date_returns_none():
+    plugin = _make_plugin()
+    assert plugin.validate_settings({}) is None
+    assert plugin.validate_settings({"customDate": ""}) is None
+    assert plugin.validate_settings({"customDate": "   "}) is None
+
+
+def test_validate_settings_randomize_ignores_custom_date():
+    plugin = _make_plugin()
+    # Random mode supplies its own date — bad customDate must not block save.
+    assert (
+        plugin.validate_settings({"randomizeApod": "true", "customDate": "1900-01-01"})
+        is None
+    )
+
+
+def test_validate_settings_pre_archive_returns_error():
+    plugin = _make_plugin()
+    err = plugin.validate_settings({"customDate": "1994-12-31"})
+    assert err is not None
+    assert "1995-06-16" in err
+
+
+def test_validate_settings_far_future_returns_error():
+    plugin = _make_plugin()
+    err = plugin.validate_settings({"customDate": "2099-12-31"})
+    assert err is not None
+    today = date.today().isoformat()
+    assert today in err
+
+
+def test_validate_settings_tomorrow_returns_error():
+    plugin = _make_plugin()
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    err = plugin.validate_settings({"customDate": tomorrow})
+    assert err is not None
+    assert date.today().isoformat() in err
+
+
+def test_validate_settings_archive_start_boundary_returns_none():
+    plugin = _make_plugin()
+    assert plugin.validate_settings({"customDate": "1995-06-16"}) is None
+
+
+def test_validate_settings_today_boundary_returns_none():
+    plugin = _make_plugin()
+    today = date.today().isoformat()
+    assert plugin.validate_settings({"customDate": today}) is None
+
+
+def test_validate_settings_invalid_format_returns_error():
+    plugin = _make_plugin()
+    err = plugin.validate_settings({"customDate": "not-a-date"})
+    assert err is not None
+    assert "format" in err.lower() or "invalid" in err.lower()
+
+
+def test_validate_settings_partial_date_returns_error():
+    plugin = _make_plugin()
+    err = plugin.validate_settings({"customDate": "2024-13-40"})
+    assert err is not None
+
+
+def test_settings_schema_advertises_min_and_max():
+    """Ensure the schema sets min=1995-06-16 and max=today on the date field."""
+    plugin = _make_plugin()
+    s = plugin.build_settings_schema()
+    custom_date_field = None
+    for section in s["sections"]:
+        for item in section["items"]:
+            if item.get("kind") == "field" and item.get("name") == "customDate":
+                custom_date_field = item
+                break
+    assert custom_date_field is not None
+    assert custom_date_field.get("type") == "date"
+    assert custom_date_field.get("min") == "1995-06-16"
+    assert custom_date_field.get("max") == date.today().isoformat()
+
+
+def test_settings_template_renders_min_and_max(client):
+    """The rendered settings page must include min/max attributes (JTN-379)."""
+    resp = client.get("/plugin/apod")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'min="1995-06-16"' in body
+    assert f'max="{date.today().isoformat()}"' in body
+
+
+def test_save_plugin_settings_rejects_pre_archive_date(client):
+    """JTN-379: POST /save_plugin_settings with pre-1995 date returns 400."""
+    data = {
+        "plugin_id": "apod",
+        "randomizeApod": "false",
+        "customDate": "1900-01-01",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    msg = body.get("error") or body.get("message") or ""
+    assert "1995-06-16" in msg
+
+
+def test_save_plugin_settings_rejects_future_date(client):
+    """JTN-379: POST /save_plugin_settings with a far-future date returns 400."""
+    data = {
+        "plugin_id": "apod",
+        "randomizeApod": "false",
+        "customDate": "2099-12-31",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    msg = body.get("error") or body.get("message") or ""
+    assert date.today().isoformat() in msg
+
+
+def test_save_plugin_settings_accepts_valid_date(client):
+    """JTN-379: a date inside the [1995-06-16, today] window saves successfully."""
+    data = {
+        "plugin_id": "apod",
+        "randomizeApod": "false",
+        "customDate": "2020-07-20",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 200
+    body = resp.get_json() or {}
+    assert body.get("success") is True


### PR DESCRIPTION
## Summary
- Adds `validate_settings` to the APOD plugin that rejects custom dates outside the `[1995-06-16, today]` window (NASA's APOD archive begins on 1995-06-16; future dates have no entry).
- Adds `min="1995-06-16"` and `max="{today}"` to the date input via the schema field, so the browser also enforces the range and shows an immediate hint.
- Both changes mirror the JTN-354 (Weather lat/lon) and JTN-355 (Image Folder path) pattern: fail-fast at save time instead of letting bad config persist with a success toast.

## Test plan
- [x] `validate_settings` returns `None` for empty/whitespace `customDate`
- [x] `validate_settings` ignores `customDate` when `randomizeApod=true`
- [x] `validate_settings` rejects `1994-12-31` with a message mentioning `1995-06-16`
- [x] `validate_settings` rejects `2099-12-31` and tomorrow with a message mentioning today
- [x] Boundary dates `1995-06-16` and today both pass
- [x] `not-a-date` and `2024-13-40` rejected as invalid format
- [x] Schema sets `min`/`max` on the `customDate` field
- [x] `/plugin/apod` settings page renders `min="1995-06-16"` and `max="<today>"`
- [x] `POST /save_plugin_settings` returns 400 for `1900-01-01` and `2099-12-31`
- [x] `POST /save_plugin_settings` returns 200 for a valid date inside the window
- [x] All 26 apod-related tests pass; lint clean (ruff + black)

Closes JTN-379

Generated with Claude Code