### PR TITLE
fix(playlist): label wrap-past-midnight ranges as "(next day)" (JTN-353)

### DIFF
--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -72,7 +72,7 @@
                             {% if playlist.name == playlist_config.active_playlist %}
                             <span class="status-chip success">Active</span>
                             {% endif %}
-                            <span class="playlist-summary-copy">{{ playlist.start_time }} - {{ playlist.end_time }}{% if playlist.cycle_minutes %} • {{ playlist.cycle_minutes }} min cycle{% endif %}</span>
+                            <span class="playlist-summary-copy">{{ playlist.start_time }} - {{ playlist.end_time }}{% if playlist.end_time < playlist.start_time %} <span class="playlist-wrap-label" title="This playlist wraps past midnight">(next day)</span>{% endif %}{% if playlist.cycle_minutes %} • {{ playlist.cycle_minutes }} min cycle{% endif %}</span>
                         </div>
                         </div>
                         <div class="playlist-toolbar">

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -344,3 +344,67 @@ def test_playlist_to_dict_no_cycle_minutes_when_unset(device_config_dev):
 
     d = pl.to_dict()
     assert "cycle_minutes" not in d
+
+
+def test_create_playlist_accepts_wraparound_times(client):
+    """JTN-353: Playlists with start > end (wraps past midnight) should be accepted.
+
+    The model already supports wraparound via Playlist.is_active(), so we accept
+    the reverse-time case rather than rejecting it.
+    """
+    payload = {
+        "playlist_name": "NightShift",
+        "start_time": "20:00",
+        "end_time": "08:00",
+    }
+    resp = client.post("/create_playlist", json=payload)
+    assert resp.status_code == 200
+    j = resp.get_json()
+    assert j.get("success") is True
+
+
+def test_playlist_page_labels_wraparound_next_day(client):
+    """JTN-353: The playlist list summary must mark wrap-past-midnight ranges with '(next day)'.
+
+    Without the label the UI renders '20:00 - 08:00' identically to a normal
+    same-day range, so users cannot tell that it wraps.
+    """
+    payload = {
+        "playlist_name": "Overnight",
+        "start_time": "22:00",
+        "end_time": "06:00",
+    }
+    resp = client.post("/create_playlist", json=payload)
+    assert resp.status_code == 200
+
+    resp = client.get("/playlist")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    # The summary line for Overnight should contain the wrap label.
+    # Find the Overnight summary section and check for the label nearby.
+    assert "22:00 - 06:00" in body
+    assert "(next day)" in body
+    assert "playlist-wrap-label" in body
+
+
+def test_playlist_page_no_wrap_label_for_normal_range(client):
+    """JTN-353: Normal same-day ranges must NOT get the '(next day)' label."""
+    payload = {
+        "playlist_name": "Daytime",
+        "start_time": "09:00",
+        "end_time": "17:00",
+    }
+    resp = client.post("/create_playlist", json=payload)
+    assert resp.status_code == 200
+
+    resp = client.get("/playlist")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    assert "09:00 - 17:00" in body
+    # The Daytime row should not carry the wrap label. We can't easily scope to
+    # just the Daytime row, so assert that when Daytime is the only non-default
+    # playlist the label markup is absent unless another wrap-range exists.
+    # To keep the assertion robust, check the substring around "09:00 - 17:00".
+    idx = body.find("09:00 - 17:00")
+    # Look within the next 200 chars for the label — it must not appear.
+    assert "(next day)" not in body[idx : idx + 200]


### PR DESCRIPTION
## Summary
- New Playlist silently accepted reverse times (e.g. `20:00 - 08:00`) and rendered them identically to a normal same-day range, so users couldn't tell whether the playlist wrapped past midnight.
- `Playlist.is_active` in `src/model.py` already handles `start > end` as a wrap-past-midnight range (covers the night-shift use case), so the fix is to keep accepting the range and label it in the UI instead of rejecting.
- `src/templates/playlist.html` now appends ` (next day)` after the summary (`HH:MM - HH:MM`) whenever `end_time < start_time`, using a dedicated `playlist-wrap-label` span for future styling.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/integration/test_playlist_routes.py tests/integration/test_playlist_more.py tests/integration/test_playlist_interactions.py tests/integration/test_playlist_crud_e2e.py tests/integration/test_playlist_coverage.py tests/unit/test_model.py -q` — 105 passed
- [x] Full suite: 3583 passed, 4 skipped (two unrelated `test_plugin_registry` failures are pre-existing on the parent branch and unaffected by this change)
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean; mypy advisory unchanged
- [x] Regression tests added:
  - `test_create_playlist_accepts_wraparound_times` — POST `/create_playlist` with `20:00 -> 08:00` returns 200
  - `test_playlist_page_labels_wraparound_next_day` — summary for `22:00 - 06:00` contains `(next day)` and `playlist-wrap-label`
  - `test_playlist_page_no_wrap_label_for_normal_range` — `09:00 - 17:00` summary does NOT contain `(next day)`

Linear: https://linear.app/jtn0123/issue/JTN-353

Generated with Claude Code