### PR TITLE
fix(api-keys): add id/name/aria-label to row inputs (JTN-383)

### DIFF
--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -40,6 +40,11 @@
     // Dirty-tracking state: true when any field has changed since last save/load.
     let _isDirty = false;
 
+    // Monotonic suffix for unique id/name/label on JS-built rows (JTN-383).
+    // Each call to addRow bumps this so assistive-tech and autofill can
+    // distinguish the inputs even when multiple rows are added in a session.
+    let _rowCounter = 0;
+
     function markDirty() {
       _isDirty = true;
       const saveBtn = document.getElementById("saveApiKeysBtn");
@@ -214,6 +219,27 @@
       updateManagedSummary();
     }
 
+    // Keep delete-button + value-input aria-labels in sync with the current
+    // key name so assistive tech hears "API key value for OPEN_AI_SECRET"
+    // instead of the generic "API key value" after the user types a name.
+    function updateRowAriaLabels(row, keyName) {
+      const trimmed = (keyName || "").trim();
+      const valInput = row.querySelector(".apikey-value");
+      const delBtn = row.querySelector(".btn-delete");
+      if (valInput) {
+        valInput.setAttribute(
+          "aria-label",
+          trimmed ? `API key value for ${trimmed}` : "API key value"
+        );
+      }
+      if (delBtn) {
+        delBtn.setAttribute(
+          "aria-label",
+          trimmed ? `Delete ${trimmed} API key` : "Delete API key row"
+        );
+      }
+    }
+
     function addRow(key = "", value = "") {
       markDirty();
       const emptyState = document.getElementById("empty-state");
@@ -223,6 +249,8 @@
         console.warn("api_keys_page: #apikeys-list not found in DOM");
         return;
       }
+      _rowCounter += 1;
+      const suffix = `new-${_rowCounter}`;
       const row = document.createElement("div");
       row.className = "apikey-row";
       row.dataset.existing = "false";
@@ -231,21 +259,31 @@
       keyInput.className = "apikey-key";
       keyInput.value = key;
       keyInput.placeholder = "KEY_NAME";
+      keyInput.id = `apikey-name-${suffix}`;
+      keyInput.name = `apikey-name-${suffix}`;
+      keyInput.setAttribute("aria-label", "API key name");
       const valInput = document.createElement("input");
       valInput.type = "text";
       valInput.className = "apikey-value";
       valInput.value = value;
       valInput.placeholder = "Enter value";
+      valInput.id = `apikey-value-${suffix}`;
+      valInput.name = `apikey-value-${suffix}`;
       const delBtn = document.createElement("button");
       delBtn.type = "button";
       delBtn.className = "btn-delete";
       delBtn.dataset.apiAction = "delete-row";
       delBtn.title = "Delete";
-      delBtn.setAttribute("aria-label", "Delete API key");
       delBtn.textContent = "\u00d7";
       row.appendChild(keyInput);
       row.appendChild(valInput);
       row.appendChild(delBtn);
+      // Initialize aria-labels now; re-run on every keyInput change so the
+      // label tracks the key name the user just typed.
+      updateRowAriaLabels(row, key);
+      keyInput.addEventListener("input", () =>
+        updateRowAriaLabels(row, keyInput.value)
+      );
       list.appendChild(row);
       (key ? row.querySelector(".apikey-value") : row.querySelector(".apikey-key")).focus();
     }

--- a/src/templates/api_keys.html
+++ b/src/templates/api_keys.html
@@ -65,8 +65,8 @@
                 {% if entries %}
                     {% for entry in entries %}
                     <div class="apikey-row" data-existing="true">
-                        <input type="text" class="apikey-key" value="{{ entry.key }}" placeholder="KEY_NAME" readonly aria-label="{{ entry.key }} key name">
-                        <input type="password" class="apikey-value" value="" placeholder="(unchanged)" readonly aria-label="{{ entry.key }} value, hidden">
+                        <input type="text" class="apikey-key" id="apikey-name-{{ loop.index0 }}" name="apikey-name-{{ loop.index0 }}" value="{{ entry.key }}" placeholder="KEY_NAME" readonly aria-label="{{ entry.key }} key name">
+                        <input type="password" class="apikey-value" id="apikey-value-{{ loop.index0 }}" name="apikey-value-{{ loop.index0 }}" value="" placeholder="(unchanged)" readonly aria-label="{{ entry.key }} value, hidden">
                         <button type="button" class="btn-delete" data-api-action="delete-row" title="Delete" aria-label="Delete {{ entry.key }} API key">×</button>
                     </div>
                     {% endfor %}

--- a/tests/integration/test_jtn_383_api_keys_labels.py
+++ b/tests/integration/test_jtn_383_api_keys_labels.py
@@ -1,0 +1,91 @@
+"""JTN-383: API Keys row inputs must have id/name/aria-label (or <label for>).
+
+Server-rendered rows were partially labeled but missing id/name; JS-built rows
+(``addRow()`` in ``api_keys_page.js``) were fully bare, so screen readers and
+browser autofill could not distinguish them.
+"""
+
+from pathlib import Path
+
+# --- Server-rendered rows (Jinja loop) ---
+
+
+def test_server_rendered_api_keys_rows_have_id_name_and_aria_label(
+    client, tmp_path, monkeypatch
+):
+    """Each row in the server-rendered /api-keys response must have id, name,
+    and aria-label on both the key input and the value input."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPEN_AI_SECRET=openai-123\nNASA_SECRET=nasa-456\n")
+    monkeypatch.setattr("blueprints.apikeys.get_env_path", lambda: str(env_file))
+
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    # Stable per-row id/name scheme for at least the first two rows.
+    assert 'id="apikey-name-0"' in html
+    assert 'name="apikey-name-0"' in html
+    assert 'id="apikey-value-0"' in html
+    assert 'name="apikey-value-0"' in html
+    assert 'id="apikey-name-1"' in html
+    assert 'id="apikey-value-1"' in html
+
+    # Existing aria-labels preserved (no regression from JTN-309/382 work).
+    assert 'aria-label="OPEN_AI_SECRET key name"' in html
+    assert 'aria-label="OPEN_AI_SECRET value, hidden"' in html
+    assert 'aria-label="NASA_SECRET key name"' in html
+
+
+# --- JS-built rows (api_keys_page.js addRow) ---
+
+
+def _js_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "api_keys_page.js"
+    )
+
+
+def test_api_keys_page_js_addrow_sets_id_name_and_aria_label():
+    """addRow() must set id, name, and aria-label on both inputs (JTN-383)."""
+    js = _js_path().read_text(encoding="utf-8")
+
+    # id/name pattern — scoped to the JS-built row so every added row is unique.
+    assert "keyInput.id = `apikey-name-${suffix}`" in js
+    assert "keyInput.name = `apikey-name-${suffix}`" in js
+    assert "valInput.id = `apikey-value-${suffix}`" in js
+    assert "valInput.name = `apikey-value-${suffix}`" in js
+
+    # Initial aria-label on the key input.
+    assert 'keyInput.setAttribute("aria-label", "API key name")' in js
+
+
+def test_api_keys_page_js_has_dynamic_aria_label_updater():
+    """The value input's aria-label must track the current key name (JTN-383).
+
+    ``updateRowAriaLabels`` is wired as an input listener on the key input so
+    the screen-reader label for the value stays meaningful as the user types.
+    """
+    js = _js_path().read_text(encoding="utf-8")
+
+    assert "function updateRowAriaLabels(row, keyName)" in js
+    assert "`API key value for ${trimmed}`" in js
+    assert "`Delete ${trimmed} API key`" in js
+    # Wired up on input events.
+    assert 'keyInput.addEventListener("input"' in js
+
+
+def test_api_keys_page_js_removes_generic_delete_aria_label():
+    """The old generic ``Delete API key`` aria-label must no longer be the
+    sole setting — it's now computed dynamically via updateRowAriaLabels."""
+    js = _js_path().read_text(encoding="utf-8")
+
+    # The generic fallback is now "Delete API key row" (set by updateRowAriaLabels
+    # when there is no key name yet). The old literal that ignored the key must
+    # not be the only labeling path anymore.
+    assert 'delBtn.setAttribute("aria-label", "Delete API key")' not in js
+    assert '"Delete API key row"' in js


### PR DESCRIPTION
## Summary

- JS-built rows in `api_keys_page.js::addRow()` had no `id`, `name`, or `aria-label` on either input — screen readers and browser autofill could not distinguish rows.
- Server-rendered rows already had `aria-label` but lacked `id`/`name`.
- Both paths are now consistent: each row gets unique `apikey-name-*` / `apikey-value-*` id+name, and value-input + delete-button aria-labels track the key name via `updateRowAriaLabels()`.

Fixes JTN-383. JTN-382 (password masking) already shipped in `44bdb56`.

## Files changed

- `src/static/scripts/api_keys_page.js` — `addRow()` assigns stable IDs, seeds aria-labels via `updateRowAriaLabels()` helper
- `src/templates/api_keys.html` — server-rendered rows get `id`/`name` via `loop.index0`
- `tests/integration/test_jtn_383_api_keys_labels.py` — 4 new tests

## Test plan

- [x] 4/4 new tests pass
- [x] `scripts/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)