### PR TITLE
fix(ui): label dashboard header current-plugin chip (JTN-638)

### DIFF
--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -38,7 +38,7 @@
                 <span class="status-chip">Playlist: {{ refresh_info.playlist }}</span>
                 {% endif %}
                 {% if refresh_info.plugin_id %}
-                <span class="status-chip">{{ plugin_names.get(refresh_info.plugin_id, refresh_info.plugin_id) }}</span>
+                <span class="status-chip" title="Currently displaying: {{ plugin_names.get(refresh_info.plugin_id, refresh_info.plugin_id) }}">Showing: {{ plugin_names.get(refresh_info.plugin_id, refresh_info.plugin_id) }}</span>
                 {% endif %}
             </div>
         </div>

--- a/tests/integration/test_main_routes.py
+++ b/tests/integration/test_main_routes.py
@@ -84,6 +84,10 @@ def test_home_now_showing_renders_from_refresh_info(client, device_config_dev):
     assert b"Home Weather" in resp.data
     assert b"Default" in resp.data
     assert b'data-page-shell="dashboard"' in resp.data
+    # JTN-638: the currently-displayed plugin chip must be labeled so
+    # first-time users understand what the chip refers to.
+    assert b"Showing:" in resp.data
+    assert b'title="Currently displaying:' in resp.data
 
 
 def test_dashboard_plugin_cards_have_valid_hrefs(client, device_config_dev):

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.6"
+version = "0.49.11"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary

- Prefixes the current-plugin chip in the dashboard header chip row with `Showing:` so its meaning is self-evident alongside the neighboring `Playlist: Default` / `800x480` chips.
- Adds a `Currently displaying: <name>` tooltip for extra discoverability.
- Preserves the friendly display-name resolution introduced in PR #393 (`plugin_names.get(...)`).

## Why

Per JTN-638 (dogfood pass 2026-04-12), the header row rendered as `20 PLUGINS | PLAYLIST: DEFAULT | WEATHER | 800x480` — the `WEATHER` chip had no label or tooltip, so first-time users had no way to know it referred to the currently-displayed plugin.

## Changes

- `src/templates/inky.html` — add `Showing:` prefix and `title` tooltip to the current-plugin chip.
- `tests/integration/test_main_routes.py` — extend `test_home_now_showing_renders_from_refresh_info` to assert the new label and tooltip.

## Test plan

- [x] `scripts/lint.sh` passes (ruff + black blocking, shellcheck, mypy strict subset)
- [x] Full suite: 3871 passed, 5 skipped
- [x] Targeted: `tests/integration/test_main_routes.py` (12 passed)

Closes JTN-638.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>