### PR TITLE
refactor(config): extract paths + refresh_info (JTN-494)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -10,8 +10,17 @@ from typing import Any
 
 from dotenv import load_dotenv, set_key, unset_key
 
-from model import PlaylistManager, RefreshInfo
+from model import PlaylistManager
 from utils.config_schema import validate_device_config
+from utils.paths import (
+    BASE_DIR as _PATHS_BASE_DIR,
+    CURRENT_IMAGE_FILE as _DEFAULT_CURRENT_IMAGE,
+    HISTORY_IMAGE_DIR as _DEFAULT_HISTORY_DIR,
+    PLUGIN_IMAGE_DIR as _DEFAULT_PLUGIN_DIR,
+    PROCESSED_IMAGE_FILE as _DEFAULT_PROCESSED_IMAGE,
+    resolve_runtime_paths,
+)
+from utils.refresh_info import RefreshInfoRepository
 
 logger = logging.getLogger(__name__)
 
@@ -68,25 +77,19 @@ def _summarize_playlist(pl: Any) -> dict:
 
 
 class Config:
-    # Base path for the project directory
-    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+    # Base path for the project directory — canonical source is utils.paths
+    BASE_DIR = _PATHS_BASE_DIR
 
     # File paths relative to the script's directory (default; can be overridden)
     config_file = os.path.join(BASE_DIR, "config", _DEVICE_JSON)
 
-    # File path for storing the current image being displayed
-    current_image_file = os.path.join(BASE_DIR, "static", "images", "current_image.png")
-
-    # File path for storing the processed image actually sent to the device
-    processed_image_file = os.path.join(
-        BASE_DIR, "static", "images", "processed_image.png"
-    )
-
-    # Directory path for storing plugin instance images
-    plugin_image_dir = os.path.join(BASE_DIR, "static", "images", "plugins")
-
-    # Directory path for storing historical processed images
-    history_image_dir = os.path.join(BASE_DIR, "static", "images", "history")
+    # Image paths — canonical defaults live in utils.paths; kept as class
+    # attributes for backward compatibility (worker.py sets them on the class
+    # before constructing a child-process Config).
+    current_image_file = _DEFAULT_CURRENT_IMAGE
+    processed_image_file = _DEFAULT_PROCESSED_IMAGE
+    plugin_image_dir = _DEFAULT_PLUGIN_DIR
+    history_image_dir = _DEFAULT_HISTORY_DIR
 
     def __getstate__(self):
         """Support pickling by excluding the unpicklable RLock.
@@ -137,21 +140,21 @@ class Config:
         self.refresh_info = self.load_refresh_info()
 
     def _resolve_runtime_paths(self):
-        runtime_dir = (os.getenv("INKYPI_RUNTIME_DIR") or "").strip()
+        runtime_dir = (os.getenv("INKYPI_RUNTIME_DIR") or "").strip() or None
         if not runtime_dir:
+            # No runtime override — use class-level defaults (may have been
+            # overridden by worker.py before construction).
             self.current_image_file = type(self).current_image_file
             self.processed_image_file = type(self).processed_image_file
             self.plugin_image_dir = type(self).plugin_image_dir
             self.history_image_dir = type(self).history_image_dir
             return
 
-        runtime_images_dir = os.path.join(runtime_dir, "images")
-        self.current_image_file = os.path.join(runtime_images_dir, "current_image.png")
-        self.processed_image_file = os.path.join(
-            runtime_images_dir, "processed_image.png"
-        )
-        self.plugin_image_dir = os.path.join(runtime_images_dir, "plugins")
-        self.history_image_dir = os.path.join(runtime_images_dir, "history")
+        paths = resolve_runtime_paths(runtime_dir)
+        self.current_image_file = paths["current_image_file"]
+        self.processed_image_file = paths["processed_image_file"]
+        self.plugin_image_dir = paths["plugin_image_dir"]
+        self.history_image_dir = paths["history_image_dir"]
 
     def _determine_config_path(self):
         """Determine which device config file to load.
@@ -532,16 +535,13 @@ class Config:
         return playlist_manager
 
     def load_refresh_info(self):
-        """Loads the refresh information from the config."""
+        """Loads the refresh information from the config.
+
+        Delegates to :class:`~utils.refresh_info.RefreshInfoRepository`.
+        """
         data = self.get_config("refresh_info", {}) or {}
-        try:
-            required = {"refresh_type", "plugin_id", "refresh_time", "image_hash"}
-            if not isinstance(data, dict) or not required.issubset(data.keys()):
-                raise ValueError("refresh_info missing required keys")
-            return RefreshInfo.from_dict(data)
-        except (KeyError, TypeError, ValueError) as e:
-            logger.warning("Invalid refresh_info in config, using defaults: %s", e)
-            return RefreshInfo("Manual Update", "", None, None)
+        self._refresh_info_repo = RefreshInfoRepository(data)
+        return self._refresh_info_repo.get()
 
     def get_playlist_manager(self):
         """Returns the playlist manager."""

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,48 @@
+"""Centralized path resolution for InkyPi.
+
+All image/config directory paths are resolved here so that every module
+imports from one place instead of reaching into ``Config`` class attributes.
+"""
+
+import os
+
+# Base path: the ``src/`` directory that contains this package.
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Default image paths (relative to BASE_DIR).
+_IMAGES_DIR = os.path.join(BASE_DIR, "static", "images")
+
+CURRENT_IMAGE_FILE = os.path.join(_IMAGES_DIR, "current_image.png")
+PROCESSED_IMAGE_FILE = os.path.join(_IMAGES_DIR, "processed_image.png")
+PLUGIN_IMAGE_DIR = os.path.join(_IMAGES_DIR, "plugins")
+HISTORY_IMAGE_DIR = os.path.join(_IMAGES_DIR, "history")
+DEFAULT_PREVIEW_IMAGE = os.path.join(_IMAGES_DIR, "inkypi.png")
+
+
+def resolve_runtime_paths(
+    runtime_dir: str | None = None,
+) -> dict[str, str]:
+    """Return a dict of image path overrides based on an optional runtime dir.
+
+    When *runtime_dir* is falsy the defaults (class-level constants above) are
+    returned.  When it is set, all image paths are rooted under
+    ``<runtime_dir>/images/``.
+
+    Keys: ``current_image_file``, ``processed_image_file``,
+    ``plugin_image_dir``, ``history_image_dir``.
+    """
+    if not runtime_dir:
+        return {
+            "current_image_file": CURRENT_IMAGE_FILE,
+            "processed_image_file": PROCESSED_IMAGE_FILE,
+            "plugin_image_dir": PLUGIN_IMAGE_DIR,
+            "history_image_dir": HISTORY_IMAGE_DIR,
+        }
+
+    runtime_images_dir = os.path.join(runtime_dir, "images")
+    return {
+        "current_image_file": os.path.join(runtime_images_dir, "current_image.png"),
+        "processed_image_file": os.path.join(runtime_images_dir, "processed_image.png"),
+        "plugin_image_dir": os.path.join(runtime_images_dir, "plugins"),
+        "history_image_dir": os.path.join(runtime_images_dir, "history"),
+    }

--- a/src/utils/refresh_info.py
+++ b/src/utils/refresh_info.py
@@ -1,0 +1,55 @@
+"""Repository for loading and persisting RefreshInfo state.
+
+Extracted from ``Config`` to separate refresh-state persistence from the
+main config god-object.
+"""
+
+import logging
+
+from model import RefreshInfo
+
+logger = logging.getLogger(__name__)
+
+
+class RefreshInfoRepository:
+    """Loads and provides access to a :class:`RefreshInfo` instance.
+
+    The repository is initialised from a raw config dict (the ``refresh_info``
+    sub-key) and exposes the resulting model object.
+    """
+
+    def __init__(self, raw_data: dict | None = None):
+        self.refresh_info = self._load(raw_data)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get(self) -> RefreshInfo:
+        """Return the current :class:`RefreshInfo`."""
+        return self.refresh_info
+
+    def set(self, refresh_info: RefreshInfo) -> None:
+        """Replace the current :class:`RefreshInfo`."""
+        self.refresh_info = refresh_info
+
+    def to_dict(self) -> dict:
+        """Serialise the current state for inclusion in the config file."""
+        return self.refresh_info.to_dict()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load(data: dict | None) -> RefreshInfo:
+        """Parse *data* into a :class:`RefreshInfo`, falling back to defaults."""
+        data = data if isinstance(data, dict) else {}
+        try:
+            required = {"refresh_type", "plugin_id", "refresh_time", "image_hash"}
+            if not required.issubset(data.keys()):
+                raise ValueError("refresh_info missing required keys")
+            return RefreshInfo.from_dict(data)
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning("Invalid refresh_info in config, using defaults: %s", e)
+            return RefreshInfo("Manual Update", "", None, None)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,68 @@
+# pyright: reportMissingImports=false
+"""Tests for the utils.paths module."""
+
+import os
+
+
+def test_base_dir_points_to_src():
+    from utils.paths import BASE_DIR
+
+    assert os.path.isdir(BASE_DIR)
+    assert os.path.basename(BASE_DIR) == "src"
+
+
+def test_default_constants_exist():
+    from utils.paths import (
+        CURRENT_IMAGE_FILE,
+        DEFAULT_PREVIEW_IMAGE,
+        HISTORY_IMAGE_DIR,
+        PLUGIN_IMAGE_DIR,
+        PROCESSED_IMAGE_FILE,
+    )
+
+    # They should all be absolute paths under src/
+    for p in [
+        CURRENT_IMAGE_FILE,
+        PROCESSED_IMAGE_FILE,
+        PLUGIN_IMAGE_DIR,
+        HISTORY_IMAGE_DIR,
+        DEFAULT_PREVIEW_IMAGE,
+    ]:
+        assert os.path.isabs(p)
+        assert "static" in p or "images" in p
+
+
+def test_resolve_runtime_paths_no_override():
+    from utils.paths import (
+        CURRENT_IMAGE_FILE,
+        HISTORY_IMAGE_DIR,
+        PLUGIN_IMAGE_DIR,
+        PROCESSED_IMAGE_FILE,
+        resolve_runtime_paths,
+    )
+
+    result = resolve_runtime_paths(None)
+    assert result["current_image_file"] == CURRENT_IMAGE_FILE
+    assert result["processed_image_file"] == PROCESSED_IMAGE_FILE
+    assert result["plugin_image_dir"] == PLUGIN_IMAGE_DIR
+    assert result["history_image_dir"] == HISTORY_IMAGE_DIR
+
+
+def test_resolve_runtime_paths_empty_string():
+    from utils.paths import CURRENT_IMAGE_FILE, resolve_runtime_paths
+
+    result = resolve_runtime_paths("")
+    assert result["current_image_file"] == CURRENT_IMAGE_FILE
+
+
+def test_resolve_runtime_paths_with_override(tmp_path):
+    from utils.paths import resolve_runtime_paths
+
+    result = resolve_runtime_paths(str(tmp_path))
+    images_dir = os.path.join(str(tmp_path), "images")
+    assert result["current_image_file"] == os.path.join(images_dir, "current_image.png")
+    assert result["processed_image_file"] == os.path.join(
+        images_dir, "processed_image.png"
+    )
+    assert result["plugin_image_dir"] == os.path.join(images_dir, "plugins")
+    assert result["history_image_dir"] == os.path.join(images_dir, "history")

--- a/tests/unit/test_refresh_info_repo.py
+++ b/tests/unit/test_refresh_info_repo.py
@@ -1,0 +1,63 @@
+# pyright: reportMissingImports=false
+"""Tests for the utils.refresh_info.RefreshInfoRepository."""
+
+from model import RefreshInfo
+from utils.refresh_info import RefreshInfoRepository
+
+
+class TestRefreshInfoRepository:
+    def test_load_valid_data(self):
+        data = {
+            "refresh_type": "Manual Update",
+            "plugin_id": "clock",
+            "refresh_time": "2025-01-01T00:00:00",
+            "image_hash": "abc123",
+        }
+        repo = RefreshInfoRepository(data)
+        ri = repo.get()
+        assert isinstance(ri, RefreshInfo)
+        assert ri.refresh_type == "Manual Update"
+        assert ri.plugin_id == "clock"
+        assert ri.refresh_time == "2025-01-01T00:00:00"
+        assert ri.image_hash == "abc123"
+
+    def test_load_none_falls_back_to_defaults(self):
+        repo = RefreshInfoRepository(None)
+        ri = repo.get()
+        assert ri.refresh_type == "Manual Update"
+        assert ri.plugin_id == ""
+        assert ri.refresh_time is None
+        assert ri.image_hash is None
+
+    def test_load_empty_dict_falls_back_to_defaults(self):
+        repo = RefreshInfoRepository({})
+        ri = repo.get()
+        assert ri.refresh_type == "Manual Update"
+        assert ri.plugin_id == ""
+
+    def test_load_missing_keys_falls_back(self):
+        repo = RefreshInfoRepository({"refresh_type": "Playlist"})
+        ri = repo.get()
+        assert ri.refresh_type == "Manual Update"  # fell back to default
+
+    def test_set_replaces_refresh_info(self):
+        repo = RefreshInfoRepository(None)
+        new_ri = RefreshInfo("Playlist", "weather", "2025-06-01T12:00:00", "xyz")
+        repo.set(new_ri)
+        assert repo.get() is new_ri
+
+    def test_to_dict_round_trip(self):
+        data = {
+            "refresh_type": "Playlist",
+            "plugin_id": "weather",
+            "refresh_time": "2025-06-01T12:00:00",
+            "image_hash": "xyz",
+            "playlist": "Default",
+            "plugin_instance": "Weather 1",
+        }
+        repo = RefreshInfoRepository(data)
+        result = repo.to_dict()
+        assert result["refresh_type"] == "Playlist"
+        assert result["plugin_id"] == "weather"
+        assert result["playlist"] == "Default"
+        assert result["plugin_instance"] == "Weather 1"


### PR DESCRIPTION
## Summary
- Extract path constants and runtime resolution from `Config` into `src/utils/paths.py`
- Extract refresh-info loading/persistence into `src/utils/refresh_info.py` (`RefreshInfoRepository`)
- `Config` now delegates to both modules, reducing god-object surface area
- 11 new targeted tests for the extracted modules; all 3660 existing tests pass

## Test plan
- [ ] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no` — 3660 passed
- [ ] `scripts/lint.sh` — all checks passed
- [ ] Verify worker.py class-attribute pattern still works (not modified, tested via existing suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)