### PR TITLE
fix(settings): add confirmation dialog to Reboot/Shutdown buttons (JTN-621)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -211,7 +211,38 @@
       }
     }
 
+    function setDeviceActionModalOpen(modalId, open) {
+      const modal = document.getElementById(modalId);
+      if (!modal) return;
+      modal.hidden = !open;
+      modal.style.display = open ? "block" : "none";
+    }
+
+    function openRebootConfirm() {
+      setDeviceActionModalOpen("rebootConfirmModal", true);
+    }
+
+    function closeRebootConfirm() {
+      setDeviceActionModalOpen("rebootConfirmModal", false);
+    }
+
+    function openShutdownConfirm() {
+      setDeviceActionModalOpen("shutdownConfirmModal", true);
+    }
+
+    function closeShutdownConfirm() {
+      setDeviceActionModalOpen("shutdownConfirmModal", false);
+    }
+
     async function handleShutdown(reboot) {
+      // JTN-621: callers must gate this behind a confirmation modal. The
+      // modal ensures an accidental tap on a touch screen doesn't make the
+      // device unreachable without physical access to recover.
+      if (reboot) {
+        closeRebootConfirm();
+      } else {
+        closeShutdownConfirm();
+      }
       showResponseModal(
         "success",
         reboot
@@ -1009,8 +1040,16 @@
       document.getElementById("refreshIsolationBtn")?.addEventListener("click", refreshIsolation);
       document.getElementById("checkUpdatesBtn")?.addEventListener("click", checkForUpdates);
       document.getElementById("startUpdateBtn")?.addEventListener("click", startUpdate);
-      document.getElementById("rebootBtn")?.addEventListener("click", () => handleShutdown(true));
-      document.getElementById("shutdownBtn")?.addEventListener("click", () => handleShutdown(false));
+      // JTN-621: Reboot/Shutdown are gated behind a confirmation modal so
+      // an accidental touch doesn't make the device unreachable.
+      document.getElementById("rebootBtn")?.addEventListener("click", openRebootConfirm);
+      document.getElementById("shutdownBtn")?.addEventListener("click", openShutdownConfirm);
+      document.getElementById("confirmRebootBtn")?.addEventListener("click", () => handleShutdown(true));
+      document.getElementById("cancelRebootBtn")?.addEventListener("click", closeRebootConfirm);
+      document.getElementById("closeRebootConfirmModalBtn")?.addEventListener("click", closeRebootConfirm);
+      document.getElementById("confirmShutdownBtn")?.addEventListener("click", () => handleShutdown(false));
+      document.getElementById("cancelShutdownBtn")?.addEventListener("click", closeShutdownConfirm);
+      document.getElementById("closeShutdownConfirmModalBtn")?.addEventListener("click", closeShutdownConfirm);
       document.getElementById("useDeviceLocation")?.addEventListener("change", (event) => {
         toggleUseDeviceLocation(event.currentTarget);
       });

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -356,6 +356,34 @@
 
     <button type="button" class="action-button settings-logs-toggle" id="settingsLogsToggle">Show Logs</button>
 
+    <!-- Reboot confirmation modal (JTN-621) -->
+    <div id="rebootConfirmModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="rebootConfirmTitle" hidden>
+        <div class="modal-content">
+            <button type="button" id="closeRebootConfirmModalBtn" class="close-button" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
+            <h2 id="rebootConfirmTitle">Reboot Device?</h2>
+            <div class="separator"></div>
+            <p>This will interrupt the display and make the web UI unavailable for approximately 30 seconds. If the device fails to come back online, physical access will be required to recover.</p>
+            <div class="buttons-container">
+                <button type="button" class="action-button warn" id="confirmRebootBtn">Reboot</button>
+                <button type="button" class="action-button" id="cancelRebootBtn">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Shutdown confirmation modal (JTN-621) -->
+    <div id="shutdownConfirmModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="shutdownConfirmTitle" hidden>
+        <div class="modal-content">
+            <button type="button" id="closeShutdownConfirmModalBtn" class="close-button" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
+            <h2 id="shutdownConfirmTitle">Shut Down Device?</h2>
+            <div class="separator"></div>
+            <p>This will power off the device. The web UI will remain unavailable until the device is manually restarted. <strong>Physical access is required to turn it back on.</strong></p>
+            <div class="buttons-container">
+                <button type="button" class="action-button warn" id="confirmShutdownBtn">Shut Down</button>
+                <button type="button" class="action-button" id="cancelShutdownBtn">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Success/Error Modal -->
     {% include 'response_modal.html' %}
     </main>

--- a/tests/static/test_device_action_confirmation.py
+++ b/tests/static/test_device_action_confirmation.py
@@ -1,0 +1,135 @@
+"""Device action confirmation dialogs (JTN-621).
+
+On a Pi Zero 2 W, an accidental tap on Reboot or Shutdown in Settings
+immediately makes the device unreachable with no physical recovery until
+power cycle. Both actions must be gated behind a confirmation modal.
+"""
+
+from pathlib import Path
+
+
+def _read_settings_html(client):
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    return resp.get_data(as_text=True)
+
+
+def _read_settings_js(client):
+    resp = client.get("/static/scripts/settings_page.js")
+    assert resp.status_code == 200
+    return resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# Template — confirmation modals exist
+# ---------------------------------------------------------------------------
+
+
+def test_reboot_confirm_modal_rendered(client):
+    """The reboot confirmation modal must be present in settings.html."""
+    html = _read_settings_html(client)
+    assert (
+        'id="rebootConfirmModal"' in html
+    ), "Reboot confirmation modal missing from settings page"
+    assert 'id="confirmRebootBtn"' in html
+    assert 'id="cancelRebootBtn"' in html
+
+
+def test_shutdown_confirm_modal_rendered(client):
+    """The shutdown confirmation modal must be present in settings.html."""
+    html = _read_settings_html(client)
+    assert (
+        'id="shutdownConfirmModal"' in html
+    ), "Shutdown confirmation modal missing from settings page"
+    assert 'id="confirmShutdownBtn"' in html
+    assert 'id="cancelShutdownBtn"' in html
+
+
+def test_confirm_modals_have_destructive_copy(client):
+    """Modals must clearly warn that physical access is required to recover."""
+    html = _read_settings_html(client)
+    # Reboot warns about UI unavailability.
+    assert (
+        "physical access" in html.lower()
+    ), "Confirmation modals must warn about needing physical access to recover"
+
+
+def test_confirm_modals_use_role_dialog(client):
+    """Modals must use role=dialog and aria-modal for accessibility."""
+    html = _read_settings_html(client)
+    # Simple presence check — both modals share the pattern.
+    for modal_id in ("rebootConfirmModal", "shutdownConfirmModal"):
+        idx = html.find(f'id="{modal_id}"')
+        assert idx != -1
+        # role=dialog and aria-modal should be on the same opening tag.
+        opening = html[idx : idx + 400]
+        assert 'role="dialog"' in opening, f"{modal_id} must have role=dialog"
+        assert 'aria-modal="true"' in opening, f"{modal_id} must be aria-modal"
+
+
+# ---------------------------------------------------------------------------
+# JS — click handlers open modal instead of firing action immediately
+# ---------------------------------------------------------------------------
+
+
+def test_reboot_button_click_opens_confirm_modal_not_shutdown(client):
+    """The rebootBtn click handler must NOT call handleShutdown directly —
+    it must open the confirmation modal instead."""
+    js = _read_settings_js(client)
+    # The old pattern fired handleShutdown(true) directly from the click.
+    # After the fix, the click opens the confirmation modal.
+    assert (
+        '"rebootBtn")?.addEventListener("click", openRebootConfirm)' in js
+        or 'getElementById("rebootBtn")?.addEventListener("click", openRebootConfirm)'
+        in js
+    ), "rebootBtn must open confirmation modal, not fire handleShutdown directly"
+
+    # Make sure the old anti-pattern is gone.
+    assert (
+        '"rebootBtn")?.addEventListener("click", () => handleShutdown(true))' not in js
+    ), "rebootBtn still wired to fire handleShutdown directly — no confirmation!"
+
+
+def test_shutdown_button_click_opens_confirm_modal_not_shutdown(client):
+    """The shutdownBtn click handler must NOT call handleShutdown directly."""
+    js = _read_settings_js(client)
+    assert (
+        '"shutdownBtn")?.addEventListener("click", openShutdownConfirm)' in js
+    ), "shutdownBtn must open confirmation modal, not fire handleShutdown directly"
+
+    assert (
+        '"shutdownBtn")?.addEventListener("click", () => handleShutdown(false))'
+        not in js
+    ), "shutdownBtn still wired to fire handleShutdown directly — no confirmation!"
+
+
+def test_confirm_buttons_wired_to_handle_shutdown(client):
+    """The confirm-action buttons inside the modals must be what actually
+    invokes handleShutdown."""
+    js = _read_settings_js(client)
+    assert "confirmRebootBtn" in js, "confirmRebootBtn not wired up"
+    assert "confirmShutdownBtn" in js, "confirmShutdownBtn not wired up"
+    assert "handleShutdown(true)" in js
+    assert "handleShutdown(false)" in js
+
+
+def test_cancel_buttons_close_modals(client):
+    """Cancel buttons must close the respective modal."""
+    js = _read_settings_js(client)
+    assert "cancelRebootBtn" in js
+    assert "cancelShutdownBtn" in js
+    assert "closeRebootConfirm" in js
+    assert "closeShutdownConfirm" in js
+
+
+# ---------------------------------------------------------------------------
+# Sanity — file on disk (belt-and-braces; matches JTN-247 style)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_js_on_disk_has_confirm_handlers():
+    js = Path("src/static/scripts/settings_page.js").read_text()
+    assert "openRebootConfirm" in js
+    assert "openShutdownConfirm" in js
+    assert "closeRebootConfirm" in js
+    assert "closeShutdownConfirm" in js


### PR DESCRIPTION
## Summary
- Adds a confirmation modal to the Reboot and Shutdown buttons in Settings -> Updates (JTN-621).
- An accidental touch on a Pi Zero 2 W previously severed the UI immediately with no path to recover without physical access. Both actions now require explicit confirmation in a modal that warns about physical-access recovery.
- Follows the existing Clear All History modal pattern: click opens the modal; the confirm button is what invokes `handleShutdown`.

## Changes
- `src/templates/settings.html`: new `#rebootConfirmModal` and `#shutdownConfirmModal` dialogs with destructive warning copy.
- `src/static/scripts/settings_page.js`: rebootBtn/shutdownBtn now open their respective modal; confirm button fires `handleShutdown`; cancel and close-button handlers close the modal.
- `tests/static/test_device_action_confirmation.py`: 9 new tests covering modal presence, a11y attrs, destructive copy, and that the old "fire immediately" anti-pattern is gone.

## Test plan
- [x] `pytest tests/static/test_device_action_confirmation.py` (9 passed)
- [x] `pytest tests/static/test_shutdown_fetch_error.py` still passes (JTN-247 regression)
- [x] Full suite: 3793 passed (2 pre-existing unrelated plugin_registry failures)
- [x] `scripts/lint.sh` clean (ruff + black)
- [ ] Manual: click Reboot -> modal opens; Cancel closes; Confirm triggers the existing success toast + reboot request
- [ ] Manual: same for Shutdown

Fixes JTN-621.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>