### PR TITLE
fix(rss): validate RSS feed URL on client and server (JTN-380)

### DIFF
--- a/src/plugins/rss/rss.py
+++ b/src/plugins/rss/rss.py
@@ -1,6 +1,7 @@
 import html
 import logging
 import re
+from urllib.parse import urlparse
 
 import feedparser
 
@@ -19,8 +20,40 @@ logger = logging.getLogger(__name__)
 
 FONT_SIZES = {"x-small": 0.7, "small": 0.9, "normal": 1, "large": 1.1, "x-large": 1.3}
 
+# Only http(s) feeds are supported; anything else (file://, javascript:, ftp://,
+# bare strings like "not-a-feed") is rejected at save time so the user sees the
+# problem immediately instead of discovering it later when generate_image runs.
+_ALLOWED_FEED_SCHEMES = frozenset({"http", "https"})
+
 
 class Rss(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject non-URL RSS feed values at save time (JTN-380).
+
+        The frontend ``<input type="url">`` enforces a URL-shaped value, but a
+        direct POST can still bypass it. Without server-side validation a bad
+        feed URL (e.g. ``definitely-not-a-feed-url``) persists with a success
+        toast and only fails later when the plugin tries to fetch the feed.
+        """
+        feed_url = (settings.get("feedUrl") or "").strip()
+        if not feed_url:
+            # ``required=True`` + validate_plugin_required_fields already
+            # rejects missing values with its own error message.
+            return None
+        try:
+            parsed = urlparse(feed_url)
+        except ValueError:
+            return f"Invalid RSS Feed URL: {feed_url!r}"
+        scheme = (parsed.scheme or "").lower()
+        if scheme not in _ALLOWED_FEED_SCHEMES:
+            return (
+                "RSS Feed URL must start with http:// or https:// "
+                f"(got {feed_url!r})."
+            )
+        if not parsed.netloc:
+            return f"RSS Feed URL is missing a host: {feed_url!r}"
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(
@@ -53,9 +86,11 @@ class Rss(BasePlugin):
                 ),
                 field(
                     "feedUrl",
+                    "url",
                     label="RSS Feed URL",
                     placeholder="https://example.com/feed.xml",
                     required=True,
+                    hint="Must start with http:// or https://",
                 ),
                 callout(
                     "Only use trusted RSS feeds. Untrusted URLs can introduce security and reliability risks.",

--- a/tests/plugins/test_rss_validation.py
+++ b/tests/plugins/test_rss_validation.py
@@ -1,0 +1,152 @@
+# pyright: reportMissingImports=false
+"""JTN-380: URL validation for the RSS plugin's feed URL field.
+
+Prior behavior silently accepted any non-empty string (e.g.
+``definitely-not-a-feed-url``), surfacing the failure later when
+``generate_image`` tried to fetch the feed. We now reject non-http(s) URLs at
+save time and render the input as ``type="url"`` for client-side feedback.
+"""
+
+import pytest
+
+
+def _make_plugin():
+    from plugins.rss.rss import Rss
+
+    return Rss({"id": "rss"})
+
+
+# ---------- validate_settings unit tests ----------
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "definitely-not-a-feed-url",
+        "not-a-url",
+        "example.com/feed",  # missing scheme
+        "ftp://example.com/feed",
+        "javascript:alert(1)",
+        "file:///etc/passwd",
+        "://example.com",  # empty scheme
+    ],
+)
+def test_validate_settings_rejects_non_http_urls(bad_url):
+    plugin = _make_plugin()
+    err = plugin.validate_settings({"feedUrl": bad_url})
+    assert err is not None
+    assert "http" in err.lower() or "invalid" in err.lower() or "host" in err.lower()
+
+
+@pytest.mark.parametrize(
+    "good_url",
+    [
+        "https://example.com/feed.xml",
+        "http://example.com/rss",
+        "https://news.ycombinator.com/rss",
+        "HTTP://Example.com/feed",  # uppercase scheme still ok
+    ],
+)
+def test_validate_settings_accepts_http_https_urls(good_url):
+    plugin = _make_plugin()
+    assert plugin.validate_settings({"feedUrl": good_url}) is None
+
+
+def test_validate_settings_empty_feed_url_returns_none():
+    """Empty/missing feedUrl is handled by the required-field validator.
+
+    ``validate_settings`` must not double-report the same error, so it returns
+    ``None`` and defers to the upstream required-field check.
+    """
+    plugin = _make_plugin()
+    assert plugin.validate_settings({}) is None
+    assert plugin.validate_settings({"feedUrl": ""}) is None
+    assert plugin.validate_settings({"feedUrl": "   "}) is None
+
+
+def test_validate_settings_rejects_url_without_host():
+    plugin = _make_plugin()
+    err = plugin.validate_settings({"feedUrl": "https://"})
+    assert err is not None
+
+
+# ---------- schema / template tests ----------
+
+
+def test_settings_schema_feed_url_is_url_type():
+    plugin = _make_plugin()
+    s = plugin.build_settings_schema()
+    feed_url_field = None
+    for section in s["sections"]:
+        for item in section["items"]:
+            if item.get("kind") == "field" and item.get("name") == "feedUrl":
+                feed_url_field = item
+                break
+    assert feed_url_field is not None, "feedUrl field missing from schema"
+    assert feed_url_field.get("type") == "url"
+    assert feed_url_field.get("required") is True
+
+
+def test_settings_template_renders_url_input(client):
+    """The rendered RSS settings page must use ``<input type="url">`` (JTN-380)."""
+    resp = client.get("/plugin/rss")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # The feedUrl input should advertise type="url" so HTML5 validation kicks in.
+    assert 'name="feedUrl"' in body
+    assert 'type="url"' in body
+
+
+# ---------- save_plugin_settings integration tests ----------
+
+
+def test_save_plugin_settings_rejects_non_url_feed(client):
+    """JTN-380: POST with a bare-string feed URL returns 400."""
+    data = {
+        "plugin_id": "rss",
+        "title": "Test Feed",
+        "feedUrl": "definitely-not-a-feed-url",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    msg = body.get("error") or body.get("message") or ""
+    assert "http" in msg.lower() or "invalid" in msg.lower()
+
+
+def test_save_plugin_settings_rejects_javascript_scheme(client):
+    """JTN-380: javascript: URLs must be rejected server-side."""
+    data = {
+        "plugin_id": "rss",
+        "title": "Test Feed",
+        "feedUrl": "javascript:alert(1)",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+
+
+def test_save_plugin_settings_rejects_ftp_scheme(client):
+    """JTN-380: ftp:// URLs must be rejected server-side."""
+    data = {
+        "plugin_id": "rss",
+        "title": "Test Feed",
+        "feedUrl": "ftp://example.com/feed",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 400
+
+
+def test_save_plugin_settings_accepts_https_feed(client):
+    """JTN-380: valid https feeds save successfully."""
+    data = {
+        "plugin_id": "rss",
+        "title": "Test Feed",
+        "feedUrl": "https://example.com/feed.xml",
+    }
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == 200
+    body = resp.get_json() or {}
+    assert body.get("success") is True


### PR DESCRIPTION
## Summary

- Adds `validate_settings` hook to the RSS plugin that rejects non-http(s) feed URLs at save time (e.g. `definitely-not-a-feed-url`, `ftp://...`, `javascript:alert(1)`, `file:///etc/passwd`)
- Changes the `feedUrl` schema field to `type="url"` with a hint so HTML5 validation kicks in before the POST
- Matches the JTN-379 precedent (commit `b246328`)

Fixes JTN-380.

## Files changed

- `src/plugins/rss/rss.py` — new `validate_settings` (urlparse-based http/https check) + `feedUrl` schema type="url" + hint
- `tests/plugins/test_rss_validation.py` — 19 tests (parametrized over bad/good URLs, schema shape, rendered template type="url", `/save_plugin_settings` 400/200 round trip)

## Test plan

- [x] 19/19 new RSS validation tests pass
- [x] Full test suite clean (3599 passed, 4 skipped; 2 pre-existing pyenv-env failures unrelated)
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck + mypy strict subset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * RSS plugin now includes enhanced feed URL validation that rejects malformed URLs, unsupported protocols, and invalid URL structures, providing clear error messages during configuration.
  * Updated the feed URL settings field to explicitly indicate it requires HTTP or HTTPS protocols, improving user guidance and preventing common configuration mistakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->