### PR TITLE
fix(settings): show inline result for Check for Updates (JTN-352)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -457,8 +457,16 @@
       const badge = document.getElementById("updateBadge");
       const latestEl = document.getElementById("latestVersion");
       const updateBtn = document.getElementById("startUpdateBtn");
+      const checkBtn = document.getElementById("checkUpdatesBtn");
       const notesContainer = document.getElementById("releaseNotesContainer");
       const notesBody = document.getElementById("releaseNotesBody");
+
+      // Show spinner + disable button while checking (JTN-352)
+      if (checkBtn) {
+        checkBtn.disabled = true;
+        const sp = checkBtn.querySelector(".btn-spinner");
+        if (sp) sp.style.display = "inline-block";
+      }
       if (badge) { badge.textContent = "Checking..."; badge.className = "status-chip"; }
       try {
         const controller = new AbortController();
@@ -466,7 +474,7 @@
         const resp = await fetch(config.versionUrl, { cache: "no-store", signal: controller.signal });
         clearTimeout(timeoutId);
         const data = await resp.json();
-        if (latestEl) latestEl.textContent = data.latest || "—";
+        if (latestEl) latestEl.textContent = data.latest || "\u2014";
         if (data.update_available) {
           if (badge) { badge.textContent = "Update available"; badge.className = "status-chip warning"; }
           if (updateBtn) updateBtn.disabled = false;
@@ -486,6 +494,13 @@
       } catch (e) {
         console.warn("Version check failed:", e);
         if (badge) { badge.textContent = "Check failed"; badge.className = "status-chip"; }
+      } finally {
+        // Re-enable button and hide spinner (JTN-352)
+        if (checkBtn) {
+          checkBtn.disabled = false;
+          const sp = checkBtn.querySelector(".btn-spinner");
+          if (sp) sp.style.display = "none";
+        }
       }
     }
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -173,7 +173,7 @@
                         </details>
                     </div>
                     <div class="update-actions">
-                        <button type="button" id="checkUpdatesBtn" class="action-button compact">Check for Updates</button>
+                        <button type="button" id="checkUpdatesBtn" class="action-button compact"><span class="btn-spinner" aria-hidden="true"></span> Check for Updates</button>
                         <button type="button" id="startUpdateBtn" class="action-button compact" disabled>Update Now</button>
                     </div>
                 </div>

--- a/tests/unit/test_check_updates_inline.py
+++ b/tests/unit/test_check_updates_inline.py
@@ -1,0 +1,111 @@
+# pyright: reportMissingImports=false
+"""Tests for inline Check for Updates feedback (JTN-352).
+
+Verifies that:
+1. The settings page renders a spinner element inside the check-updates button.
+2. The /api/version endpoint returns structured version info suitable for
+   inline display (current, latest, update_available).
+"""
+
+import time
+from unittest.mock import MagicMock
+
+
+class TestCheckUpdatesButtonSpinner:
+    """The Check for Updates button must include a .btn-spinner element."""
+
+    def test_settings_page_has_spinner_in_check_button(self, client):
+        resp = client.get("/settings")
+        assert resp.status_code == 200
+        assert b'id="checkUpdatesBtn"' in resp.data
+        assert b"btn-spinner" in resp.data
+
+    def test_settings_page_has_update_badge(self, client):
+        resp = client.get("/settings")
+        assert resp.status_code == 200
+        assert b'id="updateBadge"' in resp.data
+
+    def test_settings_page_has_version_cards(self, client):
+        resp = client.get("/settings")
+        assert resp.status_code == 200
+        assert b'id="currentVersion"' in resp.data
+        assert b'id="latestVersion"' in resp.data
+
+
+class TestApiVersionInlineResult:
+    """The /api/version response must include fields for inline display."""
+
+    def test_returns_update_available_field(self, client, monkeypatch):
+        import blueprints.settings as mod
+
+        mod._VERSION_CACHE["latest"] = "99.0.0"
+        mod._VERSION_CACHE["checked_at"] = time.time()
+        mod._VERSION_CACHE["release_notes"] = None
+        original_version = client.application.config.get("APP_VERSION")
+        try:
+            client.application.config["APP_VERSION"] = "1.0.0"
+            resp = client.get("/api/version")
+            data = resp.get_json()
+            assert "update_available" in data
+            assert "current" in data
+            assert "latest" in data
+            assert data["latest"] == "99.0.0"
+            assert data["update_available"] is True
+        finally:
+            mod._VERSION_CACHE["latest"] = None
+            mod._VERSION_CACHE["checked_at"] = 0.0
+            if original_version is not None:
+                client.application.config["APP_VERSION"] = original_version
+            else:
+                client.application.config.pop("APP_VERSION", None)
+
+    def test_up_to_date_returns_false(self, client, monkeypatch):
+        import blueprints.settings as mod
+
+        # Set latest to same as current
+        current = client.application.config.get("APP_VERSION", "0.0.1")
+        mod._VERSION_CACHE["latest"] = current
+        mod._VERSION_CACHE["checked_at"] = time.time()
+        mod._VERSION_CACHE["release_notes"] = None
+        try:
+            resp = client.get("/api/version")
+            data = resp.get_json()
+            assert data["update_available"] is False
+        finally:
+            mod._VERSION_CACHE["latest"] = None
+            mod._VERSION_CACHE["checked_at"] = 0.0
+
+    def test_includes_release_notes_when_present(self, client, monkeypatch):
+        import blueprints.settings as mod
+
+        mod._VERSION_CACHE["latest"] = "99.0.0"
+        mod._VERSION_CACHE["checked_at"] = time.time()
+        mod._VERSION_CACHE["release_notes"] = "Bug fixes and improvements"
+        try:
+            resp = client.get("/api/version")
+            data = resp.get_json()
+            assert data["release_notes"] == "Bug fixes and improvements"
+        finally:
+            mod._VERSION_CACHE["latest"] = None
+            mod._VERSION_CACHE["checked_at"] = 0.0
+            mod._VERSION_CACHE["release_notes"] = None
+
+    def test_network_failure_returns_error_gracefully(self, client, monkeypatch):
+        import blueprints.settings as mod
+
+        # Force cache miss so it tries to fetch
+        mod._VERSION_CACHE["latest"] = None
+        mod._VERSION_CACHE["checked_at"] = 0.0
+        monkeypatch.setattr(
+            "blueprints.settings.http_get",
+            MagicMock(side_effect=Exception("network down")),
+        )
+        try:
+            resp = client.get("/api/version")
+            # Should still return a valid response (not 500)
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert "current" in data
+        finally:
+            mod._VERSION_CACHE["latest"] = None
+            mod._VERSION_CACHE["checked_at"] = 0.0


### PR DESCRIPTION
## Summary
- Add a `.btn-spinner` element to the "Check for Updates" button and toggle it visible/disabled during the version-check fetch
- The status badge already showed "Checking..."/"Up to date"/"Update available"/"Check failed" but the button itself had no loading indicator, making it appear unresponsive
- Add 7 new tests covering spinner presence in template and `/api/version` response structure

## Test plan
- [ ] Navigate to Settings > Updates and click "Check for Updates"
- [ ] Verify the button shows a spinner and is disabled during the fetch
- [ ] Verify the badge updates to "Up to date" or "Update available" when done
- [ ] Verify the button re-enables after the check completes (success or failure)
- [ ] Run `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/unit/test_check_updates_inline.py` -- all 7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)