### PR TITLE
fix(api-keys): wire up + Add API Key button click handler (JTN-323)

### DIFF
--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -474,7 +474,9 @@
         const actionEl = event.target.closest("[data-api-action]");
         if (!actionEl) return;
         const action = actionEl.dataset.apiAction;
-        if (action === "delete-key") {
+        if (action === "add-row") {
+          addRow();
+        } else if (action === "delete-key") {
           deleteKey(actionEl.dataset.keyName);
         } else if (action === "delete-row") {
           deleteRow(actionEl);

--- a/src/templates/api_keys.html
+++ b/src/templates/api_keys.html
@@ -77,7 +77,7 @@
                 {% endif %}
             </div>
             <div class="add-buttons-grid">
-                <button type="button" id="addApiKeyBtn" class="btn-add"><span>+</span> Add API Key</button>
+                <button type="button" id="addApiKeyBtn" class="btn-add" data-api-action="add-row"><span>+</span> Add API Key</button>
                 <button type="button" class="btn-preset" data-api-action="add-preset" data-key="OPEN_WEATHER_MAP_SECRET" title="Used by: {{ api_key_plugins.get('OPEN_WEATHER_MAP_SECRET', []) | join(', ') }}">OPEN_WEATHER_MAP_SECRET</button>
                 <button type="button" class="btn-preset" data-api-action="add-preset" data-key="OPEN_AI_SECRET" title="Used by: {{ api_key_plugins.get('OPEN_AI_SECRET', []) | join(', ') }}">OPEN_AI_SECRET</button>
                 <button type="button" class="btn-preset" data-api-action="add-preset" data-key="NASA_SECRET" title="Used by: {{ api_key_plugins.get('NASA_SECRET', []) | join(', ') }}">NASA_SECRET</button>

--- a/tests/integration/test_jtn_323_add_button_delegation.py
+++ b/tests/integration/test_jtn_323_add_button_delegation.py
@@ -1,0 +1,32 @@
+"""Tests for JTN-323: + Add API Key button must use data-api-action delegation."""
+
+
+def test_add_button_has_data_api_action_attribute(client):
+    """JTN-323: the + Add API Key button must have data-api-action='add-row'."""
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert (
+        'data-api-action="add-row"' in html
+    ), "Add API Key button must use data-api-action='add-row' for delegation"
+
+
+def test_js_delegation_handler_covers_add_row_action(client):
+    """JTN-323: the delegated click handler must handle the 'add-row' action."""
+    resp = client.get("/static/scripts/api_keys_page.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    assert '"add-row"' in js, "JS must include an 'add-row' action case"
+    assert "addRow()" in js, "The 'add-row' action must call addRow()"
+
+
+def test_add_button_has_both_id_and_data_action(client):
+    """JTN-323: the button should have both id and data-api-action for robustness."""
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert 'id="addApiKeyBtn"' in html
+    assert 'data-api-action="add-row"' in html


### PR DESCRIPTION
## Summary
- Add `data-api-action="add-row"` to the `+ Add API Key` button so it participates in the page's event delegation pattern
- Add `"add-row"` case to the delegated click handler in `api_keys_page.js`
- The button was the only interactive element on the page that relied solely on a direct `addEventListener` in `init()`, making it fragile to script-load timing. All other buttons (preset chips, delete) already used `data-api-action` delegation.
- Also verified JTN-324 (preset chips) and JTN-325 (delete buttons) — both already work correctly via delegation; they share no code defect with this issue.

## Test plan
- [x] Added 3 integration tests asserting the button has `data-api-action="add-row"` and the JS handler covers it
- [x] Manually verified in browser: Add, Preset, and Delete all function correctly
- [x] Lint passes (`scripts/lint.sh`)
- [x] Full suite: 3630 passed, 2 skipped, 2 pre-existing env-specific failures (unrelated `test_plugin_registry`)

Closes JTN-323

🤖 Generated with [Claude Code](https://claude.com/claude-code)