### PR TITLE
fix(settings): validate plugin ID in Isolate diagnostic (JTN-385)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -675,25 +675,45 @@
     async function isolatePlugin() {
       const pluginId = document.getElementById("isolatePluginInput")?.value?.trim();
       if (!pluginId) return;
-      await fetch("/settings/isolation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ plugin_id: pluginId }),
-      });
-      await refreshIsolation();
-      await refreshHealth();
+      try {
+        const resp = await fetch("/settings/isolation", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ plugin_id: pluginId }),
+        });
+        const data = await resp.json();
+        if (!resp.ok || !data.success) {
+          showResponseModal("failure", data.error || "Failed to isolate plugin");
+          return;
+        }
+        await refreshIsolation();
+        await refreshHealth();
+      } catch (e) {
+        console.warn("Failed to isolate plugin:", e);
+        showResponseModal("failure", "Failed to isolate plugin");
+      }
     }
 
     async function unIsolatePlugin() {
       const pluginId = document.getElementById("isolatePluginInput")?.value?.trim();
       if (!pluginId) return;
-      await fetch("/settings/isolation", {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ plugin_id: pluginId }),
-      });
-      await refreshIsolation();
-      await refreshHealth();
+      try {
+        const resp = await fetch("/settings/isolation", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ plugin_id: pluginId }),
+        });
+        const data = await resp.json();
+        if (!resp.ok || !data.success) {
+          showResponseModal("failure", data.error || "Failed to unisolate plugin");
+          return;
+        }
+        await refreshIsolation();
+        await refreshHealth();
+      } catch (e) {
+        console.warn("Failed to unisolate plugin:", e);
+        showResponseModal("failure", "Failed to unisolate plugin");
+      }
     }
 
     async function safeReset() {


### PR DESCRIPTION
## Summary
- The `/settings/isolation` backend endpoint already validates unknown plugin IDs and returns HTTP 422 with an error message
- The frontend `isolatePlugin()` and `unIsolatePlugin()` JS functions were fire-and-forget -- they never checked the response status
- After the POST/DELETE, the code immediately called `refreshIsolation()` (a GET), which returned `{"isolated_plugins": [], "success": true}`, making it appear the operation succeeded even when the plugin ID was invalid
- Added proper error handling: check `resp.ok`, parse the error, and display via `showResponseModal()` consistent with all other settings page actions (e.g. `safeReset()`, `exportConfig()`)

## Test plan
- [x] Existing backend tests pass: `test_isolation_unknown_plugin_id` and `test_delete_unknown_plugin_id` in `test_settings_save.py` (HTTP 422 for unknown IDs)
- [x] Full test suite: 3627 passed (2 pre-existing failures unrelated to this change)
- [x] Lint clean (`scripts/lint.sh`)
- [ ] Manual: Settings -> Diagnostics -> type `nonexistent_plugin_xyz` -> click Isolate -> verify error modal appears instead of silent success

🤖 Generated with [Claude Code](https://claude.com/claude-code)