### PR TITLE
fix(csp): drop redundant UnicodeDecodeError in except clause (JTN-653)

### DIFF
--- a/src/blueprints/csp_report.py
+++ b/src/blueprints/csp_report.py
@@ -65,7 +65,9 @@ def _parse_report(body: bytes) -> dict:
         return {}
     try:
         data = json.loads(body)
-    except (ValueError, UnicodeDecodeError) as exc:
+    except ValueError as exc:
+        # Note: UnicodeDecodeError is a subclass of ValueError and is
+        # covered here too (non-UTF-8 bytes raise it from json.loads).
         raise _MalformedReport(str(exc)) from exc
 
     # Legacy format: {"csp-report": {...}}

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.6"
+version = "0.49.11"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary
- SonarCloud `python:S5713` (MINOR) flagged `src/blueprints/csp_report.py:68`: the `except (ValueError, UnicodeDecodeError)` tuple is redundant because `UnicodeDecodeError` is a subclass of `ValueError` and is already caught by the base branch.
- Drop `UnicodeDecodeError` and leave an inline comment noting that non-UTF-8 payloads are still covered via inheritance.
- No behavior change; all 18 `test_csp_report.py` tests (including malformed-JSON coverage) still pass.

## Changes
- `src/blueprints/csp_report.py`: simplify the `except` clause in `_parse_report`.

## Test plan
- [x] `pytest tests/test_csp_report.py` - 18 passed
- [x] Full suite: 3871 passed, 5 skipped
- [x] `scripts/lint.sh` - clean (ruff + black + shellcheck)

Fixes JTN-653. SonarCloud issue key: `AZ2DOgkqdAmmyX96gixr`.