### PR TITLE
fix(ai_image): use textarea for prompt input (JTN-377)

### DIFF
--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -29,9 +29,11 @@ class AIImage(BasePlugin):
                 "Prompt",
                 field(
                     "textPrompt",
+                    "textarea",
                     label="Prompt",
                     placeholder="A surreal breakfast floating through a neon sky.",
                     required=True,
+                    rows=4,
                 ),
                 field(
                     "randomizePrompt",

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -474,6 +474,37 @@ def test_ai_image_generate_settings_template():
     assert "settings_schema" in template
 
 
+def test_ai_image_prompt_field_is_textarea():
+    """Prompt field should be a textarea so long prompts are not clipped (JTN-377)."""
+    from plugins.ai_image.ai_image import AIImage
+
+    p = AIImage({"id": "ai_image"})
+    schema = p.build_settings_schema()
+
+    prompt_field = None
+    for section in schema["sections"]:
+        for item in section["items"]:
+            if item.get("kind") == "field" and item.get("name") == "textPrompt":
+                prompt_field = item
+                break
+        if prompt_field:
+            break
+
+    assert prompt_field is not None, "textPrompt field missing from schema"
+    assert prompt_field["type"] == "textarea"
+    assert prompt_field.get("rows") == 4
+    assert prompt_field.get("required") is True
+
+
+def test_ai_image_prompt_renders_as_textarea(client):
+    """Settings page should render the prompt as a <textarea> (JTN-377)."""
+    resp = client.get("/plugin/ai_image")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    assert "<textarea" in body
+    assert 'name="textPrompt"' in body
+
+
 def test_fetch_image_prompt_api_error_handling():
     """Test fetch_image_prompt with malformed API response."""
     from plugins.ai_image.ai_image import AIImage


### PR DESCRIPTION
## Summary
- The AI Image plugin rendered its prompt as a single-line `<input>`, causing long prompts to be clipped in the UI.
- Switch the `textPrompt` schema field to type `textarea` with `rows=4`, mirroring the AI Text plugin. Placeholder, label, and `required` are preserved, and the form field name is unchanged so backend handling is identical.
- Add tests that assert the prompt schema entry is a textarea and that `/plugin/ai_image` renders a `<textarea name=\"textPrompt\">`.

Linear: https://linear.app/jtn0123/issue/JTN-377

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/plugins/test_ai_image.py -q` (21 passed)
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no` (3582 passed; 2 unrelated pyenv-env failures in `test_plugin_registry.py`)
- [x] `scripts/lint.sh` clean

Generated with Claude Code