### PR TITLE
fix(history): clamp ?page upper bound to total_pages (JTN-359)

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -207,6 +207,17 @@ def history_page():
     images, total = _list_history_images(history_dir, offset=start, limit=per_page)
     total_pages = max(1, (total + per_page - 1) // per_page)
 
+    # Clamp upper bound: ?page=99999 should render the last valid page rather
+    # than "Page 99999 of N" over an empty grid.  When total == 0 we keep
+    # page = 1 so the empty-state template still renders correctly.
+    if page > total_pages:
+        page = total_pages
+        start = (page - 1) * per_page
+        if total > 0:
+            images, total = _list_history_images(
+                history_dir, offset=start, limit=per_page
+            )
+
     # Pull latest timing metrics if available
     try:
         ri = device_config.get_refresh_info()

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -487,6 +487,52 @@ def test_history_pagination_invalid_params(client, device_config_dev):
     assert "1 items" in body
 
 
+def test_history_pagination_clamps_upper_bound(client, device_config_dev):
+    """JTN-359: ?page=99999 should clamp to the last valid page, not render
+    "Page 99999 of N" over an empty grid."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    # Clear any leftover files from other tests in the same worker
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    # 30 items with per_page=10 -> total_pages=3
+    for i in range(30):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_clamp_{i:03d}.png")
+        )
+
+    resp = client.get("/history?page=99999&per_page=10")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    # Must NOT render the unclamped page number
+    assert "Page 99999" not in body
+    # Should clamp to last valid page
+    assert "Page 3 of 3" in body
+    # And the grid should not be empty — the last page's items should render
+    assert "display_clamp_" in body
+
+
+def test_history_pagination_clamps_upper_bound_empty_history(client, device_config_dev):
+    """JTN-359: ?page=99999 on an empty history renders the empty-state
+    cleanly (page clamps to 1 via total_pages floor, no crash, no bogus
+    'Page 99999 of 1')."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+
+    resp = client.get("/history?page=99999")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    # Empty-state copy still renders
+    assert "No history yet." in body
+    # No leaked unclamped page number
+    assert "Page 99999" not in body
+    # With total_pages==1 the pagination nav is hidden entirely, so
+    # "Page 1 of 1" should not appear either.
+    assert "Page 1 of 1" not in body
+
+
 def test_history_storage_exception_handling(client, flask_app, monkeypatch):
     import shutil as _shutil
 


### PR DESCRIPTION
## Summary
- `GET /history?page=99999` rendered `Page 99999 of 4` over an empty grid because only the lower bound (`max(page, 1)`) was clamped
- Add symmetric upper-bound clamp so out-of-range pages snap to `total_pages` and re-fetch the correct slice
- Empty-history case (`total_pages` falls through to `1`) keeps `page = 1` so the empty-state template still renders cleanly

Linear: JTN-359

## Test plan
- [x] New: `test_history_pagination_clamps_upper_bound` — 30 items, per_page=10, `?page=99999` asserts `Page 3 of 3` and non-empty grid
- [x] New: `test_history_pagination_clamps_upper_bound_empty_history` — empty dir + `?page=99999` asserts empty-state renders and no `Page 99999` leaks
- [x] Existing `test_history_pagination_invalid_params` still passes (including `?page=999`, `?page=abc`, `?per_page=-5`)
- [x] `tests/integration/test_history.py` — 45 passed
- [x] Full suite — 3582 passed (2 pre-existing failures in `test_plugin_registry.py` unrelated to this change)
- [x] `scripts/lint.sh` clean

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>