### PR TITLE
fix: show visible feedback for plugin progress buttons (JTN-347, JTN-348, JTN-331, JTN-332)

### DIFF
--- a/src/static/scripts/plugin_form.js
+++ b/src/static/scripts/plugin_form.js
@@ -30,11 +30,11 @@
     function fmtElapsed(ms){
       const s = Math.floor(ms / 1000); const m = Math.floor(s / 60); const rem = s % 60; return m > 0 ? `${m}m ${rem}s` : `${s}s`; }
     function tickClock(){ try { if (els.clock) els.clock.textContent = new Date().toLocaleTimeString(); const elapsedMs = Date.now() - getT0(); if (els.elapsed) els.elapsed.textContent = fmtElapsed(elapsedMs); if (elapsedMs > 15000 && getLastStepBase() && els.text && !getLastStepBase().includes('Done') && !getLastStepBase().includes('Failed')) { els.text.textContent = getLastStepBase() + ' (' + fmtElapsed(elapsedMs) + ')'; } } catch(e){} }
-    function setStep(text, pct){ setLastStepBase(text); if (els.block) { els.block.hidden = false; els.block.style.display = 'block'; } if (els.text) els.text.textContent = text; if (els.bar && typeof pct === 'number') { els.bar.style.width = pct + '%'; els.bar.setAttribute('aria-valuenow', pct); }
+    function setStep(text, pct){ setLastStepBase(text); if (els.block) { els.block.hidden = false; els.block.style.display = ''; } if (els.text) els.text.textContent = text; if (els.bar && typeof pct === 'number') { els.bar.style.width = pct + '%'; els.bar.setAttribute('aria-valuenow', pct); }
       if (els.list){ const li = document.createElement('li'); const ts = document.createElement('time'); ts.dateTime = new Date().toISOString(); ts.textContent = new Date().toLocaleTimeString(); li.appendChild(ts); li.appendChild(document.createTextNode(' ' + text)); els.list.appendChild(li); try { els.list.scrollTop = els.list.scrollHeight; } catch(e){} }
     }
     function start(){ setT0(Date.now()); try { if (els.list) els.list.innerHTML = ''; if (els.elapsed) els.elapsed.textContent = '0s'; if (els.clock) els.clock.textContent = new Date().toLocaleTimeString(); if (els.bar) els.bar.style.width = '10%'; } catch(e){} tickClock(); setClockTimer(setInterval(tickClock, 1000)); setStep('Preparing…', 10); }
-    function stop(){ try { if (getClockTimer()) clearInterval(getClockTimer()); } catch(e){} setTimeout(() => { if (els.block) { els.block.style.display = 'none'; els.block.hidden = true; } }, 2000); }
+    function stop(){ try { if (getClockTimer()) clearInterval(getClockTimer()); } catch(e){} setTimeout(() => { if (els.block) { els.block.style.display = ''; els.block.hidden = true; } }, 2000); }
     return { setStep, start, stop };
   }
 

--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -147,7 +147,12 @@
         if (bar) { bar.style.width = "100%"; bar.setAttribute("aria-valuenow", 100); }
         // JTN-312: clear the HTML `hidden` attribute so the block is visible;
         // setting style.display alone does not override the `hidden` attribute.
-        if (progress) setHidden(progress, false);
+        // JTN-347: also clear inline display:none left by progress.stop() —
+        // otherwise the block stays invisible even after removing `hidden`.
+        if (progress) {
+          setHidden(progress, false);
+          progress.style.display = "";
+        }
       } catch (e) { console.warn("Failed to show last progress:", e); }
     }
 

--- a/tests/static/test_calendar_button_fixes.py
+++ b/tests/static/test_calendar_button_fixes.py
@@ -1,10 +1,14 @@
-"""Tests for JTN-311 and JTN-312: calendar plugin button bug fixes.
+"""Tests for JTN-311, JTN-312, and JTN-347 cluster: plugin button bug fixes.
 
 JTN-311: Remove calendar button must be disabled (not a silent no-op) when
          only one calendar row is present.
 JTN-312: Last progress button must call a handler that makes progress visible,
          not leave the panel hidden due to the HTML `hidden` attribute.
+JTN-347/348/331/332: "Show last progress" button must produce visible feedback
+         on Clock, To-Do List, Calendar, and Screenshot plugin pages.
 """
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # JTN-311: Remove calendar button disabled when only one row
@@ -160,3 +164,76 @@ def test_request_progress_block_present_on_calendar_page(client):
         "Calendar plugin page must render requestProgress block so "
         "showLastProgress has an element to reveal (JTN-312)"
     )
+
+
+# ---------------------------------------------------------------------------
+# JTN-347/348/331/332: "Show last progress" visible feedback across plugins
+# ---------------------------------------------------------------------------
+
+
+def test_show_last_progress_clears_inline_display_style(client):
+    """JTN-347: showLastProgress must clear inline style.display left by
+    progress.stop(), otherwise the progress block stays invisible even
+    after the hidden attribute is removed."""
+    resp = client.get("/static/scripts/plugin_page.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    assert 'progress.style.display = ""' in js, (
+        "showLastProgress must reset progress.style.display to '' so inline "
+        "display:none from progress.stop() does not keep the block hidden "
+        "(JTN-347)"
+    )
+
+
+def test_progress_stop_does_not_set_display_none(client):
+    """JTN-347: progress.stop() must hide via the hidden attribute only,
+    not set style.display='none' which conflicts with showLastProgress."""
+    resp = client.get("/static/scripts/plugin_form.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    # Extract the stop function body (between "function stop()" and the next
+    # "return" that closes the initProgress IIFE).
+    stop_start = js.find("function stop()")
+    assert stop_start != -1, "stop function not found in plugin_form.js"
+    stop_body = js[stop_start : stop_start + 300]
+
+    assert "style.display = 'none'" not in stop_body, (
+        "progress.stop() must not set style.display = 'none'; "
+        "use the hidden attribute instead (JTN-347)"
+    )
+
+
+@pytest.mark.parametrize(
+    "plugin_id",
+    ["clock", "todo_list", "calendar", "screenshot"],
+    ids=["JTN-347-clock", "JTN-348-todo", "JTN-331-calendar", "JTN-332-screenshot"],
+)
+def test_show_last_progress_btn_present_on_plugin_page(client, plugin_id):
+    """JTN-347/348/331/332: Each affected plugin page must render the
+    showLastProgressBtn so users get visible feedback."""
+    resp = client.get(f"/plugin/{plugin_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    assert (
+        'id="showLastProgressBtn"' in body
+    ), f"{plugin_id} plugin page must render showLastProgressBtn"
+
+
+@pytest.mark.parametrize(
+    "plugin_id",
+    ["clock", "todo_list", "calendar", "screenshot"],
+    ids=["JTN-347-clock", "JTN-348-todo", "JTN-331-calendar", "JTN-332-screenshot"],
+)
+def test_request_progress_block_present_on_plugin_page(client, plugin_id):
+    """JTN-347/348/331/332: Each affected plugin page must include the
+    requestProgress block that showLastProgress reveals."""
+    resp = client.get(f"/plugin/{plugin_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    assert (
+        'id="requestProgress"' in body
+    ), f"{plugin_id} plugin page must render requestProgress block"


### PR DESCRIPTION
## Summary
- **Root cause**: `progress.stop()` in `plugin_form.js` set `style.display = 'none'` on the progress block, but `showLastProgress()` in `plugin_page.js` only removed the HTML `hidden` attribute — it never cleared the inline `display: none`. The block stayed invisible even when unhidden, making the "Show last progress" button a silent no-op.
- **Fix**: Clear inline `style.display` in `showLastProgress()` and stop using `style.display = 'none'` in `progress.stop()` (rely on `hidden` attribute instead).
- Affects Clock (JTN-347), To-Do List (JTN-348), Calendar (JTN-331), and Screenshot (JTN-332) plugin pages.

## Test plan
- [x] New parametrized tests verify showLastProgressBtn and requestProgress block render on all 4 plugin pages
- [x] New test confirms `showLastProgress` clears inline display style
- [x] New test confirms `progress.stop()` no longer sets `display: none`
- [x] All 21 tests in `test_calendar_button_fixes.py` pass
- [x] Full suite: 3659 passed, 2 pre-existing failures (unrelated `test_plugin_registry.py`)
- [x] Lint passes (`scripts/lint.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)