### PR TITLE
fix(security): close py/reflective-xss in playlist blueprint (JTN-326)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -530,9 +530,7 @@ def create_playlist():
     try:
         playlist = playlist_manager.get_playlist(playlist_name)
         if playlist:
-            return json_error(
-                f"Playlist with name '{playlist_name}' already exists", status=400
-            )
+            return json_error("A playlist with that name already exists", status=400)
 
         # Prevent overlapping time windows
         try:
@@ -637,7 +635,7 @@ def update_playlist(playlist_name):
 
     playlist = playlist_manager.get_playlist(playlist_name)
     if not playlist:
-        return json_error(f"Playlist '{playlist_name}' does not exist", status=400)
+        return json_error("Playlist does not exist", status=400)
 
     # Prevent overlapping (exclude the playlist being updated)
     try:
@@ -675,8 +673,8 @@ def update_playlist(playlist_name):
         )
 
     if warning:
-        return json_success(f"Updated playlist '{playlist_name}'!", warning=warning)
-    return json_success(f"Updated playlist '{playlist_name}'!")
+        return json_success("Updated playlist!", warning=warning)
+    return json_success("Updated playlist!")
 
 
 @playlist_bp.route("/delete_playlist/<string:playlist_name>", methods=["DELETE"])
@@ -689,13 +687,13 @@ def delete_playlist(playlist_name):
 
     playlist = playlist_manager.get_playlist(playlist_name)
     if not playlist:
-        return json_error(f"Playlist '{playlist_name}' does not exist", status=400)
+        return json_error("Playlist does not exist", status=400)
 
     device_config.update_atomic(
         lambda cfg: playlist_manager.delete_playlist(playlist_name)
     )
 
-    return json_success(f"Deleted playlist '{playlist_name}'!")
+    return json_success("Deleted playlist!")
 
 
 @playlist_bp.route("/update_device_cycle", methods=["PUT"])
@@ -739,7 +737,7 @@ def reorder_plugins():
 
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error(f"Playlist '{playlist_name}' not found", status=400)
+            return json_error("Playlist not found", status=400)
 
         reorder_result: list[bool] = []
 
@@ -775,7 +773,7 @@ def display_next_in_playlist():
 
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error(f"Playlist '{playlist_name}' not found", status=400)
+            return json_error("Playlist not found", status=400)
 
         # Determine current time and next eligible
         current_dt = _safe_now_device_tz(device_config)
@@ -817,7 +815,7 @@ def playlist_eta(playlist_name: str):
 
     pl = playlist_manager.get_playlist(playlist_name)
     if not pl:
-        return json_error(f"Playlist '{playlist_name}' not found", status=404)
+        return json_error("Playlist not found", status=404)
 
     # Cache key is playlist name; invalidate once per minute
     now = _safe_now_device_tz(device_config)

--- a/tests/integration/test_playlist_xss.py
+++ b/tests/integration/test_playlist_xss.py
@@ -1,0 +1,115 @@
+"""Reflective XSS regression tests for the playlist blueprint.
+
+These tests craft payloads with user-controlled values (``playlist_name``,
+``new_name``) that contain raw HTML/JS and assert the response body does NOT
+echo the tags verbatim.  All playlist endpoints return JSON via
+``jsonify(...)``; JSON responses are served with
+``Content-Type: application/json`` and do not execute as HTML, but we still
+want to ensure error messages are generic and never interpolate the raw
+attacker-controlled value.
+"""
+
+from __future__ import annotations
+
+XSS_PAYLOADS = [
+    "<script>alert(1)</script>",
+    '"><img src=x onerror=alert(1)>',
+    "<svg/onload=alert(1)>",
+    "javascript:alert(1)",
+]
+
+
+def _assert_no_raw_reflection(body: bytes | str, payload: str) -> None:
+    text = body.decode() if isinstance(body, bytes) else body
+    assert (
+        payload not in text
+    ), f"Response echoed raw XSS payload {payload!r}; body was: {text[:300]!r}"
+
+
+def test_create_playlist_duplicate_does_not_reflect_name(client):
+    """create_playlist duplicate error must not echo playlist_name."""
+    # Seed a baseline playlist first
+    resp = client.post(
+        "/create_playlist",
+        json={
+            "playlist_name": "SafeName",
+            "start_time": "00:00",
+            "end_time": "01:00",
+        },
+    )
+    assert resp.status_code == 200
+
+    for payload in XSS_PAYLOADS:
+        # Try creating a duplicate-by-name with an XSS payload name.
+        # The validator will usually reject the name as invalid, but if a
+        # duplicate path is hit, it still must not reflect.
+        r = client.post(
+            "/create_playlist",
+            json={
+                "playlist_name": payload,
+                "start_time": "00:00",
+                "end_time": "01:00",
+            },
+        )
+        # Any 4xx is acceptable; the critical check is no reflection.
+        assert r.status_code >= 400
+        assert r.headers.get("Content-Type", "").startswith("application/json")
+        _assert_no_raw_reflection(r.data, payload)
+
+
+def test_update_playlist_missing_does_not_reflect_name(client):
+    for payload in XSS_PAYLOADS:
+        r = client.put(
+            f"/update_playlist/{payload}",
+            json={
+                "new_name": "Whatever",
+                "start_time": "00:00",
+                "end_time": "01:00",
+            },
+        )
+        assert r.status_code >= 400
+        assert r.headers.get("Content-Type", "").startswith("application/json")
+        _assert_no_raw_reflection(r.data, payload)
+
+
+def test_delete_playlist_missing_does_not_reflect_name(client):
+    for payload in XSS_PAYLOADS:
+        r = client.delete(f"/delete_playlist/{payload}")
+        assert r.status_code >= 400
+        # A Flask 404 from URL routing (no matching rule) serves HTML but does
+        # not echo the raw path segment, so only require JSON content-type when
+        # the route actually matched and our handler produced the response.
+        if r.status_code != 404:
+            assert r.headers.get("Content-Type", "").startswith("application/json")
+        _assert_no_raw_reflection(r.data, payload)
+
+
+def test_reorder_plugins_missing_does_not_reflect_name(client):
+    for payload in XSS_PAYLOADS:
+        r = client.post(
+            "/reorder_plugins",
+            json={"playlist_name": payload, "ordered": []},
+        )
+        assert r.status_code >= 400
+        assert r.headers.get("Content-Type", "").startswith("application/json")
+        _assert_no_raw_reflection(r.data, payload)
+
+
+def test_display_next_missing_does_not_reflect_name(client):
+    for payload in XSS_PAYLOADS:
+        r = client.post(
+            "/display_next_in_playlist",
+            json={"playlist_name": payload},
+        )
+        assert r.status_code >= 400
+        assert r.headers.get("Content-Type", "").startswith("application/json")
+        _assert_no_raw_reflection(r.data, payload)
+
+
+def test_playlist_eta_missing_does_not_reflect_name(client):
+    for payload in XSS_PAYLOADS:
+        r = client.get(f"/playlist/eta/{payload}")
+        assert r.status_code >= 400
+        if r.status_code != 404:
+            assert r.headers.get("Content-Type", "").startswith("application/json")
+        _assert_no_raw_reflection(r.data, payload)


### PR DESCRIPTION
## Summary
Closes CodeQL `py/reflective-xss` alerts in `src/blueprints/playlist.py` by removing f-string interpolation of user-controlled playlist names from error and success response messages. All affected routes return JSON via `jsonify(...)` (Content-Type `application/json`), but removing the reflection closes the alerts at their root and hardens against future content-type handling regressions.

Strategy (per `feedback_codeql_url_redirection.md` precedent): use generic messages rather than echoing the tainted value. Covers CodeQL rule [py/reflective-xss](https://codeql.github.com/codeql-query-help/python/py-reflective-xss/).

## Alerts closed (original line numbers in playlist.py)
- L519, L523, L533 — `create_playlist` duplicate-name error
- L629, L640 — `update_playlist` not-found error
- L692 — `delete_playlist` not-found error
- L742 — `reorder_plugins` not-found error
- L778 — `display_next_in_playlist` not-found error
- L820 — `playlist_eta` not-found error

Also made `update_playlist` / `delete_playlist` success messages generic for consistency.

## Test plan
- [x] `tests/integration/test_playlist_xss.py` — new file POSTs/PUTs/DELETEs/GETs payloads (`<script>alert(1)</script>`, `\"><img src=x onerror=alert(1)>`, `<svg/onload=alert(1)>`, `javascript:alert(1)`) to each affected route and asserts the raw payload does not appear in the response body. Handler-produced responses are also asserted to carry `Content-Type: application/json`.
- [x] Existing playlist suite green: 235 passed, 0 failed (`-k playlist` across unit+integration).
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck + mypy strict subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)