### PR TITLE
fix(rss): validate feedUrl at save time (JTN-380)

### DIFF
--- a/src/plugins/rss/rss.py
+++ b/src/plugins/rss/rss.py
@@ -1,6 +1,7 @@
 import html
 import logging
 import re
+from urllib.parse import urlparse
 
 import feedparser
 
@@ -21,6 +22,28 @@ FONT_SIZES = {"x-small": 0.7, "small": 0.9, "normal": 1, "large": 1.1, "x-large"
 
 
 class Rss(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject non-URL feed values at save time (JTN-380).
+
+        The submitted ``feedUrl`` must parse to an http(s) URL with a
+        non-empty host.  Empty URLs and invalid values (e.g. ``not-a-feed``
+        or ``javascript:alert(1)``) are rejected so junk values cannot be
+        persisted even if the client-side ``type="url"`` guard is bypassed.
+        """
+        raw = settings.get("feedUrl")
+        url = (raw or "").strip() if isinstance(raw, str) else ""
+        if not url:
+            return "RSS Feed URL is required."
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return f"RSS Feed URL is not valid: {url!r}"
+        if parsed.scheme.lower() not in {"http", "https"}:
+            return f"RSS Feed URL is not valid: {url!r}"
+        if not parsed.netloc:
+            return f"RSS Feed URL is not valid: {url!r}"
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(
@@ -53,9 +76,11 @@ class Rss(BasePlugin):
                 ),
                 field(
                     "feedUrl",
+                    "url",
                     label="RSS Feed URL",
                     placeholder="https://example.com/feed.xml",
                     required=True,
+                    pattern="https?://.+",
                 ),
                 callout(
                     "Only use trusted RSS feeds. Untrusted URLs can introduce security and reliability risks.",

--- a/tests/plugins/test_rss_validation.py
+++ b/tests/plugins/test_rss_validation.py
@@ -1,0 +1,125 @@
+# pyright: reportMissingImports=false
+"""JTN-380: RSS plugin feed URL validation.
+
+The feed URL field must reject non-URL values at save time (backend
+``validate_settings``) and the rendered settings template must use a
+``type="url"`` input so the browser enforces basic URL constraints client-side.
+"""
+
+import re
+
+
+def _plugin():
+    from plugins.rss.rss import Rss
+
+    return Rss({"id": "rss"})
+
+
+def test_validate_settings_accepts_http_feed_url():
+    assert (
+        _plugin().validate_settings({"feedUrl": "http://example.com/feed.xml"}) is None
+    )
+
+
+def test_validate_settings_accepts_https_feed_url():
+    assert (
+        _plugin().validate_settings({"feedUrl": "https://news.ycombinator.com/rss"})
+        is None
+    )
+
+
+def test_validate_settings_accepts_url_without_extension():
+    # Many feeds are exposed at a bare path without a file extension.
+    assert _plugin().validate_settings({"feedUrl": "https://example.com/feed"}) is None
+
+
+def test_validate_settings_accepts_url_with_query_string():
+    assert (
+        _plugin().validate_settings(
+            {"feedUrl": "https://example.com/rss?category=news"}
+        )
+        is None
+    )
+
+
+def test_validate_settings_rejects_non_url_string():
+    error = _plugin().validate_settings({"feedUrl": "definitely-not-a-feed-url"})
+    assert error is not None
+    assert "not valid" in error.lower()
+    assert "definitely-not-a-feed-url" in error
+
+
+def test_validate_settings_rejects_bare_word():
+    error = _plugin().validate_settings({"feedUrl": "news"})
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_javascript_scheme():
+    error = _plugin().validate_settings({"feedUrl": "javascript:alert(1)"})
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_file_scheme():
+    error = _plugin().validate_settings({"feedUrl": "file:///etc/passwd"})
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_ftp_scheme():
+    error = _plugin().validate_settings({"feedUrl": "ftp://example.com/feed.xml"})
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_webcal_scheme():
+    # RSS does not use webcal:// like the Calendar plugin does.
+    error = _plugin().validate_settings({"feedUrl": "webcal://example.com/feed.xml"})
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_validate_settings_rejects_empty_url():
+    error = _plugin().validate_settings({"feedUrl": ""})
+    assert error is not None
+    assert "required" in error.lower()
+
+
+def test_validate_settings_rejects_whitespace_url():
+    error = _plugin().validate_settings({"feedUrl": "   "})
+    assert error is not None
+    assert "required" in error.lower()
+
+
+def test_validate_settings_rejects_missing_feed_url_key():
+    error = _plugin().validate_settings({})
+    assert error is not None
+    assert "required" in error.lower()
+
+
+def test_validate_settings_rejects_none_feed_url():
+    error = _plugin().validate_settings({"feedUrl": None})
+    assert error is not None
+    assert "required" in error.lower()
+
+
+def test_validate_settings_rejects_url_missing_netloc():
+    # ``http://`` parses with empty netloc; must be rejected.
+    error = _plugin().validate_settings({"feedUrl": "http://"})
+    assert error is not None
+    assert "not valid" in error.lower()
+
+
+def test_rss_feed_url_input_is_type_url_and_required(client):
+    """The RSS settings form renders a type=url input with required/pattern (JTN-380)."""
+    resp = client.get("/plugin/rss")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'name="feedUrl"' in html
+    input_tag = re.search(r'<input[^>]*name="feedUrl"[^>]*>', html)
+    assert input_tag is not None, "feedUrl input not found in rendered page"
+    tag = input_tag.group(0)
+    assert 'type="url"' in tag
+    assert "required" in tag
+    assert 'pattern="https?://.+"' in tag


### PR DESCRIPTION
## Summary

Closes JTN-380. Repro: `/plugin/rss` -> type `definitely-not-a-feed-url` into RSS Feed URL -> Save. Previously the junk string was persisted silently even though the page had security-aware copy ("Only use trusted RSS feeds").

Follows the JTN-357 Calendar URL pattern (PR #337) for consistency.

- **Template**: The `feedUrl` schema field is now rendered as `type="url"` with `pattern="https?://.+"` and `required`, so the browser enforces basic URL constraints before submit. The shared `settings_schema.html` macro already forwards `field_type` + `pattern` through to the `<input>` so no template changes are needed.
- **Backend** (`src/plugins/rss/rss.py`): new `validate_settings()` override parses the URL and rejects anything without an http/https scheme or with an empty netloc. Empty/whitespace/`None` values return a "required" error; other bad values return a "not valid" error naming the offending input. Save-time validation runs through the existing `plugin.validate_settings()` hook in `src/blueprints/plugin.py`, so bad values can never be persisted even if the client-side guard is bypassed.
- **Tests** (`tests/plugins/test_rss_validation.py`, 16 new tests): validates that http/https pass (including URLs without an extension and with a query string); `definitely-not-a-feed-url`, a bare word, empty, whitespace, missing key, `None`, `javascript:alert(1)`, `file:///etc/passwd`, `ftp://`, `webcal://`, and `http://` (empty netloc) are rejected; template render asserts the `feedUrl` input is `type="url"` + `required` + `pattern="https?://.+"`.

## Test plan

- [x] `scripts/lint.sh` - ruff + black + shellcheck green (mypy advisory unchanged)
- [x] `pytest tests/plugins/test_rss_validation.py tests/plugins/test_rss_plugin.py tests/plugins/test_rss_errors.py` - 33/33 pass
- [x] Full suite: 3596 passed, 2 pre-existing unrelated failures in `tests/unit/test_plugin_registry.py` (pyenv `python` command missing in local env; same two failures noted in PR #337; not touched by this PR)

Fixes JTN-380.

Generated with Claude Code