### PR TITLE
fix(settings): render benchmark results as a labeled table (JTN-384)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -601,6 +601,79 @@
       }
     }
 
+    function formatMs(val) {
+      if (val === null || val === undefined) return "\u2014";
+      const seconds = val / 1000;
+      return seconds < 10
+        ? seconds.toFixed(1) + "s"
+        : Math.round(seconds) + "s";
+    }
+
+    const STAGE_LABELS = {
+      request_ms: "Request",
+      generate_ms: "Generate",
+      preprocess_ms: "Preprocess",
+      display_ms: "Display",
+    };
+
+    function buildSummaryTable(summaryData) {
+      const table = document.createElement("table");
+      table.className = "bench-table";
+      const thead = document.createElement("thead");
+      thead.innerHTML =
+        "<tr><th>Stage</th><th>p50</th><th>p95</th></tr>";
+      table.appendChild(thead);
+      const tbody = document.createElement("tbody");
+      for (const [key, label] of Object.entries(STAGE_LABELS)) {
+        const row = document.createElement("tr");
+        const stage = summaryData[key] || {};
+        row.innerHTML =
+          "<td>" +
+          label +
+          "</td><td>" +
+          formatMs(stage.p50) +
+          "</td><td>" +
+          formatMs(stage.p95) +
+          "</td>";
+        tbody.appendChild(row);
+      }
+      table.appendChild(tbody);
+      return table;
+    }
+
+    const PLUGIN_AVG_LABELS = {
+      request_avg: "Request",
+      generate_avg: "Generate",
+      display_avg: "Display",
+    };
+
+    function buildPluginsTable(items) {
+      const table = document.createElement("table");
+      table.className = "bench-table";
+      const thead = document.createElement("thead");
+      const cols = ["Plugin", "Runs"].concat(
+        Object.values(PLUGIN_AVG_LABELS)
+      );
+      thead.innerHTML =
+        "<tr>" + cols.map(function (c) { return "<th>" + c + "</th>"; }).join("") + "</tr>";
+      table.appendChild(thead);
+      const tbody = document.createElement("tbody");
+      items.slice(0, 10).forEach(function (item) {
+        const row = document.createElement("tr");
+        const cells = [
+          item.plugin_id || "\u2014",
+          String(item.runs || 0),
+        ];
+        for (const key of Object.keys(PLUGIN_AVG_LABELS)) {
+          cells.push(formatMs(item[key]));
+        }
+        row.innerHTML = cells.map(function (c) { return "<td>" + c + "</td>"; }).join("");
+        tbody.appendChild(row);
+      });
+      table.appendChild(tbody);
+      return table;
+    }
+
     async function refreshBenchmarks() {
       ui.setPanelLoading?.("benchSummary", true);
       try {
@@ -610,14 +683,21 @@
         ]);
         const summary = await summaryResp.json();
         const plugins = await pluginsResp.json();
-        const output = [
-          "Benchmark Summary (24h)",
-          JSON.stringify(summary.summary || {}, null, 2),
-          "",
-          "Per-plugin Averages",
-          JSON.stringify((plugins.items || []).slice(0, 10), null, 2),
-        ];
-        document.getElementById("benchSummary").textContent = output.join("\n");
+
+        const panel = document.getElementById("benchSummary");
+        panel.textContent = "";
+
+        const heading1 = document.createElement("strong");
+        heading1.textContent = "Benchmark Summary (24h)";
+        panel.appendChild(heading1);
+        panel.appendChild(buildSummaryTable(summary.summary || {}));
+
+        if ((plugins.items || []).length > 0) {
+          const heading2 = document.createElement("strong");
+          heading2.textContent = "Per-plugin Averages";
+          panel.appendChild(heading2);
+          panel.appendChild(buildPluginsTable(plugins.items));
+        }
       } catch (e) {
         console.warn("Failed to load benchmark summary:", e);
         document.getElementById("benchSummary").textContent =

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -3163,6 +3163,28 @@ textarea:focus-visible {
   min-height: 80px;
 }
 
+.bench-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 6px 0 12px;
+  font-size: 0.92em;
+}
+
+.bench-table th,
+.bench-table td {
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-color, #ddd);
+}
+
+.bench-table th {
+  font-weight: 600;
+  opacity: 0.75;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
 /* Mobile settings nav toggle */
 .settings-mobile-toggle {
   display: none;

--- a/src/static/styles/partials/_settings.css
+++ b/src/static/styles/partials/_settings.css
@@ -374,6 +374,28 @@
   min-height: 80px;
 }
 
+.bench-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 6px 0 12px;
+  font-size: 0.92em;
+}
+
+.bench-table th,
+.bench-table td {
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-color, #ddd);
+}
+
+.bench-table th {
+  font-weight: 600;
+  opacity: 0.75;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
 /* Mobile settings nav toggle */
 .settings-mobile-toggle {
   display: none;

--- a/tests/static/test_benchmark_display.py
+++ b/tests/static/test_benchmark_display.py
@@ -1,0 +1,65 @@
+"""Tests for benchmark display formatting in settings page (JTN-384).
+
+Benchmarks should render as a labeled table, not raw JSON.stringify output.
+Null values should display as an em-dash, not the literal string 'null'.
+"""
+
+from pathlib import Path
+
+JS_PATH = Path("src/static/scripts/settings_page.js")
+
+
+def _read_js():
+    return JS_PATH.read_text()
+
+
+class TestBenchmarkNoRawJSON:
+    """Ensure refreshBenchmarks no longer dumps raw JSON to the UI."""
+
+    def test_no_json_stringify_for_summary(self):
+        """Summary data must not be rendered via JSON.stringify."""
+        js = _read_js()
+        # The old code did: JSON.stringify(summary.summary || {}, null, 2)
+        assert "JSON.stringify(summary.summary" not in js
+
+    def test_no_json_stringify_for_plugins(self):
+        """Plugin data must not be rendered via JSON.stringify."""
+        js = _read_js()
+        # The old code did: JSON.stringify((plugins.items || []).slice(0, 10), null, 2)
+        assert "JSON.stringify((plugins.items" not in js
+
+
+class TestBenchmarkTableBuilder:
+    """Ensure the JS defines proper table-building helpers."""
+
+    def test_build_summary_table_defined(self):
+        js = _read_js()
+        assert "function buildSummaryTable" in js
+
+    def test_build_plugins_table_defined(self):
+        js = _read_js()
+        assert "function buildPluginsTable" in js
+
+    def test_stage_labels_defined(self):
+        """Human-readable labels must replace raw keys like 'generate_ms'."""
+        js = _read_js()
+        for label in ("Request", "Generate", "Preprocess", "Display"):
+            assert label in js
+
+    def test_null_rendered_as_em_dash(self):
+        """formatMs must return an em-dash for null/undefined values."""
+        js = _read_js()
+        # U+2014 em-dash or its JS unicode escape
+        assert "\\u2014" in js or "\u2014" in js
+
+
+class TestBenchmarkTableCSS:
+    """Ensure the bench-table CSS class exists."""
+
+    def test_bench_table_class_in_css(self):
+        css = Path("src/static/styles/partials/_settings.css").read_text()
+        assert ".bench-table" in css
+
+    def test_bench_table_class_used_in_js(self):
+        js = _read_js()
+        assert '"bench-table"' in js


### PR DESCRIPTION
## Summary
- Replace raw `JSON.stringify` output in Settings > Diagnostics > Benchmark Summary with formatted HTML tables
- Summary table shows Stage / p50 / p95 columns with human-readable labels (Request, Generate, Preprocess, Display)
- Per-plugin averages render as a separate table with Plugin / Runs / Request / Generate / Display columns
- `null` values display as em-dash (—) instead of literal "null"; numeric values formatted as seconds (e.g., "2.6s")
- Added `.bench-table` CSS for clean table styling
- Added 8 static tests verifying the JS no longer uses `JSON.stringify` for benchmarks and defines proper table builders

## Test plan
- [x] 8 new static tests in `tests/static/test_benchmark_display.py` all pass
- [x] Lint (`scripts/lint.sh`) passes clean
- [ ] Manual: Settings → Updates → Diagnostics → Refresh Benchmarks shows labeled table, not raw JSON

Closes JTN-384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>