### PR TITLE
fix(security): redact weather plugin API key logging (JTN-326)

### DIFF
--- a/src/plugins/weather/weather_api.py
+++ b/src/plugins/weather/weather_api.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from utils.http_client import get_http_session
+from utils.logging_utils import redact_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -31,12 +32,12 @@ def get_weather_data(api_key, units, lat, long, timeout=20):
     url = WEATHER_URL.format(lat=lat, long=long, units=units, api_key=api_key)
     response = get_http_session().get(url, timeout=timeout)
     if not 200 <= response.status_code < 300:
-        # lgtm[py/clear-text-logging-sensitive-data] — logs the OpenWeatherMap
-        # error response body (JSON like {"cod":401,"message":"Invalid API key"}),
-        # not the api_key itself. The api_key is only embedded in `url` which is
-        # never logged. CodeQL taints `response` because the enclosing function
-        # accepts api_key, but the response body never contains it.
-        logger.error("Failed to retrieve weather data: %s", response.content)
+        # CodeQL taints `response` because the enclosing function accepts
+        # api_key; wrap with redact_secrets() to mask any accidental key
+        # leakage in the error body before logging.
+        logger.error(
+            "Failed to retrieve weather data: %s", redact_secrets(response.content)
+        )
         raise RuntimeError("Failed to retrieve weather data.")
 
     return response.json()
@@ -47,9 +48,9 @@ def get_air_quality(api_key, lat, long, timeout=20):
     response = get_http_session().get(url, timeout=timeout)
 
     if not 200 <= response.status_code < 300:
-        # lgtm[py/clear-text-logging-sensitive-data] — logs OWM air-pollution
-        # error body, not api_key. See get_weather_data() for full rationale.
-        logger.error("Failed to get air quality data: %s", response.content)
+        logger.error(
+            "Failed to get air quality data: %s", redact_secrets(response.content)
+        )
         raise RuntimeError("Failed to retrieve air quality data.")
 
     return response.json()
@@ -60,9 +61,7 @@ def get_location(api_key, lat, long, timeout=20):
     response = get_http_session().get(url, timeout=timeout)
 
     if not 200 <= response.status_code < 300:
-        # lgtm[py/clear-text-logging-sensitive-data] — logs OWM geocoding error
-        # body (e.g. invalid coordinates), not api_key. See get_weather_data().
-        logger.error(f"Failed to get location: {response.content}")
+        logger.error("Failed to get location: %s", redact_secrets(response.content))
         raise RuntimeError("Failed to retrieve location.")
 
     location_list = response.json()

--- a/src/plugins/weather/weather_data.py
+++ b/src/plugins/weather/weather_data.py
@@ -6,6 +6,8 @@ from zoneinfo import ZoneInfo
 
 from astral import moon
 
+from utils.logging_utils import redact_secrets
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,11 +93,13 @@ def get_wind_arrow(wind_deg: float) -> str:
 def parse_timezone(weatherdata):
     """Parse timezone from weather data"""
     if "timezone" in weatherdata:
-        # lgtm[py/clear-text-logging-sensitive-data] — logs the IANA timezone
-        # string (e.g. "America/Los_Angeles") from a public weather API response.
-        # CodeQL taints `weatherdata` because callers pass api_key to fetch it,
-        # but the timezone field never contains credentials.
-        logger.info(f"Using timezone from weather data: {weatherdata['timezone']}")
+        # CodeQL taints `weatherdata` because callers pass api_key to fetch it.
+        # Wrap with redact_secrets() so any credential-like substring is masked
+        # before reaching log handlers.
+        logger.info(
+            "Using timezone from weather data: %s",
+            redact_secrets(weatherdata["timezone"]),
+        )
         return ZoneInfo(weatherdata["timezone"])
     else:
         logger.error("Failed to retrieve Timezone from weather data")

--- a/tests/plugins/test_weather_redaction.py
+++ b/tests/plugins/test_weather_redaction.py
@@ -1,0 +1,87 @@
+# pyright: reportMissingImports=false
+"""Ensure weather plugin log calls redact potential API-key material (JTN-326).
+
+CodeQL flagged weather_api.py:39/52/65 and weather_data.py:98 with
+``py/clear-text-logging-sensitive-data`` because the enclosing functions
+receive ``api_key``. These tests confirm the response body / tainted value
+flowing into ``logger.*`` is wrapped with ``redact_secrets()`` so a leaked
+key in an upstream error payload (or timezone field) never hits the handlers
+in clear text.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from plugins.weather import weather_api, weather_data
+
+# A 40-char hex string — matches the "raw 32+ hex" secret pattern in
+# utils.logging_utils._SECRET_PATTERNS.
+_FAKE_API_KEY = "a" * 40
+_REDACTED = "***REDACTED***"
+
+
+class _FailingResponse:
+    status_code = 401
+
+    def __init__(self, body: bytes) -> None:
+        self.content = body
+
+    def json(self) -> dict:  # pragma: no cover - not hit on failure path
+        return {}
+
+
+def _install_failing_session(monkeypatch, body: bytes) -> None:
+    resp = _FailingResponse(body)
+    session = type("S", (), {"get": staticmethod(lambda *a, **kw: resp)})()
+    monkeypatch.setattr(weather_api, "get_http_session", lambda: session)
+
+
+@pytest.mark.parametrize(
+    "func, kwargs",
+    [
+        (
+            weather_api.get_weather_data,
+            {"api_key": _FAKE_API_KEY, "units": "metric", "lat": 0, "long": 0},
+        ),
+        (
+            weather_api.get_air_quality,
+            {"api_key": _FAKE_API_KEY, "lat": 0, "long": 0},
+        ),
+        (
+            weather_api.get_location,
+            {"api_key": _FAKE_API_KEY, "lat": 0, "long": 0},
+        ),
+    ],
+)
+def test_weather_api_redacts_response_body_on_error(func, kwargs, monkeypatch, caplog):
+    """Response body containing an API-key-shaped token must be redacted."""
+    leaky_body = (
+        b'{"cod":401,"message":"Invalid api_key=' + _FAKE_API_KEY.encode() + b'"}'
+    )
+    _install_failing_session(monkeypatch, leaky_body)
+
+    with caplog.at_level(logging.ERROR, logger="plugins.weather.weather_api"):
+        with pytest.raises(RuntimeError):
+            func(**kwargs)
+
+    combined = "\n".join(r.getMessage() for r in caplog.records)
+    assert _FAKE_API_KEY not in combined
+    assert _REDACTED in combined
+
+
+def test_parse_timezone_redacts_tainted_value(caplog):
+    """Timezone field reaching the log site is passed through redact_secrets."""
+    leaky = f"UTC api_key={_FAKE_API_KEY}"
+
+    with caplog.at_level(logging.INFO, logger="plugins.weather.weather_data"):
+        # ZoneInfo will reject the non-IANA string, so catch that — we only
+        # care about the log call that runs before the ZoneInfo() lookup.
+        with pytest.raises(Exception):
+            weather_data.parse_timezone({"timezone": leaky})
+
+    combined = "\n".join(r.getMessage() for r in caplog.records)
+    assert _FAKE_API_KEY not in combined
+    assert _REDACTED in combined


### PR DESCRIPTION
## Summary
- Closes CodeQL `py/clear-text-logging-sensitive-data` at:
  - `src/plugins/weather/weather_api.py:39`
  - `src/plugins/weather/weather_api.py:52`
  - `src/plugins/weather/weather_api.py:65`
  - `src/plugins/weather/weather_data.py:98`
- Wraps tainted values (response bodies and `weatherdata['timezone']`) with the existing `redact_secrets()` helper in `src/utils/logging_utils.py` (introduced by #421 — no duplication).
- Removes the prior `# lgtm[...]` suppression comments; fix is at the log-site.

## Test plan
- [x] New `tests/plugins/test_weather_redaction.py` parameterized over `get_weather_data` / `get_air_quality` / `get_location` and covering `parse_timezone` — asserts the fake API key is absent from caplog output and that `***REDACTED***` appears.
- [x] `SKIP_BROWSER=1 pytest tests/plugins/ -k weather` — 61 passed.
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck + strict mypy subset).

Parent epic: JTN-326.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by redacting sensitive credentials and API keys from error logs generated by weather API requests, preventing accidental exposure in system logs.

* **Tests**
  * Added comprehensive test coverage to verify that sensitive information is properly redacted from logging output across weather plugin API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->