### PR TITLE
feat(plugin): use HTMX for plugin settings form submission (JTN-506)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -8,6 +8,7 @@ from flask import (
     abort,
     current_app,
     jsonify,
+    make_response,
     render_template,
     request,
     send_file,
@@ -713,12 +714,17 @@ def update_now():
 def save_plugin_settings():
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()
+    htmx = _is_htmx_request()
 
     try:
         plugin_settings = parse_form(request.form)
         plugin_settings.update(handle_request_files(request.files))
         plugin_id = plugin_settings.pop(_PLUGIN_ID, None)
         if not plugin_id:
+            if htmx:
+                return _render_plugin_form_error(
+                    _ERR_PLUGIN_ID_REQUIRED, status=422, field=_PLUGIN_ID
+                )
             return json_error(
                 _ERR_PLUGIN_ID_REQUIRED,
                 status=422,
@@ -733,6 +739,8 @@ def save_plugin_settings():
         )
     except Exception as e:
         logger.exception("Error saving plugin settings: %s", e)
+        if htmx:
+            return _render_plugin_form_error(_ERR_INTERNAL, status=500)
         return json_error(_ERR_INTERNAL, status=500)
 
 
@@ -753,27 +761,78 @@ def save_plugin_settings_alias(plugin_id: str):
         )
     except Exception:
         logger.exception("Error saving plugin settings (alias)")
+        if _is_htmx_request():
+            return _render_plugin_form_error(_ERR_INTERNAL, status=500)
         return json_error(_ERR_INTERNAL, status=500)
+
+
+def _is_htmx_request() -> bool:
+    """Return True when the current request originated from HTMX (JTN-506)."""
+    try:
+        return request.headers.get("HX-Request", "").lower() == "true"
+    except RuntimeError:
+        # Outside an active request context
+        return False
+
+
+def _render_plugin_form_error(
+    message: str, status: int = 400, field: str | None = None
+):
+    """Return an HTML error partial for the plugin settings form (JTN-506).
+
+    HTMX swaps error content into ``#plugin-form-errors``; Flask clients that
+    still speak JSON never see this branch because it's gated on the
+    ``HX-Request`` header in the caller.
+    """
+    html = render_template(
+        "partials/plugin_form_errors.html",
+        error=message,
+        field=field,
+    )
+    resp = make_response(html, status)
+    resp.headers["Content-Type"] = "text/html; charset=utf-8"
+    return resp
+
+
+def _render_plugin_form_success(message: str):
+    """Return an HTMX success partial; fires ``pluginSettingsSaved`` toast event."""
+    html = render_template(
+        "partials/plugin_form_errors.html",
+        error=None,
+        message=message,
+    )
+    resp = make_response(html, 200)
+    resp.headers["Content-Type"] = "text/html; charset=utf-8"
+    # HX-Trigger lets the existing toast JS fire without a duplicate modal path
+    resp.headers["HX-Trigger"] = json.dumps(
+        {"pluginSettingsSaved": {"message": message}}
+    )
+    return resp
 
 
 def _save_plugin_settings_common(
     plugin_id, plugin_settings, device_config, playlist_manager
 ):
+    htmx = _is_htmx_request()
     plugin_config = device_config.get_plugin(plugin_id)
     if not plugin_config:
-        return json_error(
-            f"Plugin '{sanitize_response_value(plugin_id)}' not found",
-            status=404,
-        )
+        msg = f"Plugin '{sanitize_response_value(plugin_id)}' not found"
+        if htmx:
+            return _render_plugin_form_error(msg, status=404)
+        return json_error(msg, status=404)
 
     # Validate required fields and plugin-specific settings
     try:
         plugin = get_plugin_instance(plugin_config)
         validation_error = validate_plugin_required_fields(plugin, plugin_settings)
         if validation_error:
+            if htmx:
+                return _render_plugin_form_error(validation_error, status=400)
             return json_error(validation_error, status=400)
         settings_error = plugin.validate_settings(plugin_settings)
         if settings_error:
+            if htmx:
+                return _render_plugin_form_error(settings_error, status=400)
             return json_error(settings_error, status=400)
     except Exception:
         logger.debug("Could not validate plugin schema for %s", plugin_id)
@@ -807,8 +866,11 @@ def _save_plugin_settings_common(
     device_config.update_atomic(_do_save_settings)
     config_dir = os.path.dirname(device_config.config_file)
     _record_plugin_change(config_dir, instance_name, before_settings, plugin_settings)
+    success_message = "Settings saved. Add to Playlist to schedule this instance."
+    if htmx:
+        return _render_plugin_form_success(success_message)
     return json_success(
-        message="Settings saved. Add to Playlist to schedule this instance.",
+        message=success_message,
         instance_name=instance_name,
     )
 

--- a/src/static/scripts/plugin_form.js
+++ b/src/static/scripts/plugin_form.js
@@ -55,9 +55,11 @@
       url = urls.add_to_playlist; const scheduleFormData = new FormData(scheduleForm); const scheduleData = {}; for (const [k, v] of scheduleFormData.entries()) scheduleData[k] = v; formData.append('refresh_settings', JSON.stringify(scheduleData));
     } else if (action === 'update_instance'){
       url = urls.update_instance; method = 'PUT'; clearFormOnSubmit = false;
-    } else if (action === 'save_settings'){
-      url = urls.save_settings; clearFormOnSubmit = false;
     }
+    // NOTE: action === 'save_settings' is handled declaratively via HTMX on the
+    // Save Settings button (JTN-506). It is intentionally no longer routed
+    // through sendForm so validation errors can swap inline instead of firing
+    // a toast.
 
     if (loadingIndicator) loadingIndicator.style.display = 'block';
     progress.start();
@@ -160,6 +162,21 @@
     }
     return { success, result };
   }
+
+  // JTN-506: listen for HX-Trigger events from the HTMX-powered save path
+  // and fire the existing response modal so user feedback is consistent with
+  // the other plugin actions (update_now, update_instance, add_to_playlist).
+  document.addEventListener('pluginSettingsSaved', (event) => {
+    try {
+      const detail = event && event.detail ? event.detail : {};
+      const msg = detail.message || 'Settings saved.';
+      if (window.showResponseModal) {
+        window.showResponseModal('success', `Success! ${msg}`);
+      }
+    } catch (e) {
+      console.warn('pluginSettingsSaved handler error:', e);
+    }
+  });
 
   // Public API
   window.PluginForm = {

--- a/src/templates/partials/plugin_form_errors.html
+++ b/src/templates/partials/plugin_form_errors.html
@@ -1,0 +1,20 @@
+{#
+  Inline validation feedback for the plugin settings form.
+
+  Rendered by the ``/save_plugin_settings`` route when the request includes
+  the ``HX-Request: true`` header (JTN-506).  On success the caller returns
+  an empty fragment plus an ``HX-Trigger`` header so the existing toast JS
+  handler still fires — only the error state ships HTML here.
+#}
+{% if error %}
+<div class="validation-message error"
+     role="alert"
+     data-plugin-form-error
+     {% if field %}data-plugin-form-error-field="{{ field }}"{% endif %}>
+    {{ error }}
+</div>
+{% else %}
+<div class="validation-message success" role="status">
+    {{ message or "Saved." }}
+</div>
+{% endif %}

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -91,7 +91,7 @@
         {% set fit = (config.get('preview_size_mode') == 'fit') %}
         <div class="workflow-layout" data-workflow-layout>
         <section class="workflow-main-panel" data-workflow-panel="configure">
-        <form id="settingsForm" class="settings-form workflow-settings-form" aria-label="Plugin settings for {{ plugin.display_name }}">
+        <form id="settingsForm" class="settings-form workflow-settings-form" action="{{ url_for('plugin.save_plugin_settings') }}" method="post" aria-label="Plugin settings for {{ plugin.display_name }}">
             <div class="settings-container">
                 <div class="workflow-section-header">
                     <h2>Configuration</h2>
@@ -249,13 +249,23 @@
 
         <div class="workflow-action-panel">
             <span id="plugin-form-status" class="validation-message" role="status" aria-live="polite"></span>
+            <!-- HTMX swap target for inline validation feedback (JTN-506) -->
+            <div id="plugin-form-errors" class="plugin-form-errors" aria-live="polite"></div>
             <label class="workflow-device-toggle" for="toggleDeviceFrame">
                 <input type="checkbox" id="toggleDeviceFrame" aria-label="Show device frame"> Show device frame
             </label>
             {% set api_key_missing = api_key is defined and api_key and api_key.required and not api_key.present %}
             <div class="workflow-action-group">
                 <button type="button" data-plugin-action="update_now" class="action-button primary" aria-describedby="update-now-help" {% if api_key_missing %}disabled title="Configure {{ api_key.service }} API key first"{% endif %}>Update Preview</button>
-                <button type="button" data-plugin-action="save_settings" class="action-button is-secondary" aria-describedby="save-settings-help">Save Settings</button>
+                <button type="button"
+                        id="savePluginSettingsBtn"
+                        class="action-button is-secondary"
+                        aria-describedby="save-settings-help"
+                        hx-post="{{ url_for('plugin.save_plugin_settings') }}"
+                        hx-include="#settingsForm"
+                        hx-target="#plugin-form-errors"
+                        hx-swap="innerHTML"
+                        hx-disabled-elt="this">Save Settings</button>
                 {% if plugin_instance %}
                     <button type="button" data-plugin-action="update_instance" class="action-button compact" aria-describedby="update-instance-help" {% if api_key_missing %}disabled title="Configure {{ api_key.service }} API key first"{% endif %}>Update Instance</button>
                 {% else %}

--- a/tests/integration/test_plugin_htmx.py
+++ b/tests/integration/test_plugin_htmx.py
@@ -114,6 +114,39 @@ def test_save_plugin_settings_htmx_error_never_leaks_exception_text(
     assert "internal error" in body.lower()
 
 
+def test_is_htmx_request_returns_false_outside_request_context():
+    """_is_htmx_request handles the no-request-context case (JTN-506)."""
+    from blueprints.plugin import _is_htmx_request
+
+    # Called from a plain Python context, not inside a Flask request — hits the
+    # RuntimeError branch that's otherwise only reachable from background tasks.
+    assert _is_htmx_request() is False
+
+
+def test_save_plugin_settings_htmx_internal_error_has_fallback_content_type(
+    client, flask_app, monkeypatch
+):
+    """Internal error response sets text/html content-type (JTN-506)."""
+    dc = flask_app.config["DEVICE_CONFIG"]
+    monkeypatch.setattr(
+        dc,
+        "update_atomic",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("db down")),
+    )
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_text",
+            "title": "T",
+            "textModel": "gpt-4o",
+            "textPrompt": "p",
+        },
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 500
+    assert "text/html" in resp.headers.get("Content-Type", "")
+
+
 def test_plugin_page_renders_htmx_save_button(client):
     """The plugin page ships hx-* attributes on the Save Settings button."""
     resp = client.get("/plugin/ai_text")

--- a/tests/integration/test_plugin_htmx.py
+++ b/tests/integration/test_plugin_htmx.py
@@ -1,0 +1,128 @@
+# pyright: reportMissingImports=false
+"""HTMX integration coverage for the plugin settings form (JTN-506).
+
+Phase 1 scopes HTMX adoption to ``/save_plugin_settings``.  These tests lock
+in the request/response contract so future refactors don't regress:
+
+* Requests WITHOUT ``HX-Request`` continue to receive JSON (existing clients,
+  test harness, API consumers).
+* Requests WITH ``HX-Request: true`` receive HTML partials.  Validation
+  errors swap error markup into ``#plugin-form-errors``; successful saves
+  return an HTML success partial and set ``HX-Trigger`` so the existing
+  toast JS listener can fire.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def test_save_plugin_settings_htmx_returns_html_on_success(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_text",
+            "title": "HTMX Title",
+            "textModel": "gpt-4o",
+            "textPrompt": "Hello HTMX",
+        },
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    content_type = resp.headers.get("Content-Type", "")
+    assert "text/html" in content_type
+    body = resp.get_data(as_text=True)
+    # Success partial uses the .validation-message success class
+    assert "validation-message success" in body
+    assert "Settings saved" in body
+    # HX-Trigger header fires the toast handler registered in plugin_form.js
+    trigger_raw = resp.headers.get("HX-Trigger")
+    assert trigger_raw, "expected HX-Trigger header on HTMX success"
+    trigger = json.loads(trigger_raw)
+    assert "pluginSettingsSaved" in trigger
+
+
+def test_save_plugin_settings_htmx_returns_error_partial_when_plugin_missing(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "not_real_plugin"},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 404
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    body = resp.get_data(as_text=True)
+    assert "validation-message error" in body
+    assert "data-plugin-form-error" in body
+    assert "not_real_plugin" in body
+
+
+def test_save_plugin_settings_htmx_returns_error_partial_when_plugin_id_missing(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"title": "no plugin id"},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 422
+    assert "text/html" in resp.headers.get("Content-Type", "")
+    body = resp.get_data(as_text=True)
+    assert "validation-message error" in body
+    assert "plugin_id" in body
+    assert 'data-plugin-form-error-field="plugin_id"' in body
+
+
+def test_save_plugin_settings_without_htmx_header_still_returns_json(client):
+    """Legacy contract: no HX-Request header => JSON response."""
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_text",
+            "title": "JSON still works",
+            "textModel": "gpt-4o",
+            "textPrompt": "hi",
+        },
+    )
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers.get("Content-Type", "")
+    payload = resp.get_json()
+    assert payload.get("success") is True
+    assert "instance_name" in payload
+
+
+def test_save_plugin_settings_htmx_error_never_leaks_exception_text(
+    client, flask_app, monkeypatch
+):
+    """HTMX error partial should use the generic internal-error copy."""
+    dc = flask_app.config["DEVICE_CONFIG"]
+    monkeypatch.setattr(
+        dc,
+        "update_atomic",
+        lambda *args, **kwargs: (_ for _ in ()).throw(Exception("secret stack trace")),
+    )
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_text",
+            "title": "T",
+            "textModel": "gpt-4o",
+            "textPrompt": "p",
+        },
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 500
+    body = resp.get_data(as_text=True)
+    assert "secret stack trace" not in body
+    assert "internal error" in body.lower()
+
+
+def test_plugin_page_renders_htmx_save_button(client):
+    """The plugin page ships hx-* attributes on the Save Settings button."""
+    resp = client.get("/plugin/ai_text")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'id="savePluginSettingsBtn"' in body
+    assert 'hx-post="/save_plugin_settings"' in body
+    assert 'hx-target="#plugin-form-errors"' in body
+    assert 'hx-include="#settingsForm"' in body
+    # Progressive enhancement: form has action/method for no-JS fallback
+    assert 'action="/save_plugin_settings"' in body
+    assert 'id="plugin-form-errors"' in body

--- a/tests/integration/test_plugin_pages.py
+++ b/tests/integration/test_plugin_pages.py
@@ -268,11 +268,20 @@ def test_action_buttons_disabled_when_api_key_missing(client, device_config_dev)
 
     # "Update Preview" should be disabled
     assert 'disabled title="Configure Unsplash API key first"' in body
-    # "Save Settings" should NOT be disabled
-    assert 'aria-describedby="save-settings-help">Save Settings</button>' in body
-    assert (
-        "disabled" not in body.split("Save Settings")[0].split("save-settings-help")[1]
-    )
+    # "Save Settings" should NOT be disabled.  JTN-506 added HTMX attributes
+    # between aria-describedby and the button closing tag; assert on the
+    # button id + content rather than a rigid substring so the test covers
+    # intent instead of attribute ordering.
+    assert 'id="savePluginSettingsBtn"' in body
+    assert ">Save Settings</button>" in body
+    # Between the save-settings-help anchor and "Save Settings" text, the
+    # bare ``disabled`` HTML attribute must not appear (the button must
+    # remain enabled).  Use a regex to avoid matching substrings like
+    # ``hx-disabled-elt`` which is an HTMX hint, not an HTML attribute.
+    import re
+
+    save_segment = body.split("Save Settings")[0].split("save-settings-help")[1]
+    assert not re.search(r"(?:^|\s)disabled(?:=|\s|>)", save_segment)
 
 
 def test_action_buttons_enabled_when_api_key_present(client, device_config_dev):


### PR DESCRIPTION
## Summary
- Phase 1 of JTN-506: migrate the plugin "Save Settings" button to HTMX so validation errors swap inline into `#plugin-form-errors` instead of firing a toast
- Added `src/templates/partials/plugin_form_errors.html` (HTML error/success partial) and `_render_plugin_form_error` / `_render_plugin_form_success` helpers in `src/blueprints/plugin.py`; success path sets `HX-Trigger: pluginSettingsSaved` so the existing toast JS still fires
- Gated HTMX behaviour on the `HX-Request: true` header — legacy JSON callers (API consumers, existing tests) are untouched
- Progressive enhancement: `<form id="settingsForm">` now has `action`/`method`; scripted validation/error rendering for the save path removed from `plugin_form.js` (sendForm still handles update_now / update_instance / add_to_playlist)
- update_now / settings / playlist / api-keys remain on the fetch path — deferred to follow-up PRs as called out in the ticket

## Test plan
- [x] New `tests/integration/test_plugin_htmx.py` covers: HTMX success returns HTML + `HX-Trigger`, validation errors return HTML error partials, no-HTMX requests still get JSON, internal errors don't leak exception text, plugin page renders HTMX attributes
- [x] Updated `test_action_buttons_disabled_when_api_key_missing` to match the new button HTML (regex guards against matching `hx-disabled-elt`)
- [x] Full suite: 3709 passed / 4 skipped (2 pre-existing `pyenv: python: command not found` failures in `test_plugin_registry` — unrelated)
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck + mypy strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)