### PR TITLE
fix(settings): make sticky Save button selector match real DOM (JTN-572)

### DIFF
--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -6062,7 +6062,7 @@ body.modal-open {
         min-height: 180px;
     }
 
-    .settings-panel > .buttons-container,
+    .settings-panel .buttons-container,
     .api-keys-frame .buttons-container {
         position: sticky;
         bottom: 8px;
@@ -6446,7 +6446,7 @@ body.modal-open {
    buttons container to the bottom of the viewport so the primary action is
    always one click away regardless of scroll position. */
 @media (max-height: 860px) {
-    .settings-panel > .buttons-container,
+    .settings-panel .buttons-container,
     .api-keys-frame .buttons-container {
         position: sticky;
         bottom: 8px;

--- a/src/static/styles/partials/_responsive.css
+++ b/src/static/styles/partials/_responsive.css
@@ -693,7 +693,7 @@
         min-height: 180px;
     }
 
-    .settings-panel > .buttons-container,
+    .settings-panel .buttons-container,
     .api-keys-frame .buttons-container {
         position: sticky;
         bottom: 8px;
@@ -1077,7 +1077,7 @@
    buttons container to the bottom of the viewport so the primary action is
    always one click away regardless of scroll position. */
 @media (max-height: 860px) {
-    .settings-panel > .buttons-container,
+    .settings-panel .buttons-container,
     .api-keys-frame .buttons-container {
         position: sticky;
         bottom: 8px;

--- a/tests/integration/test_settings_routes.py
+++ b/tests/integration/test_settings_routes.py
@@ -146,3 +146,34 @@ def test_settings_page_image_sliders_present(client):
         assert (
             slider_name.encode() in resp.data
         ), f"Slider '{slider_name}' missing from settings page"
+
+
+def test_settings_responsive_css_sticky_save_selector_matches_real_dom():
+    """JTN-572: the Save button must actually become sticky on /settings.
+
+    The earlier JTN-599 rule used ``.settings-panel > .buttons-container`` (child
+    combinator), but the settings DOM nests the buttons-container inside
+    ``.settings-console-main``, so the selector matched zero elements and the
+    sticky rule was dead on /settings. The fix is a descendant combinator.
+    """
+    from pathlib import Path
+
+    css_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "styles"
+        / "partials"
+        / "_responsive.css"
+    )
+    content = css_path.read_text(encoding="utf-8")
+    assert ".settings-panel .buttons-container" in content, (
+        "JTN-572: _responsive.css must pin the Save button on /settings with "
+        "a descendant combinator selector."
+    )
+    # Regression guard: the broken child-combinator selector must NOT reappear.
+    assert ".settings-panel > .buttons-container" not in content, (
+        "JTN-572 regression: `.settings-panel > .buttons-container` never "
+        "matches the real DOM (buttons-container is nested inside "
+        ".settings-console-main). Use the descendant combinator instead."
+    )


### PR DESCRIPTION
## Summary

- The JTN-599 short-viewport sticky rule in `_responsive.css` used `.settings-panel > .buttons-container` (child combinator).
- But the settings DOM nests the Save bar inside `.settings-console-main`, two levels below `.settings-panel`, so the selector matched zero elements on `/settings` and the Save button still disappeared below the fold on short laptop viewports.
- Fix: switch to descendant combinator `.settings-panel .buttons-container` in both `@media (max-width: 768px)` and `@media (max-height: 860px)` blocks.
- Add a regression test asserting the descendant combinator is present and the broken `>` selector is not.

Fixes JTN-572.

## Files changed

- `src/static/styles/partials/_responsive.css` — drop `>` in both sticky rule locations
- `src/static/styles/main.css` — rebuilt from partials via `scripts/build_css.py`
- `tests/integration/test_settings_routes.py` — new `test_settings_responsive_css_sticky_save_selector_matches_real_dom`

## Test plan

- [x] New regression test passes
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck + mypy strict subset)
- [x] Existing JTN-599 `test_api_keys_responsive_css_has_short_viewport_sticky_rule` still passes (we only widened the selector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CSS selectors for button styling in the settings panel to improve layout behavior across different screen heights and sizes, ensuring consistent positioning and responsiveness.

* **Tests**
  * Added integration test to validate the updated button styling selectors work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->