### PR TITLE
feat(templates): add Jinja2 component-macro library (JTN-503)

### DIFF
--- a/src/templates/macros/components.html
+++ b/src/templates/macros/components.html
@@ -1,0 +1,54 @@
+{#- Reusable UI component macros with built-in accessibility attributes.
+    Import with: {% from 'macros/components.html' import button, form_field, modal, status_chip, card %}
+-#}
+
+{% macro button(text, type="button", variant="primary", icon=None, disabled=False, attrs={}) -%}
+<button type="{{ type }}" class="action-button{% if variant != 'primary' %} {{ variant }}{% endif %}"{% if disabled %} disabled{% endif %}{% for key, val in attrs.items() %} {{ key }}="{{ val }}"{% endfor %}>
+    {%- if icon %}<span class="button-icon" aria-hidden="true">{{ icon }}</span> {% endif -%}
+    {{ text }}
+</button>
+{%- endmacro %}
+
+{% macro form_field(name, label, type="text", required=False, value="", help_text="", error="", id="") -%}
+{% set field_id = id if id else name %}
+{% set help_id = field_id ~ '-help' if help_text else '' %}
+{% set error_id = field_id ~ '-error' if error else '' %}
+{% set described_parts = [] %}
+{%- if help_text %}{% if described_parts.append(help_id) %}{% endif %}{% endif -%}
+{%- if error %}{% if described_parts.append(error_id) %}{% endif %}{% endif -%}
+<div class="form-group">
+    <label for="{{ field_id }}" class="form-label">{{ label }}</label>
+    <input type="{{ type }}" id="{{ field_id }}" name="{{ name }}" class="form-input" value="{{ value }}"{% if required %} required aria-required="true"{% endif %}{% if error %} aria-invalid="true"{% endif %}{% if described_parts %} aria-describedby="{{ described_parts | join(' ') }}"{% endif %}>
+    {%- if help_text %}
+    <small id="{{ help_id }}" class="form-help">{{ help_text }}</small>
+    {%- endif %}
+    {%- if error %}
+    <span id="{{ error_id }}" class="validation-message" role="alert">{{ error }}</span>
+    {%- endif %}
+</div>
+{%- endmacro %}
+
+{% macro modal(id, title) -%}
+{% set title_id = id ~ 'Title' %}
+<div id="{{ id }}" class="modal" role="dialog" aria-modal="true" aria-labelledby="{{ title_id }}" hidden>
+    <div class="modal-content">
+        <button class="close-button" type="button" data-close-modal="{{ id }}" aria-label="Close">&times;</button>
+        <h2 id="{{ title_id }}">{{ title }}</h2>
+        <div class="separator"></div>
+        {{ caller() }}
+    </div>
+</div>
+{%- endmacro %}
+
+{% macro status_chip(text, variant="info") -%}
+<span class="status-chip {{ variant }}">{{ text }}</span>
+{%- endmacro %}
+
+{% macro card(title) -%}
+<div class="status-card">
+    {% if title %}<div class="status-title">{{ title }}</div>{% endif %}
+    <div class="status-body">
+        {{ caller() }}
+    </div>
+</div>
+{%- endmacro %}

--- a/src/templates/macros/components.html
+++ b/src/templates/macros/components.html
@@ -3,7 +3,7 @@
 -#}
 
 {% macro button(text, type="button", variant="primary", icon=None, disabled=False, attrs={}) -%}
-<button type="{{ type }}" class="action-button{% if variant != 'primary' %} {{ variant }}{% endif %}"{% if disabled %} disabled{% endif %}{% for key, val in attrs.items() %} {{ key }}="{{ val }}"{% endfor %}>
+<button type="{{ type }}" class="action-button{% if variant != 'primary' %} {{ variant }}{% endif %}"{% if disabled %} disabled{% endif %}{% for key, val in attrs.items() %}{% if val is not none and val is not sameas false %} {{ key }}="{{ val }}"{% endif %}{% endfor %}>
     {%- if icon %}<span class="button-icon" aria-hidden="true">{{ icon }}</span> {% endif -%}
     {{ text }}
 </button>

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -33,6 +33,7 @@
     <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-workflow" data-page-shell="workflow">
     <div class="frame workflow-frame">
         {% from 'macros/icons.html' import icon, theme_toggle, breadcrumb, PLUGIN_ICON_MAP %}
+        {% from 'macros/components.html' import status_chip, modal %}
 
         <!-- Plugin Title and Icon -->
         <div class="app-header">
@@ -76,9 +77,9 @@
 
         <div class="status-row plugin-mode-row" aria-label="Plugin mode indicators">
             {% if plugin_instance %}
-            <span class="status-chip success">Instance</span>
+            {{ status_chip('Instance', 'success') }}
             {% else %}
-            <span class="status-chip warning">Draft</span>
+            {{ status_chip('Draft', 'warning') }}
             {% endif %}
         </div>
 
@@ -327,13 +328,9 @@
     </div>
 
     <!-- Image preview (lightbox) for plugin page -->
-    <div id="imagePreviewModal" class="modal image-modal" role="dialog" aria-modal="true" aria-labelledby="imagePreviewTitle" hidden>
-        <div class="modal-content">
-            <h2 id="imagePreviewTitle" class="sr-only">Image preview</h2>
-            <button class="close-button" type="button" data-lightbox-close aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
-            <img id="imagePreviewImg" alt="Large preview" class="lightbox-preview-image"/>
-        </div>
-    </div>
+    {% call modal('imagePreviewModal', 'Image preview') %}
+        <img id="imagePreviewImg" alt="Large preview" class="lightbox-preview-image"/>
+    {% endcall %}
     <div id="requestProgress" class="progress-block" hidden>
         <div class="progress-header">
             <span id="requestProgressText">Preparing…</span>

--- a/tests/unit/test_component_macros.py
+++ b/tests/unit/test_component_macros.py
@@ -65,6 +65,13 @@ class TestButton:
         html = render("""{{ button('Act', attrs={'aria-describedby': 'help1'}) }}""")
         assert 'aria-describedby="help1"' in html
 
+    def test_attrs_none_and_false_skipped(self, render):
+        html = render(
+            """{{ button('Act', attrs={'data-x': None, 'data-y': false}) }}"""
+        )
+        assert "data-x" not in html
+        assert "data-y" not in html
+
 
 # -- form_field macro --
 

--- a/tests/unit/test_component_macros.py
+++ b/tests/unit/test_component_macros.py
@@ -1,0 +1,175 @@
+"""Tests for the Jinja2 component macro library (macros/components.html).
+
+Each test renders a macro and asserts required a11y attributes are present.
+"""
+
+import os
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+
+@pytest.fixture()
+def jinja_env():
+    """Create a Jinja2 environment pointing at the templates directory."""
+    templates_dir = os.path.join(
+        os.path.dirname(__file__), "..", "..", "src", "templates"
+    )
+    return Environment(
+        loader=FileSystemLoader(os.path.abspath(templates_dir)),
+        autoescape=True,
+        extensions=["jinja2.ext.do"],
+    )
+
+
+@pytest.fixture()
+def render(jinja_env):
+    """Helper that renders a template string with components imported."""
+
+    def _render(source, **ctx):
+        tpl = jinja_env.from_string(
+            "{% from 'macros/components.html' import button, form_field, "
+            "modal, status_chip, card %}\n" + source
+        )
+        return tpl.render(**ctx)
+
+    return _render
+
+
+# -- button macro --
+
+
+class TestButton:
+    def test_default_type_attribute(self, render):
+        html = render("{{ button('Click me') }}")
+        assert 'type="button"' in html
+        assert "Click me" in html
+
+    def test_submit_type(self, render):
+        html = render("{{ button('Send', type='submit') }}")
+        assert 'type="submit"' in html
+
+    def test_variant_class(self, render):
+        html = render("{{ button('Go', variant='is-secondary') }}")
+        assert "is-secondary" in html
+
+    def test_primary_variant_no_extra_class(self, render):
+        html = render("{{ button('Go') }}")
+        assert 'class="action-button"' in html
+
+    def test_disabled(self, render):
+        html = render("{{ button('Nope', disabled=True) }}")
+        assert "disabled" in html
+
+    def test_extra_attrs(self, render):
+        html = render("""{{ button('Act', attrs={'aria-describedby': 'help1'}) }}""")
+        assert 'aria-describedby="help1"' in html
+
+
+# -- form_field macro --
+
+
+class TestFormField:
+    def test_label_present(self, render):
+        html = render("{{ form_field('email', 'Email address') }}")
+        assert "<label" in html
+        assert 'for="email"' in html
+        assert "Email address" in html
+
+    def test_required_aria(self, render):
+        html = render("{{ form_field('name', 'Name', required=True) }}")
+        assert "required" in html
+        assert 'aria-required="true"' in html
+
+    def test_help_text_describedby(self, render):
+        html = render(
+            "{{ form_field('pw', 'Password', type='password', help_text='Min 8 chars') }}"
+        )
+        assert 'aria-describedby="pw-help"' in html
+        assert 'id="pw-help"' in html
+        assert "Min 8 chars" in html
+
+    def test_error_aria_invalid(self, render):
+        html = render("{{ form_field('age', 'Age', error='Too young') }}")
+        assert 'aria-invalid="true"' in html
+        assert 'role="alert"' in html
+        assert "Too young" in html
+
+    def test_value_set(self, render):
+        html = render("{{ form_field('city', 'City', value='Paris') }}")
+        assert 'value="Paris"' in html
+
+    def test_custom_id(self, render):
+        html = render("{{ form_field('x', 'X', id='custom_id') }}")
+        assert 'id="custom_id"' in html
+        assert 'for="custom_id"' in html
+
+    def test_help_and_error_both_describedby(self, render):
+        html = render("{{ form_field('f', 'F', help_text='Hint', error='Bad') }}")
+        assert "f-help" in html
+        assert "f-error" in html
+        assert 'aria-describedby="f-help f-error"' in html
+
+
+# -- modal macro --
+
+
+class TestModal:
+    def test_role_dialog(self, render):
+        html = render("{% call modal('testModal', 'Test Title') %}body{% endcall %}")
+        assert 'role="dialog"' in html
+
+    def test_aria_modal(self, render):
+        html = render("{% call modal('testModal', 'Test Title') %}body{% endcall %}")
+        assert 'aria-modal="true"' in html
+
+    def test_aria_labelledby(self, render):
+        html = render("{% call modal('myModal', 'My Title') %}content{% endcall %}")
+        assert 'aria-labelledby="myModalTitle"' in html
+        assert 'id="myModalTitle"' in html
+        assert "My Title" in html
+
+    def test_close_button(self, render):
+        html = render("{% call modal('m1', 'T') %}b{% endcall %}")
+        assert 'aria-label="Close"' in html
+
+    def test_body_rendered(self, render):
+        html = render("{% call modal('m2', 'T') %}<p>Hello</p>{% endcall %}")
+        assert "<p>Hello</p>" in html
+
+
+# -- status_chip macro --
+
+
+class TestStatusChip:
+    def test_default_variant(self, render):
+        html = render("{{ status_chip('Online') }}")
+        assert "status-chip" in html
+        assert "info" in html
+        assert "Online" in html
+
+    def test_custom_variant(self, render):
+        html = render("{{ status_chip('Error', 'danger') }}")
+        assert "danger" in html
+
+    def test_success_variant(self, render):
+        html = render("{{ status_chip('Active', 'success') }}")
+        assert "success" in html
+
+
+# -- card macro --
+
+
+class TestCard:
+    def test_title_rendered(self, render):
+        html = render("{% call card('My Card') %}content{% endcall %}")
+        assert "My Card" in html
+        assert "status-card" in html
+
+    def test_body_rendered(self, render):
+        html = render("{% call card('C') %}<span>inner</span>{% endcall %}")
+        assert "<span>inner</span>" in html
+
+    def test_no_title(self, render):
+        html = render("{% call card('') %}body{% endcall %}")
+        assert "status-title" not in html


### PR DESCRIPTION
## Summary
- Create `src/templates/macros/components.html` with five reusable macros: `button`, `form_field`, `modal`, `status_chip`, `card` — each emitting correct ARIA attributes by default.
- Adopt `status_chip` and `modal` in `plugin.html` (replacing 2 inline status chips and the image-preview modal) as proof-of-concept.
- Add 24 unit tests (`tests/unit/test_component_macros.py`) verifying a11y attributes on every macro (role, aria-labelledby, aria-required, aria-invalid, aria-describedby, etc.).

## Test plan
- [x] 24 new macro tests pass locally
- [ ] CI passes (ruff, black, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced reusable UI components with enhanced accessibility features, including improved keyboard navigation and screen reader support.

* **Improvements**
  * Standardized component library for consistent user experience across the platform.

* **Tests**
  * Added comprehensive test coverage for UI component functionality and accessibility compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->