### PR TITLE
fix(security): redact sensitive data in base_plugin logs (JTN-326)

### DIFF
--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -200,6 +200,7 @@ class BasePlugin:
                 safe_err = redact_secrets(e)
                 logger.warning("Failed to read CSS file %s: %s", safe_path, safe_err)
                 raise RuntimeError(f"Unable to read CSS file {safe_path}") from e
+        extra_css: object = None
         try:
             extra_css = (template_params.get("plugin_settings", {}) or {}).get(
                 "extra_css"

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -10,6 +10,7 @@ from PIL import Image
 from utils.app_utils import get_fonts, resolve_path
 from utils.image_loader import AdaptiveImageLoader
 from utils.image_utils import take_screenshot_html
+from utils.logging_utils import redact_secrets
 from utils.progress import (
     complete_step,
     fail_step,
@@ -180,11 +181,11 @@ class BasePlugin:
                 try:
                     css_files.append(os.path.join(self.render_dir, fname))
                 except Exception as e:
-                    # lgtm[py/clear-text-logging-sensitive-data] — logs a CSS
-                    # filename and exception text. CodeQL taints `template_params`
-                    # upstream as potentially sensitive, but `fname` is a static
-                    # asset path and `e` is an os.path.join error string.
-                    logger.warning("Failed to add extra CSS file %s: %s", fname, e)
+                    logger.warning(
+                        "Failed to add extra CSS file %s: %s",
+                        redact_secrets(fname),
+                        redact_secrets(e),
+                    )
         return css_files
 
     def _build_inline_css(self, css_files, template_params):
@@ -195,11 +196,10 @@ class BasePlugin:
                 with open(css_path, encoding="utf-8") as f:
                     inline_css.append(f.read())
             except Exception as e:
-                # lgtm[py/clear-text-logging-sensitive-data] — logs an on-disk
-                # CSS file path and the OSError text. No credentials or user
-                # input flow into either argument.
-                logger.warning("Failed to read CSS file %s: %s", css_path, e)
-                raise RuntimeError(f"Unable to read CSS file {css_path}") from e
+                safe_path = redact_secrets(css_path)
+                safe_err = redact_secrets(e)
+                logger.warning("Failed to read CSS file %s: %s", safe_path, safe_err)
+                raise RuntimeError(f"Unable to read CSS file {safe_path}") from e
         try:
             extra_css = (template_params.get("plugin_settings", {}) or {}).get(
                 "extra_css"
@@ -207,11 +207,11 @@ class BasePlugin:
             if isinstance(extra_css, str) and extra_css.strip():
                 inline_css.append(extra_css)
         except Exception as e:
-            # lgtm[py/clear-text-logging-sensitive-data] — logs the user-provided
-            # extra_css string (CSS rules from plugin settings, not credentials)
-            # and the exception text when settings parsing fails. extra_css is
-            # plugin styling input, not a secret.
-            logger.warning("Failed to process extra CSS string %r: %s", extra_css, e)
+            safe_extra_css = redact_secrets(extra_css)
+            safe_err = redact_secrets(e)
+            logger.warning(
+                "Failed to process extra CSS string %r: %s", safe_extra_css, safe_err
+            )
             raise RuntimeError("Unable to process extra CSS string") from e
         return inline_css
 

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -81,6 +81,17 @@ def _redact(text: str) -> str:
     return text
 
 
+def redact_secrets(value: object) -> str:
+    """Return a string form of *value* with known secret patterns masked.
+
+    Public sanitizer for call sites that need to log values potentially
+    derived from user-supplied settings (e.g. ``template_params`` dicts that
+    CodeQL flags as sensitive sources). Non-string inputs are coerced with
+    ``str()`` before redaction.
+    """
+    return _redact(value if isinstance(value, str) else str(value))
+
+
 def _redact_value(value: object) -> object:
     """Redact *value* if it is a string; leave all other types untouched."""
     if isinstance(value, str):

--- a/tests/unit/test_base_plugin.py
+++ b/tests/unit/test_base_plugin.py
@@ -297,3 +297,86 @@ def test_render_image_with_screenshot_timeout(monkeypatch):
 
     assert out is not None
     assert captured_timeout[0] == 5000
+
+
+# ---- CSS helper exception-path tests (JTN-326) ----
+def test_build_inline_css_missing_file_raises_and_logs_redacted(caplog):
+    """_build_inline_css wraps missing CSS path in RuntimeError and logs a redacted message."""
+    import logging
+
+    from plugins.base_plugin.base_plugin import BasePlugin
+
+    p = BasePlugin({"id": "clock"})
+
+    missing = "/nonexistent/__inkypi_test__/style.css"
+    with caplog.at_level(logging.WARNING, logger="plugins.base_plugin.base_plugin"):
+        try:
+            p._build_inline_css([missing], {"plugin_settings": {}})
+        except RuntimeError as exc:
+            assert "Unable to read CSS file" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+    assert any("Failed to read CSS file" in r.getMessage() for r in caplog.records)
+
+
+def test_build_inline_css_extra_css_non_string_is_tolerated():
+    """extra_css that is not a string is ignored (no exception, no log)."""
+    from plugins.base_plugin.base_plugin import BasePlugin
+
+    p = BasePlugin({"id": "clock"})
+
+    # extra_css as a dict/list is simply skipped by the isinstance() guard.
+    out = p._build_inline_css([], {"plugin_settings": {"extra_css": {"bad": 1}}})
+    assert out == []
+
+
+def test_build_css_files_accepts_extra_css_files_list():
+    """_build_css_files happily appends valid filenames from the extra list."""
+    from plugins.base_plugin.base_plugin import BasePlugin
+
+    p = BasePlugin({"id": "clock"})
+
+    files = p._build_css_files("plugin.css", ["extra1.css", "extra2.css"])
+    assert any(f.endswith("extra1.css") for f in files)
+    assert any(f.endswith("extra2.css") for f in files)
+
+
+def test_build_css_files_bad_fname_is_logged_and_skipped(caplog):
+    """Non-string fname causes os.path.join to raise; warning is logged with redaction."""
+    import logging
+
+    from plugins.base_plugin.base_plugin import BasePlugin
+
+    p = BasePlugin({"id": "clock"})
+
+    with caplog.at_level(logging.WARNING, logger="plugins.base_plugin.base_plugin"):
+        # 42 is not a str/bytes — os.path.join raises TypeError
+        files = p._build_css_files(None, [42])
+
+    # Base plugin.css is still present; bad entry was skipped.
+    assert any(f.endswith("plugin.css") for f in files)
+    assert any("Failed to add extra CSS file" in r.getMessage() for r in caplog.records)
+
+
+def test_build_inline_css_extra_css_lookup_failure_raises_and_logs(caplog):
+    """A plugin_settings value that is truthy but not a Mapping raises AttributeError."""
+    import logging
+
+    from plugins.base_plugin.base_plugin import BasePlugin
+
+    p = BasePlugin({"id": "clock"})
+
+    with caplog.at_level(logging.WARNING, logger="plugins.base_plugin.base_plugin"):
+        try:
+            # plugin_settings=[1] is truthy, so `... or {}` short-circuits to [1],
+            # and list has no .get() — raises AttributeError inside the try block.
+            p._build_inline_css([], {"plugin_settings": [1]})
+        except RuntimeError as exc:
+            assert "Unable to process extra CSS string" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+    assert any(
+        "Failed to process extra CSS string" in r.getMessage() for r in caplog.records
+    )

--- a/tests/unit/test_redact_secrets.py
+++ b/tests/unit/test_redact_secrets.py
@@ -1,0 +1,40 @@
+"""Unit tests for utils.logging_utils.redact_secrets (JTN-326).
+
+Covers the public sanitizer used by call sites that log values which CodeQL
+flags as potentially sensitive (e.g. plugin ``template_params`` derived
+fields). The filter-level behaviour is covered elsewhere; these tests just
+exercise the direct function entry point.
+"""
+
+from utils.logging_utils import redact_secrets
+
+
+def test_redact_secrets_masks_api_key_assignment():
+    out = redact_secrets("api_key=supersecret123")
+    assert "supersecret123" not in out
+    assert "***REDACTED***" in out
+
+
+def test_redact_secrets_masks_bearer_token():
+    out = redact_secrets("Authorization: Bearer abc.def-XYZ_123=")
+    assert "abc.def-XYZ_123=" not in out
+    assert "***REDACTED***" in out
+
+
+def test_redact_secrets_masks_long_hex_string():
+    token = "a" * 40
+    out = redact_secrets(f"token value {token} trailing")
+    assert token not in out
+    assert "***REDACTED***" in out
+
+
+def test_redact_secrets_leaves_benign_string_unchanged():
+    text = "/opt/inkypi/plugins/foo/render/style.css"
+    assert redact_secrets(text) == text
+
+
+def test_redact_secrets_coerces_non_string_input():
+    err = FileNotFoundError("missing: /tmp/style.css")
+    out = redact_secrets(err)
+    assert isinstance(out, str)
+    assert "/tmp/style.css" in out

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.19"
+version = "0.49.20"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary
- Fixes CodeQL `py/clear-text-logging-sensitive-data` alerts #16 and #17 at `src/plugins/base_plugin/base_plugin.py:201` and `:214` (plus the sibling site at `:187` that shared the same taint).
- Introduces a public `redact_secrets()` helper in `src/utils/logging_utils.py` that reuses the existing secret-pattern sanitizer (powering `SecretRedactionFilter`) so CodeQL sees an explicit sanitizer barrier.
- Call sites now wrap `css_path`, `fname`, `extra_css`, and the exception text in `redact_secrets()` before formatting into the log message. Previous `# lgtm[...]` markers (honored by LGTM, not CodeQL) are removed.

## Why
Both sites log values derived from `template_params`, which CodeQL taints as potentially sensitive because plugin settings dicts can carry API keys. The existing global `SecretRedactionFilter` only runs at logger-handler time, which CodeQL does not recognize as a sanitizer for the message args. Redacting explicitly at the call site resolves the alert without altering behavior for benign paths.

## Test plan
- [x] New unit tests in `tests/unit/test_redact_secrets.py` cover api_key, Bearer token, long-hex, benign path, and non-string input cases.
- [x] `scripts/lint.sh` passes (ruff + black).
- [x] `SKIP_BROWSER=1 pytest tests/plugins/ tests/unit/` — 2516 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)