### PR TITLE
fix(playlist): allow arbitrary HH:MM in time selector (JTN-647)

### DIFF
--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -487,8 +487,8 @@
         document.getElementById("modalTitle").textContent = "Update Playlist";
         document.getElementById("playlist_name").value = playlistName;
         document.getElementById("editingPlaylistName").value = playlistName;
-        document.getElementById("start_time").value = startTime;
-        document.getElementById("end_time").value = endTime;
+        document.getElementById("start_time").value = _normaliseTimeForInput(startTime);
+        document.getElementById("end_time").value = _normaliseTimeForInput(endTime);
         const cycleInput = document.getElementById('cycle_minutes');
         if (cycleInput){ cycleInput.value = cycleMinutes || ''; }
         if (modal) modal.dataset.mode = "edit";
@@ -617,20 +617,11 @@
         } catch(e){ showResponseModal('failure', 'Failed to trigger display'); }
     }
 
-    function populateTimeOptions() {
-        let startSelect = document.getElementById("start_time");
-        let endSelect = document.getElementById("end_time");
-        startSelect.innerHTML = "";
-        endSelect.innerHTML = "";
-        for (let hour = 0; hour < 24; hour++) {
-            for (let minutes of [0, 15, 30, 45]) {
-                let time = hour.toString().padStart(2, '0') + ":" + minutes.toString().padStart(2, '0');
-                startSelect.innerHTML += `<option value="${time}">${time}</option>`;
-                endSelect.innerHTML += `<option value="${time}">${time}</option>`;
-            }
-        }
-        startSelect.innerHTML += `<option value="24:00">24:00</option>`;
-        endSelect.innerHTML += `<option value="24:00">24:00</option>`;
+    // Normalise a stored HH:MM (or "24:00") value to a form accepted by <input type="time">.
+    function _normaliseTimeForInput(value) {
+        if (!value) return value;
+        if (value === "24:00") return "23:59";
+        return value;
     }
 
     function initDeviceClock(){
@@ -673,7 +664,6 @@
     }
 
     function init(){
-        populateTimeOptions();
         document.querySelectorAll('.playlist-item .plugin-list').forEach(enableDrag);
         // Bind header buttons
         const newBtn = document.getElementById('newPlaylistBtn');

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -176,9 +176,9 @@
                 </div>
                 <div class="form-group">
                     <label for="start_time" class="form-label">Display from </label>
-                    <select id="start_time" name="start_time" class="form-input" aria-required="true"></select>
+                    <input type="time" id="start_time" name="start_time" class="form-input" step="60" value="09:00" aria-required="true" required>
                     <label for="end_time" class="form-label"> to </label>
-                    <select id="end_time" name="end_time" class="form-input" aria-required="true"></select>
+                    <input type="time" id="end_time" name="end_time" class="form-input" step="60" value="17:00" aria-required="true" required>
                 </div>
                 <div class="form-group">
                     <label for="cycle_minutes" class="form-label">Cycle override (minutes)</label>

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -438,3 +438,42 @@ def test_playlist_default_all_day_renders_as_all_day(client, device_config_dev):
     chunk = body[idx : idx + 600]
     assert "All day" in chunk
     assert "00:00 - 24:00" not in chunk
+
+
+def test_playlist_form_uses_native_time_input(client):
+    """JTN-647: start/end time fields must be <input type="time"> (not a 15-min <select>).
+
+    This lets users schedule arbitrary HH:MM values (e.g. 09:05) instead of the
+    legacy quarter-hour-only dropdown options.
+    """
+    resp = client.get("/playlist")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+
+    # Native time input renders for both start and end, not a <select>.
+    assert 'type="time"' in body
+    assert 'id="start_time"' in body
+    assert 'id="end_time"' in body
+    # The legacy <select> dropdowns should be gone.
+    assert '<select id="start_time"' not in body
+    assert '<select id="end_time"' not in body
+
+
+def test_create_playlist_accepts_non_quarter_hour_times(client):
+    """JTN-647: backend accepts arbitrary HH:MM values like 09:05 or 07:10."""
+    payload = {
+        "playlist_name": "OddHours",
+        "start_time": "09:05",
+        "end_time": "07:10",  # wraps past midnight; still a valid distinct time
+    }
+    resp = client.post("/create_playlist", json=payload)
+    assert resp.status_code == 200
+
+    # Update to another non-quarter-hour value.
+    upd = {
+        "new_name": "OddHours",
+        "start_time": "06:37",
+        "end_time": "22:13",
+    }
+    resp = client.put("/update_playlist/OddHours", json=upd)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Replace the 15-minute-increment `<select>` dropdowns for playlist start/end time with `<input type="time" step="60">`, so users can schedule non-quarter-hour times like `09:05` or `07:10`.
- Delete the now-unused `populateTimeOptions()` helper and normalise the legacy `24:00` sentinel to `23:59` when populating the edit modal (native time inputs max out at `23:59`; the backend's `Playlist._to_minutes` already accepts either).
- Backend validation already accepts any valid `HH:MM`, so this is primarily a frontend change.

Fixes JTN-647.

## Test plan
- [x] New regression test asserts `<input type="time">` renders for both start and end fields and legacy `<select>` is gone.
- [x] New regression test creates/updates a playlist with `09:05`, `07:10`, `06:37`, `22:13` via the API.
- [x] Full suite: 3855 passed, 5 skipped.
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck; mypy strict subset clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)