### PR TITLE
fix(security): implement /api/csp-report to accept violation reports (JTN-628)

### DIFF
--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -30,8 +30,15 @@ logger = logging.getLogger(__name__)
 _CACHE_1_YEAR = 31_536_000
 _CACHE_1_DAY = 86_400
 _CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
-_CSRF_EXEMPT_PATHS = frozenset({"/healthz", "/readyz"})
-_RATE_EXEMPT = frozenset({"/healthz", "/readyz"})
+#: Endpoints that MUST skip CSRF validation because the caller is a
+#: browser-initiated automatic request with no session cookie:
+#:   * /healthz, /readyz — monitoring probes
+#:   * /api/csp-report — CSP violation reports sent by the browser itself
+#:     (JTN-628). Browsers never attach a CSRF token to these requests, so
+#:     the endpoint has its own rate-limiting and size-limiting defenses
+#:     baked into the blueprint handler.
+_CSRF_EXEMPT_PATHS = frozenset({"/healthz", "/readyz", "/api/csp-report"})
+_RATE_EXEMPT = frozenset({"/healthz", "/readyz", "/api/csp-report"})
 _MUTATE_WINDOW = 60  # seconds
 _MUTATE_MAX = 60  # requests per IP per window
 

--- a/src/blueprints/csp_report.py
+++ b/src/blueprints/csp_report.py
@@ -25,6 +25,11 @@ csp_report_bp = Blueprint("csp_report", __name__)
 # legitimate browser reports; blocks flooded or replayed traffic.
 _csp_report_limiter = SlidingWindowLimiter(20, 60)
 
+# Hard cap on report body size. Legitimate browser reports are typically
+# < 4 KiB; anything larger is almost certainly abuse. Oversized bodies
+# are rejected without parsing or logging the payload.
+_MAX_REPORT_BYTES = 16 * 1024
+
 _SOURCE_FILE_RE = re.compile(r'"source-file"\s*:\s*"([^"]*)"')
 _DOCUMENT_URI_RE = re.compile(r'"document-uri"\s*:\s*"([^"]*)"')
 
@@ -44,14 +49,24 @@ def _redact_url(url: str) -> str:
     return url
 
 
+class _MalformedReport(ValueError):
+    """Raised when a CSP report body cannot be decoded as JSON."""
+
+
 def _parse_report(body: bytes) -> dict:
-    """Parse a CSP report body; return an empty dict on failure."""
+    """Parse a CSP report body.
+
+    Returns an empty dict for an empty body (browsers occasionally POST
+    empty reports). Raises :class:`_MalformedReport` when the body is
+    non-empty but cannot be decoded as JSON — the caller is expected to
+    translate that into an HTTP 400 response (JTN-628).
+    """
     if not body:
         return {}
     try:
         data = json.loads(body)
-    except (ValueError, UnicodeDecodeError):
-        return {}
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise _MalformedReport(str(exc)) from exc
 
     # Legacy format: {"csp-report": {...}}
     if isinstance(data, dict) and "csp-report" in data:
@@ -106,8 +121,28 @@ def receive_csp_report() -> Response:
             "CSP report endpoint received unexpected content-type: %s", content_type
         )
 
-    body = request.get_data(cache=False)
-    report = _parse_report(body)
+    # Size-limit the body before reading it all into memory. Legitimate
+    # browser reports are tiny; oversized payloads are treated as abuse
+    # and discarded with a 204 so we neither log nor echo them back.
+    content_length = request.content_length or 0
+    if content_length > _MAX_REPORT_BYTES:
+        return Response(status=204)
+    body = request.get_data(cache=False, parse_form_data=False)
+    if len(body) > _MAX_REPORT_BYTES:
+        return Response(status=204)
+
+    try:
+        report = _parse_report(body)
+    except _MalformedReport:
+        # Return 400 per RFC 7807 / JTN-628 spec. Do NOT echo the body
+        # back in the response (defensive: prevents reflected XSS-style
+        # vectors via attacker-controlled report contents).
+        return Response(
+            '{"error":"malformed CSP report"}',
+            status=400,
+            content_type="application/json",
+        )
+
     sanitised = _sanitise_report(report)
     logger.warning("CSP violation: %s", json.dumps(sanitised))
 

--- a/tests/test_csp_report.py
+++ b/tests/test_csp_report.py
@@ -157,12 +157,48 @@ def test_empty_body_returns_204(csp_client):
     assert resp.status_code == 204
 
 
-def test_invalid_json_body_returns_204(csp_client):
-    """Malformed JSON must not crash — returns 204."""
+def test_invalid_json_body_returns_400(csp_client):
+    """Malformed JSON must be rejected with HTTP 400 (JTN-628)."""
     resp = csp_client.post(
         "/api/csp-report",
         data=b"not-json!!!",
         content_type="application/csp-report",
+    )
+    assert resp.status_code == 400
+    # The response MUST NOT echo the malformed body back (defensive).
+    assert b"not-json" not in resp.data
+
+
+def test_invalid_json_body_reports_application_json(csp_client):
+    """400 response uses application/json content-type."""
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=b"{broken",
+        content_type="application/csp-report",
+    )
+    assert resp.status_code == 400
+    assert resp.content_type.startswith("application/json")
+
+
+def test_oversized_body_is_discarded(csp_client):
+    """Bodies larger than 16 KiB are discarded without logging."""
+    huge = b'{"csp-report":{"blocked-uri":"' + (b"A" * 20_000) + b'"}}'
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=huge,
+        content_type="application/csp-report",
+    )
+    # Oversized bodies get a 204 (silently discarded) — the server MUST
+    # NOT fingerprint the limiter by returning a distinct error code.
+    assert resp.status_code == 204
+
+
+def test_reports_api_v2_content_type_accepted(csp_client):
+    """application/reports+json (Reporting API v2) is accepted."""
+    resp = csp_client.post(
+        "/api/csp-report",
+        data=json.dumps(_MODERN_CSP_REPORT),
+        content_type="application/reports+json",
     )
     assert resp.status_code == 204
 
@@ -240,6 +276,65 @@ def test_custom_csp_with_existing_report_uri_not_duplicated(monkeypatch):
     assert (
         csp.count("report-uri") == 1
     ), f"'report-uri' must appear exactly once; got: {csp!r}"
+
+
+def _make_csp_app_with_full_middleware() -> Flask:
+    """Build an app with the real CSRF + rate-limit middleware registered.
+
+    This exercises the exemption added in JTN-628: /api/csp-report MUST
+    bypass CSRF and the sliding-window rate limiter even though it is a
+    POST to a path that would otherwise be rejected with 403.
+    """
+    app = Flask(__name__)
+    app.secret_key = "test-csp-integration"
+    app.config["TESTING"] = True
+
+    from app_setup.security_middleware import (
+        setup_csrf_protection,
+        setup_rate_limiting,
+    )
+    from blueprints.csp_report import csp_report_bp
+
+    setup_csrf_protection(app)
+    setup_rate_limiting(app)
+    app.register_blueprint(csp_report_bp)
+    return app
+
+
+def test_post_without_csrf_token_succeeds_full_middleware():
+    """Integration: POST without CSRF token returns 204 (JTN-628)."""
+    client = _make_csp_app_with_full_middleware().test_client()
+    resp = client.post(
+        "/api/csp-report",
+        data=json.dumps(_SAMPLE_CSP_REPORT),
+        content_type="application/csp-report",
+    )
+    # Before JTN-628 this returned 403 (CSRF rejection).
+    assert resp.status_code == 204
+
+
+def test_malformed_json_through_full_middleware_returns_400():
+    """Integration: malformed JSON yields 400 even with CSRF+rate-limit registered."""
+    client = _make_csp_app_with_full_middleware().test_client()
+    resp = client.post(
+        "/api/csp-report",
+        data=b"definitely-not-json",
+        content_type="application/csp-report",
+    )
+    assert resp.status_code == 400
+
+
+def test_wrong_content_type_still_accepted_if_valid_json():
+    """Unexpected content-type with valid JSON is logged and returns 204."""
+    client = _make_csp_app_with_full_middleware().test_client()
+    resp = client.post(
+        "/api/csp-report",
+        data=json.dumps(_SAMPLE_CSP_REPORT),
+        content_type="text/plain",
+    )
+    # Browsers sometimes send odd content-types; we accept the body if
+    # it parses, and return 204 regardless of content-type.
+    assert resp.status_code == 204
 
 
 def test_modern_report_api_returns_204_and_logs(caplog, csp_client):


### PR DESCRIPTION
## Summary
- Exempt `/api/csp-report` from global CSRF + rate-limit middleware so browser-initiated CSP violation reports are no longer rejected with HTTP 403 (JTN-628).
- Return HTTP 400 (application/json) on malformed JSON bodies; previously these were silently swallowed as 204.
- Size-limit accepted bodies to 16 KiB and discard oversized payloads silently so the per-endpoint sliding-window limiter cannot be fingerprinted.

Before the fix, every `Content-Security-Policy-Report-Only` violation reported by a browser hit `/api/csp-report`, failed CSRF validation, and came back 403. All reports were silently discarded. The endpoint already had its own 20-reports-per-minute per-IP limiter, so exempting it from the global middleware is safe.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/test_csp_report.py` — 18 passed
- [x] Full suite: 3790 passed, 2 pre-existing pyenv-related failures in `test_plugin_registry.py` (unrelated)
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck)
- [x] New integration tests cover: POST without CSRF succeeds, malformed JSON -> 400, oversized body -> 204, `application/reports+json` accepted

Fixes JTN-628.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>