### PR TITLE
fix(release): regenerate uv.lock + keep in sync on release (JTN-655)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,5 +120,9 @@ upload_to_pypi = false
 # build_command) avoids relying on shell {version} expansion, which PSR does
 # NOT perform — the previous `echo '{version}'` wrote the literal placeholder
 # into VERSION on every release.
-assets = ["VERSION"]
-build_command = "printf '%s\\n' \"$NEW_VERSION\" > VERSION"
+assets = ["VERSION", "uv.lock"]
+# Regenerate VERSION from the canonical pyproject.toml value AND refresh uv.lock
+# so the inkypi package version in the lockfile tracks the release bump.
+# Without `uv lock`, the lockfile drifts from pyproject.toml and the "Lockfile
+# drift" CI check fails on every new PR (see JTN-655).
+build_command = "printf '%s\\n' \"$NEW_VERSION\" > VERSION && uv lock"

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.16"
+version = "0.49.19"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary

- `main` had `uv.lock` drifting behind `pyproject.toml` (was 0.49.16 vs 0.49.19) — the **Lockfile drift** CI check was red on every new PR as a result.
- Regenerated `uv.lock` to match current `pyproject.toml` version.
- Extended the semantic-release `build_command` to run `uv lock` alongside the `VERSION` write, and added `uv.lock` to `assets` so future releases keep the lockfile in lockstep (JTN-655 item 2 — the durable fix).

Fixes JTN-655. Unblocks a parallel PR batch queued behind this.

## Test plan
- [x] `scripts/lint.sh` passes
- [x] `uv lock` produces the diff committed here
- [ ] Lockfile drift CI turns green
- [ ] Next release cycle regenerates `uv.lock` automatically (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process to automatically synchronize dependency files with project configuration during releases, ensuring build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->