### PR TITLE
fix(plugin): show empty-state on Last progress for Weather and AI Image (JTN-634)

### DIFF
--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -114,16 +114,37 @@
             }
           }
         }
-        if (!data) {
-          showResponseModal("failure", "No recent progress to show");
-          return;
-        }
         const progress = document.getElementById("requestProgress");
         const textEl = document.getElementById("requestProgressText");
         const clockEl = document.getElementById("requestProgressClock");
         const elapsedEl = document.getElementById("requestProgressElapsed");
         const list = document.getElementById("requestProgressList");
         const bar = document.getElementById("requestProgressBar");
+        // JTN-634: Previously, the no-data path surfaced a toast only, which
+        // users (especially on Weather / AI Image where validation often
+        // blocks the first Update Now attempt before any snapshot is saved)
+        // reported as "no feedback". Show an empty-state inside the progress
+        // block itself so the click always produces a clearly visible result
+        // anchored to the "Last progress" button.
+        if (!data) {
+          if (list) {
+            list.innerHTML = "";
+            const li = document.createElement("li");
+            li.className = "progress-empty-state";
+            li.textContent =
+              "No progress data yet — run Update Now to see progress here.";
+            list.appendChild(li);
+          }
+          if (textEl) textEl.textContent = "No progress data yet";
+          if (clockEl) clockEl.textContent = "—";
+          if (elapsedEl) elapsedEl.textContent = "—";
+          if (bar) { bar.style.width = "0%"; bar.setAttribute("aria-valuenow", 0); }
+          if (progress) {
+            setHidden(progress, false);
+            progress.style.display = "";
+          }
+          return;
+        }
         if (list) {
           list.innerHTML = "";
           data.lines.forEach((rawLine) => {

--- a/tests/static/test_calendar_button_fixes.py
+++ b/tests/static/test_calendar_button_fixes.py
@@ -141,15 +141,19 @@ def test_show_last_progress_btn_present_on_calendar_page(client):
 
 
 def test_show_last_progress_no_data_shows_modal(client):
-    """JTN-312: When localStorage has no data, showLastProgress must call
-    showResponseModal with a user-visible message, not silently fail."""
+    """JTN-312 / JTN-634: When localStorage has no data, showLastProgress
+    must surface a user-visible empty-state message. Originally (JTN-312)
+    this went through showResponseModal; JTN-634 moved the message inside
+    the progress block itself so Weather / AI Image users whose first click
+    happens before any Update Now still get clearly anchored feedback."""
     resp = client.get("/static/scripts/plugin_page.js")
     assert resp.status_code == 200
     js = resp.get_data(as_text=True)
 
-    assert "No recent progress to show" in js, (
-        "showLastProgress must display 'No recent progress to show' via "
-        "showResponseModal when localStorage has no data (JTN-312)"
+    assert "No progress data yet" in js, (
+        "showLastProgress must render 'No progress data yet' empty-state "
+        "text when localStorage has no snapshot so Weather / AI Image users "
+        "get visible feedback on first click (JTN-634)"
     )
 
 
@@ -237,3 +241,63 @@ def test_request_progress_block_present_on_plugin_page(client, plugin_id):
     assert (
         'id="requestProgress"' in body
     ), f"{plugin_id} plugin page must render requestProgress block"
+
+
+# ---------------------------------------------------------------------------
+# JTN-634: "Show last progress" visible feedback on Weather and AI Image
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "plugin_id",
+    ["weather", "ai_image"],
+    ids=["JTN-634-weather", "JTN-634-ai_image"],
+)
+def test_show_last_progress_btn_present_on_weather_and_ai_image(client, plugin_id):
+    """JTN-634: Weather and AI Image plugin pages must render the
+    showLastProgressBtn so users get visible feedback — these plugins were
+    not covered by the PR #377 regression suite and still silently no-oped
+    when localStorage was empty (common because their required fields fail
+    client-side validation before sendForm ever saves a snapshot)."""
+    resp = client.get(f"/plugin/{plugin_id}")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    assert (
+        'id="showLastProgressBtn"' in body
+    ), f"{plugin_id} plugin page must render showLastProgressBtn (JTN-634)"
+    assert (
+        'id="requestProgress"' in body
+    ), f"{plugin_id} plugin page must render requestProgress block (JTN-634)"
+
+
+def test_show_last_progress_no_data_reveals_progress_block(client):
+    """JTN-634: When localStorage has no snapshot, showLastProgress must
+    reveal the requestProgress block with an empty-state message — not only
+    emit a toast. Anchoring feedback to the button's visual target is what
+    Weather / AI Image users expected (previously the toast-only fallback
+    was reported as 'no feedback')."""
+    resp = client.get("/static/scripts/plugin_page.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    fn_start = js.find("function showLastProgress()")
+    assert fn_start != -1, "showLastProgress function not found"
+    # Generous window so the empty-state branch is included.
+    fn_body = js[fn_start : fn_start + 3000]
+
+    # No-data branch must set the progress block visible (not just toast).
+    assert "setHidden(progress, false)" in fn_body, (
+        "showLastProgress must unhide the progress block in the no-data "
+        "branch so users see visible feedback anchored to the button "
+        "(JTN-634)"
+    )
+    assert "No progress data yet" in fn_body, (
+        "showLastProgress must render an empty-state message in the "
+        "progress block when no snapshot is available (JTN-634)"
+    )
+    # Empty state should clear the bar so it doesn't imply a completed run.
+    assert 'bar.style.width = "0%"' in fn_body, (
+        "Empty-state branch should reset the progress bar to 0% rather "
+        "than leaving a stale fill (JTN-634)"
+    )


### PR DESCRIPTION
## Summary

PR #377 (JTN-347/348/331/332) made the **Last progress** button work on Clock, To-Do, Calendar, and Screenshot by clearing the inline `display:none` left by `progress.stop()`. Weather and AI Image still appeared to *show no feedback* because their required settings fields (latitude / longitude / textPrompt) frequently fail client-side validation — the first **Update Now** click short-circuits in `handleAction` before `sendForm` runs, so no progress snapshot is ever persisted. A later click of **Last progress** then hit the no-data branch, which surfaced only a transient toast — easy to miss and not anchored to the button.

## Fix

Move the empty-state message inside the `requestProgress` block itself. The button now always reveals a clearly visible panel, either with real snapshot data or with the string **"No progress data yet — run Update Now to see progress here."** The progress bar is reset to 0% in the empty state so the UI doesn't imply a completed run.

## Root cause verification

Reproduced on `/plugin/weather` with the dev server:

1. `localStorage.clear()`
2. Click **Update Now** without filling latitude/longitude → validation toast fires, `handleAction` returns before `sendForm`, nothing gets saved to `localStorage`.
3. Click **Last progress** → old behaviour was a tiny toast; new behaviour reveals the progress block with the empty-state message.

Confirmed the happy-path (with a real snapshot in `localStorage`) still works on both Weather and AI Image — the block shows the stored summary, line items, and completed bar.

## Files changed

- `src/static/scripts/plugin_page.js` — `showLastProgress()` now handles the no-data branch by unhiding the progress block and writing the empty-state copy, instead of calling `showResponseModal` only.
- `tests/static/test_calendar_button_fixes.py` — updated the existing JTN-312 no-data assertion and added parametrized regressions for Weather + AI Image plus an empty-state branch assertion.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no` — **3856 passed, 5 skipped**
- [x] `scripts/lint.sh` — ruff + black + shellcheck + strict mypy subset clean
- [x] Manual (Chrome, dev server): empty-state renders on Weather and AI Image; real-snapshot path still renders stored lines and summary
- [x] Manual: Clock happy-path unchanged (regression sanity check for PR #377 behaviour)

Fixes JTN-634.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>