### PR TITLE
fix(a11y): use human-readable timestamps in history aria-labels (JTN-642)

### DIFF
--- a/src/templates/partials/history_grid.html
+++ b/src/templates/partials/history_grid.html
@@ -8,7 +8,7 @@
     <div class="history-card">
         <a class="history-thumb" href="{{ url_for('history.history_image', filename=img.filename) }}" aria-label="Preview image from {{ img.mtime_str }}">
             <div class="img-skeleton" aria-hidden="true"></div>
-            <img class="history-image" src="{{ url_for('history.history_image', filename=img.filename) }}" alt="History image from {{ img.mtime_str }}" loading="lazy" decoding="async">
+            <img class="history-image" src="{{ url_for('history.history_image', filename=img.filename) }}" alt="History from {{ img.mtime_str }}" loading="lazy" decoding="async">
         </a>
         <div class="history-card-body">
             <div class="history-meta">

--- a/src/templates/partials/history_grid.html
+++ b/src/templates/partials/history_grid.html
@@ -6,9 +6,9 @@
 <div class="history-grid">
     {% for img in images %}
     <div class="history-card">
-        <a class="history-thumb" href="{{ url_for('history.history_image', filename=img.filename) }}" aria-label="Preview {{ img.filename }}">
+        <a class="history-thumb" href="{{ url_for('history.history_image', filename=img.filename) }}" aria-label="Preview image from {{ img.mtime_str }}">
             <div class="img-skeleton" aria-hidden="true"></div>
-            <img class="history-image" src="{{ url_for('history.history_image', filename=img.filename) }}" alt="{{ img.filename }}" loading="lazy" decoding="async">
+            <img class="history-image" src="{{ url_for('history.history_image', filename=img.filename) }}" alt="History image from {{ img.mtime_str }}" loading="lazy" decoding="async">
         </a>
         <div class="history-card-body">
             <div class="history-meta">
@@ -27,9 +27,9 @@
                 {% endif %}
             </div>
             <div class="history-actions">
-                <button id="btn-{{ img.filename }}" class="btn btn-primary" type="button" data-history-action="display" data-filename="{{ img.filename }}" aria-label="Display {{ img.filename }}">Display</button>
-                <a class="btn" href="{{ url_for('history.history_image', filename=img.filename) }}" download aria-label="Download {{ img.filename }}">Download</a>
-                <button class="btn btn-danger" type="button" data-history-action="delete" data-filename="{{ img.filename }}" aria-label="Delete {{ img.filename }}">Delete</button>
+                <button id="btn-{{ img.filename }}" class="btn btn-primary" type="button" data-history-action="display" data-filename="{{ img.filename }}" aria-label="Display image from {{ img.mtime_str }}">Display</button>
+                <a class="btn" href="{{ url_for('history.history_image', filename=img.filename) }}" download aria-label="Download image from {{ img.mtime_str }}">Download</a>
+                <button class="btn btn-danger" type="button" data-history-action="delete" data-filename="{{ img.filename }}" aria-label="Delete image from {{ img.mtime_str }}">Delete</button>
             </div>
         </div>
     </div>

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -688,7 +688,7 @@ def test_list_history_images_no_limit_returns_all(device_config_dev):
 
 
 def test_history_action_buttons_have_aria_labels(client, device_config_dev):
-    """JTN-202: action buttons include aria-label with filename for assistive tech."""
+    """JTN-642: action buttons include aria-label with human-readable timestamp for assistive tech."""
     d = device_config_dev.history_image_dir
     os.makedirs(d, exist_ok=True)
     fname = "display_20250101_060000.png"
@@ -698,9 +698,17 @@ def test_history_action_buttons_have_aria_labels(client, device_config_dev):
     assert resp.status_code == 200
     body = resp.data.decode("utf-8")
 
-    assert f'aria-label="Display {fname}"' in body
-    assert f'aria-label="Download {fname}"' in body
-    assert f'aria-label="Delete {fname}"' in body
+    # Labels must not embed the raw timestamp-based filename (poor SR UX).
+    assert f'aria-label="Display {fname}"' not in body
+    assert f'aria-label="Download {fname}"' not in body
+    assert f'aria-label="Delete {fname}"' not in body
+
+    # Labels should reference a human-readable mtime (e.g., "Apr 08, 2026 08:01 PM").
+    # Assert the descriptive prefix is present for each action.
+    assert 'aria-label="Display image from ' in body
+    assert 'aria-label="Download image from ' in body
+    assert 'aria-label="Delete image from ' in body
+    assert 'aria-label="Preview image from ' in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from PIL import Image
 
@@ -709,6 +710,22 @@ def test_history_action_buttons_have_aria_labels(client, device_config_dev):
     assert 'aria-label="Download image from ' in body
     assert 'aria-label="Delete image from ' in body
     assert 'aria-label="Preview image from ' in body
+
+    assert f'aria-label="Display image from {fname}"' not in body
+    assert f'aria-label="Download image from {fname}"' not in body
+    assert f'aria-label="Delete image from {fname}"' not in body
+    assert f'aria-label="Preview image from {fname}"' not in body
+
+    labels = re.findall(r'aria-label="([^"]+)"', body)
+    action_prefixes = (
+        "Display image from ",
+        "Download image from ",
+        "Delete image from ",
+        "Preview image from ",
+    )
+    for label in labels:
+        if label.startswith(action_prefixes):
+            assert fname not in label
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace raw timestamp filenames (e.g. `display_20260408_200114.png`) with the already-computed human-readable `mtime_str` (e.g. `Apr 08, 2026 08:01 PM`) inside the aria-labels of every history item button (Display / Download / Delete), the thumbnail preview link, and the thumbnail `img` alt text.
- Screen reader users no longer have to hear the timestamp-encoded filename repeated for every action across 20+ history items per page.
- Filename remains visible as the `history-name` text and is still used for the button id / data attributes, so no functional behavior changes.

Closes JTN-642. Related: JTN-383 (same pattern on API Keys page).

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/integration/test_history.py` — 48 passed
- [x] Full suite: 3784 passed, 5 skipped, 2 pre-existing unrelated failures (`test_plugin_registry` pyenv env issue)
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean
- [ ] Manual verify on `/history`: screen reader announces "Delete image from Apr 08, 2026 08:01 PM" instead of filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * History view image labels (preview links, thumbnails, and action controls for display, download, delete, and preview) now reference each image’s modification timestamp instead of the filename.

* **Tests**
  * Updated tests to assert the new timestamp-based ARIA labels and to ensure filenames are no longer exposed in those labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->