### PR TITLE
fix(ui): close js/xss-through-dom on playlist.js (JTN-326)

### DIFF
--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -808,29 +808,19 @@
             const loadThumb = async (img) => {
                 if (img.getAttribute('data-loaded') === '1') return;
                 const url = img.getAttribute('data-src');
-                if (!url) return;
-                // Validate URL is a safe same-origin relative path before assigning
-                // to img.src. Thumbnails are always served as site-relative paths
-                // (e.g. "/static/images/..."), so we reject anything else to close
-                // the js/xss-through-dom taint flow from DOM-sourced attribute.
-                let safeUrl;
-                try {
-                    const parsed = new URL(url, window.location.origin);
-                    if (parsed.origin === window.location.origin &&
-                        (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
-                        safeUrl = parsed.pathname + parsed.search;
-                    }
-                } catch(_) { /* invalid URL — leave safeUrl undefined */ }
-                if (!safeUrl) {
+                // Strictly allow only site-relative thumbnail paths under /static/
+                // with a whitelisted character set. Rejects anything DOM-sourced
+                // that could flow into the img.src sink (js/xss-through-dom).
+                if (!url || !/^\/static\/[A-Za-z0-9._\-/]+(\?[A-Za-z0-9._\-=&%]*)?$/.test(url)) {
                     img.style.display = 'none';
                     const sk0 = img.previousElementSibling; if (sk0) sk0.style.display = 'none';
                     img.setAttribute('data-loaded', '1');
                     return;
                 }
                 try {
-                    const resp = await fetch(safeUrl, { method: 'HEAD' });
+                    const resp = await fetch(url, { method: 'HEAD' });
                     if (resp.ok) {
-                        img.src = safeUrl;
+                        img.src = url;
                         img.style.display = '';
                         img.setAttribute('data-loaded', '1');
                     } else {

--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -809,13 +809,28 @@
                 if (img.getAttribute('data-loaded') === '1') return;
                 const url = img.getAttribute('data-src');
                 if (!url) return;
+                // Validate URL is a safe same-origin relative path before assigning
+                // to img.src. Thumbnails are always served as site-relative paths
+                // (e.g. "/static/images/..."), so we reject anything else to close
+                // the js/xss-through-dom taint flow from DOM-sourced attribute.
+                let safeUrl;
                 try {
-                    const resp = await fetch(url, { method: 'HEAD' });
+                    const parsed = new URL(url, window.location.origin);
+                    if (parsed.origin === window.location.origin &&
+                        (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+                        safeUrl = parsed.pathname + parsed.search;
+                    }
+                } catch(_) { /* invalid URL — leave safeUrl undefined */ }
+                if (!safeUrl) {
+                    img.style.display = 'none';
+                    const sk0 = img.previousElementSibling; if (sk0) sk0.style.display = 'none';
+                    img.setAttribute('data-loaded', '1');
+                    return;
+                }
+                try {
+                    const resp = await fetch(safeUrl, { method: 'HEAD' });
                     if (resp.ok) {
-                        // lgtm[js/xss-through-dom] — assigning to img.src can never
-                        // execute JavaScript. The browser fetches the URL as an image;
-                        // even javascript:/data: URIs in <img src> do not run script.
-                        img.src = url;
+                        img.src = safeUrl;
                         img.style.display = '';
                         img.setAttribute('data-loaded', '1');
                     } else {

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.19"
+version = "0.49.20"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary
- Closes CodeQL alert #1 (`js/xss-through-dom`, warning) at `src/static/scripts/playlist.js:818`.
- Replaces an ineffective `lgtm[js/xss-through-dom]` comment with a real sanitizer: parse the DOM-sourced `data-src` value via `new URL(..., window.location.origin)`, require same-origin + http(s), and rebuild a safe `pathname + search` string before assigning it to `img.src` / `fetch()`.
- Thumbnails are always served as site-relative paths, so this is a no-op for legitimate values and rejects anything unexpected.

## Alert
- Rule: `js/xss-through-dom` — "DOM text reinterpreted as HTML"
- File: `src/static/scripts/playlist.js:818`

## Test plan
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean
- [x] `SKIP_BROWSER=1 pytest tests/static/` — 318 passed
- [x] `pytest tests/static/ -k playlist` — 36 passed
- [ ] CodeQL re-scan on PR confirms alert closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)