### PR TITLE
fix(auth): close open-redirect by rebuilding next URL from validated parts (JTN-654)

### DIFF
--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
+from urllib.parse import quote, unquote, urlsplit
 
 from flask import (
     Blueprint,
@@ -25,19 +27,65 @@ _MAX_FAILED_ATTEMPTS = 5
 _LOCKOUT_SECONDS = 60
 _LOGIN_TEMPLATE = "login.html"
 
+# Allow-list of characters permitted in each decoded path segment. Any
+# segment containing other characters causes the redirect to fall back to '/'.
+_SAFE_SEGMENT_RE = re.compile(r"\A[A-Za-z0-9\-._~!$&'()*+,;=:@]*\Z")
+
 
 def _safe_next_url(raw: str | None) -> str:
-    """Return *raw* only when it's a same-origin relative path; otherwise '/'.
+    """Return a safe same-origin redirect path, or '/' when *raw* is unsafe.
 
-    Open-redirect guard: rejects schemes, network-location URLs, protocol-relative
-    URLs, and anything that does not start with a single '/'. Empty/None → '/'.
+    Open-redirect guard (CodeQL py/url-redirection, JTN-326): the returned
+    path is *reconstructed* from validated structural pieces (decoded path
+    segments passed through an allow-list regex and then re-quoted) rather
+    than being the raw request string. CodeQL's taint tracker does not
+    propagate through validate-then-reuse patterns, so building the result
+    from `quote()` of literal-safe components is what clears the alert.
+
+    Rejects schemes, network-location URLs, protocol-relative URLs ('//evil'),
+    backslash tricks ('/\\evil'), anything not starting with a single '/',
+    and any segment containing characters outside the conservative path
+    allow-list (e.g., control chars, '<', '>', whitespace).
     """
     if not raw:
         return "/"
-    # Reject protocol-relative ('//evil.com') and absolute ('http://evil.com')
-    if not raw.startswith("/") or raw.startswith("//"):
+    # Reject any control characters (newlines, tabs, NUL, etc.) up front —
+    # urlsplit silently strips some of them, which could otherwise let a
+    # payload bypass the segment allow-list.
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in raw):
         return "/"
-    return raw
+    # Reject protocol-relative ('//evil.com') and backslash-authority tricks.
+    if not raw.startswith("/") or raw.startswith("//") or raw.startswith("/\\"):
+        return "/"
+    # Parse with a dummy scheme+host so urlsplit routes the value through the
+    # standard URL parser; we only consume the path+query components below.
+    try:
+        parts = urlsplit("http://localhost" + raw)
+    except ValueError:
+        return "/"
+    # Any netloc from the parse means the raw value slipped past the prefix
+    # checks (shouldn't happen given the checks above, but belt-and-braces).
+    if parts.netloc != "localhost":
+        return "/"
+    # Validate each decoded path segment against the allow-list, then rebuild
+    # the path from re-quoted literals. This severs the taint chain from
+    # `raw` to the returned value, since the result is a concatenation of
+    # quote()'d validated segments with literal '/' separators.
+    safe_segments: list[str] = []
+    for segment in parts.path.split("/"):
+        decoded = unquote(segment)
+        if not _SAFE_SEGMENT_RE.fullmatch(decoded):
+            return "/"
+        safe_segments.append(quote(decoded, safe=""))
+    safe_path = "/".join(safe_segments) or "/"
+    if not safe_path.startswith("/"):
+        safe_path = "/" + safe_path
+    # Preserve an optional query string, rebuilt from allow-listed characters.
+    if parts.query:
+        if not re.fullmatch(r"[A-Za-z0-9\-._~!$&'()*+,;=:@/?%]*", parts.query):
+            return safe_path
+        safe_path = safe_path + "?" + parts.query
+    return safe_path
 
 
 def _is_locked_out() -> bool:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -284,3 +284,61 @@ class TestAuthEnabled:
 
         with client.session_transaction() as sess:
             assert sess.get("authed") is not True
+
+
+# ---------------------------------------------------------------------------
+# Tests — open-redirect guard (_safe_next_url)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeNextUrl:
+    """Regression tests for CodeQL py/url-redirection guard in blueprints.auth."""
+
+    @pytest.fixture()
+    def safe_next_url(self, monkeypatch):
+        _make_auth_app(pin=None, monkeypatch=monkeypatch)
+        from blueprints.auth import _safe_next_url
+
+        return _safe_next_url
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            None,
+            "",
+            "http://evil.com/",
+            "https://evil.com/path",
+            "//evil.com/path",
+            "/\\evil.com",
+            "javascript:alert(1)",
+            "foo/bar",  # missing leading slash
+            "/path\nwith-newline",
+            "/path with space",
+            "/<script>",
+        ],
+    )
+    def test_rejects_unsafe_inputs(self, safe_next_url, raw):
+        assert safe_next_url(raw) == "/"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "/",
+            "/home",
+            "/settings/general",
+            "/plugin/weather/123",
+            "/path/to-thing_with.chars~",
+        ],
+    )
+    def test_accepts_safe_paths(self, safe_next_url, raw):
+        # Result must be a same-origin relative path starting with '/'.
+        result = safe_next_url(raw)
+        assert result.startswith("/")
+        assert "://" not in result
+        # Re-quoted segments should preserve the meaningful path structure.
+        assert result.rstrip("/") == raw.rstrip("/") or result == "/"
+
+    def test_preserves_safe_query_string(self, safe_next_url):
+        result = safe_next_url("/home?tab=latest&page=2")
+        assert result.startswith("/home?")
+        assert "tab=latest" in result

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.15"
+version = "0.49.16"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary

CodeQL `py/url-redirection` alerts [#55](https://github.com/jtn0123/InkyPi/security/code-scanning/55) and [#56](https://github.com/jtn0123/InkyPi/security/code-scanning/56) flagged `src/blueprints/auth.py:69` and `:96` because `_safe_next_url` previously returned the raw request string after a structural check — a **validate-then-reuse** pattern that CodeQL's taint tracker does not follow through.

Per the lesson from JTN-317 (see `memory/feedback_codeql_url_redirection.md`): the fix is to **rebuild** the URL from validated structural components, not validate-then-reuse.

## Changes

- `src/blueprints/auth.py` — rewrite `_safe_next_url` so the returned value is reconstructed from validated structural components:
  1. Reject empty/None, control characters (newlines, NUL, etc. that `urlsplit` silently strips), protocol-relative URLs (`//evil`), backslash-authority (`/\\evil`), and anything not starting with `/`
  2. Parse via `urlsplit("http://localhost" + raw)` to route through the stdlib URL parser
  3. Decode each path segment, validate against a strict allow-list regex, and re-quote via `urllib.parse.quote(..., safe="")`
  4. Re-join with literal `/` separators; append optional query string only after it is independently validated

The returned value is now a concatenation of `quote()`'d literal-safe segments — CodeQL sees no data-flow from the raw request attribute to the returned path.

- `tests/test_auth.py` — add 17 parameterized regression tests covering unsafe inputs (protocol-relative, backslash tricks, control chars, schemes, disallowed chars), safe paths, and query-string preservation.

## Test plan

- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/test_auth.py` — 33/33 pass
- [x] Full suite — 3888 passed, 5 skipped
- [x] `scripts/lint.sh` — clean (ruff + black)
- [x] Closes CodeQL alerts #55 and #56

Linear: [JTN-654](https://linear.app/jtn0123/issue/JTN-654) (parent: JTN-326)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced URL redirect validation in authentication flows to improve security. The system now enforces rigorous checks on redirect paths to ensure proper and safe handling. Invalid or suspicious redirects are now rejected and handled securely with a fallback to a default location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->