### PR TITLE
test(a11y): guard Style accordion chevron flip (JTN-643)

### DIFF
--- a/tests/integration/test_collapsible_sections_e2e.py
+++ b/tests/integration/test_collapsible_sections_e2e.py
@@ -58,6 +58,51 @@ def test_settings_tabs_switch(live_server, browser_page):
         assert page.locator("#saveSettingsBtn").is_visible()
 
 
+def test_plugin_style_accordion_chevron_flips(live_server, browser_page):
+    """JTN-643: The Style accordion chevron on plugin pages must visually flip
+    between the collapsed (▼) and expanded (▲) states, matching Settings.
+
+    The CSS contract is driven by `aria-expanded`: when the header has
+    `aria-expanded="true"`, `_toggle.css` applies `transform: rotate(180deg)`
+    to `.collapsible-icon`. This test exercises the real browser so a future
+    regression (e.g. removing the CSS rule, swapping the chevron to a display
+    mode transforms can't apply to, or forgetting to toggle aria-expanded)
+    is caught end-to-end.
+    """
+    page = browser_page
+    navigate_and_wait(page, live_server, "/plugin/weather")
+
+    header = page.locator("button.collapsible-header[data-collapsible-toggle]").first
+    icon = header.locator(".collapsible-icon")
+
+    # Collapsed baseline: aria-expanded=false, no rotation applied.
+    assert header.get_attribute("aria-expanded") == "false"
+    transform_collapsed = icon.evaluate("el => getComputedStyle(el).transform")
+    assert transform_collapsed in (
+        "none",
+        "matrix(1, 0, 0, 1, 0, 0)",
+    ), f"Collapsed icon should not be rotated; got {transform_collapsed!r}"
+
+    # Expand and verify the 180deg rotation is applied.
+    header.click()
+    page.wait_for_timeout(300)
+    assert header.get_attribute("aria-expanded") == "true"
+    transform_expanded = icon.evaluate("el => getComputedStyle(el).transform")
+    # A 180deg rotation serialises as matrix(-1, 0, 0, -1, 0, 0).
+    assert (
+        transform_expanded == "matrix(-1, 0, 0, -1, 0, 0)"
+    ), f"Expanded icon should be rotated 180deg; got {transform_expanded!r}"
+    # For transforms to take effect the element cannot be a plain inline box.
+    assert icon.evaluate("el => getComputedStyle(el).display") != "inline"
+
+    # Collapse again and confirm the rotation is cleared.
+    header.click()
+    page.wait_for_timeout(300)
+    assert header.get_attribute("aria-expanded") == "false"
+    transform_collapsed_again = icon.evaluate("el => getComputedStyle(el).transform")
+    assert transform_collapsed_again in ("none", "matrix(1, 0, 0, 1, 0, 0)")
+
+
 def test_playlist_details_expand(live_server, device_config_dev, browser_page):
     """Playlist details toggle expands and collapses on desktop."""
     prepare_playlist(device_config_dev)

--- a/tests/static/test_collapsible_icon_direction.py
+++ b/tests/static/test_collapsible_icon_direction.py
@@ -8,6 +8,11 @@ the chevron character stays ▼ in markup and the `.collapsible-header[aria-expa
 .collapsible-icon { transform: rotate(180deg); }` rule in _toggle.css rotates it
 when the section is open. This avoids a double-flip when both mechanisms were
 active, which made the chevron appear unchanged between states.
+
+JTN-643 added a regression guard: the chevron span must remain in a
+non-inline box (via `float: right` or an explicit `display:` value) so the
+CSS transform actually applies — transforms have no visible effect on plain
+inline boxes, which would silently bring the "stuck ▼" bug back.
 """
 
 
@@ -70,6 +75,42 @@ def test_collapsible_css_rotates_icon_when_expanded(client):
         '.collapsible-header[aria-expanded="true"] .collapsible-icon' in compact
     ), "CSS rule driving chevron rotation from aria-expanded is missing"
     assert "rotate(180deg)" in compact
+
+
+def test_collapsible_icon_is_not_inline_so_transform_applies(client):
+    """JTN-643: CSS `transform` has no visible effect on plain inline boxes.
+
+    The chevron span relies on being rendered as a block-level box (via
+    `float: right`, which implicitly computes display to block) so the
+    `rotate(180deg)` rule actually flips it. If a future refactor drops the
+    float without replacing it with an explicit non-inline display, the
+    chevron would silently stay ▼ in every state — the exact regression
+    JTN-643 reported.
+    """
+    resp = client.get("/static/styles/main.css")
+    assert resp.status_code == 200
+    css = resp.get_data(as_text=True)
+    compact = " ".join(css.split())
+
+    # Locate the `.collapsible-icon { ... }` declaration block.
+    needle = ".collapsible-icon {"
+    start = compact.find(needle)
+    assert start != -1, "`.collapsible-icon` rule not found in bundled CSS"
+    block_end = compact.find("}", start)
+    block = compact[start:block_end]
+
+    # Either `float: right` (which implicitly makes the box non-inline) or an
+    # explicit non-inline `display` is required for `transform` to apply.
+    has_float = "float: right" in block or "float:right" in block
+    has_block_display = any(
+        f"display: {mode}" in block or f"display:{mode}" in block
+        for mode in ("block", "inline-block", "flex", "inline-flex", "grid")
+    )
+    assert has_float or has_block_display, (
+        "`.collapsible-icon` must establish a non-inline box so `transform: "
+        "rotate(180deg)` can actually flip the chevron. Add `float: right` "
+        "or an explicit `display:` declaration."
+    )
 
 
 def test_collapsible_click_is_delegated_in_ui_helpers(client):


### PR DESCRIPTION
## Summary
- PR #389 (JTN-623) already fixed the "Style ▼ stays ▼" behaviour by letting CSS rotate `.collapsible-icon` 180deg off `[aria-expanded="true"]`. Verified live on `/plugin/weather`: click flips `aria-expanded` to `true` and computes `transform: matrix(-1,0,0,-1,0,0)`, rendering the chevron as ▲.
- JTN-643 was filed ~30 min before #389 merged (as a secondary symptom tracked separately) and is already resolved in code. This PR adds regression guards so the "stuck chevron" symptom cannot silently return.

## Changes
- `tests/static/test_collapsible_icon_direction.py`: new assertion that `.collapsible-icon` keeps `float: right` (or declares a non-inline `display:`). Dropping the float without replacement would silently break the rotate transform while aria-expanded still flipped — the exact regression JTN-643 reported.
- `tests/integration/test_collapsible_sections_e2e.py`: new Playwright test exercising the Style header on `/plugin/weather`. Asserts both `aria-expanded` toggling AND the computed `transform` matrix on the chevron span, plus that the span is not `display: inline`.

## Test plan
- [x] `SKIP_BROWSER=1 pytest tests/` — 3872 passed, 5 skipped
- [x] `pytest tests/integration/test_collapsible_sections_e2e.py tests/static/test_collapsible_icon_direction.py` — 10 passed
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean
- [x] Manual verify via Playwright: ▼ (collapsed) → ▲ (expanded) → ▼ (collapsed) on `/plugin/weather`

Closes JTN-643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)