### PR TITLE
fix(a11y): toggle aria-expanded on Style collapsible (JTN-623)

### DIFF
--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -642,9 +642,8 @@
       document.querySelectorAll("[data-close-modal]").forEach((button) => {
         button.addEventListener("click", () => closeModal(button.dataset.closeModal));
       });
-      document.querySelectorAll("[data-collapsible-toggle]").forEach((button) => {
-        button.addEventListener("click", () => ui.toggleCollapsible?.(button));
-      });
+      // Collapsible toggle is bound via delegation in ui_helpers.js so every
+      // `[data-collapsible-toggle]` button updates aria-expanded consistently.
       document.querySelectorAll("[data-frame-option]").forEach((option) => {
         option.addEventListener("click", () => selectedFrame(option));
         option.addEventListener("keydown", (event) => {

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -978,9 +978,8 @@
     }
 
     function bindButtons() {
-      for (const button of document.querySelectorAll("[data-collapsible-toggle]")) {
-        button.addEventListener("click", () => ui.toggleCollapsible?.(button));
-      }
+      // Collapsible toggle is bound via delegation in ui_helpers.js so every
+      // `[data-collapsible-toggle]` button updates aria-expanded consistently.
 
       // Dirty-state: snapshot initial form values and disable Save until something changes
       const saveBtn = document.getElementById("saveSettingsBtn");

--- a/src/static/scripts/ui_helpers.js
+++ b/src/static/scripts/ui_helpers.js
@@ -1,14 +1,15 @@
 (function () {
   function toggleCollapsible(button) {
     const content = button?.nextElementSibling;
-    const icon = button?.querySelector(".collapsible-icon");
     if (!button || !content) return;
     const isOpen = content.classList.contains("is-open");
     button.classList.toggle("active", !isOpen);
     button.setAttribute("aria-expanded", String(!isOpen));
     content.classList.toggle("is-open", !isOpen);
     content.removeAttribute("hidden");
-    if (icon) icon.textContent = isOpen ? "▼" : "▲";
+    // Chevron direction is driven by CSS via `[aria-expanded="true"]` so we
+    // don't mutate textContent here — that would double-flip against the
+    // CSS rotate transform. See src/static/styles/partials/_toggle.css.
     const sectionId = button.closest('.collapsible')?.id;
     if (sectionId) {
       savePref('collapsible_', sectionId, !isOpen);
@@ -25,7 +26,6 @@
       if (saved === null) return;
       const shouldBeOpen = saved === 'true';
       const content = button.nextElementSibling;
-      const icon = button.querySelector(".collapsible-icon");
       const isOpen = content?.classList.contains("is-open");
       if (shouldBeOpen !== isOpen) {
         button.classList.toggle("active", shouldBeOpen);
@@ -34,7 +34,6 @@
           content.classList.toggle("is-open", shouldBeOpen);
           content.removeAttribute("hidden");
         }
-        if (icon) icon.textContent = shouldBeOpen ? "▲" : "▼";
       }
     });
   }
@@ -45,14 +44,12 @@
     );
     buttons.forEach((button) => {
       const content = button.nextElementSibling;
-      const icon = button.querySelector(".collapsible-icon");
       button.classList.toggle("active", open);
       button.setAttribute("aria-expanded", String(open));
       if (content) {
         content.classList.toggle("is-open", open);
         content.removeAttribute("hidden");
       }
-      if (icon) icon.textContent = open ? "▲" : "▼";
     });
   }
 
@@ -114,4 +111,16 @@
     syncModalOpenState,
     toggleCollapsible,
   };
+
+  // Delegated click handler so every `[data-collapsible-toggle]` button
+  // reliably toggles aria-expanded, regardless of whether a page script
+  // remembered to wire its own listener. Guarded to only run once even if
+  // this module is evaluated multiple times.
+  if (typeof document !== "undefined" && !document.__inkypiCollapsibleBound) {
+    document.__inkypiCollapsibleBound = true;
+    document.addEventListener("click", (event) => {
+      const button = event.target?.closest?.("[data-collapsible-toggle]");
+      if (button) toggleCollapsible(button);
+    });
+  }
 })();

--- a/tests/static/test_collapsible_icon_direction.py
+++ b/tests/static/test_collapsible_icon_direction.py
@@ -1,7 +1,13 @@
 """Tests for collapsible section arrow icon direction logic.
 
-JTN-244: The toggle function must show ▼ when closing and ▲ when opening,
-reflecting the *new* (post-toggle) state, not the old state.
+JTN-244 originally asserted that the toggle function swapped textContent
+between ▼ and ▲ to reflect the post-toggle state.
+
+JTN-623 replaced that JS-driven textContent swap with a pure CSS approach:
+the chevron character stays ▼ in markup and the `.collapsible-header[aria-expanded="true"]
+.collapsible-icon { transform: rotate(180deg); }` rule in _toggle.css rotates it
+when the section is open. This avoids a double-flip when both mechanisms were
+active, which made the chevron appear unchanged between states.
 """
 
 
@@ -10,25 +16,71 @@ def test_ui_helpers_script_exists(client):
     assert resp.status_code == 200
 
 
-def test_toggle_collapsible_icon_reflects_post_toggle_state(client):
-    """JTN-244: Icon ternary must use the inverted isOpen value.
+def test_toggle_collapsible_updates_aria_expanded(client):
+    """JTN-623: toggleCollapsible must flip aria-expanded between true/false.
 
-    Before the fix, ``isOpen ? "▲" : "▼"`` used the pre-toggle state, so the
-    arrow was backwards. The correct logic is ``isOpen ? "▼" : "▲"``:
-    - when the section *was* open (isOpen=true) we are closing it → show ▼
-    - when the section *was* closed (isOpen=false) we are opening it → show ▲
+    This is the primary a11y contract: screen readers rely on aria-expanded
+    to announce the accordion state.
     """
     resp = client.get("/static/scripts/ui_helpers.js")
     assert resp.status_code == 200
     js = resp.get_data(as_text=True)
 
-    # The correct (fixed) ternary must be present
-    assert 'isOpen ? "▼" : "▲"' in js
+    toggle_start = js.find("function toggleCollapsible(")
+    assert toggle_start != -1, "toggleCollapsible function not found"
+    toggle_end = js.find("\n  }", toggle_start)
+    toggle_body = js[toggle_start:toggle_end]
 
-    # The inverted (buggy) ternary must NOT appear in toggleCollapsible
-    # (restoreCollapsibles and setCollapsibles use the same icon chars differently,
-    # so we narrow the check to the toggle function body)
+    # The function must set aria-expanded to the inverted pre-toggle state
+    assert 'setAttribute("aria-expanded", String(!isOpen))' in toggle_body
+
+
+def test_toggle_collapsible_does_not_mutate_icon_text(client):
+    """JTN-623: Chevron rotation must come from CSS, not JS textContent.
+
+    Before the fix, the JS swapped icon.textContent between ▼ and ▲ while
+    CSS also rotated the element 180deg via `[aria-expanded="true"]`. The
+    two mechanisms cancelled out and the icon appeared unchanged when the
+    section opened. The fix is to drop the textContent swap entirely and
+    let CSS own the visual flip.
+    """
+    resp = client.get("/static/scripts/ui_helpers.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
     toggle_start = js.find("function toggleCollapsible(")
     toggle_end = js.find("\n  }", toggle_start)
     toggle_body = js[toggle_start:toggle_end]
-    assert 'isOpen ? "▲" : "▼"' not in toggle_body
+
+    # The JS must no longer mutate the icon's textContent — CSS handles it.
+    assert "icon.textContent" not in toggle_body
+    # And the ternary that used to swap characters must be gone.
+    assert '"▼" : "▲"' not in toggle_body
+    assert '"▲" : "▼"' not in toggle_body
+
+
+def test_collapsible_css_rotates_icon_when_expanded(client):
+    """The CSS contract: aria-expanded="true" rotates the chevron 180deg."""
+    resp = client.get("/static/styles/main.css")
+    assert resp.status_code == 200
+    css = resp.get_data(as_text=True)
+    # Normalise whitespace for robust matching
+    compact = " ".join(css.split())
+    assert (
+        '.collapsible-header[aria-expanded="true"] .collapsible-icon' in compact
+    ), "CSS rule driving chevron rotation from aria-expanded is missing"
+    assert "rotate(180deg)" in compact
+
+
+def test_collapsible_click_is_delegated_in_ui_helpers(client):
+    """JTN-623: A document-level delegated click handler guarantees that
+    every `[data-collapsible-toggle]` button toggles aria-expanded, even if
+    a page-specific script forgot to wire its own listener.
+    """
+    resp = client.get("/static/scripts/ui_helpers.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+    assert "[data-collapsible-toggle]" in js
+    assert 'document.addEventListener("click"' in js
+    # Guard flag prevents double-binding if the module is re-evaluated.
+    assert "__inkypiCollapsibleBound" in js


### PR DESCRIPTION
## Summary
- Move collapsible click handling into a document-level delegated listener in `ui_helpers.js` so every `[data-collapsible-toggle]` button reliably updates `aria-expanded` — fixes screen readers reporting the Style accordion as always collapsed.
- Let CSS own the chevron rotation. The JS was swapping `▼`/`▲` textContent while `_toggle.css` also rotated the icon 180deg on `[aria-expanded="true"]`; the two cancelled out and the chevron appeared unchanged.
- Remove now-redundant per-button collapsible bindings in `plugin_page.js` and `settings_page.js`.

Closes JTN-623.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/static/test_collapsible_icon_direction.py` — 5 passed (3 new assertions: aria toggles, CSS rotation rule exists, delegated click handler exists)
- [x] Full suite: 3787 passed, 2 pre-existing unrelated failures (pyenv env issue on `test_plugin_registry`), 5 skipped
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean
- [ ] Manual verify on `/plugin/weather`: click Style, inspect accessibility tree shows `expanded=true`, chevron rotates

🤖 Generated with [Claude Code](https://claude.com/claude-code)