### PR TITLE
fix(history): wire up Next/Prev pagination links (JTN-330)

### DIFF
--- a/src/static/scripts/history_page.js
+++ b/src/static/scripts/history_page.js
@@ -282,6 +282,13 @@
       bindThumbLightbox();
       bindActions();
       globalThis.updateHistoryStorage = updateStorage;
+
+      // Re-bind skeleton handlers after HTMX swaps new grid content.
+      // The htmx:afterSettle event fires after the DOM has fully settled,
+      // ensuring the new images are available for binding.
+      document.body.addEventListener("htmx:afterSettle", function () {
+        bindImages();
+      });
     }
 
     return { init };

--- a/src/templates/partials/history_grid.html
+++ b/src/templates/partials/history_grid.html
@@ -42,7 +42,7 @@
        href="{{ url_for('history.history_page', page=page - 1, per_page=per_page) }}"
        hx-get="{{ url_for('history.history_page', page=page - 1, per_page=per_page) }}"
        hx-target="#history-grid-container"
-       hx-swap="outerHTML"
+       hx-swap="outerHTML show:#history-grid-container:top"
        hx-push-url="true">Previous</a>
     {% else %}
     <span class="btn" style="opacity: 0.4; pointer-events: none;">Previous</span>
@@ -53,7 +53,7 @@
        href="{{ url_for('history.history_page', page=page + 1, per_page=per_page) }}"
        hx-get="{{ url_for('history.history_page', page=page + 1, per_page=per_page) }}"
        hx-target="#history-grid-container"
-       hx-swap="outerHTML"
+       hx-swap="outerHTML show:#history-grid-container:top"
        hx-push-url="true">Next</a>
     {% else %}
     <span class="btn" style="opacity: 0.4; pointer-events: none;">Next</span>

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -787,3 +787,77 @@ def test_list_history_images_only_reads_limit_sidecars(device_config_dev, monkey
     assert len(images) == limit
     # Should have loaded at most `limit` sidecars, not all 10
     assert load_count["n"] <= limit
+
+
+# ---------------------------------------------------------------------------
+# HTMX pagination partial swap tests (JTN-330)
+# ---------------------------------------------------------------------------
+
+
+def test_htmx_pagination_returns_different_content_per_page(client, device_config_dev):
+    """JTN-330: HTMX partial for page 1 and page 2 must contain different images."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    names = [f"display_20250301_{i:06d}.png" for i in range(20)]
+    for name in names:
+        Image.new("RGB", (10, 10), "white").save(os.path.join(d, name))
+
+    hx = {"HX-Request": "true"}
+    r1 = client.get("/history?page=1&per_page=10", headers=hx)
+    r2 = client.get("/history?page=2&per_page=10", headers=hx)
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+
+    body1 = r1.get_data(as_text=True)
+    body2 = r2.get_data(as_text=True)
+
+    imgs_p1 = {n for n in names if n in body1}
+    imgs_p2 = {n for n in names if n in body2}
+
+    assert len(imgs_p1) == 10, f"Page 1 should show 10 images, got {len(imgs_p1)}"
+    assert len(imgs_p2) == 10, f"Page 2 should show 10 images, got {len(imgs_p2)}"
+    assert not imgs_p1 & imgs_p2, "HTMX partials for page 1 and 2 must not overlap"
+
+
+def test_pagination_links_include_scroll_show_modifier(client, device_config_dev):
+    """JTN-330: pagination links must include show: modifier so the grid
+    scrolls into view after HTMX swap."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    for i in range(15):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_20250301_{i:06d}.png")
+        )
+
+    resp = client.get("/history?page=1&per_page=10")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    assert "show:#history-grid-container:top" in body, (
+        "Next link hx-swap must include show:#history-grid-container:top "
+        "so the browser scrolls to the grid after swap"
+    )
+
+
+def test_htmx_partial_is_not_full_page(client, device_config_dev):
+    """JTN-330: HTMX partial must not include the full page shell."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    for i in range(5):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_20250301_{i:06d}.png")
+        )
+
+    resp = client.get("/history", headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    assert "<html" not in body, "HTMX partial must not include <html> tag"
+    assert "history-grid-container" in body, "Partial must contain the grid container"

--- a/tests/static/test_history_actions.py
+++ b/tests/static/test_history_actions.py
@@ -454,3 +454,18 @@ def test_history_template_boot_invokes_page_controller(client):
     assert "InkyPiHistoryPage" in body, "Boot script must reference InkyPiHistoryPage"
     assert ".create(" in body, "Boot script must call .create() to instantiate the page"
     assert ".init()" in body, "Boot script must call .init() to wire up event handlers"
+
+
+def test_history_page_js_rebinds_images_after_htmx_swap(client):
+    """JTN-330: history_page.js must listen for htmx:afterSettle to rebind
+    image skeleton handlers after HTMX swaps the grid."""
+    resp = client.get("/static/scripts/history_page.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    assert (
+        "htmx:afterSettle" in js
+    ), "history_page.js must listen for htmx:afterSettle to rebind images after swap"
+    assert (
+        "bindImages" in js
+    ), "htmx:afterSettle handler must call bindImages to rebind skeleton handlers"


### PR DESCRIPTION
## Summary
- Add `show:#history-grid-container:top` to `hx-swap` on Next/Prev pagination links so the viewport scrolls to the grid after HTMX swaps new page content
- Listen for `htmx:afterSettle` in `history_page.js` to re-bind image skeleton handlers on newly loaded grid content
- Add 4 integration/static tests covering HTMX partial content, scroll modifier presence, and JS rebinding

## Root cause
The HTMX `outerHTML` swap replaced the grid container correctly, but the viewport stayed at the bottom of the page (near the pagination nav). After clicking Next, the user saw the same pagination area and perceived no change. Adding the `show:` scroll modifier ensures the grid scrolls into view after each page change.

## Test plan
- [x] HTMX partial for page 1 vs page 2 returns disjoint image sets
- [x] Pagination links include `show:#history-grid-container:top` in `hx-swap`
- [x] HTMX partial omits full page shell (`<html>` tag absent)
- [x] `history_page.js` contains `htmx:afterSettle` listener
- [x] Full suite: 3631 passed, 4 skipped (2 pre-existing failures in `test_plugin_registry`)
- [x] Lint: ruff + black + shellcheck clean

Closes JTN-330

🤖 Generated with [Claude Code](https://claude.com/claude-code)