### PR TITLE
fix(history): add context labels and tooltips to header metric chips (JTN-626)

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -218,22 +218,61 @@ def history_page():
                 history_dir, offset=start, limit=per_page
             )
 
-    # Pull latest timing metrics if available
+    # Pull latest timing metrics if available, along with provenance context
+    # (plugin + timestamp) so the template can label the chips unambiguously.
+    metrics: dict = {
+        "request_ms": None,
+        "generate_ms": None,
+        "preprocess_ms": None,
+        "display_ms": None,
+        "plugin_id": None,
+        "plugin_display_name": None,
+        "refresh_type": None,
+        "refresh_time": None,
+        "refresh_time_str": None,
+    }
     try:
         ri = device_config.get_refresh_info()
-        metrics = {
-            "request_ms": getattr(ri, "request_ms", None),
-            "generate_ms": getattr(ri, "generate_ms", None),
-            "preprocess_ms": getattr(ri, "preprocess_ms", None),
-            "display_ms": getattr(ri, "display_ms", None),
-        }
+        metrics["request_ms"] = getattr(ri, "request_ms", None)
+        metrics["generate_ms"] = getattr(ri, "generate_ms", None)
+        metrics["preprocess_ms"] = getattr(ri, "preprocess_ms", None)
+        metrics["display_ms"] = getattr(ri, "display_ms", None)
+        plugin_id = getattr(ri, "plugin_id", None) or None
+        metrics["plugin_id"] = plugin_id
+        metrics["refresh_type"] = getattr(ri, "refresh_type", None) or None
+        refresh_time = getattr(ri, "refresh_time", None) or None
+        metrics["refresh_time"] = refresh_time
+        # Resolve plugin display name if we have a plugin id.
+        if plugin_id:
+            try:
+                plugins_list = device_config.get_plugins() or []
+                for p in plugins_list:
+                    if p.get("id") == plugin_id:
+                        metrics["plugin_display_name"] = (
+                            p.get("display_name") or plugin_id
+                        )
+                        break
+            except Exception:
+                logger.exception("Failed to resolve plugin display name")
+        # Format the refresh timestamp in the device timezone when possible.
+        if refresh_time:
+            try:
+                dt = datetime.fromisoformat(refresh_time)
+                tz_now = (
+                    now_device_tz(device_config)
+                    if device_config
+                    else datetime.now(tz=get_timezone("UTC"))
+                )
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                dt = dt.astimezone(tz_now.tzinfo)
+                metrics["refresh_time_str"] = (
+                    dt.strftime("%Y-%m-%d %H:%M").lstrip("0").replace(" 0", " ")
+                )
+            except Exception:
+                metrics["refresh_time_str"] = refresh_time
     except Exception:
-        metrics = {
-            "request_ms": None,
-            "generate_ms": None,
-            "preprocess_ms": None,
-            "display_ms": None,
-        }
+        logger.exception("Failed to load refresh metrics for history page")
     # Compute storage usage for the history directory's filesystem
     free_bytes = None
     total_bytes = None

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -701,6 +701,27 @@ main[data-page-shell="workflow"] .frame {
   padding: 12px;
 }
 
+.metric-strip-block {
+  margin-bottom: 18px;
+}
+
+.metric-strip-block .metric-strip {
+  margin-bottom: 0;
+}
+
+.metric-strip-heading {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  color: var(--text);
+}
+
+.metric-strip-caption {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0 0 10px 0;
+}
+
 .empty-state {
   text-align: center;
   padding: 40px 20px;

--- a/src/static/styles/partials/_layout.css
+++ b/src/static/styles/partials/_layout.css
@@ -447,6 +447,27 @@ main[data-page-shell="workflow"] .frame {
   padding: 12px;
 }
 
+.metric-strip-block {
+  margin-bottom: 18px;
+}
+
+.metric-strip-block .metric-strip {
+  margin-bottom: 0;
+}
+
+.metric-strip-heading {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  color: var(--text);
+}
+
+.metric-strip-caption {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0 0 10px 0;
+}
+
 .empty-state {
   text-align: center;
   padding: 40px 20px;

--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -56,32 +56,53 @@
             </div>
         </div>
         {% if metrics and (metrics.request_ms is not none or metrics.generate_ms is not none or metrics.preprocess_ms is not none or metrics.display_ms is not none) %}
-        <div class="metric-strip compact">
-            {% if metrics.request_ms is not none %}
-            <div class="metric-pill">
-                <span class="metric-pill-label">Request</span>
-                <span class="metric-pill-value">{{ metrics.request_ms }} ms</span>
+        {% set _plugin_label = metrics.plugin_display_name or metrics.plugin_id or 'the most recent plugin' %}
+        {% set _when_label = metrics.refresh_time_str or metrics.refresh_time %}
+        {% set _context_suffix %}{% if _when_label %} on {{ _when_label }}{% endif %}{% endset %}
+        <section class="metric-strip-block" aria-labelledby="latestRenderHeading">
+            <h2 id="latestRenderHeading" class="metric-strip-heading">Last render timings</h2>
+            <p class="metric-strip-caption">
+                {% if metrics.plugin_display_name or metrics.plugin_id %}
+                    Most recent refresh for <strong>{{ _plugin_label }}</strong>{% if _when_label %} on {{ _when_label }}{% endif %}{% if metrics.refresh_type %} ({{ metrics.refresh_type }}){% endif %}.
+                {% else %}
+                    Timings from the most recent refresh{% if _when_label %} on {{ _when_label }}{% endif %}.
+                {% endif %}
+            </p>
+            <div class="metric-strip compact" role="list">
+                {% if metrics.request_ms is not none %}
+                <div class="metric-pill" role="listitem"
+                     title="Request phase of the last image generation for {{ _plugin_label }}{{ _context_suffix }}"
+                     aria-label="Request phase: {{ metrics.request_ms }} milliseconds for {{ _plugin_label }}{{ _context_suffix }}">
+                    <span class="metric-pill-label">Request</span>
+                    <span class="metric-pill-value">{{ metrics.request_ms }} ms</span>
+                </div>
+                {% endif %}
+                {% if metrics.generate_ms is not none %}
+                <div class="metric-pill" role="listitem"
+                     title="Last image generation for {{ _plugin_label }}{{ _context_suffix }}"
+                     aria-label="Generate phase: {{ metrics.generate_ms }} milliseconds for {{ _plugin_label }}{{ _context_suffix }}">
+                    <span class="metric-pill-label">Generate</span>
+                    <span class="metric-pill-value">{{ metrics.generate_ms }} ms</span>
+                </div>
+                {% endif %}
+                {% if metrics.preprocess_ms is not none %}
+                <div class="metric-pill" role="listitem"
+                     title="Preprocess phase of the last image generation for {{ _plugin_label }}{{ _context_suffix }}"
+                     aria-label="Preprocess phase: {{ metrics.preprocess_ms }} milliseconds for {{ _plugin_label }}{{ _context_suffix }}">
+                    <span class="metric-pill-label">Preprocess</span>
+                    <span class="metric-pill-value">{{ metrics.preprocess_ms }} ms</span>
+                </div>
+                {% endif %}
+                {% if metrics.display_ms is not none %}
+                <div class="metric-pill" role="listitem"
+                     title="Display update phase of the last render for {{ _plugin_label }}{{ _context_suffix }}"
+                     aria-label="Display phase: {{ metrics.display_ms }} milliseconds for {{ _plugin_label }}{{ _context_suffix }}">
+                    <span class="metric-pill-label">Display</span>
+                    <span class="metric-pill-value">{{ metrics.display_ms }} ms</span>
+                </div>
+                {% endif %}
             </div>
-            {% endif %}
-            {% if metrics.generate_ms is not none %}
-            <div class="metric-pill">
-                <span class="metric-pill-label">Generate</span>
-                <span class="metric-pill-value">{{ metrics.generate_ms }} ms</span>
-            </div>
-            {% endif %}
-            {% if metrics.preprocess_ms is not none %}
-            <div class="metric-pill">
-                <span class="metric-pill-label">Preprocess</span>
-                <span class="metric-pill-value">{{ metrics.preprocess_ms }} ms</span>
-            </div>
-            {% endif %}
-            {% if metrics.display_ms is not none %}
-            <div class="metric-pill">
-                <span class="metric-pill-label">Display</span>
-                <span class="metric-pill-value">{{ metrics.display_ms }} ms</span>
-            </div>
-            {% endif %}
-        </div>
+        </section>
         {% endif %}
         <div class="separator"></div>
 

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -99,6 +99,67 @@ def test_history_page_moves_clear_action_to_reset_cache(client, device_config_de
     assert 'id="historyClearBtn"' in body
 
 
+def test_history_metric_chips_include_plugin_context(client, device_config_dev):
+    """JTN-626: header timing chips must carry provenance context.
+
+    The GENERATE / Request / Preprocess / Display chips shown above the grid
+    must be labelled with the plugin and refresh timestamp they came from,
+    both as a visible caption and via ``title`` / ``aria-label`` attributes so
+    screen-reader and hover users get the same disambiguating context.
+    """
+    from model import RefreshInfo
+
+    device_config_dev.refresh_info = RefreshInfo(
+        refresh_type="Playlist",
+        plugin_id="weather",
+        refresh_time="2026-04-08T19:40:00+00:00",
+        image_hash=0,
+        request_ms=123,
+        generate_ms=2622,
+        preprocess_ms=45,
+        display_ms=678,
+    )
+
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    # Visible label / caption so the chips are explained in-page.
+    assert "Last render timings" in body
+    assert "Most recent refresh for" in body
+    # Plugin name resolves to the registered display_name ("Weather") when
+    # the plugin_id is registered, otherwise falls back to the raw plugin_id.
+    assert "Weather" in body or "weather" in body
+    # Refresh timestamp is surfaced in the caption.
+    assert "2026-04-08" in body
+    assert "Playlist" in body
+
+    # Every rendered chip must carry both a title tooltip and an aria-label
+    # that names the plugin and timestamp; the Generate chip specifically must
+    # reference "image generation" (the event being measured).
+    assert 'title="Last image generation for' in body
+    assert "on 2026-04-08 19:40" in body
+    assert 'aria-label="Generate phase: 2622 milliseconds for' in body
+    assert 'aria-label="Request phase: 123 milliseconds for' in body
+
+
+def test_history_metric_chips_hidden_when_no_metrics(client, device_config_dev):
+    """Without any timing data the header block should not render at all."""
+    from model import RefreshInfo
+
+    device_config_dev.refresh_info = RefreshInfo(
+        refresh_type="Manual Update",
+        plugin_id="",
+        refresh_time=None,
+        image_hash=None,
+    )
+
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    assert "Last render timings" not in body
+
+
 def test_history_image_blocks_path_traversal(client):
     """Bug 4: history_image should reject path traversal attempts."""
     resp = client.get("/history/image/../../etc/passwd")


### PR DESCRIPTION
## Summary
- History page header showed bare `GENERATE / 2622 ms` chips with no explanation of what event the time measured, when it was taken, or which plugin it came from.
- Wrap the strip in a labelled section ("Last render timings") with a caption naming the plugin, refresh timestamp, and refresh type, and give every chip a `title` + `aria-label` carrying the full provenance (e.g. `Last image generation for Weather on 2026-04-08 19:40`).
- Extend the blueprint context with `plugin_id`, `plugin_display_name`, `refresh_type`, and a device-timezone-formatted `refresh_time_str` derived from the latest `RefreshInfo`.

## Test plan
- [x] `pytest tests/integration/test_history.py` — 52 passed, including two new regression tests covering present + absent metrics.
- [x] `pytest tests/` — 3873 passed, 5 skipped.
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean; mypy advisory only.

Linear: JTN-626

🤖 Generated with [Claude Code](https://claude.com/claude-code)