### PR TITLE
fix(settings): return specific error for out-of-range cycle interval (JTN-351)

### DIFF
--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -360,16 +360,25 @@ def _validate_settings_form(form_data):
             code="validation_error",
             details={"field": "unit"},
         )
-    if not interval or not interval.isnumeric():
+    if not interval or not interval.strip():
         return json_error(
             "Refresh interval is required",
             status=422,
             code="validation_error",
             details={"field": "interval"},
         )
-    if int(interval) <= 0:
+    try:
+        interval_int = int(interval)
+    except (ValueError, TypeError):
         return json_error(
-            "Plugin Cycle Interval must be greater than zero",
+            "Refresh interval must be a number",
+            status=422,
+            code="validation_error",
+            details={"field": "interval"},
+        )
+    if interval_int < 1:
+        return json_error(
+            "Refresh interval must be at least 1",
             status=422,
             code="validation_error",
             details={"field": "interval"},

--- a/tests/integration/test_settings_save_errors.py
+++ b/tests/integration/test_settings_save_errors.py
@@ -76,6 +76,80 @@ def test_save_settings_missing_timezone_and_bad_time_format(client):
     assert resp.status_code == 422
 
 
+_VALID_BASE = {
+    "deviceName": "D",
+    "orientation": "horizontal",
+    "invertImage": "",
+    "logSystemStats": "",
+    "timezoneName": "UTC",
+    "timeFormat": "24h",
+    "unit": "minute",
+    "saturation": "1.0",
+    "brightness": "1.0",
+    "sharpness": "1.0",
+    "contrast": "1.0",
+}
+
+
+def test_save_settings_interval_missing_returns_required(client):
+    """Missing interval field returns 'is required' message."""
+    data = dict(_VALID_BASE)
+    # interval key is absent
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    assert "Refresh interval is required" in resp.get_json()["error"]
+
+
+def test_save_settings_interval_empty_returns_required(client):
+    """Empty string interval returns 'is required' message."""
+    data = dict(_VALID_BASE, interval="")
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    assert "Refresh interval is required" in resp.get_json()["error"]
+
+
+def test_save_settings_interval_non_numeric_returns_must_be_number(client):
+    """Non-numeric interval returns 'must be a number' message."""
+    data = dict(_VALID_BASE, interval="abc")
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    assert "Refresh interval must be a number" in resp.get_json()["error"]
+
+
+def test_save_settings_interval_float_returns_must_be_number(client):
+    """Decimal interval returns 'must be a number' (int expected)."""
+    data = dict(_VALID_BASE, interval="2.5")
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    assert "Refresh interval must be a number" in resp.get_json()["error"]
+
+
+def test_save_settings_interval_negative_returns_at_least_1(client):
+    """Negative interval returns 'must be at least 1', not 'is required'."""
+    data = dict(_VALID_BASE, interval="-5")
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    body = resp.get_json()
+    assert "must be at least 1" in body["error"]
+    assert "required" not in body["error"].lower()
+
+
+def test_save_settings_interval_zero_returns_at_least_1(client):
+    """Zero interval returns 'must be at least 1'."""
+    data = dict(_VALID_BASE, interval="0")
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    assert "must be at least 1" in resp.get_json()["error"]
+
+
+def test_save_settings_interval_exceeds_24h(client):
+    """Interval exceeding 24 hours returns appropriate error."""
+    data = dict(_VALID_BASE, interval="1500", unit="minute")
+    resp = client.post("/save_settings", data=data)
+    assert resp.status_code == 422
+    assert "24 hours" in resp.get_json()["error"]
+
+
 def test_save_settings_success_triggers_config_change_signal(client, monkeypatch):
     # Spy refresh_task.signal_config_change
 


### PR DESCRIPTION
## Summary
- Replace the misleading "Refresh interval is required" error that appeared when saving a negative or non-numeric Plugin Cycle Interval value
- Split validation into three distinct checks: missing/empty → "is required", non-numeric → "must be a number", below minimum → "must be at least 1"
- Root cause: `str.isnumeric()` returns `False` for negative numbers (the `-` sign is not numeric), so `-5` fell into the "is required" branch

## Test plan
- [x] Added 7 new integration tests covering every validation branch (missing, empty, non-numeric, float, negative, zero, exceeds 24h)
- [x] Verified the negative-interval test explicitly asserts "required" is **not** in the error message
- [x] Full test suite passes (3634 passed, 2 pre-existing failures unrelated to this change)
- [x] Lint clean (`scripts/lint.sh`)

Closes JTN-351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>