### PR TITLE
fix(settings): add /settings/diagnostics route to prevent 404 (JTN-627)

### DIFF
--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -2,7 +2,7 @@
 
 from zoneinfo import available_timezones
 
-from flask import current_app, render_template, request
+from flask import current_app, redirect, render_template, request
 
 import blueprints.settings as _mod
 from utils.http_utils import json_error, json_internal_error, json_success
@@ -87,6 +87,18 @@ def settings_page():
     return render_template(
         "settings.html", device_settings=device_config.get_config(), timezones=timezones
     )
+
+
+@_mod.settings_bp.route("/settings/diagnostics", methods=["GET"])
+def diagnostics_redirect():
+    """Redirect /settings/diagnostics to the Diagnostics accordion on /settings.
+
+    Diagnostics is an accordion embedded in the main settings page rather than
+    a standalone page. Users who bookmark or follow direct links to
+    ``/settings/diagnostics`` previously hit a 404 (JTN-627); redirect them to
+    the anchor on the settings page instead.
+    """
+    return redirect("/settings#diagnostics", code=302)
 
 
 @_mod.settings_bp.route("/settings/backup", methods=["GET"])

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -203,6 +203,7 @@
 
                 <!-- Diagnostics -->
                 <div class="collapsible" id="section-observability">
+                    <span id="diagnostics" class="anchor-target" aria-hidden="true"></span>
                     <button type="button" class="collapsible-header" aria-expanded="false" data-collapsible-toggle>
                         Diagnostics <span class="collapsible-icon" aria-hidden="true">&#9660;</span>
                     </button>

--- a/tests/unit/test_settings_blueprint.py
+++ b/tests/unit/test_settings_blueprint.py
@@ -507,3 +507,27 @@ class TestHelpers:
         from blueprints.settings import _benchmarks_enabled
 
         assert _benchmarks_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# /settings/diagnostics redirect (JTN-627)
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsRedirect:
+    """``/settings/diagnostics`` must not 404; it redirects to the accordion anchor."""
+
+    def test_diagnostics_redirects_to_settings_anchor(self, client):
+        resp = client.get("/settings/diagnostics", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/settings#diagnostics")
+
+    def test_diagnostics_follow_redirect_renders_settings(self, client):
+        resp = client.get("/settings/diagnostics", follow_redirects=True)
+        assert resp.status_code == 200
+        # Diagnostics anchor target must be present so the fragment resolves.
+        assert b'id="diagnostics"' in resp.data
+
+    def test_diagnostics_direct_not_404(self, client):
+        resp = client.get("/settings/diagnostics")
+        assert resp.status_code != 404


### PR DESCRIPTION
## Summary
- Adds `GET /settings/diagnostics` that 302-redirects to `/settings#diagnostics` so bookmarks and direct links no longer 404.
- Adds an `id="diagnostics"` anchor target next to the Diagnostics accordion so the fragment resolves to the correct section.
- Covers the behavior with integration tests (302 status, Location header, no 404, and anchor presence after following the redirect).

Linear: JTN-627

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/unit/test_settings_blueprint.py::TestDiagnosticsRedirect`
- [x] Full test suite (only 2 pre-existing pyenv-related failures in `test_plugin_registry.py`, unrelated to this change)
- [x] `scripts/lint.sh` passes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>