### PR TITLE
fix(ui): label current-plugin chip on home page (JTN-638)

### DIFF
--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -38,7 +38,10 @@
                 <span class="status-chip">Playlist: {{ refresh_info.playlist }}</span>
                 {% endif %}
                 {% if refresh_info.plugin_id %}
-                <span class="status-chip">{{ plugin_names.get(refresh_info.plugin_id, refresh_info.plugin_id) }}</span>
+                {% set _current_plugin_name = plugin_names.get(refresh_info.plugin_id, refresh_info.plugin_id) %}
+                <span class="status-chip" data-chip="current-plugin"
+                      title="Currently displayed plugin: {{ _current_plugin_name }}"
+                      aria-label="Currently displayed plugin: {{ _current_plugin_name }}">Current: {{ _current_plugin_name }}</span>
                 {% endif %}
             </div>
         </div>

--- a/tests/integration/test_main_routes.py
+++ b/tests/integration/test_main_routes.py
@@ -201,3 +201,33 @@ def test_dashboard_shows_generic_message_when_no_preview_and_no_plugin_id(
     assert resp.status_code == 200
     assert b"Display a plugin to see details here." in resp.data
     assert b"Last display info unavailable." not in resp.data
+
+
+def test_home_current_plugin_chip_has_label_and_tooltip(client, device_config_dev):
+    """JTN-638: Dashboard current-plugin chip must have a visible label + title/aria-label.
+
+    Without the label, users see a bare "WEATHER" chip with no context indicating it
+    refers to the currently displayed plugin.
+    """
+    device_config_dev.refresh_info = RefreshInfo(
+        refresh_type="Playlist",
+        plugin_id="weather",
+        refresh_time="2025-01-01T00:00:00",
+        image_hash=123,
+        playlist="Default",
+        plugin_instance="Home Weather",
+    )
+    device_config_dev.write_config()
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    # The chip must carry the current-plugin marker and have both a title and aria-label
+    assert 'data-chip="current-plugin"' in html
+    # The chip should render a visible "Current:" label prefix, matching the
+    # "Playlist: ..." chip style for consistency
+    assert "Current: " in html
+    # Tooltip + screen-reader label must describe what the chip represents
+    assert 'title="Currently displayed plugin:' in html
+    assert 'aria-label="Currently displayed plugin:' in html


### PR DESCRIPTION
## Summary
- The dashboard header rendered a bare chip like `WEATHER` with no context label, leaving first-time users unable to tell that it referred to the currently displayed plugin.
- Added a `Current:` prefix to match the neighboring `Playlist:` chip style for visual consistency.
- Added `title` and `aria-label` attributes so hover and screen-reader users see "Currently displayed plugin: <name>".

## Test plan
- [x] New regression test `test_home_current_plugin_chip_has_label_and_tooltip` in `tests/integration/test_main_routes.py` asserts label, tooltip, and aria-label are present.
- [x] Full suite: 3872 passed, 5 skipped.
- [x] `scripts/lint.sh` clean (ruff + black).

Linear: JTN-638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Current plugin indicator now displays with a "Current:" label prefix for improved clarity and visibility.

* **Tests**
  * Added integration test to verify the current plugin chip displays proper labeling and accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->