### PR TITLE
fix(playlist): validate refresh_settings on update_plugin_instance (JTN-381)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -122,7 +122,7 @@ def _check_playlist_overlap(new_start, new_end, playlists, exclude_name=None):
     return None
 
 
-def _validate_plugin_refresh_settings(refresh_settings):
+def validate_plugin_refresh_settings(refresh_settings):
     """Validate the refresh portion of an add_plugin request.
 
     Returns ``(refresh_config, error_response)``.  Exactly one of the two
@@ -331,9 +331,7 @@ def add_plugin():
                 f"Plugin instance '{instance_name}' already exists", status=400
             )
 
-        refresh_config, refresh_err = _validate_plugin_refresh_settings(
-            refresh_settings
-        )
+        refresh_config, refresh_err = validate_plugin_refresh_settings(refresh_settings)
         if refresh_err:
             return refresh_err
 

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -304,6 +304,38 @@ def update_plugin_instance(instance_name: str):
                 status=404,
             )
 
+        # JTN-381: parse and validate refresh_settings if present. The frontend
+        # Refresh Settings modal posts this as a JSON-stringified form field;
+        # previously it was accepted blindly, saved into settings verbatim,
+        # and the new refresh config was never applied — reload silently
+        # reverted the user's change while the toast said "success".
+        new_refresh_config = None
+        raw_refresh = plugin_settings.pop("refresh_settings", None)
+        if raw_refresh is not None:
+            try:
+                refresh_payload = json.loads(raw_refresh)
+            except (TypeError, ValueError):
+                return json_error(
+                    "Refresh settings must be valid JSON",
+                    status=400,
+                    code="validation_error",
+                    details={"field": "refresh_settings"},
+                )
+            if not isinstance(refresh_payload, dict):
+                return json_error(
+                    "Refresh settings must be an object",
+                    status=400,
+                    code="validation_error",
+                    details={"field": "refresh_settings"},
+                )
+            from blueprints.playlist import validate_plugin_refresh_settings
+
+            new_refresh_config, refresh_err = validate_plugin_refresh_settings(
+                refresh_payload
+            )
+            if refresh_err:
+                return refresh_err
+
         # Validate required fields and plugin-specific settings
         plugin_config = device_config.get_plugin(plugin_id)
         if plugin_config:
@@ -324,6 +356,8 @@ def update_plugin_instance(instance_name: str):
 
         def _do_update_instance(cfg):
             plugin_instance.settings = plugin_settings
+            if new_refresh_config is not None:
+                plugin_instance.refresh = new_refresh_config
 
         device_config.update_atomic(_do_update_instance)
         config_dir = os.path.dirname(device_config.config_file)

--- a/tests/integration/test_jtn_381_refresh_settings_validation.py
+++ b/tests/integration/test_jtn_381_refresh_settings_validation.py
@@ -1,0 +1,159 @@
+"""JTN-381: /update_plugin_instance must validate the refresh_settings payload.
+
+Previously the route parsed the form, shoved the raw ``refresh_settings``
+JSON string into plugin_instance.settings, and returned 200 success —
+leaving plugin_instance.refresh untouched so reloading silently reverted
+the user's new interval while the modal showed a green success toast.
+"""
+
+import json
+
+
+def _setup_playlist_for_instance(device_config_dev):
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default", "00:00", "24:00")
+    pl = pm.get_playlist("Default")
+    if not pm.find_plugin("ai_text", "Inst One"):
+        pl.add_plugin(
+            {
+                "plugin_id": "ai_text",
+                "name": "Inst One",
+                "plugin_settings": {},
+                "refresh": {"interval": 300},
+            }
+        )
+    device_config_dev.write_config()
+
+
+def _put(client, instance_name, refresh_settings, extra=None):
+    # ai_text requires textPrompt + textModel — supply sensible defaults so the
+    # existing required-field validator doesn't mask what we're testing here.
+    data = {
+        "plugin_id": "ai_text",
+        "textPrompt": "hello world",
+        "textModel": "gpt-4o-mini",
+        "refresh_settings": json.dumps(refresh_settings),
+    }
+    if extra:
+        data.update(extra)
+    return client.put(f"/update_plugin_instance/{instance_name}", data=data)
+
+
+def test_update_plugin_instance_rejects_interval_above_max(client, device_config_dev):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = _put(
+        client,
+        "Inst One",
+        {"refreshType": "interval", "interval": "5000", "unit": "minute"},
+    )
+    assert resp.status_code == 422
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+    assert "between 1 and 999" in (body.get("message") or body.get("error") or "")
+
+    pm = device_config_dev.get_playlist_manager()
+    inst = pm.find_plugin("ai_text", "Inst One")
+    assert inst is not None
+    # Refresh config must be unchanged from the fixture default.
+    assert inst.refresh == {"interval": 300}
+
+
+def test_update_plugin_instance_rejects_interval_below_min(client, device_config_dev):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = _put(
+        client,
+        "Inst One",
+        {"refreshType": "interval", "interval": "0", "unit": "minute"},
+    )
+    assert resp.status_code == 422
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 300}
+
+
+def test_update_plugin_instance_rejects_non_numeric_interval(client, device_config_dev):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = _put(
+        client,
+        "Inst One",
+        {"refreshType": "interval", "interval": "abc", "unit": "minute"},
+    )
+    assert resp.status_code == 422
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 300}
+
+
+def test_update_plugin_instance_rejects_invalid_unit(client, device_config_dev):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = _put(
+        client,
+        "Inst One",
+        {"refreshType": "interval", "interval": "15", "unit": "century"},
+    )
+    assert resp.status_code == 422
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 300}
+
+
+def test_update_plugin_instance_accepts_valid_interval(client, device_config_dev):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = _put(
+        client,
+        "Inst One",
+        {"refreshType": "interval", "interval": "15", "unit": "minute"},
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 15 * 60}
+
+
+def test_update_plugin_instance_accepts_valid_scheduled(client, device_config_dev):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = _put(
+        client,
+        "Inst One",
+        {"refreshType": "scheduled", "refreshTime": "09:30"},
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"scheduled": "09:30"}
+
+
+def test_update_plugin_instance_rejects_malformed_json_refresh_settings(
+    client, device_config_dev
+):
+    _setup_playlist_for_instance(device_config_dev)
+    resp = client.put(
+        "/update_plugin_instance/Inst One",
+        data={
+            "plugin_id": "ai_text",
+            "textPrompt": "hello world",
+            "textModel": "gpt-4o-mini",
+            "refresh_settings": "not valid json",
+        },
+    )
+    assert resp.status_code == 400
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 300}
+
+
+def test_update_plugin_instance_without_refresh_settings_still_works(
+    client, device_config_dev
+):
+    """Callers that don't send refresh_settings (e.g. older flows) must not
+    hit the new validator. The refresh config stays unchanged."""
+    _setup_playlist_for_instance(device_config_dev)
+    resp = client.put(
+        "/update_plugin_instance/Inst One",
+        data={
+            "plugin_id": "ai_text",
+            "textPrompt": "hello world",
+            "textModel": "gpt-4o-mini",
+        },
+    )
+    assert resp.status_code == 200
+    pm = device_config_dev.get_playlist_manager()
+    assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 300}


### PR DESCRIPTION
## Summary

- `/update_plugin_instance` accepted the Refresh Settings modal's JSON-stringified `refresh_settings` form field, stored it verbatim in `plugin_instance.settings`, and never applied it to `plugin_instance.refresh`. Out-of-range intervals (e.g. 5000) silently reverted on reload while the modal showed a green success toast.
- Route now pops `refresh_settings` from the form dict, JSON-parses it (400 on malformed), and runs it through the shared validator that `add_plugin` already uses. On success, the validated refresh config is persisted inside the same atomic update that writes `plugin_settings`.
- Range (1–999) and unit (minute/hour/day) checks are identical to the add_plugin path, so behavior stays consistent between create and update.

Fixes JTN-381.

## Files changed

- `src/blueprints/playlist.py` — rename `_validate_plugin_refresh_settings` → `validate_plugin_refresh_settings` to make it importable.
- `src/blueprints/plugin.py` — `update_plugin_instance` parses and validates `refresh_settings`, returns 422 with field details on validation error, persists the validated refresh config alongside plugin_settings.
- `tests/integration/test_jtn_381_refresh_settings_validation.py` — 8 new tests: above-max, below-min, non-numeric interval, invalid unit, valid interval, valid scheduled, malformed JSON, and a no-op case when the caller doesn't send refresh_settings at all.

## Test plan

- [x] 8/8 new JTN-381 tests pass
- [x] Existing `tests/integration/test_plugin_routes.py` + `test_playlist_routes.py` unchanged (56 pass)
- [x] `scripts/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)