### PR TITLE
fix(ui): add Plugins level to plugin page breadcrumb (JTN-637)

### DIFF
--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -122,7 +122,7 @@
         </main>
 
         <!-- Plugin navigation section -->
-        <section aria-label="Available plugins">
+        <section id="plugins" aria-label="Available plugins">
             <h2 class="plugins-title compact">Plugins</h2>
         {% set icon_map = PLUGIN_ICON_MAP %}
             <div class="plugins-container dashboard-grid">

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -75,7 +75,11 @@
         </div>
 
         <div class="separator"></div>
-        {{ breadcrumb([{'label': 'Home', 'url': url_for('main.main_page')}, {'label': plugin.display_name}]) }}
+        {{ breadcrumb([
+            {'label': 'Home', 'url': url_for('main.main_page')},
+            {'label': 'Plugins', 'url': url_for('main.main_page') + '#plugins'},
+            {'label': plugin.display_name},
+        ]) }}
 
         <div class="status-row plugin-mode-row" aria-label="Plugin mode indicators">
             {% if plugin_instance %}

--- a/tests/integration/test_breadcrumbs.py
+++ b/tests/integration/test_breadcrumbs.py
@@ -39,13 +39,19 @@ def test_api_keys_breadcrumb(client):
 
 
 def test_plugin_breadcrumb(client):
-    """GET /plugin/<id> contains breadcrumb with Home and the plugin display name."""
+    """GET /plugin/<id> contains breadcrumb with Home, Plugins, and the plugin display name."""
     # "clock" is a built-in plugin type whose plugin-info.json defines display_name="Clock"
     resp = client.get("/plugin/clock")
     assert resp.status_code == 200
     html = resp.data.decode()
     assert "Home" in html
     assert "Clock" in html
+    # JTN-637: intermediate "Plugins" level links back to the home page plugin list
+    assert ">Plugins</a>" in html
+    assert 'href="/#plugins"' in html
+    # Leaf item (plugin display name) should carry aria-current and not be a link
+    assert 'aria-current="page"' in html
+    assert "<span>Clock</span>" in html
 
 
 def test_breadcrumb_last_item_not_linked(client):


### PR DESCRIPTION
## Summary
- Insert an intermediate "Plugins" item between "Home" and the plugin display name in the plugin page breadcrumb so users can jump back to the plugin list without relying on the browser Back button.
- Add an `id="plugins"` anchor to the "Available plugins" section on the home page so the new breadcrumb link (`/#plugins`) lands users directly on the plugin grid.
- Extend the existing breadcrumb regression test to assert the new link and that the leaf still carries `aria-current="page"`.

Closes JTN-637.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/integration/test_breadcrumbs.py` (6 passed)
- [x] Full suite: 3871 passed, 5 skipped
- [x] `scripts/lint.sh` (ruff + black + shellcheck clean; mypy advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Breadcrumb navigation on plugin pages now displays a three-level hierarchy: Home → Plugins → Current plugin name for improved navigation clarity.
  * Plugins section now supports direct anchor linking for easier reference and navigation.

* **Tests**
  * Updated breadcrumb tests to verify the new three-level navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->