### PR TITLE
feat(api): async job queue for plugin renders (JTN-497)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -16,6 +16,7 @@ from flask import (
 
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task import ManualRefresh, PlaylistRefresh
+from refresh_task.job_queue import get_job_queue
 from utils.app_utils import handle_request_files, parse_form, resolve_path
 from utils.fallback_image import render_error_image
 from utils.form_utils import (
@@ -593,8 +594,90 @@ def _push_update_now_fallback_from_current_exception(
     )
 
 
+@plugin_bp.route("/api/job/<job_id>", methods=["GET"])
+def job_status(job_id: str):
+    """Poll the status of an asynchronous render job."""
+    queue = get_job_queue()
+    info = queue.get_status(job_id)
+    return jsonify(info), 200
+
+
+def _run_update_now(app, plugin_id, plugin_settings):
+    """Execute plugin render in a background thread (job-queue worker).
+
+    Needs the Flask *app* so we can push an application context — the worker
+    thread has none by default.
+    """
+    with app.app_context():
+        device_config = app.config[_CONFIG_KEY]
+        refresh_task = app.config["REFRESH_TASK"]
+        display_manager = app.config["DISPLAY_MANAGER"]
+
+        if refresh_task.running:
+            metrics = refresh_task.manual_update(
+                ManualRefresh(plugin_id, plugin_settings)
+            )
+            return {
+                "success": True,
+                "message": _MSG_DISPLAY_UPDATED,
+                "metrics": metrics,
+            }
+
+        logger.info("Refresh task not running, updating display directly")
+        plugin_config = device_config.get_plugin(plugin_id)
+        if not plugin_config:
+            raise RuntimeError(f"Plugin '{plugin_id}' not found")
+
+        plugin = get_plugin_instance(plugin_config)
+        with track_progress() as tracker:
+            _t_req_start = perf_counter()
+            _t_gen_start = perf_counter()
+            image = plugin.generate_image(plugin_settings, device_config)
+            generate_ms = int((perf_counter() - _t_gen_start) * 1000)
+            history_meta = {
+                "refresh_type": "Manual Update",
+                "plugin_id": plugin_id,
+                "playlist": None,
+                "plugin_instance": None,
+            }
+            _safe_display_image(
+                display_manager,
+                image,
+                plugin_config.get("image_settings", []),
+                history_meta,
+            )
+            try:
+                ri = device_config.get_refresh_info()
+                display_ms = getattr(ri, "display_ms", None)
+                preprocess_ms = getattr(ri, "preprocess_ms", None)
+            except Exception:
+                display_ms = preprocess_ms = None
+            request_ms = int((perf_counter() - _t_req_start) * 1000)
+            return {
+                "success": True,
+                "message": _MSG_DISPLAY_UPDATED,
+                "metrics": {
+                    "request_ms": request_ms,
+                    "display_ms": display_ms,
+                    "generate_ms": generate_ms,
+                    "preprocess_ms": preprocess_ms,
+                    "steps": tracker.get_steps(),
+                },
+            }
+
+
 @plugin_bp.route("/update_now", methods=["POST"])
 def update_now():
+    """Render a plugin image and push it to the display.
+
+    When the client sends ``X-Async: true`` (or ``?async=1``), the render is
+    enqueued on a background thread and the response is **202 Accepted** with
+    ``{"job_id": "…"}``.  The caller then polls ``GET /api/job/<job_id>``
+    until status is ``done`` or ``error``.
+
+    Without the async flag the request behaves synchronously (legacy mode) so
+    existing callers and tests are unaffected.
+    """
     device_config = current_app.config[_CONFIG_KEY]
     refresh_task = current_app.config["REFRESH_TASK"]
     display_manager = current_app.config["DISPLAY_MANAGER"]
@@ -611,6 +694,17 @@ def update_now():
                 details={"field": _PLUGIN_ID},
             )
 
+        want_async = request.headers.get(
+            "X-Async", ""
+        ).lower() == "true" or request.args.get("async", "").lower() in ("1", "true")
+
+        if want_async:
+            queue = get_job_queue()
+            app = current_app._get_current_object()  # real app, not proxy
+            job_id = queue.enqueue(_run_update_now, app, plugin_id, plugin_settings)
+            return jsonify({"job_id": job_id}), 202
+
+        # --- Synchronous (legacy) path ---
         if refresh_task.running:
             metrics = refresh_task.manual_update(
                 ManualRefresh(plugin_id, plugin_settings)

--- a/src/refresh_task/job_queue.py
+++ b/src/refresh_task/job_queue.py
@@ -1,0 +1,150 @@
+"""Lightweight thread-pool job queue for non-blocking plugin renders.
+
+Provides ``enqueue(fn, *args, **kwargs) -> job_id`` and ``get_status(job_id)``
+so HTTP handlers can return 202 Accepted and let the caller poll for results.
+
+No external dependencies (no Celery, no Redis) — uses a stdlib
+``concurrent.futures.ThreadPoolExecutor``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Singleton job queue — created lazily via ``get_job_queue()``.
+_instance: JobQueue | None = None
+_instance_lock = threading.Lock()
+
+# Job status constants
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_DONE = "done"
+STATUS_ERROR = "error"
+
+# Default max workers — kept low; Pi Zero has limited resources.
+_DEFAULT_MAX_WORKERS = 2
+
+
+class JobQueue:
+    """A thin wrapper around :class:`ThreadPoolExecutor` with status tracking."""
+
+    def __init__(self, max_workers: int = _DEFAULT_MAX_WORKERS) -> None:
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="job-queue"
+        )
+        self._jobs: dict[str, _JobEntry] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def enqueue(self, fn: Any, *args: Any, **kwargs: Any) -> str:
+        """Submit *fn(*args, **kwargs)* for background execution.
+
+        Returns a unique ``job_id`` (UUID4 hex string) that can be passed to
+        :meth:`get_status` to poll for completion.
+        """
+        job_id = uuid.uuid4().hex
+        entry = _JobEntry(job_id)
+
+        with self._lock:
+            self._jobs[job_id] = entry
+
+        future = self._executor.submit(self._run, entry, fn, *args, **kwargs)
+        entry.future = future
+        return job_id
+
+    def get_status(self, job_id: str) -> dict[str, Any]:
+        """Return the current status of *job_id*.
+
+        Returns a dict with keys:
+        - ``status``: one of ``pending``, ``running``, ``done``, ``error``
+        - ``result``: the return value when ``status == "done"``
+        - ``error``:  a string description when ``status == "error"``
+        """
+        with self._lock:
+            entry = self._jobs.get(job_id)
+
+        if entry is None:
+            return {"status": "unknown", "error": "Job not found"}
+
+        return entry.to_dict()
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Shut down the underlying thread pool."""
+        self._executor.shutdown(wait=wait)
+
+    @property
+    def pending_jobs(self) -> int:
+        """Number of jobs that have not yet completed (pending or running)."""
+        with self._lock:
+            return sum(
+                1
+                for e in self._jobs.values()
+                if e.status in (STATUS_PENDING, STATUS_RUNNING)
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _run(entry: _JobEntry, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        entry.status = STATUS_RUNNING
+        try:
+            result = fn(*args, **kwargs)
+            entry.result = result
+            entry.status = STATUS_DONE
+            return result
+        except Exception as exc:
+            logger.exception("Job %s failed", entry.job_id)
+            entry.error = str(exc)
+            entry.status = STATUS_ERROR
+            raise
+
+
+class _JobEntry:
+    """Mutable record tracking one enqueued job."""
+
+    __slots__ = ("job_id", "status", "result", "error", "future")
+
+    def __init__(self, job_id: str) -> None:
+        self.job_id = job_id
+        self.status: str = STATUS_PENDING
+        self.result: Any = None
+        self.error: str | None = None
+        self.future: Future | None = None  # type: ignore[type-arg]
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"status": self.status}
+        if self.status == STATUS_DONE and self.result is not None:
+            d["result"] = self.result
+        if self.status == STATUS_ERROR and self.error is not None:
+            d["error"] = self.error
+        return d
+
+
+def get_job_queue() -> JobQueue:
+    """Return the module-level singleton :class:`JobQueue`, creating it lazily."""
+    global _instance
+    if _instance is None:
+        with _instance_lock:
+            if _instance is None:
+                _instance = JobQueue()
+    return _instance
+
+
+def reset_job_queue() -> None:
+    """Shut down and discard the singleton (test helper)."""
+    global _instance
+    with _instance_lock:
+        if _instance is not None:
+            _instance.shutdown(wait=False)
+            _instance = None

--- a/src/static/scripts/plugin_form.js
+++ b/src/static/scripts/plugin_form.js
@@ -65,24 +65,79 @@
     const timeoutId = setTimeout(() => controller.abort(), 90000);
     try {
       progress.setStep('Sending…', 30);
-      const response = await fetch(url, { method, body: formData, signal: controller.signal });
-      progress.setStep('Waiting (device)…', 60);
-      result = await response.json();
-      if (response.ok){
-        // metrics display
-        const m = result && result.metrics || null;
-        if (m && Array.isArray(m.steps) && m.steps.length){ let pct = 60; const inc = 30 / m.steps.length; for (const step of m.steps){ pct += inc; progress.setStep(`${step.name} ${step.elapsed_ms} ms`, pct); await new Promise(r => setTimeout(r, 50)); } }
-        const parts = []; const add = (label, val) => { if (val !== null && val !== undefined) parts.push(`${label} ${val} ms`); };
-        if (m){ add('Request', m.request_ms); add('Generate', m.generate_ms); add('Preprocess', m.preprocess_ms); add('Display', m.display_ms); }
-        if (parts.length){ progress.setStep(parts.join(' • '), 90); }
-        if (window.showResponseModal) window.showResponseModal('success', `Success! ${result.message}`);
-        success = true;
-        // Call the success callback to refresh images
-        if (typeof onAfterSuccess === 'function') {
-          try { onAfterSuccess(); } catch(e){ console.error('onAfterSuccess callback error:', e); }
+      // Request async processing for update_now so the browser doesn't block
+      const headers = {};
+      if (action === 'update_now' || url === urls.update_now) { headers['X-Async'] = 'true'; }
+      const response = await fetch(url, { method, body: formData, signal: controller.signal, headers });
+
+      // -- Async job-queue flow for update_now (202 Accepted) --
+      if (response.status === 202) {
+        const accepted = await response.json();
+        const jobId = accepted.job_id;
+        progress.setStep('Rendering (background)…', 40);
+
+        // Poll /api/job/<id> until done or error
+        const POLL_INTERVAL_MS = 1000;
+        const MAX_POLLS = 90; // 90s total
+        let polls = 0;
+        let jobDone = false;
+        while (polls < MAX_POLLS) {
+          await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+          polls++;
+          if (controller.signal.aborted) break;
+          try {
+            const pollResp = await fetch('/api/job/' + jobId, { signal: controller.signal });
+            const jobInfo = await pollResp.json();
+            if (jobInfo.status === 'running') {
+              progress.setStep('Rendering (background)…', 40 + Math.min(polls, 50));
+            } else if (jobInfo.status === 'done') {
+              result = jobInfo.result || { success: true, message: 'Display updated' };
+              // metrics display
+              const m = result && result.metrics || null;
+              if (m && Array.isArray(m.steps) && m.steps.length){ let pct = 60; const inc = 30 / m.steps.length; for (const step of m.steps){ pct += inc; progress.setStep(`${step.name} ${step.elapsed_ms} ms`, pct); await new Promise(r => setTimeout(r, 50)); } }
+              const parts = []; const add = (label, val) => { if (val !== null && val !== undefined) parts.push(`${label} ${val} ms`); };
+              if (m){ add('Request', m.request_ms); add('Generate', m.generate_ms); add('Preprocess', m.preprocess_ms); add('Display', m.display_ms); }
+              if (parts.length){ progress.setStep(parts.join(' • '), 90); }
+              if (window.showResponseModal) window.showResponseModal('success', `Success! ${result.message}`);
+              success = true;
+              if (typeof onAfterSuccess === 'function') { try { onAfterSuccess(); } catch(e){ console.error('onAfterSuccess callback error:', e); } }
+              jobDone = true;
+              break;
+            } else if (jobInfo.status === 'error') {
+              result = { error: jobInfo.error || 'Plugin render failed' };
+              if (window.showResponseModal) window.showResponseModal('failure', `Error! ${result.error}`);
+              jobDone = true;
+              break;
+            }
+            // status === 'pending' — keep polling
+          } catch (pollErr) {
+            if (pollErr.name === 'AbortError') break;
+            console.warn('Poll error:', pollErr);
+          }
+        }
+        if (!jobDone && !controller.signal.aborted) {
+          if (window.showResponseModal) window.showResponseModal('failure', 'Request timed out. The plugin may still be processing \u2014 check back in a moment.');
         }
       } else {
-        if (window.showResponseModal) window.showResponseModal('failure', `Error!  ${result.error}`);
+        // -- Synchronous response (non-update_now routes) --
+        progress.setStep('Waiting (device)…', 60);
+        result = await response.json();
+        if (response.ok){
+          // metrics display
+          const m = result && result.metrics || null;
+          if (m && Array.isArray(m.steps) && m.steps.length){ let pct = 60; const inc = 30 / m.steps.length; for (const step of m.steps){ pct += inc; progress.setStep(`${step.name} ${step.elapsed_ms} ms`, pct); await new Promise(r => setTimeout(r, 50)); } }
+          const parts = []; const add = (label, val) => { if (val !== null && val !== undefined) parts.push(`${label} ${val} ms`); };
+          if (m){ add('Request', m.request_ms); add('Generate', m.generate_ms); add('Preprocess', m.preprocess_ms); add('Display', m.display_ms); }
+          if (parts.length){ progress.setStep(parts.join(' • '), 90); }
+          if (window.showResponseModal) window.showResponseModal('success', `Success! ${result.message}`);
+          success = true;
+          // Call the success callback to refresh images
+          if (typeof onAfterSuccess === 'function') {
+            try { onAfterSuccess(); } catch(e){ console.error('onAfterSuccess callback error:', e); }
+          }
+        } else {
+          if (window.showResponseModal) window.showResponseModal('failure', `Error!  ${result.error}`);
+        }
       }
     } catch (e){
       console.error('Error in plugin form submission:', e);

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -199,7 +199,157 @@ def test_update_now_plugin_not_found(client):
     assert "Plugin 'nonexistent' not found" in resp.get_json().get("error", "")
 
 
+def test_update_now_async_returns_202_with_job_id(client):
+    """POST /update_now with X-Async returns 202 Accepted with a job_id."""
+    resp = client.post(
+        "/update_now",
+        data={"plugin_id": "clock"},
+        headers={"X-Async": "true"},
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert "job_id" in data
+    assert isinstance(data["job_id"], str)
+    assert len(data["job_id"]) == 32
+
+
+def test_update_now_sync_still_works(client):
+    """POST /update_now without X-Async keeps the legacy synchronous path."""
+    resp = client.post("/update_now", data={"plugin_id": "clock"})
+    # Should be 200 (sync path), not 202
+    assert resp.status_code == 200
+
+
+def test_update_now_missing_plugin_id_returns_422(client):
+    """POST /update_now without plugin_id still returns 422."""
+    resp = client.post("/update_now", data={})
+    assert resp.status_code == 422
+
+
+def test_job_status_unknown_id(client):
+    """GET /api/job/<unknown> returns status 'unknown'."""
+    resp = client.get("/api/job/does_not_exist_at_all_1234")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "unknown"
+
+
+def test_update_now_async_poll_completes(client, flask_app, monkeypatch):
+    """Full 202 -> poll -> done flow for async update_now."""
+    import time
+
+    from PIL import Image
+
+    import plugins.clock.clock as clock_mod
+    from refresh_task.job_queue import get_job_queue
+
+    def fake_generate(self, settings, device_config):
+        return Image.new("RGB", device_config.get_resolution(), "white")
+
+    monkeypatch.setattr(clock_mod.Clock, "generate_image", fake_generate, raising=True)
+
+    display_manager = flask_app.config["DISPLAY_MANAGER"]
+    monkeypatch.setattr(
+        display_manager,
+        "display_image",
+        lambda image, image_settings=None, history_meta=None: None,
+        raising=True,
+    )
+
+    refresh_task = flask_app.config["REFRESH_TASK"]
+    refresh_task.running = False
+
+    resp = client.post(
+        "/update_now",
+        data={"plugin_id": "clock"},
+        headers={"X-Async": "true"},
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    # Poll until done — must finish before monkeypatch cleanup
+    for _ in range(50):
+        poll = client.get(f"/api/job/{job_id}")
+        data = poll.get_json()
+        if data["status"] in ("done", "error"):
+            break
+        time.sleep(0.1)
+
+    assert data["status"] == "done"
+    assert data["result"]["success"] is True
+
+    # Wait for background thread to fully exit before monkeypatch restores
+    queue = get_job_queue()
+    for _ in range(20):
+        if queue.pending_jobs == 0:
+            break
+        time.sleep(0.05)
+
+
+def test_update_now_async_poll_error(client, flask_app, monkeypatch):
+    """Async update_now job that raises shows status 'error' when polled."""
+    import time
+
+    from refresh_task.job_queue import get_job_queue
+
+    refresh_task = flask_app.config["REFRESH_TASK"]
+    refresh_task.running = False
+
+    # Use a plugin that doesn't exist — guaranteed to raise without monkeypatch timing issues
+    resp = client.post(
+        "/update_now",
+        data={"plugin_id": "nonexistent_plugin_xyz"},
+        headers={"X-Async": "true"},
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(50):
+        poll = client.get(f"/api/job/{job_id}")
+        data = poll.get_json()
+        if data["status"] in ("done", "error"):
+            break
+        time.sleep(0.1)
+
+    assert data["status"] == "error"
+    assert "not found" in data["error"]
+
+    # Ensure background thread finishes before test cleanup
+    queue = get_job_queue()
+    for _ in range(20):
+        if queue.pending_jobs == 0:
+            break
+        time.sleep(0.05)
+
+
+def test_update_now_async_plugin_not_found(client, flask_app):
+    """Plugin not found is reported via the job error status."""
+    import time
+
+    refresh_task = flask_app.config["REFRESH_TASK"]
+    refresh_task.running = False
+
+    resp = client.post(
+        "/update_now",
+        data={"plugin_id": "nonexistent"},
+        headers={"X-Async": "true"},
+    )
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    for _ in range(50):
+        poll = client.get(f"/api/job/{job_id}")
+        data = poll.get_json()
+        if data["status"] in ("done", "error"):
+            break
+        time.sleep(0.1)
+
+    assert data["status"] == "error"
+    assert "not found" in data["error"]
+
+
 def test_update_now_exception_handling(client, flask_app, monkeypatch):
+    """Sync path: exceptions yield 500."""
     import blueprints.plugin as plugin_mod
 
     monkeypatch.setattr(

--- a/tests/unit/test_job_queue.py
+++ b/tests/unit/test_job_queue.py
@@ -1,0 +1,138 @@
+# pyright: reportMissingImports=false
+"""Unit tests for refresh_task.job_queue."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from refresh_task.job_queue import (
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_RUNNING,
+    JobQueue,
+    get_job_queue,
+    reset_job_queue,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Ensure the module-level singleton is reset between tests."""
+    reset_job_queue()
+    yield
+    reset_job_queue()
+
+
+class TestJobQueue:
+    """Core JobQueue behaviour."""
+
+    def test_enqueue_returns_job_id(self):
+        q = JobQueue()
+        jid = q.enqueue(lambda: 42)
+        assert isinstance(jid, str)
+        assert len(jid) == 32  # uuid4 hex
+        q.shutdown()
+
+    def test_job_completes_with_done_status(self):
+        q = JobQueue()
+        jid = q.enqueue(lambda: "hello")
+        # Wait for completion
+        for _ in range(50):
+            info = q.get_status(jid)
+            if info["status"] == STATUS_DONE:
+                break
+            time.sleep(0.05)
+        assert info["status"] == STATUS_DONE
+        assert info["result"] == "hello"
+        q.shutdown()
+
+    def test_job_error_status(self):
+        def _fail():
+            raise ValueError("boom")
+
+        q = JobQueue()
+        jid = q.enqueue(_fail)
+        for _ in range(50):
+            info = q.get_status(jid)
+            if info["status"] == STATUS_ERROR:
+                break
+            time.sleep(0.05)
+        assert info["status"] == STATUS_ERROR
+        assert "boom" in info["error"]
+        q.shutdown()
+
+    def test_unknown_job_id(self):
+        q = JobQueue()
+        info = q.get_status("nonexistent")
+        assert info["status"] == "unknown"
+        q.shutdown()
+
+    def test_pending_jobs_count(self):
+        barrier = threading.Event()
+
+        def _block():
+            barrier.wait(timeout=5)
+
+        q = JobQueue(max_workers=1)
+        q.enqueue(_block)
+        q.enqueue(_block)
+        # At least one should still be pending/running
+        time.sleep(0.1)
+        assert q.pending_jobs >= 1
+        barrier.set()
+        q.shutdown(wait=True)
+
+    def test_job_transitions_through_running(self):
+        started = threading.Event()
+        proceed = threading.Event()
+
+        def _slow():
+            started.set()
+            proceed.wait(timeout=5)
+            return "ok"
+
+        q = JobQueue(max_workers=1)
+        jid = q.enqueue(_slow)
+        started.wait(timeout=5)
+        info = q.get_status(jid)
+        assert info["status"] == STATUS_RUNNING
+        proceed.set()
+        for _ in range(50):
+            info = q.get_status(jid)
+            if info["status"] == STATUS_DONE:
+                break
+            time.sleep(0.05)
+        assert info["status"] == STATUS_DONE
+        q.shutdown()
+
+    def test_enqueue_with_args_and_kwargs(self):
+        def _add(a, b, extra=0):
+            return a + b + extra
+
+        q = JobQueue()
+        jid = q.enqueue(_add, 1, 2, extra=10)
+        for _ in range(50):
+            info = q.get_status(jid)
+            if info["status"] == STATUS_DONE:
+                break
+            time.sleep(0.05)
+        assert info["result"] == 13
+        q.shutdown()
+
+
+class TestSingleton:
+    """get_job_queue / reset_job_queue singleton management."""
+
+    def test_get_returns_same_instance(self):
+        q1 = get_job_queue()
+        q2 = get_job_queue()
+        assert q1 is q2
+
+    def test_reset_creates_new_instance(self):
+        q1 = get_job_queue()
+        reset_job_queue()
+        q2 = get_job_queue()
+        assert q1 is not q2


### PR DESCRIPTION
## Summary
- Add `src/refresh_task/job_queue.py` — a `ThreadPoolExecutor`-backed job queue with `enqueue()` / `get_status()` API
- Add `GET /api/job/<job_id>` endpoint for polling job status (pending/running/done/error)
- `POST /update_now` returns 202 Accepted with `{job_id}` when client sends `X-Async: true` header; sync path preserved for backward compatibility
- Frontend `plugin_form.js` sends `X-Async: true` and polls `/api/job/<id>` with progress UI updates
- `Config.write_config` already uses a threading mutex (`_config_lock`) — no change needed

## Test plan
- [x] 9 new unit tests for `JobQueue` (lifecycle, error, args, singleton)
- [x] 7 new integration tests for async 202/poll flow (success, error, not-found, unknown job)
- [x] All 3643 existing tests pass (2 pre-existing pyenv-only failures unrelated)
- [x] `scripts/lint.sh` passes (ruff + black + mypy strict + shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)