### PR TITLE
fix(ui): small polish pass — pagination, jargon, 24:00, colons (JTN-636, JTN-640, JTN-639, JTN-645)

### DIFF
--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -3885,6 +3885,13 @@ input:disabled, select:disabled, textarea:disabled {
   opacity: 0.7;
 }
 
+.pagination-disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+  color: var(--text-muted, currentColor);
+}
+
 /* Enhanced skeleton loader system */
 .skeleton,
 .img-skeleton,

--- a/src/static/styles/partials/_history.css
+++ b/src/static/styles/partials/_history.css
@@ -161,3 +161,10 @@
   font-size: 0.9rem;
   opacity: 0.7;
 }
+
+.pagination-disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+  color: var(--text-muted, currentColor);
+}

--- a/src/templates/partials/history_grid.html
+++ b/src/templates/partials/history_grid.html
@@ -45,7 +45,7 @@
        hx-swap="outerHTML show:#history-grid-container:top"
        hx-push-url="true">Previous</a>
     {% else %}
-    <span class="btn" style="opacity: 0.4; pointer-events: none;">Previous</span>
+    <span class="btn pagination-disabled" aria-disabled="true">Previous</span>
     {% endif %}
     <span class="pagination-info">Page {{ page }} of {{ total_pages }}</span>
     {% if page < total_pages %}
@@ -56,7 +56,7 @@
        hx-swap="outerHTML show:#history-grid-container:top"
        hx-push-url="true">Next</a>
     {% else %}
-    <span class="btn" style="opacity: 0.4; pointer-events: none;">Next</span>
+    <span class="btn pagination-disabled" aria-disabled="true">Next</span>
     {% endif %}
 </nav>
 {% endif %}

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -52,7 +52,7 @@
                 {% if playlist_config.active_playlist %}
                 <span class="status-chip">Active: {{ playlist_config.active_playlist }}</span>
                 {% endif %}
-                <span class="status-chip">Device cadence: {{ device_cycle_minutes }} min</span>
+                <span class="status-chip">Refresh interval: {{ device_cycle_minutes }} min</span>
             </div>
         </div>
 
@@ -72,7 +72,8 @@
                             {% if playlist.name == playlist_config.active_playlist %}
                             <span class="status-chip success">Active</span>
                             {% endif %}
-                            <span class="playlist-summary-copy">{{ playlist.start_time }} - {{ playlist.end_time }}{% if playlist.end_time < playlist.start_time %} <span class="playlist-wrap-label" title="This playlist wraps past midnight">(next day)</span>{% endif %}{% if playlist.cycle_minutes %} • {{ playlist.cycle_minutes }} min cycle{% endif %}</span>
+                            {% set _is_all_day = playlist.start_time == '00:00' and playlist.end_time in ('24:00', '23:59') %}
+                            <span class="playlist-summary-copy">{% if _is_all_day %}All day{% else %}{{ playlist.start_time }} - {{ playlist.end_time }}{% endif %}{% if not _is_all_day and playlist.end_time < playlist.start_time %} <span class="playlist-wrap-label" title="This playlist wraps past midnight">(next day)</span>{% endif %}{% if playlist.cycle_minutes %} • {{ playlist.cycle_minutes }} min cycle{% endif %}</span>
                         </div>
                         </div>
                         <div class="playlist-toolbar">

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -259,28 +259,28 @@
                     </button>
                     <div class="settings-container collapsible-content" hidden>
                         <div class="form-group">
-                            <label for="saturation" class="form-label form-label-min-width">Saturation:</label>
+                            <label for="saturation" class="form-label form-label-min-width">Saturation</label>
                             <span id="saturation-value" class="slider-value">{{ device_settings.get('image_settings', {}).get('saturation', 1.0) }}</span>
                             <input type="range" id="saturation" name="saturation" class="form-input slider-max-width settings-slider" min="0" max="2" step="0.1" value="{{ device_settings.get('image_settings', {}).get('saturation', 1.0) }}" />
                         </div>
                         <div class="form-group">
-                            <label for="contrast" class="form-label form-label-min-width">Contrast:</label>
+                            <label for="contrast" class="form-label form-label-min-width">Contrast</label>
                             <span id="contrast-value" class="slider-value">{{ device_settings.get('image_settings', {}).get('contrast', 1.0) }}</span>
                             <input type="range" id="contrast" name="contrast" class="form-input slider-max-width settings-slider" min="0" max="2" step="0.1" value="{{ device_settings.get('image_settings', {}).get('contrast', 1.0) }}" />
                          </div>
                         <div class="form-group">
-                            <label for="sharpness" class="form-label form-label-min-width">Sharpness:</label>
+                            <label for="sharpness" class="form-label form-label-min-width">Sharpness</label>
                             <span id="sharpness-value" class="slider-value">{{ device_settings.get('image_settings', {}).get('sharpness', 1.0) }}</span>
                             <input type="range" id="sharpness" name="sharpness" class="form-input slider-max-width settings-slider" min="0" max="2" step="0.1" value="{{ device_settings.get('image_settings', {}).get('sharpness', 1.0) }}" />
                         </div>
                         <div class="form-group">
-                            <label for="brightness" class="form-label form-label-min-width">Brightness:</label>
+                            <label for="brightness" class="form-label form-label-min-width">Brightness</label>
                             <span id="brightness-value" class="slider-value">{{ device_settings.get('image_settings', {}).get('brightness', 1.0) }}</span>
                             <input type="range" id="brightness" name="brightness" class="form-input slider-max-width settings-slider" min="0" max="2" step="0.1" value="{{ device_settings.get('image_settings', {}).get('brightness', 1.0) }}" />
                         </div>
                         {% if device_settings.get('display_type', 'inky') == 'inky' %}
                         <div class="form-group">
-                            <label for="inky_saturation" class="form-label form-label-min-width">Inky Driver Saturation:</label>
+                            <label for="inky_saturation" class="form-label form-label-min-width">Inky Driver Saturation</label>
                             <span id="inky_saturation-value" class="slider-value">{{ device_settings.get('image_settings', {}).get('inky_saturation', 0.5) }}</span>
                             <input
                                 type="range"

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -861,3 +861,46 @@ def test_htmx_partial_is_not_full_page(client, device_config_dev):
 
     assert "<html" not in body, "HTMX partial must not include <html> tag"
     assert "history-grid-container" in body, "Partial must contain the grid container"
+
+
+def test_history_pagination_previous_disabled_has_disabled_class(
+    client, device_config_dev
+):
+    """JTN-636: On page 1, 'Previous' must render with .pagination-disabled
+    styling so it is visually distinguishable from the active 'Next' link."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    for i in range(15):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_jtn636_{i:03d}.png")
+        )
+
+    resp = client.get("/history?page=1&per_page=10")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Page 1 should show Previous as a disabled <span> with the disabled class.
+    assert "pagination-disabled" in body
+    # The pagination-disabled control should be aria-disabled for a11y
+    assert 'aria-disabled="true"' in body
+    # Inline opacity hack from before the fix must not be used
+    assert 'style="opacity: 0.4; pointer-events: none;"' not in body
+
+
+def test_history_pagination_next_disabled_on_last_page(client, device_config_dev):
+    """JTN-636: On the last page, 'Next' must also use .pagination-disabled."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    for i in range(15):
+        Image.new("RGB", (10, 10), "white").save(
+            os.path.join(d, f"display_jtn636b_{i:03d}.png")
+        )
+
+    resp = client.get("/history?page=2&per_page=10")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "pagination-disabled" in body

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -408,3 +408,33 @@ def test_playlist_page_no_wrap_label_for_normal_range(client):
     idx = body.find("09:00 - 17:00")
     # Look within the next 200 chars for the label — it must not appear.
     assert "(next day)" not in body[idx : idx + 200]
+
+
+def test_playlist_header_chip_uses_plain_language_refresh_interval(client):
+    """JTN-640: Playlists header chip must say 'Refresh interval', not jargon
+    'Device cadence'."""
+    resp = client.get("/playlist")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Device cadence" not in body
+    assert "Refresh interval" in body
+
+
+def test_playlist_default_all_day_renders_as_all_day(client, device_config_dev):
+    """JTN-639: A playlist spanning 00:00 - 24:00 should render 'All day'
+    instead of the non-standard '24:00' end time."""
+    pm = device_config_dev.get_playlist_manager()
+    # Ensure a Default-like playlist exists with the full-day range
+    pm.add_playlist("JTN639AllDay", "00:00", "24:00")
+    device_config_dev.write_config()
+
+    resp = client.get("/playlist")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Find the all-day playlist block and assert its summary copy
+    idx = body.find("JTN639AllDay")
+    assert idx != -1
+    chunk = body[idx : idx + 600]
+    assert "All day" in chunk
+    assert "00:00 - 24:00" not in chunk

--- a/tests/integration/test_settings_routes.py
+++ b/tests/integration/test_settings_routes.py
@@ -177,3 +177,29 @@ def test_settings_responsive_css_sticky_save_selector_matches_real_dom():
         "matches the real DOM (buttons-container is nested inside "
         ".settings-console-main). Use the descendant combinator instead."
     )
+
+
+def test_settings_image_processing_labels_have_no_trailing_colon(client):
+    """JTN-645: Image Processing slider labels should not end in a colon —
+    the rest of the settings form uses colon-free labels."""
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    for bad in (
+        ">Saturation:<",
+        ">Contrast:<",
+        ">Sharpness:<",
+        ">Brightness:<",
+        ">Inky Driver Saturation:<",
+    ):
+        assert bad not in body, f"Found unwanted trailing colon label: {bad!r}"
+
+    # Positive: colon-free labels are present
+    for good in (
+        ">Saturation<",
+        ">Contrast<",
+        ">Sharpness<",
+        ">Brightness<",
+    ):
+        assert good in body, f"Expected label without colon: {good!r}"


### PR DESCRIPTION
## Summary
Four tiny UI polish fixes bundled together, all P4 template tweaks surfaced during the 2026-04-12 dogfood pass.

- **JTN-636** — History pagination: disabled Previous/Next spans now use a dedicated `.pagination-disabled` class (reduced opacity, `cursor: default`, `pointer-events: none`, `aria-disabled=\"true\"`) instead of an inline style, so page 1's Previous is visually distinguishable from the active Next link.
- **JTN-640** — Playlists header chip: \"Device cadence\" (internal jargon) swapped for plain \"Refresh interval\".
- **JTN-639** — Playlists whose range spans the full day (`00:00` to `24:00`/`23:59`) now render as \"All day\" instead of the non-standard `24:00` end time.
- **JTN-645** — Settings Image Processing slider labels (Saturation, Contrast, Sharpness, Brightness, Inky Driver Saturation) no longer end with trailing colons, matching the rest of the settings form.

## Test plan
- [x] `SKIP_BROWSER=1 pytest tests/` — 3820 passed, 5 skipped
- [x] `scripts/lint.sh` — ruff + black + shellcheck + mypy strict clean
- [x] New regression assertions in `tests/integration/test_history.py`, `test_playlist_routes.py`, `test_settings_routes.py`
- [ ] Manual spot-check: `/history` page 1 Previous appears muted; `/playlist` shows \"Refresh interval\" chip and \"All day\" for Default; `/settings` → Image Processing shows colon-free labels

Fixes JTN-636, JTN-640, JTN-639, JTN-645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)