### PR TITLE
fix(security): suppress stack-trace exposure in main.py (JTN-326)

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -339,9 +339,9 @@ def display_next():
                 refresh_task.manual_update(
                     PlaylistRefresh(playlist, plugin_instance, force=True)
                 )
-            except Exception as exc:
+            except Exception:
                 logger.exception("manual_update failed")
-                return json_error(f"Plugin update failed: {exc}", status=400)
+                return json_error("Plugin update failed", status=400)
         else:
             # Direct path similar to update_now
             from time import perf_counter
@@ -356,8 +356,9 @@ def display_next():
             _t_gen_start = perf_counter()
             try:
                 image = plugin.generate_image(plugin_instance.settings, device_config)
-            except RuntimeError as exc:
-                return json_error(str(exc), status=400)
+            except RuntimeError:
+                logger.exception("generate_image failed in display_next")
+                return json_error("Plugin image generation failed", status=400)
             generate_ms = int((perf_counter() - _t_gen_start) * 1000)
             try:
                 save_stage_event(

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -339,7 +339,10 @@ def display_next():
                 refresh_task.manual_update(
                     PlaylistRefresh(playlist, plugin_instance, force=True)
                 )
-            except Exception:
+            except RuntimeError:
+                # refresh_task.manual_update raises RuntimeError when the
+                # manual-update queue is full; treat as a client-side 400.
+                # Other exceptions fall through to the outer 500 handler.
                 logger.exception("manual_update failed")
                 return json_error("Plugin update failed", status=400)
         else:

--- a/tests/unit/test_display_next_error_handling.py
+++ b/tests/unit/test_display_next_error_handling.py
@@ -58,7 +58,10 @@ class TestGenerateImageRuntimeError:
         assert resp.status_code == 400
         body = resp.get_json()
         assert body["success"] is False
-        assert "API key missing for clock plugin" in body["error"]
+        # Generic message only — raw exception detail must not leak
+        # (CodeQL py/stack-trace-exposure).
+        assert body["error"] == "Plugin image generation failed"
+        assert "API key missing for clock plugin" not in resp.get_data(as_text=True)
 
     @pytest.mark.integration
     def test_generate_image_runtime_error_does_not_trigger_cooldown(
@@ -150,5 +153,7 @@ class TestManualUpdateFailure:
         assert resp.status_code == 400
         body = resp.get_json()
         assert body["success"] is False
-        assert "Plugin update failed" in body["error"]
-        assert "background task crashed" in body["error"]
+        # Generic message only — raw exception detail must not leak
+        # (CodeQL py/stack-trace-exposure).
+        assert body["error"] == "Plugin update failed"
+        assert "background task crashed" not in resp.get_data(as_text=True)

--- a/tests/unit/test_main_blueprint_coverage.py
+++ b/tests/unit/test_main_blueprint_coverage.py
@@ -199,7 +199,7 @@ def test_display_next_after_successful_request_respects_cooldown(
 
 
 def test_display_next_exception(client, flask_app, device_config_dev):
-    """Plugin generation error via manual_update returns 400 with message."""
+    """Plugin generation error via manual_update returns 400 without leaking exception text."""
     mock_playlist = MagicMock()
     mock_plugin_inst = MagicMock()
     mock_plugin_inst.plugin_id = "test_plugin"
@@ -211,18 +211,65 @@ def test_display_next_exception(client, flask_app, device_config_dev):
     mock_playlist.name = "Test Playlist"
     mock_playlist.get_next_eligible_plugin.return_value = mock_plugin_inst
 
+    secret_detail = "SECRET_STACKTRACE_DETAIL_abc123"
     with patch.object(device_config_dev, "get_playlist_manager", return_value=mock_pm):
         refresh_task = flask_app.config["REFRESH_TASK"]
         refresh_task.running = True
-        refresh_task.manual_update = MagicMock(
-            side_effect=RuntimeError("generation failed")
-        )
+        refresh_task.manual_update = MagicMock(side_effect=RuntimeError(secret_detail))
 
         resp = client.post("/display-next")
     assert resp.status_code == 400
     body = resp.get_json()
-    assert "Plugin update failed" in body["error"]
-    assert "generation failed" in body["error"]
+    # Generic message only; raw exception detail must not leak to the client
+    # (CodeQL py/stack-trace-exposure regression).
+    assert body["error"] == "Plugin update failed"
+    assert secret_detail not in resp.get_data(as_text=True)
+
+
+def test_display_next_direct_generate_error_no_leak(
+    client, flask_app, device_config_dev
+):
+    """Direct (non-refresh_task) path must not leak RuntimeError text.
+
+    Regression for CodeQL py/stack-trace-exposure (src/blueprints/main.py:360).
+    """
+    mock_playlist = MagicMock()
+    mock_plugin_inst = MagicMock()
+    mock_plugin_inst.plugin_id = "test_plugin"
+    mock_plugin_inst.name = "Test"
+    mock_plugin_inst.settings = {}
+
+    mock_pm = MagicMock()
+    mock_pm.determine_active_playlist.return_value = mock_playlist
+    mock_playlist.name = "Test Playlist"
+    mock_playlist.get_next_eligible_plugin.return_value = mock_plugin_inst
+
+    secret_detail = "LEAKY_RUNTIME_DETAIL_xyz789"
+
+    mock_plugin = MagicMock()
+    mock_plugin.generate_image.side_effect = RuntimeError(secret_detail)
+
+    refresh_task = flask_app.config["REFRESH_TASK"]
+    refresh_task.running = False
+
+    with (
+        patch.object(device_config_dev, "get_playlist_manager", return_value=mock_pm),
+        patch.object(
+            device_config_dev,
+            "get_plugin",
+            return_value={"id": "test_plugin", "image_settings": []},
+        ),
+        patch(
+            "plugins.plugin_registry.get_plugin_instance",
+            return_value=mock_plugin,
+        ),
+    ):
+        resp = client.post("/display-next")
+
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["error"] == "Plugin image generation failed"
+    assert secret_detail not in resp.get_data(as_text=True)
 
 
 # ---- /api/plugin_order ----

--- a/uv.lock
+++ b/uv.lock
@@ -442,7 +442,7 @@ wheels = [
 
 [[package]]
 name = "inkypi"
-version = "0.49.19"
+version = "0.49.20"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },


### PR DESCRIPTION
## Summary
- CodeQL `py/stack-trace-exposure` (error) flagged `src/blueprints/main.py` at lines 344, 360, and 476 where raw exception detail leaked into JSON error responses.
- Both sinks (the `manual_update` path at 344 and the direct `generate_image` path at 360) now return a static message; the `/refresh` alias at 476 reaches the same code via `display_next`, so it is fixed transitively.
- Exceptions are still captured via `logger.exception(...)` for server-side diagnosis.

## Fix
- `return json_error(f\"Plugin update failed: {exc}\", ...)` -> `return json_error(\"Plugin update failed\", ...)`
- `return json_error(str(exc), ...)` -> `return json_error(\"Plugin image generation failed\", ...)` with a preceding `logger.exception(...)`.

## Test plan
- [x] New regression test `test_display_next_direct_generate_error_no_leak` asserts a secret RuntimeError string never appears in the response body.
- [x] Updated `test_display_next_exception` and the two existing tests in `tests/unit/test_display_next_error_handling.py` to assert the new sanitized body.
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck pass; mypy strict subset clean).
- [x] Full suite: `3934 passed, 5 skipped`.

Rule: `py/stack-trace-exposure` | Linear: JTN-326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses for plugin update failures now return a generic message instead of raw exception details.
  * Error responses for plugin image generation failures now return a generic message instead of raw exception details.

* **Tests**
  * Updated unit tests to verify correct error message formatting across multiple failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->