### PR TITLE
fix(image_upload,image_folder): pre-select Background Fill radio in draft (JTN-632)

### DIFF
--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -47,6 +47,15 @@ def list_files_in_folder(folder_path):
 
 
 class ImageFolder(BasePlugin):
+    def generate_settings_template(self):
+        # JTN-632: Disable the legacy "Style" collapsible. Its hardcoded
+        # `backgroundOption` radios collide with the schema-driven Background
+        # Fill radio group and cause two options to render as `checked`,
+        # leaving the user's Background Fill selection indeterminate.
+        template_params = super().generate_settings_template()
+        template_params["style_settings"] = False
+        return template_params
+
     def validate_settings(self, settings: dict) -> str | None:
         """Reject missing/unreadable/empty folder paths at save time.
 

--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -36,6 +36,15 @@ def _resolve_background_color(
 
 
 class ImageUpload(BasePlugin):
+    def generate_settings_template(self):
+        # JTN-632: Disable the legacy "Style" collapsible. Its hardcoded
+        # `backgroundOption` radios collide with the schema-driven Background
+        # Fill radio group and cause two options to render as `checked`,
+        # leaving the user's Background Fill selection indeterminate.
+        template_params = super().generate_settings_template()
+        template_params["style_settings"] = False
+        return template_params
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/tests/plugins/test_image_folder.py
+++ b/tests/plugins/test_image_folder.py
@@ -125,3 +125,59 @@ def test_generate_image_invalid_background_color_falls_back(
         device_config_dev,
     )
     assert img is not None
+
+
+def test_image_folder_background_option_has_default_blur_in_schema():
+    """JTN-632: The Background Fill radio_segment must declare a default so
+    that DRAFT renders pre-select one option (Blur). Without a default,
+    neither radio is checked and users can save in an indeterminate state."""
+    from plugins.image_folder.image_folder import ImageFolder
+
+    sch = ImageFolder({"id": "image_folder"}).build_settings_schema()
+
+    def _find_field(obj, name):
+        if isinstance(obj, dict):
+            if obj.get("name") == name:
+                return obj
+            for v in obj.values():
+                found = _find_field(v, name)
+                if found is not None:
+                    return found
+        elif isinstance(obj, list):
+            for item in obj:
+                found = _find_field(item, name)
+                if found is not None:
+                    return found
+        return None
+
+    bg = _find_field(sch, "backgroundOption")
+    assert bg is not None
+    assert bg.get("default") == "blur", (
+        "image_folder backgroundOption must default to 'blur' so the radio "
+        "group has a pre-selected option in DRAFT mode (JTN-632)"
+    )
+
+
+def test_image_folder_draft_page_preselects_blur_radio(client):
+    """JTN-632: Rendering /plugin/image_folder with no saved instance
+    (DRAFT mode) must pre-check exactly one Background Fill radio option."""
+    import re
+
+    resp = client.get("/plugin/image_folder")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    radios = re.findall(
+        r'<input[^>]*name="backgroundOption"[^>]*>',
+        body,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert len(radios) >= 2, "expected at least two backgroundOption radios"
+    checked_radios = [r for r in radios if re.search(r"\bchecked\b", r)]
+    assert len(checked_radios) == 1, (
+        f"expected exactly one backgroundOption radio to be pre-checked in "
+        f"DRAFT mode, found {len(checked_radios)} (JTN-632)"
+    )
+    assert re.search(
+        r'value="blur"', checked_radios[0]
+    ), "the pre-checked backgroundOption radio must be 'blur' (JTN-632)"

--- a/tests/plugins/test_image_upload.py
+++ b/tests/plugins/test_image_upload.py
@@ -449,3 +449,61 @@ def test_image_upload_invalid_background_color_falls_back(
             device_config_dev,
         )
         assert result is not None
+
+
+def test_image_upload_background_option_has_default_blur_in_schema():
+    """JTN-632: The Background Fill radio_segment must declare a default so
+    that DRAFT renders pre-select one option (Blur). Without a default,
+    neither radio is checked and users can save in an indeterminate state."""
+    from plugins.image_upload.image_upload import ImageUpload
+
+    sch = ImageUpload({"id": "image_upload"}).build_settings_schema()
+
+    def _find_field(obj, name):
+        if isinstance(obj, dict):
+            if obj.get("name") == name:
+                return obj
+            for v in obj.values():
+                found = _find_field(v, name)
+                if found is not None:
+                    return found
+        elif isinstance(obj, list):
+            for item in obj:
+                found = _find_field(item, name)
+                if found is not None:
+                    return found
+        return None
+
+    bg = _find_field(sch, "backgroundOption")
+    assert bg is not None
+    assert bg.get("default") == "blur", (
+        "image_upload backgroundOption must default to 'blur' so the radio "
+        "group has a pre-selected option in DRAFT mode (JTN-632)"
+    )
+
+
+def test_image_upload_draft_page_preselects_blur_radio(client):
+    """JTN-632: Rendering /plugin/image_upload with no saved instance
+    (DRAFT mode) must pre-check exactly one Background Fill radio option."""
+    import re
+
+    resp = client.get("/plugin/image_upload")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    # Locate the backgroundOption radio inputs and assert exactly one is checked.
+    radios = re.findall(
+        r'<input[^>]*name="backgroundOption"[^>]*>',
+        body,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert len(radios) >= 2, "expected at least two backgroundOption radios"
+    checked_radios = [r for r in radios if re.search(r"\bchecked\b", r)]
+    assert len(checked_radios) == 1, (
+        f"expected exactly one backgroundOption radio to be pre-checked in "
+        f"DRAFT mode, found {len(checked_radios)} (JTN-632)"
+    )
+    # The pre-checked option must be 'blur' to match generate_image fallback.
+    assert re.search(
+        r'value="blur"', checked_radios[0]
+    ), "the pre-checked backgroundOption radio must be 'blur' (JTN-632)"


### PR DESCRIPTION
## Summary
- Fixes JTN-632: Background Fill radio group rendered two `checked` inputs on `/plugin/image_upload` and `/plugin/image_folder`, leaving draft selection indeterminate.
- Root cause: the legacy Style collapsible in `plugin.html` hardcodes a second `<input name="backgroundOption" value="color" checked>` that collides with the schema-driven radio group.
- Both plugins already expose a schema-driven Background Fill field and ignore all Style fields (Frame, Margins, Text Color, background upload, etc.), so disabling `style_settings` removes the collision without behavior changes.
- With Style off, the schema's `default="blur"` pre-selects exactly one radio in DRAFT mode, matching the `generate_image` fallback.

## Test plan
- [x] `pytest tests/plugins/test_image_upload.py tests/plugins/test_image_folder.py` — 23 passed
- [x] Full suite: 3857 passed, 5 skipped
- [x] `scripts/lint.sh` — all blocking checks clean
- [x] New regression tests assert exactly one `backgroundOption` radio is `checked` on GET `/plugin/image_upload` and `/plugin/image_folder` in DRAFT mode, and that its value is `blur`.

Linear: JTN-632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "blur" as the default background fill option for image-related functionality.

* **Bug Fixes**
  * Disabled style settings in image plugins to streamline the configuration interface.

* **Tests**
  * Added test coverage verifying background fill defaults and rendering behavior in image plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->