### PR TITLE
fix(plugin): hide raw slug subtitle and add DRAFT tooltip (JTN-622, JTN-644)

### DIFF
--- a/src/templates/macros/components.html
+++ b/src/templates/macros/components.html
@@ -40,8 +40,8 @@
 </div>
 {%- endmacro %}
 
-{% macro status_chip(text, variant="info") -%}
-<span class="status-chip {{ variant }}">{{ text }}</span>
+{% macro status_chip(text, variant="info", title=None, describedby=None) -%}
+<span class="status-chip {{ variant }}"{% if title %} title="{{ title }}"{% endif %}{% if describedby %} aria-describedby="{{ describedby }}"{% endif %}>{{ text }}</span>
 {%- endmacro %}
 
 {% macro card(title) -%}

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -46,7 +46,9 @@
                         {% if ph_icon %}{{ icon(ph_icon, 'app-icon') | safe }}{% else %}<img src="{{ url_for('plugin.image', plugin_id=plugin.id, filename='icon.png') }}" alt="{{ plugin.display_name }} icon" class="app-icon">{% endif %}
                         <div class="title-stack">
                             <h1 class="app-title">{{ plugin.display_name }}</h1>
-                            <span class="app-subtitle">{{ plugin.id }}</span>
+                            {% if request.args.get('debug') %}
+                            <span class="app-subtitle" data-debug-slug>{{ plugin.id }}</span>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
@@ -77,9 +79,11 @@
 
         <div class="status-row plugin-mode-row" aria-label="Plugin mode indicators">
             {% if plugin_instance %}
-            {{ status_chip('Instance', 'success') }}
+            {{ status_chip('Instance', 'success', title='This plugin has saved settings stored as an instance.', describedby='instance-chip-help') }}
+            <span id="instance-chip-help" class="sr-only">This plugin has saved settings stored as an instance.</span>
             {% else %}
-            {{ status_chip('Draft', 'warning') }}
+            {{ status_chip('Draft', 'warning', title='This plugin has not been saved yet. Use the save action below to activate it.', describedby='draft-chip-help') }}
+            <span id="draft-chip-help" class="sr-only">This plugin has not been saved yet. Use the save action below to activate it.</span>
             {% endif %}
         </div>
 

--- a/tests/integration/test_plugin_pages.py
+++ b/tests/integration/test_plugin_pages.py
@@ -396,6 +396,57 @@ def test_plugin_page_update_instance_url_encodes_instance_name_with_spaces(clien
     assert "update_plugin_instance/My Instance" not in body
 
 
+def test_plugin_page_hides_raw_slug_subtitle(client):
+    """JTN-622: Raw plugin slug must not be rendered as a visible subtitle.
+
+    End users have no reason to see the internal filesystem slug
+    (ai_image, clock, weather, etc.). The <span class="app-subtitle">
+    containing the slug should be absent from the default page render.
+    """
+    for plugin_id in ("ai_image", "clock", "weather"):
+        resp = client.get(f"/plugin/{plugin_id}")
+        assert resp.status_code == 200
+        body = resp.data.decode("utf-8")
+        # The app-subtitle span must not be present by default.
+        assert (
+            'class="app-subtitle"' not in body
+        ), f"/plugin/{plugin_id} still renders app-subtitle span with raw slug"
+        # Also ensure the slug doesn't appear as the inner text of any
+        # element with data-debug-slug attribute (which only renders in debug mode).
+        assert "data-debug-slug" not in body
+
+
+def test_plugin_page_shows_slug_subtitle_in_debug_mode(client):
+    """JTN-622: Raw slug subtitle is available behind ?debug=1 for diagnostics."""
+    resp = client.get("/plugin/ai_image?debug=1")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    assert 'class="app-subtitle"' in body
+    assert "data-debug-slug" in body
+
+
+def test_plugin_page_draft_badge_has_explanation(client):
+    """JTN-644: The Draft badge must expose an explanation via title and/or aria-describedby."""
+    # A plugin page with no plugin_instance query param renders the Draft chip.
+    resp = client.get("/plugin/clock")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    # Locate the Draft chip
+    import re
+
+    match = re.search(r'<span class="status-chip warning"[^>]*>Draft</span>', body)
+    assert match, "Draft status chip not found on /plugin/clock"
+    chip_html = match.group(0)
+    assert "title=" in chip_html, f"Draft chip missing title attribute: {chip_html}"
+    assert (
+        "aria-describedby=" in chip_html
+    ), f"Draft chip missing aria-describedby: {chip_html}"
+    # And the hidden describedby element must exist.
+    assert 'id="draft-chip-help"' in body
+    assert "save action" in body or "Save Settings" in body
+
+
 def test_wizard_ids_not_duplicated_in_static_html(client):
     """JTN-220: wizardPrev and wizardNext must each appear at most once in rendered HTML.
 


### PR DESCRIPTION
## Summary
- JTN-622: Removed the visible `{{ plugin.id }}` subtitle from the plugin page header. The raw filesystem slug (`ai_image`, `clock`, `weather`, ...) is an internal identifier with no user-facing value. Kept behind `?debug=1` for diagnostics.
- JTN-644: The Draft status chip now carries a `title` tooltip and an `aria-describedby` hint pointing to a visually-hidden explanation so both sighted and screen-reader users understand what DRAFT means and how to clear it. Same treatment applied to the Instance chip.
- Extended the `status_chip` macro with optional `title` / `describedby` params so future chips can do the same.

## Test plan
- [x] New integration tests in `tests/integration/test_plugin_pages.py`:
  - `test_plugin_page_hides_raw_slug_subtitle` — no `app-subtitle` span by default
  - `test_plugin_page_shows_slug_subtitle_in_debug_mode` — slug shown when `?debug=1`
  - `test_plugin_page_draft_badge_has_explanation` — Draft chip has `title=` and `aria-describedby=` with a populated sr-only helper
- [x] Full test suite: 3818 passed, 5 skipped
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck)

Closes JTN-622
Closes JTN-644

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>