### PR TITLE
fix(history): polish pass — source fallback, metric tooltip, danger zone (JTN-626, JTN-631, JTN-649)

### DIFF
--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -3836,6 +3836,62 @@ input:disabled, select:disabled, textarea:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  margin-top: 8px;
+  padding: 20px;
+  border-width: 2px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--error) 20%, transparent);
+}
+
+.history-danger-zone .danger-zone-body {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.history-danger-zone p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.history-danger-zone h3 {
+  color: var(--error);
+}
+
+.danger-zone-divider {
+  margin: 28px 0 16px;
+  border: 0;
+  border-top: 1px solid var(--panel-border);
+  opacity: 0.75;
+}
+
+.danger-zone-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-bottom: 2px;
+}
+
+.history-source-unknown {
+  color: var(--text-muted, var(--text-secondary));
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .history-danger-zone {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .history-danger-zone .header-button.is-danger {
+    width: 100%;
+  }
 }
 
 .thumbnail-preview-modal {

--- a/src/static/styles/partials/_history.css
+++ b/src/static/styles/partials/_history.css
@@ -113,6 +113,62 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  margin-top: 8px;
+  padding: 20px;
+  border-width: 2px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--error) 20%, transparent);
+}
+
+.history-danger-zone .danger-zone-body {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.history-danger-zone p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.history-danger-zone h3 {
+  color: var(--error);
+}
+
+.danger-zone-divider {
+  margin: 28px 0 16px;
+  border: 0;
+  border-top: 1px solid var(--panel-border);
+  opacity: 0.75;
+}
+
+.danger-zone-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-bottom: 2px;
+}
+
+.history-source-unknown {
+  color: var(--text-muted, var(--text-secondary));
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .history-danger-zone {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .history-danger-zone .header-button.is-danger {
+    width: 100%;
+  }
 }
 
 .thumbnail-preview-modal {

--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -56,27 +56,30 @@
             </div>
         </div>
         {% if metrics and (metrics.request_ms is not none or metrics.generate_ms is not none or metrics.preprocess_ms is not none or metrics.display_ms is not none) %}
-        <div class="metric-strip compact">
+        <p id="history-metric-strip-desc" class="sr-only">
+            Latencies from the most recent refresh. Values are per-stage durations in milliseconds.
+        </p>
+        <div class="metric-strip compact" role="group" aria-label="Latest refresh latency" aria-describedby="history-metric-strip-desc">
             {% if metrics.request_ms is not none %}
-            <div class="metric-pill">
+            <div class="metric-pill" title="Time spent fetching upstream data during the last refresh" aria-label="Request latency: {{ metrics.request_ms }} milliseconds (time fetching upstream data on last refresh)">
                 <span class="metric-pill-label">Request</span>
                 <span class="metric-pill-value">{{ metrics.request_ms }} ms</span>
             </div>
             {% endif %}
             {% if metrics.generate_ms is not none %}
-            <div class="metric-pill">
+            <div class="metric-pill" title="Time spent rendering the plugin image during the last refresh" aria-label="Generate latency: {{ metrics.generate_ms }} milliseconds (plugin render time on last refresh)">
                 <span class="metric-pill-label">Generate</span>
                 <span class="metric-pill-value">{{ metrics.generate_ms }} ms</span>
             </div>
             {% endif %}
             {% if metrics.preprocess_ms is not none %}
-            <div class="metric-pill">
+            <div class="metric-pill" title="Time spent preprocessing the image (resize, dither) during the last refresh" aria-label="Preprocess latency: {{ metrics.preprocess_ms }} milliseconds (resize and dither on last refresh)">
                 <span class="metric-pill-label">Preprocess</span>
                 <span class="metric-pill-value">{{ metrics.preprocess_ms }} ms</span>
             </div>
             {% endif %}
             {% if metrics.display_ms is not none %}
-            <div class="metric-pill">
+            <div class="metric-pill" title="Time spent pushing pixels to the e-ink panel during the last refresh" aria-label="Display latency: {{ metrics.display_ms }} milliseconds (pushing pixels to the panel on last refresh)">
                 <span class="metric-pill-label">Display</span>
                 <span class="metric-pill-value">{{ metrics.display_ms }} ms</span>
             </div>
@@ -87,13 +90,15 @@
 
         {% include 'partials/history_grid.html' %}
         {% if total > 0 %}
-        <div class="danger-zone history-danger-zone">
-            <div>
-                <h3>Reset cache</h3>
-                <p>Remove all saved history images from this device when you want to reclaim local storage quickly.</p>
+        <hr class="danger-zone-divider" aria-hidden="true">
+        <section class="danger-zone history-danger-zone" role="region" aria-labelledby="historyDangerZoneTitle">
+            <div class="danger-zone-body">
+                <span class="danger-zone-label">Danger zone</span>
+                <h3 id="historyDangerZoneTitle">Reset cache</h3>
+                <p>Remove all saved history images from this device when you want to reclaim local storage quickly. This action cannot be undone.</p>
             </div>
             <button id="historyClearBtn" class="header-button is-danger" type="button">Clear All</button>
-        </div>
+        </section>
         {% endif %}
     </div>
 

--- a/src/templates/partials/history_grid.html
+++ b/src/templates/partials/history_grid.html
@@ -15,7 +15,7 @@
                 <div class="history-name" title="{{ img.filename }}">{{ img.filename }}</div>
                 <div class="history-sub">{{ img.mtime_str }} • {{ img.size_str }}</div>
                 {% if img.meta and (img.meta.refresh_type or img.meta.plugin_id) %}
-                <div class="history-sub">
+                <div class="history-sub history-source">
                     <span>Source:</span>
                     <span>
                         {{ img.meta.refresh_type or "Manual" }}
@@ -23,6 +23,11 @@
                         {%- if img.meta.playlist %} &bull; {{ img.meta.playlist }}{% endif %}
                         {%- if img.meta.plugin_instance and img.meta.plugin_instance != img.meta.plugin_id %} &bull; {{ img.meta.plugin_instance }}{% endif %}
                     </span>
+                </div>
+                {% else %}
+                <div class="history-sub history-source history-source-unknown" title="No provenance metadata was recorded for this entry. Older history entries predate source tracking.">
+                    <span>Source:</span>
+                    <span>Unknown</span>
                 </div>
                 {% endif %}
             </div>

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -565,8 +565,8 @@ def test_history_manual_metadata_rendered(client, device_config_dev):
     assert "weather" in text
 
 
-def test_history_no_sidecar_no_source(client, device_config_dev):
-    """Entries without JSON sidecars should not show a Source line."""
+def test_history_no_sidecar_shows_unknown_source(client, device_config_dev):
+    """Entries without JSON sidecars show a consistent "Source: Unknown" line (JTN-631)."""
     d = device_config_dev.history_image_dir
     os.makedirs(d, exist_ok=True)
     fname = "display_20250101_040000.png"
@@ -577,7 +577,10 @@ def test_history_no_sidecar_no_source(client, device_config_dev):
     assert resp.status_code == 200
     text = resp.get_data(as_text=True)
     assert "display_20250101_040000" in text
-    assert "Source:" not in text
+    # Every entry now shows a Source line for consistency
+    assert "Source:" in text
+    assert "Unknown" in text
+    assert "history-source-unknown" in text
 
 
 def test_history_metadata_deduplicates_instance(client, device_config_dev):
@@ -904,3 +907,54 @@ def test_history_pagination_next_disabled_on_last_page(client, device_config_dev
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "pagination-disabled" in body
+
+
+# ---------------------------------------------------------------------------
+# JTN-626 — metric chips expose context via tooltip / aria-label
+# ---------------------------------------------------------------------------
+
+
+def test_history_metric_pills_have_context_tooltip(client, device_config_dev):
+    """Metric chips (Generate, Request, etc.) must have a title and aria-label
+    so users can tell what the "2622 ms" number actually measures."""
+    # Force a refresh_info with a generate_ms value so the pill is rendered.
+    device_config = device_config_dev
+    ri = device_config.get_refresh_info()
+    ri.generate_ms = 2622
+    ri.request_ms = 100
+    ri.preprocess_ms = 50
+    ri.display_ms = 800
+
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Region exposes an aria-label and a hidden describedby paragraph
+    assert 'aria-label="Latest refresh latency"' in body
+    assert 'id="history-metric-strip-desc"' in body
+    # Each pill has a tooltip and explanatory aria-label
+    assert "Time spent rendering the plugin image" in body
+    assert "Generate latency: 2622 milliseconds" in body
+    assert "Request latency: 100 milliseconds" in body
+
+
+# ---------------------------------------------------------------------------
+# JTN-649 — danger zone has clear visual separation + label
+# ---------------------------------------------------------------------------
+
+
+def test_history_danger_zone_has_visual_separation(client, device_config_dev):
+    """Reset-cache section should render as a distinct danger zone with a
+    divider, a "Danger zone" label, and a region landmark (JTN-649)."""
+    d = device_config_dev.history_image_dir
+    os.makedirs(d, exist_ok=True)
+    Image.new("RGB", (10, 10), "white").save(os.path.join(d, "display_jtn649_01.png"))
+
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "danger-zone-divider" in body
+    assert "danger-zone-label" in body
+    assert "Danger zone" in body
+    # Section landmark wraps the reset-cache controls
+    assert 'role="region"' in body
+    assert 'aria-labelledby="historyDangerZoneTitle"' in body

--- a/tests/static/test_ui_enhancements.py
+++ b/tests/static/test_ui_enhancements.py
@@ -108,6 +108,10 @@ def test_main_css_contains_workflow_and_management_shells(client):
     assert ".settings-console-layout" in css_content
     assert ".settings-side-nav" in css_content
     assert ".danger-zone" in css_content
+    # JTN-649 — history danger zone has a divider + label + unknown-source style
+    assert ".danger-zone-divider" in css_content
+    assert ".danger-zone-label" in css_content
+    assert ".history-source-unknown" in css_content
     assert ".playlist-toggle-button" in css_content
     assert ".modal-sheet" in css_content
     assert "body.modal-open" in css_content


### PR DESCRIPTION
## Summary

Three related history-page polish fixes bundled together.

- **JTN-626** — Metric chips (`Request` / `Generate` / `Preprocess` / `Display`) now carry a `title` tooltip and a descriptive `aria-label` so users can tell what a raw "2622 ms" number actually measures. The strip is wrapped in a region landmark with a screen-reader-only describedby paragraph.
- **JTN-631** — Every history entry now renders a Source line. Entries without sidecar provenance show `Source: Unknown` in a muted italic style with a tooltip explaining older entries predate source tracking. Consistent UI beats silent omission.
- **JTN-649** — The reset-cache section is now a proper danger zone: horizontal divider above, red "Danger zone" pill label, error-colored heading, beefier padding/border, region landmark, and stacked layout on narrow viewports (Clear All becomes full-width).

## Test plan

- [x] Integration: `test_history_no_sidecar_shows_unknown_source` — "Unknown" fallback renders
- [x] Integration: `test_history_metric_pills_have_context_tooltip` — metric chips carry `title=` and explanatory `aria-label`
- [x] Integration: `test_history_danger_zone_has_visual_separation` — divider, label, and region landmark render
- [x] Static: `.danger-zone-divider`, `.danger-zone-label`, `.history-source-unknown` asserted in bundled CSS
- [x] Full suite: 3873 passed, 5 skipped
- [x] `scripts/lint.sh` — ruff + black + shellcheck all clean

Closes JTN-626, JTN-631, JTN-649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)