### PR TITLE
fix: restore API Keys page button actions (JTN-325, JTN-324, JTN-323)

### DIFF
--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -500,4 +500,25 @@
   }
 
   globalThis.InkyPiApiKeysPage = { create: createApiKeysPage };
+
+  // Self-initialise from data-* attributes on the page container so no
+  // inline <script> is needed (CSP blocks inline JS in production).
+  // The deferred script attribute ensures the DOM is ready when this runs.
+  function autoInit() {
+    const frame = document.querySelector(".api-keys-frame");
+    if (!frame) return;
+    const config = {
+      deleteManagedUrl: frame.dataset.deleteManagedUrl || "",
+      mode: frame.dataset.mode || "managed",
+      saveGenericUrl: frame.dataset.saveGenericUrl || "",
+      saveManagedUrl: frame.dataset.saveManagedUrl || "",
+    };
+    createApiKeysPage(config).init();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", autoInit);
+  } else {
+    autoInit();
+  }
 })();

--- a/src/templates/api_keys.html
+++ b/src/templates/api_keys.html
@@ -7,7 +7,12 @@
     {% from 'macros/icons.html' import icon, theme_toggle, empty_state, breadcrumb %}
     {% from 'macros/api_key_card.html' import api_key_card %}
     <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-management" data-page-shell="management">
-    <div class="frame api-keys-frame">
+    <div class="frame api-keys-frame"
+         data-delete-managed-url="{{ url_for('settings.delete_api_key') }}"
+         data-mode="{{ api_keys_mode | default('managed') }}"
+         data-save-generic-url="{{ url_for('apikeys.save_apikeys') }}"
+         data-save-managed-url="{{ url_for('settings.save_api_keys') }}"
+    >
         {% set key_summary = namespace(provider_count=(entries|length if entries is defined else 0), configured_count=0) %}
         {% if api_keys_mode == 'managed' %}
             {% set key_summary.provider_count = 6 %}
@@ -103,15 +108,4 @@
 
     {% include 'response_modal.html' %}
     </main>
-    <script>
-        window.__INKYPI_API_KEYS_BOOT__ = {
-            deleteManagedUrl: {{ url_for('settings.delete_api_key') | tojson }},
-            mode: {{ api_keys_mode | default('managed') | tojson }},
-            saveGenericUrl: {{ url_for('apikeys.save_apikeys') | tojson }},
-            saveManagedUrl: {{ url_for('settings.save_api_keys') | tojson }},
-        };
-        document.addEventListener('DOMContentLoaded', () => {
-            window.InkyPiApiKeysPage.create(window.__INKYPI_API_KEYS_BOOT__).init();
-        });
-    </script>
 {% endblock %}

--- a/tests/integration/test_api_keys_csp_boot.py
+++ b/tests/integration/test_api_keys_csp_boot.py
@@ -1,0 +1,113 @@
+"""Regression tests for JTN-325, JTN-324, JTN-323: API Keys page buttons.
+
+Root cause: the page boot config lived in an inline <script> block that CSP
+``script-src 'self'`` silently blocked in production.  The fix moves the boot
+config to ``data-*`` attributes on the page container and has the external JS
+self-initialise from the DOM, eliminating the need for inline JS.
+"""
+
+from __future__ import annotations
+
+import re  # noqa: I001 — re is used below; import order is intentional
+
+# -- JTN-323: + Add API Key button must work ----------------------------------
+
+
+def test_no_inline_script_in_api_keys_page(client):
+    """The api_keys page must not contain an inline <script> boot block.
+
+    CSP ``script-src 'self'`` blocks inline scripts, which silently
+    prevented all button handlers from initialising (JTN-323/324/325).
+    """
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    # The old pattern was: <script> window.__INKYPI_API_KEYS_BOOT__ = ...
+    assert (
+        "__INKYPI_API_KEYS_BOOT__" not in html
+    ), "Inline boot config must be removed; use data-* attributes instead"
+
+
+def test_api_keys_frame_has_data_attributes(client):
+    """The .api-keys-frame container must carry data-* boot config attributes."""
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "data-delete-managed-url=" in html
+    assert "data-mode=" in html
+    assert "data-save-generic-url=" in html
+    assert "data-save-managed-url=" in html
+
+
+def test_js_self_initialises_from_data_attributes(client):
+    """The external JS must read data-* attributes and self-initialise."""
+    resp = client.get("/static/scripts/api_keys_page.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    assert "autoInit" in js, "JS must contain an autoInit function"
+    assert ".api-keys-frame" in js, "JS must query the frame element for data-* attrs"
+    assert "dataset" in js, "JS must read data-* attributes via dataset"
+
+
+# -- JTN-324: Suggested key chips must trigger row creation --------------------
+
+
+def test_preset_buttons_use_delegation(client):
+    """JTN-324: preset chip buttons must use data-api-action='add-preset'."""
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    preset_count = html.count('data-api-action="add-preset"')
+    assert (
+        preset_count >= 6
+    ), f"Expected at least 6 preset chip buttons, found {preset_count}"
+
+
+def test_js_handles_add_preset_action(client):
+    """JTN-324: the delegated click handler must handle the 'add-preset' action."""
+    resp = client.get("/static/scripts/api_keys_page.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    assert '"add-preset"' in js, "JS must include an 'add-preset' action case"
+    assert "addPreset" in js, "The 'add-preset' action must call addPreset"
+
+
+# -- JTN-325: Delete button must confirm and remove entries --------------------
+
+
+def test_delete_button_uses_delegation(client):
+    """JTN-325: delete buttons in generic mode use data-api-action='delete-row'."""
+    # Verify the JS handler supports both delete actions
+    js_resp = client.get("/static/scripts/api_keys_page.js")
+    js = js_resp.get_data(as_text=True)
+
+    assert '"delete-row"' in js, "JS must handle 'delete-row' action"
+    assert '"delete-key"' in js, "JS must handle 'delete-key' action for managed mode"
+
+
+def test_external_js_loaded_with_defer(client):
+    """The api_keys_page.js script tag must use defer (not inline) for CSP compat."""
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    pattern = re.compile(r"<script[^>]*api_keys_page\.js[^>]*defer[^>]*>")
+    assert pattern.search(
+        html
+    ), "api_keys_page.js must be loaded via a <script defer> tag"
+
+
+def test_data_mode_attribute_matches_generic(client):
+    """The generic API keys page must set data-mode='generic'."""
+    resp = client.get("/api-keys")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert (
+        'data-mode="generic"' in html
+    ), "data-mode attribute must reflect the actual api_keys_mode"


### PR DESCRIPTION
## Summary
- **Root cause**: The inline `<script>` boot block that initialised the API Keys page JS was silently blocked by CSP `script-src 'self'` in production, making Delete buttons (JTN-325), preset chips (JTN-324), and the + Add API Key button (JTN-323) all no-ops
- **Fix**: Moved boot config (`deleteManagedUrl`, `mode`, `saveGenericUrl`, `saveManagedUrl`) to `data-*` attributes on the `.api-keys-frame` container; the external `api_keys_page.js` now self-initialises from the DOM via an `autoInit()` function
- **Same pattern** as the history page regression (PR #370) — inline JS blocked by CSP

## Changed files
- `src/templates/api_keys.html` — removed inline `<script>` block, added `data-*` attributes to frame div
- `src/static/scripts/api_keys_page.js` — added `autoInit()` that reads `data-*` attrs and calls `createApiKeysPage(config).init()`
- `tests/integration/test_api_keys_csp_boot.py` — 8 regression tests verifying no inline script, data attributes present, JS self-init, delegation wiring

## Test plan
- [x] All 8 new regression tests pass
- [x] All 43 existing API keys integration tests pass
- [x] Full suite: 3746 passed (12 pre-existing failures unrelated to this PR)
- [x] Lint clean (ruff + black + mypy strict + shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)