### PR TITLE
fix(playlist): add confirmation + success toast to Display Next (JTN-630)

### DIFF
--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -77,6 +77,7 @@
         const modalIds = [
             'deleteInstanceModal',
             'deletePlaylistModal',
+            'displayNextConfirmModal',
             'thumbnailPreviewModal',
             'refreshSettingsModal',
             'deviceCycleModal',
@@ -95,6 +96,9 @@
                 return;
             case 'deletePlaylistModal':
                 closeDeletePlaylistModal();
+                return;
+            case 'displayNextConfirmModal':
+                closeDisplayNextConfirmModal();
                 return;
             case 'thumbnailPreviewModal':
                 closeThumbnailPreview();
@@ -594,7 +598,10 @@
         try{
             const resp = await fetch(C.display_next_url, { method:'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ playlist_name: name }) });
             const j = await handleJsonResponse(resp);
-            if (resp.ok && j && j.success){ setTimeout(() => { location.reload(); }, 500); }
+            if (resp.ok && j && j.success){
+                showResponseModal('success', 'Display updated — refreshing…');
+                setTimeout(() => { location.reload(); }, 500);
+            }
         } catch(e){ showResponseModal('failure', 'Failed to trigger display'); }
     }
 
@@ -686,8 +693,9 @@
         });
         document.querySelectorAll('.run-next-btn').forEach(btn => {
             btn.addEventListener('click', (e) => {
-                const name = e.currentTarget.getAttribute('data-playlist');
-                displayNextInPlaylist(name);
+                const el = e.currentTarget;
+                const name = el.getAttribute('data-playlist');
+                openDisplayNextConfirmModal(name, el);
             });
         });
         document.querySelectorAll('.delete-playlist-btn').forEach(btn => {
@@ -758,6 +766,7 @@
         // Cancel buttons on delete confirm modals
         document.getElementById('cancelDeletePlaylistBtn')?.addEventListener('click', closeDeletePlaylistModal);
         document.getElementById('cancelDeleteInstanceBtn')?.addEventListener('click', closeDeleteInstanceModal);
+        document.getElementById('cancelDisplayNextBtn')?.addEventListener('click', closeDisplayNextConfirmModal);
 
         // Device cadence editor
         const editCadence = document.getElementById('editDeviceCycleBtn');
@@ -842,6 +851,7 @@
             if (event.target?.id === 'deviceCycleModal') closeDeviceCycleModal();
             if (event.target?.id === 'deletePlaylistModal') closeDeletePlaylistModal();
             if (event.target?.id === 'deleteInstanceModal') closeDeleteInstanceModal();
+            if (event.target?.id === 'displayNextConfirmModal') closeDisplayNextConfirmModal();
         });
         document.addEventListener('keydown', (event) => {
             if (event.key !== 'Escape') return;
@@ -968,8 +978,28 @@
     }
     function closeDeleteInstanceModal(){ setModalOpen('deleteInstanceModal', false); }
 
+    function openDisplayNextConfirmModal(name, triggerEl){
+        const el = document.getElementById('displayNextConfirmModal');
+        const txt = document.getElementById('displayNextConfirmText');
+        const btn = document.getElementById('confirmDisplayNextBtn');
+        if (!el || !txt || !btn) {
+            // Fallback: if the modal isn't present for any reason, fire the action directly.
+            displayNextInPlaylist(name);
+            return;
+        }
+        txt.textContent = `Advance '${name}' to the next plugin now?`;
+        setModalOpen('displayNextConfirmModal', true, triggerEl);
+        btn.onclick = async function(){
+            closeDisplayNextConfirmModal();
+            await displayNextInPlaylist(name);
+        };
+    }
+    function closeDisplayNextConfirmModal(){ setModalOpen('displayNextConfirmModal', false); }
+
     window.openDeletePlaylistModal = openDeletePlaylistModal;
     window.closeDeletePlaylistModal = closeDeletePlaylistModal;
     window.openDeleteInstanceModal = openDeleteInstanceModal;
     window.closeDeleteInstanceModal = closeDeleteInstanceModal;
+    window.openDisplayNextConfirmModal = openDisplayNextConfirmModal;
+    window.closeDisplayNextConfirmModal = closeDisplayNextConfirmModal;
 })();

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -220,6 +220,18 @@
         </div>
     </div>
 
+    <!-- Display Next Confirm Modal -->
+    <div id="displayNextConfirmModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="displayNextConfirmTitle" hidden>
+        <div class="modal-content modal-sheet">
+            <h2 id="displayNextConfirmTitle" class="sr-only">Confirm display next plugin</h2>
+            <p id="displayNextConfirmText"></p>
+            <div class="buttons-container">
+                <button type="button" class="action-button" id="confirmDisplayNextBtn">Display Next</button>
+                <button type="button" class="action-button is-secondary" id="cancelDisplayNextBtn">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Delete Instance Confirm Modal -->
     <div id="deleteInstanceModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteInstanceTitle" hidden>
         <div class="modal-content modal-sheet">

--- a/tests/integration/test_playlist_empty_state.py
+++ b/tests/integration/test_playlist_empty_state.py
@@ -13,8 +13,10 @@ def test_playlist_display_next_hidden_when_empty(client, device_config_dev):
 
     # The playlist card should exist
     assert 'data-playlist-name="Empty"' in html
-    # But no Display Next button should appear (no plugins)
-    assert "Display Next" not in html
+    # But no Display Next button should appear (no plugins).
+    # Note: the shared confirmation modal still renders in the page chrome,
+    # so we assert specifically that no .run-next-btn is emitted.
+    assert "run-next-btn" not in html
 
 
 def test_playlist_display_next_shown_when_has_plugins(client, device_config_dev):
@@ -37,7 +39,8 @@ def test_playlist_display_next_shown_when_has_plugins(client, device_config_dev)
     html = resp.data.decode()
 
     assert 'data-playlist-name="WithPlugins"' in html
-    assert "Display Next" in html
+    assert "run-next-btn" in html
+    assert 'data-playlist="WithPlugins"' in html
 
 
 def test_playlist_display_next_mixed(client, device_config_dev):
@@ -64,6 +67,8 @@ def test_playlist_display_next_mixed(client, device_config_dev):
     assert 'data-playlist-name="HasItems"' in html
     assert 'data-playlist-name="NoItems"' in html
 
-    # Display Next should appear exactly once (only for HasItems)
-    assert html.count("Display Next") == 1
+    # The per-card Display Next button should appear exactly once (only
+    # for HasItems). The shared display-next confirmation modal is part
+    # of the page chrome and is asserted separately.
+    assert html.count("run-next-btn") == 1
     assert 'data-playlist="HasItems"' in html

--- a/tests/static/test_display_next_confirmation.py
+++ b/tests/static/test_display_next_confirmation.py
@@ -1,0 +1,119 @@
+"""Display Next confirmation dialog (JTN-630).
+
+The "Display Next" button on each playlist card used to fire immediately
+with no confirmation and no success/error feedback, leaving the user
+unsure whether the action was sent. It must now open a confirmation modal
+(matching the Delete Playlist pattern) and surface a success toast so the
+user has positive feedback.
+"""
+
+from __future__ import annotations
+
+
+def _read_playlist_html(client) -> str:
+    resp = client.get("/playlist")
+    assert resp.status_code == 200
+    return resp.get_data(as_text=True)
+
+
+def _read_playlist_js(client) -> str:
+    resp = client.get("/static/scripts/playlist.js")
+    assert resp.status_code == 200
+    return resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# Template — confirmation modal exists and is accessible
+# ---------------------------------------------------------------------------
+
+
+def test_display_next_confirm_modal_rendered(client):
+    """The display next confirmation modal must be present in playlist.html."""
+    html = _read_playlist_html(client)
+    assert (
+        'id="displayNextConfirmModal"' in html
+    ), "Display Next confirmation modal missing from playlist page"
+    assert 'id="confirmDisplayNextBtn"' in html
+    assert 'id="cancelDisplayNextBtn"' in html
+
+
+def test_display_next_modal_uses_role_dialog(client):
+    html = _read_playlist_html(client)
+    idx = html.find('id="displayNextConfirmModal"')
+    assert idx != -1
+    opening = html[idx : idx + 400]
+    assert 'role="dialog"' in opening
+    assert 'aria-modal="true"' in opening
+
+
+def test_display_next_modal_has_labelledby(client):
+    html = _read_playlist_html(client)
+    idx = html.find('id="displayNextConfirmModal"')
+    assert idx != -1
+    opening = html[idx : idx + 400]
+    assert 'aria-labelledby="displayNextConfirmTitle"' in opening
+    # The referenced heading must exist in the DOM.
+    assert 'id="displayNextConfirmTitle"' in html
+
+
+# ---------------------------------------------------------------------------
+# JS — click handler opens modal instead of firing action immediately
+# ---------------------------------------------------------------------------
+
+
+def test_run_next_btn_opens_confirm_modal_not_fire_directly(client):
+    """The .run-next-btn click handler must open the confirmation modal,
+    not invoke displayNextInPlaylist immediately."""
+    js = _read_playlist_js(client)
+    # New pattern: click handler routes through openDisplayNextConfirmModal.
+    assert (
+        "openDisplayNextConfirmModal(name" in js
+    ), "run-next-btn click handler must open the confirmation modal"
+
+    # Old anti-pattern (bare displayNextInPlaylist from the click handler)
+    # must be gone. We look for the literal single-line call that used to
+    # live in the forEach body.
+    assert (
+        "displayNextInPlaylist(name);\n            });" not in js
+    ), "run-next-btn is still wired to fire displayNextInPlaylist directly — no confirmation!"
+
+
+def test_display_next_helper_exists_and_is_async(client):
+    """The helper that actually performs the fetch stays available for the
+    confirm button and for the public window.* API (used by other callers
+    and by tests)."""
+    js = _read_playlist_js(client)
+    assert "async function displayNextInPlaylist(name)" in js
+    assert "window.displayNextInPlaylist = displayNextInPlaylist" in js
+    assert "window.openDisplayNextConfirmModal = openDisplayNextConfirmModal" in js
+
+
+def test_display_next_success_surfaces_toast(client):
+    """On success, the user must see positive feedback (toast) — previously
+    there was only a silent reload, per JTN-630."""
+    js = _read_playlist_js(client)
+    assert "showResponseModal('success'" in js, (
+        "Display Next success path must call showResponseModal('success', ...) "
+        "so the user has positive feedback — this is the JTN-630 fix"
+    )
+
+
+def test_display_next_cancel_button_wired(client):
+    """Cancel button on the confirm modal must close the modal."""
+    js = _read_playlist_js(client)
+    assert (
+        "getElementById('cancelDisplayNextBtn')?.addEventListener('click', "
+        "closeDisplayNextConfirmModal)" in js
+    )
+
+
+def test_display_next_modal_registered_for_escape_and_backdrop(client):
+    """The confirm modal must participate in the shared Escape/backdrop-close
+    plumbing used by the other playlist modals."""
+    js = _read_playlist_js(client)
+    # Backdrop click closes it.
+    assert (
+        "event.target?.id === 'displayNextConfirmModal'" in js
+    ), "displayNextConfirmModal must close on backdrop click"
+    # It is tracked by getOpenModalId so Escape works.
+    assert "'displayNextConfirmModal'," in js


### PR DESCRIPTION
## Summary
- Adds a confirmation modal to the per-playlist **Display Next** button, matching the existing Delete Playlist / Delete Instance modal pattern.
- Surfaces a success toast (\"Display updated — refreshing…\") on the success path so users have positive feedback — previously the click fired silently with only a reload.
- Cancel button, backdrop click, and Escape all close the modal (wired through the shared `getOpenModalId` / `closeModalById` plumbing).

## Why
Observed during the 2026-04-12 dogfood pass (JTN-630): clicking *Display Next* on a playlist card triggered the action immediately with no confirmation dialog and no toast. Users couldn't tell whether the Pi had received the command.

## Changes
- `src/templates/playlist.html`: new `#displayNextConfirmModal` dialog with destructive-action a11y attrs (`role=dialog`, `aria-modal`, `aria-labelledby`).
- `src/static/scripts/playlist.js`:
  - `.run-next-btn` click handler now opens the confirm modal instead of firing `displayNextInPlaylist` directly.
  - Added `openDisplayNextConfirmModal` / `closeDisplayNextConfirmModal` helpers; registered in `getOpenModalId`, `closeModalById`, backdrop-click and cancel-button handlers.
  - `displayNextInPlaylist` now calls `showResponseModal('success', …)` before the page reloads.
- `tests/static/test_display_next_confirmation.py`: 8 new tests covering modal markup, a11y, click-handler rewire, success-toast call, cancel wiring, and Escape/backdrop registration.
- `tests/integration/test_playlist_empty_state.py`: tightened the assertions that used to match the literal \"Display Next\" string to target `.run-next-btn` instead (the confirm modal now renders in page chrome even for empty playlists).

## Scope note
Sibling dogfood issue JTN-621 (Reboot/Shutdown confirmation) is covered separately by PR #388 and is out of scope here.

## Test plan
- [x] `pytest tests/static/test_display_next_confirmation.py` — 8 passed
- [x] `pytest tests/static/ tests/integration/test_playlist_*` regression — 35 passed
- [x] Full suite: 3792 passed, 5 skipped (2 pre-existing unrelated `test_plugin_registry` failures also present on `main`)
- [x] `scripts/lint.sh` clean (ruff + black)
- [ ] Manual: click *Display Next* on a non-empty playlist → modal opens; Cancel closes; Confirm fires request + success toast + reload
- [ ] Manual: click *Display Next* on an empty playlist → the existing \"no items\" failure toast still shows (guarded before the modal)

Fixes JTN-630.