### PR TITLE
fix(security): rebuild redirect URL to close CodeQL open-redirect alert (JTN-317)

### DIFF
--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -14,6 +14,7 @@ import logging
 import os
 import secrets
 from time import perf_counter
+from urllib.parse import quote, urlencode, urlunsplit
 
 from flask import Flask, abort, g, make_response, redirect, request, session
 
@@ -121,10 +122,18 @@ def setup_https_redirect(app: Flask, *, dev_mode: bool) -> None:
         # CodeQL py/url-redirection alert #52). ``request.url`` is
         # built from the client-supplied ``Host`` header, so using it
         # directly in a ``Location`` header lets an attacker point the
-        # redirect at an arbitrary domain. Instead we:
+        # redirect at an arbitrary domain. Per the repo pattern for this
+        # CodeQL rule, "validate then reuse" leaves the alert open — the
+        # target URL must be rebuilt from individually validated and
+        # freshly serialised components. We therefore:
         #   1. Validate the request host against an allow-list.
-        #   2. Rebuild the redirect target from the allow-listed host
-        #      value (not the raw header) plus the request path.
+        #   2. Rebuild the authority from the matching allow-list entry
+        #      (not the raw header).
+        #   3. Re-percent-encode the path via ``quote`` and re-serialise
+        #      the query string via ``urlencode`` so no attacker-chosen
+        #      bytes flow through verbatim.
+        #   4. Assemble the final URL with ``urlunsplit`` using a hard-
+        #      coded ``https`` scheme literal.
         allowed_hosts = _load_allowed_hosts()
         raw_host = request.host or ""
         host_name, _sep, host_port = raw_host.partition(":")
@@ -139,16 +148,23 @@ def setup_https_redirect(app: Flask, *, dev_mode: bool) -> None:
         # the port (if present) is digits-only; still, guard it.
         if host_port and host_port.isdigit():
             safe_authority = f"{host_name}:{host_port}"
-        # Preserve path + query string. ``full_path`` always ends with
-        # a ``?`` even when there are no query args, so strip it.
-        path_and_query = request.full_path
-        if path_and_query.endswith("?"):
-            path_and_query = path_and_query[:-1]
-        # NOSONAR — the https:// literal is intentional: we are
-        # upgrading the request to https. SonarCloud rule S5332 is a
-        # false positive here.
-        url = f"https://{safe_authority}{path_and_query}"  # NOSONAR
-        return redirect(url, code=301)
+        # Re-encode path and query from validated request components.
+        # ``request.path`` is already URL-decoded by Werkzeug; re-quote
+        # it (keeping ``/``) so the Location header is well-formed and
+        # no attacker-controlled bytes pass through untouched.
+        safe_path = quote(request.path or "/", safe="/")
+        # ``request.args`` is a MultiDict; ``urlencode(..., doseq=True)``
+        # deterministically re-serialises it, dropping any malformed
+        # bytes that slipped past decoding.
+        safe_query = urlencode(list(request.args.items(multi=True)), doseq=True)
+        # Hard-coded scheme literal — the whole point of this handler
+        # is to upgrade to https. NOSONAR silences S5332 which flags
+        # any ``http://``/``https://`` literal as a potential cleartext
+        # transmission.
+        safe_url = urlunsplit(
+            ("https", safe_authority, safe_path, safe_query, "")
+        )  # NOSONAR
+        return redirect(safe_url, code=301)
 
 
 # ---------------------------------------------------------------------------

--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -158,9 +158,9 @@ def setup_https_redirect(app: Flask, *, dev_mode: bool) -> None:
         # bytes that slipped past decoding.
         safe_query = urlencode(list(request.args.items(multi=True)), doseq=True)
         # Hard-coded scheme literal — the whole point of this handler
-        # is to upgrade to https. NOSONAR silences S5332 which flags
-        # any ``http://``/``https://`` literal as a potential cleartext
-        # transmission.
+        # is to upgrade to https. The inline suppression below silences
+        # S5332 which flags any ``http://``/``https://`` literal as a
+        # potential cleartext transmission.
         safe_url = urlunsplit(
             ("https", safe_authority, safe_path, safe_query, "")
         )  # NOSONAR

--- a/tests/unit/test_security_middleware_https_redirect.py
+++ b/tests/unit/test_security_middleware_https_redirect.py
@@ -204,6 +204,62 @@ def test_redirect_omits_trailing_question_mark_when_no_query(monkeypatch):
     assert resp.location == "https://localhost/"
 
 
+def test_redirect_reencodes_path_and_query(monkeypatch):
+    """The redirect URL must be rebuilt via ``urlunsplit`` from validated
+    components — not by string-concatenating ``request.full_path``.
+
+    This is the fix pattern required to close CodeQL ``py/url-redirection``
+    alert #52: validate-then-reuse leaves the taint path intact, so the
+    Location header is re-assembled from (hardcoded https scheme,
+    allow-listed host, re-quoted path, re-urlencoded query).
+    """
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    # A path with a space (URL-decoded by Werkzeug) must come back
+    # percent-encoded in the Location header.
+    resp = client.get("/hello%20world", headers={"Host": "localhost"})
+    assert resp.status_code == 301
+    assert resp.location == "https://localhost/hello%20world"
+
+
+def test_redirect_drops_fragment_and_normalises_query(monkeypatch):
+    """Fragments never travel over HTTP so the rebuilt URL must have none,
+    and multi-value query strings must round-trip deterministically."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/x?a=1&a=2&b=3", headers={"Host": "localhost"})
+    assert resp.status_code == 301
+    assert resp.location == "https://localhost/x?a=1&a=2&b=3"
+
+
+def test_redirect_never_uses_spoofed_host_even_in_path(monkeypatch):
+    """Even if an attacker embeds a hostname-like string in the path, the
+    Location header still points at the allow-listed host."""
+    mod = _reload_inkypi(
+        monkeypatch,
+        env={"INKYPI_FORCE_HTTPS": "1", "INKYPI_ENV": "production"},
+    )
+    app = mod.app
+
+    client = app.test_client()
+    resp = client.get("/@evil.com/path", headers={"Host": "localhost"})
+    assert resp.status_code == 301
+    # The scheme://authority prefix must be the allow-listed host.
+    assert resp.location is not None
+    assert resp.location.startswith("https://localhost/")
+    assert "evil.com" not in resp.location.split("/", 3)[2]
+
+
 def test_allowed_host_ignores_port_suffix(monkeypatch):
     """``localhost:5000`` should count as the allow-listed ``localhost``."""
     mod = _reload_inkypi(

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.6"
+version = "0.49.11"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary
- Rebuild the HTTPS-upgrade redirect URL from individually validated components using `urlunsplit` (hard-coded `https` scheme, allow-listed authority, re-quoted path, re-urlencoded query) instead of concatenating `request.full_path`.
- Breaks the CodeQL `py/url-redirection` taint flow from the untrusted `Host` header into `redirect()` — alert #52 should now auto-close.
- Matches the repo's established fix pattern for this rule: validate-then-reuse leaves the alert open; rebuild from validated parts closes it.

## Why the previous fix (PR #317) left the alert open
PR #317 added a host allow-list but still passed a string built from `request.full_path` into `redirect()`. CodeQL's taint tracker doesn't model the allow-list `in` check as sanitisation when the *same* tainted `request.full_path` then flows into the sink. Rebuilding via `urlunsplit` with freshly-serialised path/query components removes the taint edge.

## Test plan
- [x] `tests/unit/test_security_middleware_https_redirect.py` — 12 tests pass (3 new regression tests added for re-quoting, query round-trip, and host-in-path spoofing).
- [x] Full suite: 3874 passed, 5 skipped.
- [x] `scripts/lint.sh` green (ruff + black + shellcheck + mypy strict subset).
- [ ] Post-merge: confirm CodeQL re-scan closes alert #52.

Closes JTN-317.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>