### PR TITLE
fix(ui): restore main nav on 404 page (JTN-641)

### DIFF
--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -14,9 +14,9 @@
                     </div>
                 </div>
                 <nav class="header-actions" role="navigation" aria-label="Site navigation">
-                    <a href="{{ url_for('history.history_page') }}" class="header-button icon" aria-label="History">{{ icon('clock-counter-clockwise', 'icon-image') | safe }}</a>
-                    <a href="{{ url_for('playlist.playlists') }}" class="header-button icon" aria-label="Playlists">{{ icon('squares-four', 'icon-image') | safe }}</a>
-                    <a href="{{ url_for('settings.settings_page') }}" class="header-button icon" aria-label="Settings">{{ icon('gear-six', 'icon-image') | safe }}</a>
+                    <a href="{{ url_for('history.history_page') }}" class="header-button icon" title="History">{{ icon('clock-counter-clockwise', 'icon-image') | safe }}<span class="sr-only">History</span></a>
+                    <a href="{{ url_for('playlist.playlists') }}" class="header-button icon" title="Playlists">{{ icon('squares-four', 'icon-image') | safe }}<span class="sr-only">Playlists</span></a>
+                    <a href="{{ url_for('settings.settings_page') }}" class="header-button icon" title="Settings">{{ icon('gear-six', 'icon-image') | safe }}<span class="sr-only">Settings</span></a>
                 </nav>
             </div>
         </header>

--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -4,17 +4,22 @@
     <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
     <div class="frame">
         {% from 'macros/icons.html' import icon, theme_toggle %}
-        <div class="app-header">
+        <header class="app-header" role="banner">
             <div class="header-content">
                 <div class="header-identity">
-                    <a href="/" class="header-button icon" title="Home" aria-label="Home">{{ icon('house', 'icon-image') | safe }}</a>
+                    <a href="{{ url_for('main.main_page') }}" class="header-button icon" title="Home" aria-label="Home">{{ icon('house', 'icon-image') | safe }}</a>
                     {{ theme_toggle() }}
                     <div class="title-container">
                         <h1 class="app-title">Page Not Found</h1>
                     </div>
                 </div>
+                <nav class="header-actions" role="navigation" aria-label="Site navigation">
+                    <a href="{{ url_for('history.history_page') }}" class="header-button icon" aria-label="History">{{ icon('clock-counter-clockwise', 'icon-image') | safe }}</a>
+                    <a href="{{ url_for('playlist.playlists') }}" class="header-button icon" aria-label="Playlists">{{ icon('squares-four', 'icon-image') | safe }}</a>
+                    <a href="{{ url_for('settings.settings_page') }}" class="header-button icon" aria-label="Settings">{{ icon('gear-six', 'icon-image') | safe }}</a>
+                </nav>
             </div>
-        </div>
+        </header>
         <div class="separator"></div>
         <div class="page-intro" style="text-align: center; padding: 4rem 1rem;">
             <h2 style="font-size: 4rem; margin-bottom: 0.5rem; opacity: 0.3;">404</h2>

--- a/tests/integration/test_error_pages.py
+++ b/tests/integration/test_error_pages.py
@@ -1,0 +1,38 @@
+"""Regression tests for error pages (JTN-641).
+
+Users who land on a 404 page must still have access to the full site
+navigation (History, Playlists, Settings) so there is a discovery path
+from any broken URL.
+"""
+
+from __future__ import annotations
+
+
+def test_404_page_includes_main_navigation(client):
+    """404 HTML page must expose links to History, Playlists, and Settings."""
+    resp = client.get("/this-url-does-not-exist", headers={"Accept": "text/html"})
+    assert resp.status_code == 404
+    body = resp.data
+    # Nav links users need for site discovery.
+    assert b'href="/playlist"' in body
+    assert b'href="/history"' in body
+    assert b'href="/settings"' in body
+    # Still has the Home link and the "Page Not Found" heading.
+    assert b"Page Not Found" in body
+    assert b'href="/"' in body
+
+
+def test_404_page_includes_nav_landmark(client):
+    """404 page should render a <nav> landmark for site navigation."""
+    resp = client.get("/another-bogus-url", headers={"Accept": "text/html"})
+    assert resp.status_code == 404
+    assert b'aria-label="Site navigation"' in resp.data
+
+
+def test_404_json_response_unaffected(client):
+    """JSON clients should still receive a structured JSON error, not HTML."""
+    resp = client.get("/still-not-there", headers={"Accept": "application/json"})
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data["success"] is False
+    assert "Not found" in data["error"]

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.5"
+version = "0.49.6"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary
- 404 page now renders the full site navigation (History, Playlists, Settings) alongside the existing Home and theme toggle, matching the header on inky/playlist/settings pages
- Users who hit a broken URL retain a discovery path instead of hitting a dead-end

## Test plan
- [x] New regression tests in `tests/integration/test_error_pages.py` assert the 404 HTML response contains `href=\"/playlist\"`, `href=\"/history\"`, `href=\"/settings\"`, and the `Site navigation` nav landmark
- [x] Existing `test_404_page_renders_styled_html` and `test_404_json_still_returns_json` remain green
- [x] Full suite: 3856 passed, 5 skipped
- [x] `scripts/lint.sh` — ruff + black + shellcheck all green (mypy advisory)

Fixes JTN-641.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>