### PR TITLE
refactor(refresh_task): decouple subprocess from Config via RefreshContext (JTN-495)

### DIFF
--- a/src/refresh_task/__init__.py
+++ b/src/refresh_task/__init__.py
@@ -10,6 +10,7 @@ from refresh_task.actions import (
     PlaylistRefresh,
     RefreshAction,
 )
+from refresh_task.context import RefreshContext
 from refresh_task.task import RefreshTask
 from refresh_task.worker import (
     _execute_refresh_attempt_worker,
@@ -19,6 +20,7 @@ from refresh_task.worker import (
 )
 
 __all__ = [
+    "RefreshContext",
     "RefreshTask",
     "RefreshAction",
     "ManualRefresh",

--- a/src/refresh_task/context.py
+++ b/src/refresh_task/context.py
@@ -1,0 +1,97 @@
+"""Pickle-safe context for subprocess plugin execution.
+
+``RefreshContext`` captures the minimal set of configuration values that
+a subprocess worker needs to restore a functional ``Config`` singleton and
+execute a plugin refresh.  By limiting the payload to primitive types and
+strings, we avoid serialising the entire ``Config`` object graph — which
+was fragile, especially under ``forkserver`` / ``spawn`` start methods.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RefreshContext:
+    """Immutable, pickle-safe snapshot of device configuration for subprocesses.
+
+    All fields are primitives or strings so the dataclass can be safely
+    serialised across the ``multiprocessing`` process boundary regardless
+    of the start method (fork, forkserver, spawn).
+
+    Attributes:
+        config_file: Absolute path to the ``device.json`` config file.
+        current_image_file: Path where the current display image is stored.
+        processed_image_file: Path where the preprocessed display image is stored.
+        plugin_image_dir: Directory for per-plugin cached images.
+        history_image_dir: Directory for historical image snapshots.
+        resolution: ``(width, height)`` tuple for the display.
+        timezone: IANA timezone string (e.g. ``"America/New_York"``).
+    """
+
+    config_file: str
+    current_image_file: str
+    processed_image_file: str
+    plugin_image_dir: str
+    history_image_dir: str
+    resolution: tuple[int, int]
+    timezone: str
+
+    @classmethod
+    def from_config(cls, device_config) -> RefreshContext:
+        """Build a ``RefreshContext`` from a live :class:`Config` instance.
+
+        This is the canonical factory used at the application boundary
+        (e.g. ``create_app()``) to snapshot the current configuration
+        before handing it to ``RefreshTask``.
+
+        Args:
+            device_config: A :class:`config.Config` instance.
+
+        Returns:
+            A frozen ``RefreshContext`` dataclass.
+        """
+        try:
+            res = device_config.get_resolution()
+            width, height = int(res[0]), int(res[1])
+        except Exception:
+            width, height = 800, 480
+
+        tz = "UTC"
+        try:
+            tz = device_config.get_config("timezone", default="UTC") or "UTC"
+        except Exception:
+            pass
+
+        return cls(
+            config_file=str(getattr(device_config, "config_file", "")),
+            current_image_file=str(getattr(device_config, "current_image_file", "")),
+            processed_image_file=str(
+                getattr(device_config, "processed_image_file", "")
+            ),
+            plugin_image_dir=str(getattr(device_config, "plugin_image_dir", "")),
+            history_image_dir=str(getattr(device_config, "history_image_dir", "")),
+            resolution=(width, height),
+            timezone=str(tz),
+        )
+
+    def restore_child_config(self):
+        """Rebuild the ``Config`` singleton inside a subprocess from this snapshot.
+
+        Sets the class-level path attributes on ``Config`` before
+        constructing a new instance, mirroring the legacy
+        ``_restore_child_config`` behaviour but sourcing values from
+        this dataclass instead of a pickled ``Config`` object.
+
+        Returns:
+            A new :class:`Config` instance initialised from the snapshot paths.
+        """
+        from config import Config
+
+        Config.config_file = self.config_file
+        Config.current_image_file = self.current_image_file
+        Config.processed_image_file = self.processed_image_file
+        Config.plugin_image_dir = self.plugin_image_dir
+        Config.history_image_dir = self.history_image_dir
+        return Config()

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from model import PlaylistManager, RefreshInfo
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task.actions import ManualUpdateRequest, PlaylistRefresh
+from refresh_task.context import RefreshContext
 from refresh_task.worker import (
     _execute_refresh_attempt_worker,
     _get_mp_context,
@@ -70,6 +71,7 @@ class RefreshTask:
     def __init__(self, device_config, display_manager):
         self.device_config = device_config
         self.display_manager = display_manager
+        self.refresh_context = RefreshContext.from_config(device_config)
 
         self.thread = None
         self.lock = threading.Lock()
@@ -925,7 +927,7 @@ class RefreshTask:
                 result_queue,
                 plugin_config,
                 refresh_action,
-                self.device_config,
+                self.refresh_context,
                 current_dt,
             ),
             daemon=True,
@@ -1325,7 +1327,12 @@ class RefreshTask:
         return dict(self.plugin_health)
 
     def signal_config_change(self):
-        """Notify the background thread that config has changed (e.g., interval updated)."""
+        """Notify the background thread that config has changed (e.g., interval updated).
+
+        Also rebuilds the ``RefreshContext`` snapshot so that subsequent
+        subprocess launches pick up the latest configuration values.
+        """
+        self.refresh_context = RefreshContext.from_config(self.device_config)
         if self.running:
             with self.condition:
                 self.condition.notify_all()

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -37,17 +37,25 @@ def _get_mp_context():
 def _restore_child_config(device_config):
     """Re-initialise the Config singleton inside a subprocess from a serialised snapshot.
 
-    ``multiprocessing`` serialises ``device_config`` across the process
-    boundary.  The child process must reconstruct the singleton by setting the
-    class-level path attributes before calling ``Config()``.
+    Accepts either a :class:`RefreshContext` dataclass (preferred) or a
+    legacy pickled ``Config`` object.  When a ``RefreshContext`` is provided
+    its :meth:`restore_child_config` method is used directly; otherwise the
+    legacy path-attribute dance is performed for backwards compatibility.
 
     Args:
-        device_config: A serialised snapshot of the parent's device config
-            object, carrying the file paths needed to rebuild the singleton.
+        device_config: A :class:`RefreshContext` snapshot **or** a legacy
+            serialised ``Config`` object carrying the file paths needed to
+            rebuild the singleton in the child process.
 
     Returns:
         A new :class:`Config` instance initialised from the snapshot paths.
     """
+    from refresh_task.context import RefreshContext
+
+    if isinstance(device_config, RefreshContext):
+        return device_config.restore_child_config()
+
+    # Legacy fallback: raw Config object was pickled across the boundary.
     from config import Config
 
     Config.config_file = device_config.config_file
@@ -89,7 +97,7 @@ def _execute_refresh_attempt_worker(
     result_queue,
     plugin_config: dict,
     refresh_action,
-    device_config,
+    refresh_context,
     current_dt,
 ):
     """Entry point for a plugin execution subprocess.
@@ -105,12 +113,12 @@ def _execute_refresh_attempt_worker(
             result dict to the parent process.
         plugin_config: The raw plugin configuration dict from device.json.
         refresh_action: The :class:`RefreshAction` describing what to run.
-        device_config: A serialised snapshot of the parent's device config,
-            used to restore the child Config singleton.
+        refresh_context: A :class:`RefreshContext` snapshot (or legacy
+            ``Config`` object) used to restore the child Config singleton.
         current_dt: The current device-timezone datetime passed to the plugin.
     """
     try:
-        child_config = _restore_child_config(device_config)
+        child_config = _restore_child_config(refresh_context)
         plugin = get_plugin_instance(plugin_config)
         image = refresh_action.execute(plugin, child_config, current_dt)
         plugin_meta = None

--- a/tests/unit/test_refresh_context.py
+++ b/tests/unit/test_refresh_context.py
@@ -1,0 +1,221 @@
+"""Tests for RefreshContext dataclass and its integration with RefreshTask/worker."""
+
+import pickle
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from refresh_task.context import RefreshContext
+
+
+class TestRefreshContext:
+    """Unit tests for the RefreshContext dataclass."""
+
+    def test_from_config_captures_all_fields(self):
+        """RefreshContext.from_config should snapshot all relevant Config fields."""
+        mock_config = MagicMock()
+        mock_config.config_file = "/tmp/device.json"
+        mock_config.current_image_file = "/tmp/current.png"
+        mock_config.processed_image_file = "/tmp/processed.png"
+        mock_config.plugin_image_dir = "/tmp/plugins"
+        mock_config.history_image_dir = "/tmp/history"
+        mock_config.get_resolution.return_value = (800, 480)
+        mock_config.get_config.return_value = "America/New_York"
+
+        ctx = RefreshContext.from_config(mock_config)
+
+        assert ctx.config_file == "/tmp/device.json"
+        assert ctx.current_image_file == "/tmp/current.png"
+        assert ctx.processed_image_file == "/tmp/processed.png"
+        assert ctx.plugin_image_dir == "/tmp/plugins"
+        assert ctx.history_image_dir == "/tmp/history"
+        assert ctx.resolution == (800, 480)
+        assert ctx.timezone == "America/New_York"
+
+    def test_from_config_defaults_timezone_to_utc(self):
+        """When timezone config is missing or None, default to UTC."""
+        mock_config = MagicMock()
+        mock_config.config_file = "/tmp/device.json"
+        mock_config.current_image_file = "/tmp/current.png"
+        mock_config.processed_image_file = "/tmp/processed.png"
+        mock_config.plugin_image_dir = "/tmp/plugins"
+        mock_config.history_image_dir = "/tmp/history"
+        mock_config.get_resolution.return_value = (600, 400)
+        mock_config.get_config.return_value = None
+
+        ctx = RefreshContext.from_config(mock_config)
+
+        assert ctx.timezone == "UTC"
+
+    def test_from_config_handles_get_config_exception(self):
+        """When get_config raises, timezone should fall back to UTC."""
+        mock_config = MagicMock()
+        mock_config.config_file = "/tmp/device.json"
+        mock_config.current_image_file = "/tmp/current.png"
+        mock_config.processed_image_file = "/tmp/processed.png"
+        mock_config.plugin_image_dir = "/tmp/plugins"
+        mock_config.history_image_dir = "/tmp/history"
+        mock_config.get_resolution.return_value = (800, 480)
+        mock_config.get_config.side_effect = RuntimeError("config error")
+
+        ctx = RefreshContext.from_config(mock_config)
+
+        assert ctx.timezone == "UTC"
+
+    def test_pickle_roundtrip(self):
+        """RefreshContext must survive pickle serialisation (subprocess boundary)."""
+        ctx = RefreshContext(
+            config_file="/tmp/device.json",
+            current_image_file="/tmp/current.png",
+            processed_image_file="/tmp/processed.png",
+            plugin_image_dir="/tmp/plugins",
+            history_image_dir="/tmp/history",
+            resolution=(800, 480),
+            timezone="Europe/London",
+        )
+
+        pickled = pickle.dumps(ctx)
+        restored = pickle.loads(pickled)
+
+        assert restored == ctx
+        assert restored.resolution == (800, 480)
+        assert restored.timezone == "Europe/London"
+
+    def test_frozen_immutability(self):
+        """RefreshContext fields should not be mutable after creation."""
+        ctx = RefreshContext(
+            config_file="/tmp/device.json",
+            current_image_file="/tmp/current.png",
+            processed_image_file="/tmp/processed.png",
+            plugin_image_dir="/tmp/plugins",
+            history_image_dir="/tmp/history",
+            resolution=(800, 480),
+            timezone="UTC",
+        )
+        with pytest.raises(AttributeError):
+            ctx.timezone = "US/Eastern"
+
+    def test_restore_child_config(self):
+        """restore_child_config should set Config class attrs and return an instance."""
+        ctx = RefreshContext(
+            config_file="/tmp/device.json",
+            current_image_file="/tmp/current.png",
+            processed_image_file="/tmp/processed.png",
+            plugin_image_dir="/tmp/plugins",
+            history_image_dir="/tmp/history",
+            resolution=(800, 480),
+            timezone="UTC",
+        )
+
+        mock_config_instance = MagicMock()
+        with patch("config.Config") as MockConfig:
+            MockConfig.return_value = mock_config_instance
+
+            result = ctx.restore_child_config()
+
+            assert MockConfig.config_file == "/tmp/device.json"
+            assert MockConfig.current_image_file == "/tmp/current.png"
+            assert MockConfig.processed_image_file == "/tmp/processed.png"
+            assert MockConfig.plugin_image_dir == "/tmp/plugins"
+            assert MockConfig.history_image_dir == "/tmp/history"
+            assert result is mock_config_instance
+
+
+class TestWorkerRefreshContextIntegration:
+    """Tests that worker.py correctly handles RefreshContext."""
+
+    def test_restore_child_config_with_refresh_context(self):
+        """_restore_child_config should delegate to RefreshContext.restore_child_config."""
+        from refresh_task.worker import _restore_child_config
+
+        ctx = RefreshContext(
+            config_file="/tmp/device.json",
+            current_image_file="/tmp/current.png",
+            processed_image_file="/tmp/processed.png",
+            plugin_image_dir="/tmp/plugins",
+            history_image_dir="/tmp/history",
+            resolution=(800, 480),
+            timezone="UTC",
+        )
+
+        mock_config_instance = MagicMock()
+        # Config is imported lazily inside restore_child_config, so patch
+        # at the canonical module level.
+        with patch("config.Config") as MockConfig:
+            MockConfig.return_value = mock_config_instance
+            result = _restore_child_config(ctx)
+            assert result is mock_config_instance
+            # Verify it set the paths from RefreshContext
+            assert MockConfig.config_file == "/tmp/device.json"
+            assert MockConfig.plugin_image_dir == "/tmp/plugins"
+
+    def test_restore_child_config_legacy_fallback(self):
+        """_restore_child_config should still work with a legacy Config-like object."""
+        from refresh_task.worker import _restore_child_config
+
+        legacy_config = MagicMock()
+        legacy_config.config_file = "/tmp/device.json"
+        legacy_config.current_image_file = "/tmp/current.png"
+        legacy_config.processed_image_file = "/tmp/processed.png"
+        legacy_config.plugin_image_dir = "/tmp/plugins"
+        legacy_config.history_image_dir = "/tmp/history"
+
+        mock_config_instance = MagicMock()
+        # Config is imported lazily in the legacy branch, patch at canonical module.
+        with patch("config.Config") as MockConfig:
+            MockConfig.return_value = mock_config_instance
+
+            result = _restore_child_config(legacy_config)
+
+            assert MockConfig.config_file == "/tmp/device.json"
+            assert result is mock_config_instance
+
+
+class TestRefreshTaskContextIntegration:
+    """Tests that RefreshTask builds and uses RefreshContext."""
+
+    def test_refresh_task_creates_context(self):
+        """RefreshTask.__init__ should build a RefreshContext from device_config."""
+        from refresh_task.task import RefreshTask
+
+        mock_config = MagicMock()
+        mock_config.config_file = "/tmp/device.json"
+        mock_config.current_image_file = "/tmp/current.png"
+        mock_config.processed_image_file = "/tmp/processed.png"
+        mock_config.plugin_image_dir = "/tmp/plugins"
+        mock_config.history_image_dir = "/tmp/history"
+        mock_config.get_resolution.return_value = (800, 480)
+        mock_config.get_config.return_value = "UTC"
+
+        mock_display = MagicMock()
+
+        task = RefreshTask(mock_config, mock_display)
+
+        assert isinstance(task.refresh_context, RefreshContext)
+        assert task.refresh_context.config_file == "/tmp/device.json"
+        assert task.refresh_context.resolution == (800, 480)
+
+    def test_signal_config_change_rebuilds_context(self):
+        """signal_config_change should rebuild the RefreshContext snapshot."""
+        from refresh_task.task import RefreshTask
+
+        mock_config = MagicMock()
+        mock_config.config_file = "/tmp/device.json"
+        mock_config.current_image_file = "/tmp/current.png"
+        mock_config.processed_image_file = "/tmp/processed.png"
+        mock_config.plugin_image_dir = "/tmp/plugins"
+        mock_config.history_image_dir = "/tmp/history"
+        mock_config.get_resolution.return_value = (800, 480)
+        mock_config.get_config.return_value = "UTC"
+
+        mock_display = MagicMock()
+        task = RefreshTask(mock_config, mock_display)
+
+        original_ctx = task.refresh_context
+
+        # Simulate config change
+        mock_config.get_resolution.return_value = (1024, 768)
+        task.signal_config_change()
+
+        assert task.refresh_context is not original_ctx
+        assert task.refresh_context.resolution == (1024, 768)


### PR DESCRIPTION
## Summary
- Introduces `RefreshContext` dataclass (`src/refresh_task/context.py`) — a frozen, pickle-safe snapshot of the Config fields needed by subprocess workers (paths, resolution, timezone)
- Refactors `worker.py` to accept `RefreshContext` instead of pickling the full `Config` object across the process boundary; legacy `Config` objects still accepted for backwards compatibility
- `RefreshTask.__init__` builds a `RefreshContext` from the live Config; `signal_config_change()` rebuilds it so subprocess launches pick up updated values

## Test plan
- [x] 10 new unit tests covering: `from_config` factory, pickle roundtrip, immutability, `restore_child_config`, worker integration (both RefreshContext and legacy fallback), RefreshTask context creation, and config-change rebuild
- [x] All 3,659 existing tests pass (2 pre-existing failures in `test_plugin_registry` unrelated to this change)
- [x] Lint clean (`scripts/lint.sh` — ruff, black, mypy strict subset, shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)