### PR TITLE
feat(a11y): wire up axe-core scans in Playwright tests (JTN-507)

### DIFF
--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -247,6 +247,7 @@
         <div id="pluginMeta" class="image-meta workflow-meta" hidden><div id="pluginMetaContent"></div></div>
 
         <div class="workflow-action-panel">
+            <span id="plugin-form-status" class="validation-message" role="status" aria-live="polite"></span>
             <label class="workflow-device-toggle" for="toggleDeviceFrame">
                 <input type="checkbox" id="toggleDeviceFrame" aria-label="Show device frame"> Show device frame
             </label>

--- a/src/templates/response_modal.html
+++ b/src/templates/response_modal.html
@@ -1,5 +1,6 @@
 <!-- Reusable Success/Failure Notification Modal -->
-<div id="responseModal" class="response-modal success-failure-modal" role="dialog" aria-modal="true" aria-labelledby="modalMessage" aria-label="Notification" aria-live="assertive">
+<!-- aria-live="assertive" announces modal text to screen readers immediately (JTN-507) -->
+<div id="responseModal" class="response-modal success-failure-modal" role="alertdialog" aria-modal="true" aria-labelledby="modalMessage" aria-label="Notification" aria-live="assertive">
     <div id="modalContent" class="response-modal-content">
         <button type="button" class="close-button" id="responseModalClose" aria-label="Close"><svg class="close-icon" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg"><line x1="200" y1="56" x2="56" y2="200" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="200" y1="200" x2="56" y2="56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/></svg></button>
         <p id="modalMessage"></p>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -299,7 +299,8 @@
 
         <!-- Buttons -->
         <div class="buttons-container">
-            <button type="button" id="saveSettingsBtn" class="action-button">Save</button>
+            <span id="settings-form-status" class="validation-message" role="status" aria-live="polite"></span>
+            <button type="button" id="saveSettingsBtn" class="action-button" aria-describedby="settings-form-status">Save</button>
         </div>
         </div>
         </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ UI_BROWSER_TESTS = {
     "test_cross_page_navigation_e2e.py",
 }
 A11Y_BROWSER_TESTS = {
+    "test_axe_a11y.py",
     "test_more_a11y.py",
     "test_playlist_a11y.py",
 }

--- a/tests/integration/test_axe_a11y.py
+++ b/tests/integration/test_axe_a11y.py
@@ -1,0 +1,133 @@
+"""
+Axe-core accessibility scans for every main route.
+
+These tests load each page in a real Playwright browser, inject axe-core, and
+assert zero *new* violations.  Known pre-existing violations are whitelisted
+with TODO references so they can be burned down incrementally.
+
+Gate: SKIP_BROWSER=1 or SKIP_A11Y=1 causes pytest to skip collection entirely
+(handled by conftest.pytest_ignore_collect).
+
+To run:
+    playwright install chromium
+    SKIP_A11Y=0 PYTHONPATH=src pytest tests/integration/test_axe_a11y.py -q
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+# ── Routes to scan ──────────────────────────────────────────────────────────
+_ROUTES: list[tuple[str, str]] = [
+    ("home", "/"),
+    ("settings", "/settings"),
+    ("playlist", "/playlist"),
+    ("history", "/history"),
+    ("api_keys", "/settings/api-keys"),
+    ("plugin_clock", "/plugin/clock"),
+]
+
+# ── Known violations whitelisted per-route ──────────────────────────────────
+# Each entry maps an axe rule-id to a TODO ticket so regressions are tracked.
+_KNOWN_VIOLATIONS: dict[str, set[str]] = {
+    # landmark-one-main / region fire because axe sees content outside <main>
+    # due to skip-link and modal markup.  TODO(JTN-508): restructure base.html.
+    #
+    # landmark-banner-is-top-level fires on pages with <header role="banner">
+    # nested inside <main>.  TODO(JTN-508): move banner outside <main>.
+    #
+    # aria-dialog-name fires on the response modal and schedule modal when
+    # aria-labelledby points to an empty <p>.  TODO(JTN-509): set modal title.
+    #
+    # color-contrast fires on some status chips and placeholder text.
+    # TODO(JTN-510): audit contrast ratios.
+    "home": {"landmark-one-main", "region"},
+    "settings": {
+        "landmark-one-main",
+        "region",
+        "landmark-banner-is-top-level",  # TODO(JTN-508)
+        "aria-dialog-name",  # TODO(JTN-509)
+        "color-contrast",  # TODO(JTN-510)
+    },
+    "playlist": {
+        "landmark-one-main",
+        "region",
+        "landmark-banner-is-top-level",  # TODO(JTN-508)
+        "heading-order",  # TODO(JTN-508): h3 inside empty-state skips h2
+        "aria-dialog-name",  # TODO(JTN-509)
+        "color-contrast",  # TODO(JTN-510)
+    },
+    "history": {
+        "landmark-one-main",
+        "region",
+        "landmark-banner-is-top-level",  # TODO(JTN-508)
+        "heading-order",  # TODO(JTN-508)
+        "aria-dialog-name",  # TODO(JTN-509)
+        "color-contrast",  # TODO(JTN-510)
+    },
+    "api_keys": {
+        "landmark-one-main",
+        "region",
+        "landmark-banner-is-top-level",  # TODO(JTN-508)
+        "heading-order",  # TODO(JTN-508)
+        "aria-dialog-name",  # TODO(JTN-509)
+        "color-contrast",  # TODO(JTN-510)
+    },
+    "plugin_clock": {
+        "landmark-one-main",
+        "region",
+        "aria-dialog-name",  # TODO(JTN-509)
+        "color-contrast",  # TODO(JTN-510)
+        "nested-interactive",  # TODO(JTN-511): collapsible button wraps interactive
+        "aria-hidden-focus",  # TODO(JTN-511): hidden modal contains focusable elements
+    },
+}
+
+
+def _load_axe_js() -> str:
+    axe_path = Path(__file__).resolve().parent.parent / "fixtures" / "axe.min.js"
+    return axe_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(
+    os.getenv("SKIP_A11Y", "").lower() in ("1", "true"),
+    reason="A11y checks skipped by env",
+)
+@pytest.mark.parametrize("route_name,route_path", _ROUTES, ids=[r[0] for r in _ROUTES])
+def test_axe_scan(live_server, route_name, route_path):
+    """Run axe-core against *route_path* and fail on unknown violations."""
+    from playwright.sync_api import sync_playwright
+
+    axe_js = _load_axe_js()
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        try:
+            page = browser.new_page(viewport={"width": 1280, "height": 900})
+            page.goto(
+                f"{live_server}{route_path}",
+                wait_until="domcontentloaded",
+                timeout=30_000,
+            )
+            page.wait_for_selector("[data-page-shell]", timeout=10_000)
+            page.wait_for_timeout(300)
+
+            # Inject axe-core and run the scan
+            page.add_script_tag(content=axe_js)
+            result = page.evaluate("() => axe.run(document)")
+        finally:
+            browser.close()
+
+    known = _KNOWN_VIOLATIONS.get(route_name, set())
+    new_violations = [
+        v for v in (result.get("violations") or []) if v["id"] not in known
+    ]
+
+    if new_violations:
+        summary = "\n".join(
+            f"  - {v['id']} ({v['impact']}): {v['description']}" for v in new_violations
+        )
+        pytest.fail(f"New a11y violations on {route_name}:\n{summary}")


### PR DESCRIPTION
## Summary
- Add `tests/integration/test_axe_a11y.py` with parametrized axe-core scans for all 6 main routes (home, settings, playlist, history, api_keys, plugin/clock)
- Whitelist known pre-existing violations with TODO tickets (JTN-508 through JTN-511) so the suite lands green and catches regressions
- Add `aria-live="polite"` status regions for inline form error announcements in plugin.html and settings.html
- Upgrade response_modal.html to `role="alertdialog"` with `aria-live="assertive"` for screen reader announcements
- Register new test in conftest `A11Y_BROWSER_TESTS` for proper `SKIP_BROWSER` / `SKIP_A11Y` gating

## Test plan
- [x] `SKIP_A11Y=0 pytest tests/integration/test_axe_a11y.py -q` -- 6 passed
- [x] `SKIP_BROWSER=1 pytest tests/` -- 3630 passed (2 pre-existing failures unrelated)
- [x] `scripts/lint.sh` -- all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)