### PR TITLE
refactor(api): standardize JSON response envelope across blueprints (JTN-500)

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -15,7 +15,7 @@ from flask import (
     send_from_directory,
 )
 
-from utils.http_utils import json_error
+from utils.http_utils import json_error, json_success
 from utils.image_serving import maybe_serve_webp
 from utils.rate_limiter import CooldownLimiter
 
@@ -243,7 +243,7 @@ def save_plugin_order():
             status=400,
         )
     device_config.set_plugin_order(order)
-    return jsonify({"success": True})
+    return json_success()
 
 
 @main_bp.route("/sw.js", methods=["GET"])
@@ -459,20 +459,14 @@ def display_next():
     except Exception:
         pass
 
-    return (
-        jsonify(
-            {
-                "success": True,
-                "message": "Display updated",
-                "metrics": {
-                    "request_ms": request_ms,
-                    "generate_ms": generate_ms,
-                    "preprocess_ms": preprocess_ms,
-                    "display_ms": display_ms,
-                },
-            }
-        ),
-        200,
+    return json_success(
+        message="Display updated",
+        metrics={
+            "request_ms": request_ms,
+            "generate_ms": generate_ms,
+            "preprocess_ms": preprocess_ms,
+            "display_ms": display_ms,
+        },
     )
 
 

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -24,7 +24,7 @@ from utils.form_utils import (
     sanitize_response_value,
     validate_plugin_required_fields,
 )
-from utils.http_utils import APIError, json_error
+from utils.http_utils import APIError, json_error, json_success
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 from utils.plugin_history import record_change as _record_plugin_change
 from utils.progress import track_progress
@@ -270,7 +270,7 @@ def delete_plugin_instance():
         logger.exception("EXCEPTION CAUGHT: %s", e)
         return json_error(_ERR_INTERNAL, status=500)
 
-    return jsonify({"success": True, "message": "Deleted plugin instance."})
+    return json_success(message="Deleted plugin instance.")
 
 
 @plugin_bp.route("/update_plugin_instance/<string:instance_name>", methods=["PUT"])
@@ -370,12 +370,7 @@ def update_plugin_instance(instance_name: str):
     except Exception:
         return json_error(_ERR_INTERNAL, status=500)
 
-    return jsonify(
-        {
-            "success": True,
-            "message": f"Updated plugin instance {instance_name}.",
-        }
-    )
+    return json_success(message=f"Updated plugin instance {instance_name}.")
 
 
 @plugin_bp.route("/display_plugin_instance", methods=["POST"])
@@ -410,7 +405,7 @@ def display_plugin_instance():
     except Exception:
         return json_error(_ERR_INTERNAL, status=500)
 
-    return jsonify({"success": True, "message": _MSG_DISPLAY_UPDATED}), 200
+    return json_success(message=_MSG_DISPLAY_UPDATED)
 
 
 @plugin_bp.route(
@@ -434,11 +429,8 @@ def force_retry_plugin_instance(plugin_id: str, instance_name: str):
             f"Plugin instance '{sanitize_response_value(instance_name)}' not found",
             status=404,
         )
-    return jsonify(
-        {
-            "success": True,
-            "message": f"Circuit-breaker reset for '{sanitize_response_value(instance_name)}'.",
-        }
+    return json_success(
+        message=f"Circuit-breaker reset for '{sanitize_response_value(instance_name)}'.",
     )
 
 
@@ -533,10 +525,7 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
             "preprocess_ms": preprocess_ms,
             "steps": tracker.get_steps(),
         }
-    return (
-        jsonify({"success": True, "message": _MSG_DISPLAY_UPDATED, "metrics": metrics}),
-        200,
-    )
+    return json_success(message=_MSG_DISPLAY_UPDATED, metrics=metrics)
 
 
 def _push_update_now_fallback(
@@ -709,16 +698,7 @@ def update_now():
             metrics = refresh_task.manual_update(
                 ManualRefresh(plugin_id, plugin_settings)
             )
-            return (
-                jsonify(
-                    {
-                        "success": True,
-                        "message": _MSG_DISPLAY_UPDATED,
-                        "metrics": metrics,
-                    }
-                ),
-                200,
-            )
+            return json_success(message=_MSG_DISPLAY_UPDATED, metrics=metrics)
         else:
             logger.info("Refresh task not running, updating display directly")
             return _update_now_direct(
@@ -827,15 +807,9 @@ def _save_plugin_settings_common(
     device_config.update_atomic(_do_save_settings)
     config_dir = os.path.dirname(device_config.config_file)
     _record_plugin_change(config_dir, instance_name, before_settings, plugin_settings)
-    return (
-        jsonify(
-            {
-                "success": True,
-                "message": "Settings saved. Add to Playlist to schedule this instance.",
-                "instance_name": instance_name,
-            }
-        ),
-        200,
+    return json_success(
+        message="Settings saved. Add to Playlist to schedule this instance.",
+        instance_name=instance_name,
     )
 
 

--- a/src/blueprints/settings/_benchmarks.py
+++ b/src/blueprints/settings/_benchmarks.py
@@ -2,10 +2,10 @@
 
 import sqlite3
 
-from flask import jsonify, request
+from flask import request
 
 import blueprints.settings as _mod
-from utils.http_utils import json_error, json_internal_error
+from utils.http_utils import json_error, json_internal_error, json_success
 from utils.messages import BENCHMARKS_API_DISABLED_ERROR
 
 
@@ -32,29 +32,26 @@ def benchmarks_summary():
         gen = [int(r["generate_ms"]) for r in rows if r["generate_ms"] is not None]
         pre = [int(r["preprocess_ms"]) for r in rows if r["preprocess_ms"] is not None]
         dsp = [int(r["display_ms"]) for r in rows if r["display_ms"] is not None]
-        return jsonify(
-            {
-                "success": True,
-                "count": len(rows),
-                "summary": {
-                    "request_ms": {
-                        "p50": _mod._pct(req, 0.5),
-                        "p95": _mod._pct(req, 0.95),
-                    },
-                    "generate_ms": {
-                        "p50": _mod._pct(gen, 0.5),
-                        "p95": _mod._pct(gen, 0.95),
-                    },
-                    "preprocess_ms": {
-                        "p50": _mod._pct(pre, 0.5),
-                        "p95": _mod._pct(pre, 0.95),
-                    },
-                    "display_ms": {
-                        "p50": _mod._pct(dsp, 0.5),
-                        "p95": _mod._pct(dsp, 0.95),
-                    },
+        return json_success(
+            count=len(rows),
+            summary={
+                "request_ms": {
+                    "p50": _mod._pct(req, 0.5),
+                    "p95": _mod._pct(req, 0.95),
                 },
-            }
+                "generate_ms": {
+                    "p50": _mod._pct(gen, 0.5),
+                    "p95": _mod._pct(gen, 0.95),
+                },
+                "preprocess_ms": {
+                    "p50": _mod._pct(pre, 0.5),
+                    "p95": _mod._pct(pre, 0.95),
+                },
+                "display_ms": {
+                    "p50": _mod._pct(dsp, 0.5),
+                    "p95": _mod._pct(dsp, 0.95),
+                },
+            },
         )
     except Exception as e:
         return json_internal_error("benchmarks summary", details={"error": str(e)})
@@ -100,12 +97,9 @@ def benchmarks_refreshes():
                 (since, limit),
             ).fetchall()
         next_cursor = str(rows[-1]["id"]) if rows else None
-        return jsonify(
-            {
-                "success": True,
-                "items": [dict(r) for r in rows],
-                "next_cursor": next_cursor,
-            }
+        return json_success(
+            items=[dict(r) for r in rows],
+            next_cursor=next_cursor,
         )
     except Exception as e:
         return json_internal_error("benchmarks refreshes", details={"error": str(e)})
@@ -160,7 +154,7 @@ def benchmarks_plugins():
             }
             for r in rows
         ]
-        return jsonify({"success": True, "items": items})
+        return json_success(items=items)
     except Exception as e:
         return json_internal_error("benchmarks plugins", details={"error": str(e)})
     finally:
@@ -194,7 +188,7 @@ def benchmarks_stages():
             """,
             (refresh_id,),
         ).fetchall()
-        return jsonify({"success": True, "items": [dict(r) for r in rows]})
+        return json_success(items=[dict(r) for r in rows])
     except Exception as e:
         return json_internal_error("benchmarks stages", details={"error": str(e)})
     finally:

--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -2,10 +2,10 @@
 
 from zoneinfo import available_timezones
 
-from flask import current_app, jsonify, render_template, request
+from flask import current_app, render_template, request
 
 import blueprints.settings as _mod
-from utils.http_utils import json_error, json_internal_error
+from utils.http_utils import json_error, json_internal_error, json_success
 from utils.time_utils import calculate_seconds
 
 
@@ -18,7 +18,7 @@ def plugin_isolation():
     registered_ids = {plugin["id"] for plugin in device_config.get_plugins()}
 
     if request.method == "GET":
-        return jsonify({"success": True, "isolated_plugins": sorted(set(isolated))})
+        return json_success(isolated_plugins=sorted(set(isolated)))
 
     body = request.get_json(silent=True)
     if not isinstance(body, dict):
@@ -46,12 +46,12 @@ def plugin_isolation():
             device_config.update_value(
                 "isolated_plugins", sorted(set(isolated)), write=True
             )
-        return jsonify({"success": True, "isolated_plugins": sorted(set(isolated))})
+        return json_success(isolated_plugins=sorted(set(isolated)))
 
     # DELETE
     isolated = [p for p in isolated if p != normalized_plugin_id]
     device_config.update_value("isolated_plugins", sorted(set(isolated)), write=True)
-    return jsonify({"success": True, "isolated_plugins": sorted(set(isolated))})
+    return json_success(isolated_plugins=sorted(set(isolated)))
 
 
 @_mod.settings_bp.route("/settings/safe_reset", methods=["POST"])
@@ -75,7 +75,7 @@ def safe_reset():
         keep["log_system_stats"] = False
         keep["isolated_plugins"] = []
         device_config.update_config(keep)
-        return jsonify({"success": True, "message": "Safe reset applied."})
+        return json_success(message="Safe reset applied.")
     except Exception as e:
         return json_internal_error("safe reset", details={"error": str(e)})
 
@@ -150,7 +150,7 @@ def export_settings():
             data["env_keys"] = keys
 
         # JSON response for now; a file download route can be added if needed
-        return jsonify({"success": True, "data": data})
+        return json_success(data=data)
     except Exception as e:
         _mod.logger.exception("Error exporting settings")
         return json_internal_error(
@@ -204,7 +204,7 @@ def import_settings():
                 except Exception:
                     _mod.logger.exception("Failed setting env key during import: %s", k)
 
-        return jsonify({"success": True, "message": "Import completed"})
+        return json_success(message="Import completed")
     except Exception as e:
         _mod.logger.exception("Error importing settings")
         return json_internal_error(
@@ -299,10 +299,10 @@ def save_api_keys():
                 continue
             device_config.set_env_key(key, value)
             updated.append(key)
-        response = {"success": True, "message": "API keys saved.", "updated": updated}
+        extra: dict = {"updated": updated}
         if skipped_placeholder:
-            response["skipped_placeholder"] = skipped_placeholder
-        return jsonify(response)
+            extra["skipped_placeholder"] = skipped_placeholder
+        return json_success(message="API keys saved.", **extra)
     except Exception:
         _mod.logger.exception("Error saving API keys")
         return json_internal_error(
@@ -329,7 +329,7 @@ def delete_api_key():
         return json_error("Invalid key name", status=400)
     try:
         device_config.unset_env_key(key)
-        return jsonify({"success": True, "message": f"Deleted {key}."})
+        return json_success(message=f"Deleted {key}.")
     except Exception:
         _mod.logger.exception("Error deleting API key")
         return json_internal_error(
@@ -530,7 +530,7 @@ def save_settings():
             "saving device settings",
             details={"hint": "Check numeric values and config file permissions."},
         )
-    return jsonify({"success": True, "message": "Saved settings."})
+    return json_success(message="Saved settings.")
 
 
 # Legacy route aliases used by older UI/tests.

--- a/src/blueprints/settings/_health.py
+++ b/src/blueprints/settings/_health.py
@@ -5,10 +5,10 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from flask import Response, current_app, jsonify, request, stream_with_context
+from flask import Response, current_app, request, stream_with_context
 
 import blueprints.settings as _mod
-from utils.http_utils import json_error, json_internal_error
+from utils.http_utils import json_error, json_internal_error, json_success
 from utils.progress_events import get_progress_bus, to_sse
 
 
@@ -44,7 +44,7 @@ def health_plugins():
         except Exception:
             window_min = 1440
         health = _filter_health_by_window(health, window_min)
-        return jsonify({"success": True, "items": health})
+        return json_success(items=health)
     except Exception as e:
         return json_internal_error("health plugins", details={"error": str(e)})
 
@@ -52,7 +52,7 @@ def health_plugins():
 @_mod.settings_bp.route("/api/health/system", methods=["GET"])
 def health_system():
     try:
-        data: dict[str, Any] = {"success": True}
+        data: dict[str, Any] = {}
         try:
             import psutil  # type: ignore
 
@@ -65,7 +65,7 @@ def health_system():
             data["memory_percent"] = None
             data["disk_percent"] = None
             data["uptime_seconds"] = None
-        return jsonify(data)
+        return json_success(**data)
     except Exception as e:
         return json_internal_error("health system", details={"error": str(e)})
 

--- a/src/blueprints/settings/_system.py
+++ b/src/blueprints/settings/_system.py
@@ -2,10 +2,10 @@
 
 import subprocess
 
-from flask import jsonify, request
+from flask import request
 
 import blueprints.settings as _mod
-from utils.http_utils import json_error, json_internal_error
+from utils.http_utils import json_error, json_internal_error, json_success
 
 
 def _sanitize_log_value(value: str, max_len: int = 500) -> str:
@@ -49,7 +49,7 @@ def client_log():
             _mod.logger.error(line)
         else:
             _mod.logger.info(line)
-        return jsonify({"success": True})
+        return json_success()
     except Exception:
         _mod.logger.exception("/settings/client_log failure")
         return json_internal_error(
@@ -93,7 +93,7 @@ def shutdown():
             subprocess.run(["sudo", "shutdown", "-h", "now"], check=True)
         # Refresh the cooldown timestamp to the actual success time
         _mod._shutdown_limiter.record()
-        return jsonify({"success": True})
+        return json_success()
     except subprocess.CalledProcessError as e:
         # Roll back so the cooldown isn't consumed by a failed attempt
         _mod._shutdown_limiter.reset()

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -6,7 +6,7 @@ from flask import current_app, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 import blueprints.settings as _mod
-from utils.http_utils import json_error, json_internal_error
+from utils.http_utils import json_error, json_internal_error, json_success
 
 
 @_mod.settings_bp.route("/settings/update", methods=["POST"])  # start update
@@ -37,10 +37,7 @@ def start_update():
             target_tag = raw.strip()
 
         if target_tag and not _mod._TAG_RE.fullmatch(target_tag):
-            return (
-                jsonify({"success": False, "error": "Invalid target version format"}),
-                400,
-            )
+            return json_error("Invalid target version format", status=400)
 
         script_path = _mod._get_update_script_path()
         # NOTE: the systemd unit name is now generated *inside*
@@ -59,17 +56,13 @@ def start_update():
         # the state mutation here to avoid re-entering the non-reentrant lock.
         with _mod._update_lock:
             if _mod._UPDATE_STATE.get("running"):
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "error": "Update already in progress.",
-                            "running": True,
-                            "unit": _mod._UPDATE_STATE.get("unit"),
-                        }
-                    ),
-                    409,
-                )
+                # NOTE: ``running`` and ``unit`` are kept at the top level for
+                # backward compatibility with existing clients and tests.
+                response, _ = json_error("Update already in progress.", status=409)
+                payload = response.get_json()
+                payload["running"] = True
+                payload["unit"] = _mod._UPDATE_STATE.get("unit")
+                return jsonify(payload), 409
             # Flip the state while still holding the lock (inlined to avoid
             # re-acquiring the non-reentrant lock inside _set_update_state).
             new_unit = f"{unit}.service" if use_systemd else None
@@ -95,13 +88,10 @@ def start_update():
         else:
             _mod._start_update_fallback_thread(script_path, target_tag=target_tag)
 
-        return jsonify(
-            {
-                "success": True,
-                "running": True,
-                "unit": _mod._UPDATE_STATE.get("unit"),
-                "message": "Update started. Watch the Logs panel for progress.",
-            }
+        return json_success(
+            message="Update started. Watch the Logs panel for progress.",
+            running=True,
+            unit=_mod._UPDATE_STATE.get("unit"),
         )
     except Exception as e:
         _mod.logger.exception("/settings/update error")

--- a/src/blueprints/stats.py
+++ b/src/blueprints/stats.py
@@ -19,6 +19,7 @@ import logging
 
 from flask import Blueprint, current_app, jsonify
 
+from utils.http_utils import json_error
 from utils.refresh_stats import compute_stats
 
 logger = logging.getLogger(__name__)
@@ -44,7 +45,7 @@ def refresh_stats():
         }
     except Exception:
         logger.exception("Failed to compute refresh stats")
-        return jsonify({"error": "failed to compute stats"}), 500
+        return json_error("failed to compute stats", status=500)
 
     response = jsonify(payload)
     response.headers["Cache-Control"] = "public, max-age=60"

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -1,3 +1,44 @@
+"""HTTP helpers and canonical JSON response envelope (JTN-500).
+
+Canonical JSON envelope
+-----------------------
+All JSON API routes should return responses built via :func:`json_success` or
+:func:`json_error` so clients can rely on a single stable shape.
+
+Success envelope::
+
+    {
+        "success": true,
+        "message": "<optional human-readable summary>",
+        "request_id": "<uuid, when inside a request context>",
+        ...payload fields (e.g. "data", "items", "metrics")...
+    }
+
+Error envelope::
+
+    {
+        "success": false,
+        "error": "<human-readable message>",
+        "code": "<optional app error code>",
+        "details": { ... optional structured detail ... },
+        "request_id": "<uuid, when inside a request context>"
+    }
+
+Rules of thumb
+~~~~~~~~~~~~~~
+* Prefer ``json_success(message=..., data=..., meta=...)`` over
+  ``jsonify({"success": True, ...})`` so ``request_id`` and future envelope
+  fields are added automatically.
+* For errors, raise :class:`APIError` or return ``json_error(...)``.  Do not
+  return ``jsonify({"success": False, "error": "..."})`` directly — that shape
+  skips ``request_id`` and bypasses the central error logging path.
+* Pagination envelopes should place page data under ``items`` and cursor
+  information under ``next_cursor``/``meta``.
+* Pure data read endpoints (e.g. ``/api/version/info``) MAY return a raw JSON
+  object without the ``success`` key for backwards compatibility, but any new
+  endpoint should use the canonical envelope.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/tests/contracts/test_json_envelope.py
+++ b/tests/contracts/test_json_envelope.py
@@ -1,0 +1,162 @@
+"""Contract tests: canonical JSON envelope (JTN-500).
+
+All JSON API routes that signal an outcome (success or failure) must return a
+response shaped like the canonical envelope documented in
+``src/utils/http_utils.py``:
+
+Success::
+
+    {
+        "success": true,
+        "message": "<optional>",
+        "request_id": "<uuid when in a request context>",
+        ...payload...
+    }
+
+Error::
+
+    {
+        "success": false,
+        "error": "<message>",
+        "code": "<optional>",
+        "details": {...},
+        "request_id": "<uuid>"
+    }
+
+These tests exercise a representative set of routes via the Flask test client
+and assert the envelope shape.  Pure data-read routes (e.g. ``/api/version``,
+``/api/uptime``) are intentionally exempt — see the module docstring.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _assert_success_envelope(payload: dict) -> None:
+    assert isinstance(payload, dict), f"response not a dict: {payload!r}"
+    assert payload.get("success") is True, f"expected success=True, got {payload!r}"
+    # request_id should be populated whenever we are inside a request context.
+    assert (
+        isinstance(payload.get("request_id"), str) and payload["request_id"]
+    ), f"missing request_id in success envelope: {payload!r}"
+
+
+def _assert_error_envelope(payload: dict) -> None:
+    assert isinstance(payload, dict), f"response not a dict: {payload!r}"
+    assert payload.get("success") is False, f"expected success=False, got {payload!r}"
+    assert (
+        isinstance(payload.get("error"), str) and payload["error"]
+    ), f"missing error string in error envelope: {payload!r}"
+    assert (
+        isinstance(payload.get("request_id"), str) and payload["request_id"]
+    ), f"missing request_id in error envelope: {payload!r}"
+
+
+# ---------------------------------------------------------------------------
+# Success envelope coverage
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_order_success_envelope(client, flask_app):
+    """POST /api/plugin_order returns the canonical success envelope."""
+    device_config = flask_app.config["DEVICE_CONFIG"]
+    plugin_ids = sorted({p["id"] for p in device_config.get_plugins()})
+    resp = client.post(
+        "/api/plugin_order",
+        data=json.dumps({"order": plugin_ids}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    _assert_success_envelope(resp.get_json())
+
+
+def test_health_plugins_success_envelope(client):
+    """GET /api/health/plugins returns the canonical success envelope."""
+    resp = client.get("/api/health/plugins")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    _assert_success_envelope(body)
+    assert "items" in body
+
+
+def test_health_system_success_envelope(client):
+    """GET /api/health/system returns the canonical success envelope."""
+    resp = client.get("/api/health/system")
+    assert resp.status_code == 200
+    _assert_success_envelope(resp.get_json())
+
+
+def test_isolation_get_success_envelope(client):
+    """GET /settings/isolation returns the canonical success envelope."""
+    resp = client.get("/settings/isolation")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    _assert_success_envelope(body)
+    assert "isolated_plugins" in body
+
+
+def test_safe_reset_success_envelope(client):
+    """POST /settings/safe_reset returns the canonical success envelope."""
+    resp = client.post("/settings/safe_reset")
+    assert resp.status_code == 200
+    _assert_success_envelope(resp.get_json())
+
+
+# ---------------------------------------------------------------------------
+# Error envelope coverage
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_order_validation_error_envelope(client):
+    """POST /api/plugin_order with a bad body returns the error envelope."""
+    resp = client.post(
+        "/api/plugin_order",
+        data="not-json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    _assert_error_envelope(resp.get_json())
+
+
+def test_isolation_bad_json_error_envelope(client):
+    """POST /settings/isolation with a non-object body returns the error envelope."""
+    resp = client.post(
+        "/settings/isolation",
+        data=json.dumps([]),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    _assert_error_envelope(resp.get_json())
+
+
+def test_delete_api_key_invalid_error_envelope(client):
+    """POST /settings/delete_api_key with an unknown key returns the error envelope."""
+    resp = client.post("/settings/delete_api_key", data={"key": "NOT_A_REAL_KEY"})
+    assert resp.status_code == 400
+    _assert_error_envelope(resp.get_json())
+
+
+def test_plugin_history_invalid_name_error_envelope(client):
+    """GET /api/plugins/instance/<bad>/history returns the error envelope."""
+    # '/' is not in the allowed name charset; flask routing will 404 before
+    # the handler runs, so pick something that passes the path but fails the
+    # regex check inside the handler.
+    resp = client.get("/api/plugins/instance/.hidden/history")
+    assert resp.status_code in (400, 404)
+    _assert_error_envelope(resp.get_json())
+
+
+# ---------------------------------------------------------------------------
+# request_id propagation
+# ---------------------------------------------------------------------------
+
+
+def test_request_id_header_round_trip(client):
+    """If the client supplies X-Request-Id, the envelope echoes it."""
+    rid = "test-req-id-12345"
+    resp = client.get("/api/health/system", headers={"X-Request-Id": rid})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    _assert_success_envelope(body)
+    assert body["request_id"] == rid


### PR DESCRIPTION
## Summary
- Document the canonical JSON envelope in `src/utils/http_utils.py` (success/error shapes, `request_id`, rules of thumb).
- Migrate remaining `jsonify({"success": True, ...})` and raw `{"success": False, "error": ...}` calls in `main.py`, `plugin.py`, `stats.py`, and `settings/_*.py` to the central `json_success` / `json_error` helpers so every JSON response carries `request_id` automatically.
- Add `tests/contracts/test_json_envelope.py` to assert the envelope shape (success, error, and `X-Request-Id` round-trip) on a representative set of routes.
- Preserve legacy top-level `running`/`unit` fields on the 409 duplicate-update response for backward compatibility.

## Test plan
- [x] `pytest tests/contracts/test_json_envelope.py` (10 passed)
- [x] `pytest tests/ --ignore=tests/benchmarks` (3713 passed, only 2 pre-existing pyenv-env unit failures)
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now include standardized request identifiers for improved tracking and debugging across all endpoints.

* **Tests**
  * Added contract tests to validate consistent API response structure across multiple endpoints.

* **Documentation**
  * Enhanced HTTP utilities documentation with guidelines for canonical JSON response envelopes and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->