### PR TITLE
test(plugin_registry): use sys.executable for pyenv compatibility (JTN-625)

### DIFF
--- a/tests/unit/test_plugin_registry.py
+++ b/tests/unit/test_plugin_registry.py
@@ -2,6 +2,7 @@
 import importlib
 import logging
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -54,9 +55,16 @@ def _base_env() -> dict[str, str]:
 def _read_pythonpath_from_shell(
     env: dict[str, str],
 ) -> subprocess.CompletedProcess[str]:
+    # Use sys.executable rather than the bare string "python" so this test does
+    # not depend on PATH resolution. On macOS with pyenv, a `python` shim may
+    # resolve to a version that is not installed, causing
+    # "pyenv: python: command not found" even though the running interpreter
+    # is perfectly healthy. The behavior under test is PYTHONPATH propagation
+    # from scripts/venv.sh, which is independent of which interpreter is used.
+    python_bin = shlex.quote(sys.executable)
     command = (
         "source scripts/venv.sh >/dev/null 2>&1 && "
-        "python - <<'PY'\n"
+        f"{python_bin} - <<'PY'\n"
         "import os\n"
         "print(os.environ.get('PYTHONPATH', ''))\n"
         "PY\n"


### PR DESCRIPTION
## Summary
- Fixes two tests in `tests/unit/test_plugin_registry.py` that fail on macOS local dev with `pyenv: python: command not found`
- Root cause: the shell heredoc invoked a bare `python`, which goes through pyenv's PATH shim; on many macOS dev setups that shim points at an uninstalled interpreter
- Fix: invoke `sys.executable` (the interpreter already running the test), shell-escaped via `shlex.quote`. PYTHONPATH propagation — the actual behavior under test — is unchanged

## Test plan
- [x] `tests/unit/test_plugin_registry.py` passes locally on macOS (10/10)
- [x] Full suite: 3786 passed, 5 skipped
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck + mypy strict subset)
- [ ] CI green on Ubuntu (`actions/setup-python` still works — `sys.executable` is always valid)

Closes JTN-625.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure reliability for Python interpreter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->