### PR TITLE
fix(security): close reflected-xss + stack-trace in plugin blueprint (JTN-326)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -22,7 +22,6 @@ from utils.app_utils import handle_request_files, parse_form, resolve_path
 from utils.fallback_image import render_error_image
 from utils.form_utils import (
     sanitize_log_field,
-    sanitize_response_value,
     validate_plugin_required_fields,
 )
 from utils.http_utils import APIError, json_error, json_success
@@ -42,6 +41,10 @@ _ERR_INTERNAL = "An internal error occurred"
 _ERR_NOT_FOUND = "Not Found"
 _MSG_DISPLAY_UPDATED = "Display updated"
 _ERR_PLUGIN_ID_REQUIRED = "plugin_id is required"
+_ERR_PLUGIN_INSTANCE_NOT_FOUND = "Plugin instance not found"
+_ERR_PLUGIN_NOT_FOUND = "Plugin not found"
+_ERR_PLAYLIST_NOT_FOUND = "Playlist not found"
+_MSG_CIRCUIT_BREAKER_RESET = "Circuit-breaker reset for plugin instance."
 
 
 def _cacheable_send_file(path: str, ttl_env: str = "INKYPI_RENDER_CACHE_TTL_S"):
@@ -87,8 +90,13 @@ def plugin_page(plugin_id: str):
                 plugin_id, plugin_instance_name
             )
             if not plugin_instance:
+                logger.warning(
+                    "Plugin instance lookup failed: plugin_id=%s instance=%s",
+                    sanitize_log_field(plugin_id),
+                    sanitize_log_field(plugin_instance_name),
+                )
                 return json_error(
-                    f"Plugin instance: {sanitize_response_value(plugin_instance_name)} does not exist",
+                    _ERR_PLUGIN_INSTANCE_NOT_FOUND,
                     status=404,
                 )
             template_params["plugin_settings"] = plugin_instance.settings
@@ -301,8 +309,13 @@ def update_plugin_instance(instance_name: str):
             )
         plugin_instance = playlist_manager.find_plugin(plugin_id, instance_name)
         if not plugin_instance:
+            logger.warning(
+                "update_instance: plugin instance not found plugin_id=%s instance=%s",
+                sanitize_log_field(plugin_id),
+                sanitize_log_field(instance_name),
+            )
             return json_error(
-                f"Plugin instance: {sanitize_response_value(instance_name)} does not exist",
+                _ERR_PLUGIN_INSTANCE_NOT_FOUND,
                 status=404,
             )
 
@@ -391,12 +404,23 @@ def display_plugin_instance():
     try:
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error(f"Playlist {playlist_name} not found", status=400)
+            logger.warning(
+                "display_plugin_instance: playlist not found name=%s",
+                sanitize_log_field(playlist_name),
+            )
+            return json_error(_ERR_PLAYLIST_NOT_FOUND, status=400)
 
         plugin_instance = playlist.find_plugin(plugin_id, plugin_instance_name)
         if not plugin_instance:
+            logger.warning(
+                "display_plugin_instance: plugin instance not found "
+                "playlist=%s plugin_id=%s instance=%s",
+                sanitize_log_field(playlist_name),
+                sanitize_log_field(plugin_id),
+                sanitize_log_field(plugin_instance_name),
+            )
             return json_error(
-                f"Plugin instance '{sanitize_response_value(plugin_instance_name)}' not found",
+                _ERR_PLUGIN_INSTANCE_NOT_FOUND,
                 status=400,
             )
 
@@ -426,12 +450,22 @@ def force_retry_plugin_instance(plugin_id: str, instance_name: str):
         return json_error("Circuit-breaker reset not supported", status=501)
     found = refresh_task.reset_circuit_breaker(plugin_id, instance_name)
     if not found:
+        logger.warning(
+            "force_retry: plugin instance not found plugin_id=%s instance=%s",
+            sanitize_log_field(plugin_id),
+            sanitize_log_field(instance_name),
+        )
         return json_error(
-            f"Plugin instance '{sanitize_response_value(instance_name)}' not found",
+            _ERR_PLUGIN_INSTANCE_NOT_FOUND,
             status=404,
         )
+    logger.info(
+        "Circuit-breaker reset for plugin_id=%s instance=%s",
+        sanitize_log_field(plugin_id),
+        sanitize_log_field(instance_name),
+    )
     return json_success(
-        message=f"Circuit-breaker reset for '{sanitize_response_value(instance_name)}'.",
+        message=_MSG_CIRCUIT_BREAKER_RESET,
     )
 
 
@@ -461,9 +495,11 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
     """
     plugin_config = device_config.get_plugin(plugin_id)
     if not plugin_config:
-        return json_error(
-            f"Plugin '{sanitize_response_value(plugin_id)}' not found", status=404
+        logger.warning(
+            "_update_now_direct: plugin not found plugin_id=%s",
+            sanitize_log_field(plugin_id),
         )
+        return json_error(_ERR_PLUGIN_NOT_FOUND, status=404)
 
     plugin = get_plugin_instance(plugin_config)
     with track_progress() as tracker:
@@ -473,9 +509,10 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
             image = plugin.generate_image(plugin_settings, device_config)
         except RuntimeError as e:
             # RuntimeError is raised by plugins to signal a user-actionable
-            # failure (bad config, upstream API returned empty, etc.).  The
-            # message is explicitly authored by the plugin as user-facing copy
-            # and is safe to surface — plugins should never put secrets there.
+            # failure (bad config, upstream API returned empty, etc.).  Do not
+            # echo the exception text to the client — CodeQL
+            # py/stack-trace-exposure, and plugin messages can occasionally
+            # embed tainted fragments.  Log the details server-side (JTN-326).
             logger.exception(
                 "Plugin %s failed to generate preview",
                 sanitize_log_field(plugin_id),
@@ -484,7 +521,7 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
                 plugin_id, plugin_config, device_config, display_manager, e
             )
             return json_error(
-                sanitize_response_value(str(e)),
+                _ERR_INTERNAL,
                 status=400,
                 code="plugin_error",
             )
@@ -816,10 +853,13 @@ def _save_plugin_settings_common(
     htmx = _is_htmx_request()
     plugin_config = device_config.get_plugin(plugin_id)
     if not plugin_config:
-        msg = f"Plugin '{sanitize_response_value(plugin_id)}' not found"
+        logger.warning(
+            "_save_plugin_settings_common: plugin not found plugin_id=%s",
+            sanitize_log_field(plugin_id),
+        )
         if htmx:
-            return _render_plugin_form_error(msg, status=404)
-        return json_error(msg, status=404)
+            return _render_plugin_form_error(_ERR_PLUGIN_NOT_FOUND, status=404)
+        return json_error(_ERR_PLUGIN_NOT_FOUND, status=404)
 
     # Validate required fields and plugin-specific settings
     try:

--- a/tests/integration/test_api_json_errors.py
+++ b/tests/integration/test_api_json_errors.py
@@ -22,7 +22,11 @@ def test_update_now_surfaces_plugin_error_json(client, monkeypatch):
     assert resp.status_code == 400
     data = resp.get_json()
     assert isinstance(data, dict)
-    assert data["error"] == "boom"
+    # JTN-326: plugin RuntimeError text must NOT be echoed back
+    # (py/stack-trace-exposure).  Response is now a generic message.
+    assert "boom" not in data["error"]
+    assert data["error"] == "An internal error occurred"
+    assert data.get("code") == "plugin_error"
 
 
 def test_save_plugin_settings_error_json(client, flask_app, monkeypatch):

--- a/tests/integration/test_jtn_341_clock_preview.py
+++ b/tests/integration/test_jtn_341_clock_preview.py
@@ -130,9 +130,11 @@ def test_clock_update_preview_runtime_error_returns_400_and_logs(
     assert resp.status_code == 400
     body = resp.json or {}
     assert body.get("success") is False
-    # Plugin-authored message (plugins raise RuntimeError with user-visible copy)
-    # must be surfaced.  This is the contract: silent success -> visible error.
-    assert plugin_authored_message in body.get("error", "")
+    # JTN-326: the plugin RuntimeError message is NO LONGER reflected back to
+    # the client (py/stack-trace-exposure).  The response carries a generic
+    # message and the real cause is logged server-side.
+    assert plugin_authored_message not in body.get("error", "")
+    assert body.get("error") == "An internal error occurred"
     assert body.get("code") == "plugin_error"
 
     # logger.exception (JTN-318): stacktrace must be captured, and any record

--- a/tests/integration/test_plugin_htmx.py
+++ b/tests/integration/test_plugin_htmx.py
@@ -53,7 +53,10 @@ def test_save_plugin_settings_htmx_returns_error_partial_when_plugin_missing(cli
     body = resp.get_data(as_text=True)
     assert "validation-message error" in body
     assert "data-plugin-form-error" in body
-    assert "not_real_plugin" in body
+    # JTN-326: generic error — plugin_id is NOT reflected in the response body
+    # (py/reflective-xss).
+    assert "not_real_plugin" not in body
+    assert "Plugin not found" in body
 
 
 def test_save_plugin_settings_htmx_returns_error_partial_when_plugin_id_missing(client):

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -8,11 +8,14 @@ def test_plugin_page_not_found(client):
 
 
 def test_plugin_page_sanitizes_missing_instance_name(client):
+    """JTN-326: response body must not reflect user input — py/reflective-xss."""
     resp = client.get("/plugin/ai_text?instance=%3Cscript%3Ealert(1)%3C%2Fscript%3E")
     assert resp.status_code == 404
     error = resp.get_json().get("error", "")
     assert "<script>" not in error
-    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in error
+    assert "&lt;script&gt;" not in error
+    assert "alert(1)" not in error
+    assert error == "Plugin instance not found"
 
 
 # Skip this test - the exception handling is already covered by existing tests
@@ -89,10 +92,15 @@ def test_update_plugin_instance_missing_instance_name(client):
 def test_update_plugin_instance_plugin_not_found(client):
     resp = client.put("/update_plugin_instance/test", data={"plugin_id": "nonexistent"})
     assert resp.status_code == 404
-    assert "Plugin instance: test does not exist" in resp.get_json().get("error", "")
+    assert "Plugin instance not found" in resp.get_json().get("error", "")
 
 
-def test_update_plugin_instance_sanitizes_missing_instance_name(client):
+def test_update_plugin_instance_does_not_reflect_instance_name(client):
+    """JTN-326: tainted URL path must not be echoed in the response body.
+
+    Regression test for py/reflective-xss CodeQL alert — error message is
+    now fully generic and the user-supplied instance name is only logged.
+    """
     resp = client.put(
         "/update_plugin_instance/%3Cscript%3Ealert(1)%3E",
         data={"plugin_id": "ai_text"},
@@ -100,7 +108,9 @@ def test_update_plugin_instance_sanitizes_missing_instance_name(client):
     assert resp.status_code == 404
     error = resp.get_json().get("error", "")
     assert "<script>" not in error
-    assert "&lt;script&gt;alert(1)&gt;" in error
+    assert "&lt;script&gt;" not in error
+    assert "alert(1)" not in error
+    assert error == "Plugin instance not found"
 
 
 def test_update_plugin_instance_api_error_handling(client, flask_app, monkeypatch):
@@ -144,7 +154,7 @@ def test_display_plugin_instance_playlist_not_found(client):
         },
     )
     assert resp.status_code == 400
-    assert "Playlist NonExistent not found" in resp.get_json().get("error", "")
+    assert resp.get_json().get("error", "") == "Playlist not found"
 
 
 def test_display_plugin_instance_plugin_not_found(client):
@@ -157,10 +167,11 @@ def test_display_plugin_instance_plugin_not_found(client):
         },
     )
     assert resp.status_code == 400
-    assert "Plugin instance 'nonexistent' not found" in resp.get_json().get("error", "")
+    assert "Plugin instance not found" in resp.get_json().get("error", "")
 
 
-def test_display_plugin_instance_sanitizes_missing_instance_name(client):
+def test_display_plugin_instance_does_not_reflect_instance_name(client):
+    """JTN-326: tainted body must not be echoed — py/reflective-xss regression."""
     resp = client.post(
         "/display_plugin_instance",
         json={
@@ -172,7 +183,27 @@ def test_display_plugin_instance_sanitizes_missing_instance_name(client):
     assert resp.status_code == 400
     error = resp.get_json().get("error", "")
     assert "<script>" not in error
-    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in error
+    assert "&lt;script&gt;" not in error
+    assert "alert(1)" not in error
+    assert error == "Plugin instance not found"
+
+
+def test_display_plugin_instance_does_not_reflect_playlist_name(client):
+    """JTN-326: tainted playlist_name must not be echoed — py/reflective-xss."""
+    resp = client.post(
+        "/display_plugin_instance",
+        json={
+            "playlist_name": "<img src=x onerror=alert(1)>",
+            "plugin_id": "ai_text",
+            "plugin_instance": "test",
+        },
+    )
+    assert resp.status_code == 400
+    error = resp.get_json().get("error", "")
+    assert "<img" not in error
+    assert "onerror" not in error
+    assert "alert(1)" not in error
+    assert error == "Playlist not found"
 
 
 def test_display_plugin_instance_exception_handling(client, flask_app, monkeypatch):
@@ -196,7 +227,21 @@ def test_display_plugin_instance_exception_handling(client, flask_app, monkeypat
 def test_update_now_plugin_not_found(client):
     resp = client.post("/update_now", data={"plugin_id": "nonexistent"})
     assert resp.status_code == 404
-    assert "Plugin 'nonexistent' not found" in resp.get_json().get("error", "")
+    error = resp.get_json().get("error", "")
+    assert error == "Plugin not found"
+    # JTN-326: plugin_id must NOT be reflected in the response body.
+    assert "nonexistent" not in error
+
+
+def test_update_now_does_not_reflect_plugin_id(client):
+    """JTN-326: tainted plugin_id form value must not be reflected."""
+    resp = client.post("/update_now", data={"plugin_id": "<script>alert(1)</script>"})
+    assert resp.status_code == 404
+    error = resp.get_json().get("error", "")
+    assert "<script>" not in error
+    assert "&lt;script&gt;" not in error
+    assert "alert(1)" not in error
+    assert error == "Plugin not found"
 
 
 def test_update_now_async_returns_202_with_job_id(client):
@@ -383,13 +428,37 @@ def test_save_plugin_settings_exception_handling(client, flask_app, monkeypatch)
 def test_save_plugin_settings_rejects_unknown_plugin_id(client):
     resp = client.post("/save_plugin_settings", data={"plugin_id": "not_real_plugin"})
     assert resp.status_code == 404
-    assert resp.get_json()["error"] == "Plugin 'not_real_plugin' not found"
+    error = resp.get_json()["error"]
+    assert error == "Plugin not found"
+    # JTN-326: plugin_id must NOT be reflected.
+    assert "not_real_plugin" not in error
 
 
 def test_save_plugin_settings_alias_rejects_unknown_plugin_id(client):
     resp = client.post("/plugin/not_real_plugin/save", data={"title": "Test"})
     assert resp.status_code == 404
-    assert resp.get_json()["error"] == "Plugin 'not_real_plugin' not found"
+    error = resp.get_json()["error"]
+    assert error == "Plugin not found"
+    # JTN-326: URL path plugin_id must NOT be reflected.
+    assert "not_real_plugin" not in error
+
+
+def test_save_plugin_settings_alias_does_not_reflect_url_plugin_id(client):
+    """JTN-326: URL-path plugin_id (py/reflective-xss alert line 756) scrubbed.
+
+    The Flask route converter accepts an arbitrary non-slash string, so a
+    tainted plugin_id reaches the handler unchanged.  Verify that the 404
+    response body does NOT contain any part of the user-supplied id.
+    """
+    tainted = "xss_marker_abc123"
+    resp = client.post(
+        f"/plugin/{tainted}/save",
+        data={"title": "Test"},
+    )
+    assert resp.status_code == 404
+    error = resp.get_json()["error"]
+    assert tainted not in error
+    assert error == "Plugin not found"
 
 
 def test_delete_plugin_instance_missing(client):
@@ -671,12 +740,18 @@ def test_plugin_page_instance_url_plus_encoding_decoded_correctly(
 def test_plugin_page_instance_nonexistent_returns_friendly_404(
     client, device_config_dev
 ):
-    """GET /plugin/<id>?instance=<missing> returns 404 with a descriptive message (JTN-221)."""
+    """GET /plugin/<id>?instance=<missing> returns 404 (JTN-221 / JTN-326).
+
+    Message is now generic — instance name is only logged server-side to
+    avoid reflecting user input (py/reflective-xss).
+    """
     resp = client.get("/plugin/weather?instance=nonexistent instance")
     assert resp.status_code == 404
     body = resp.get_json()
     assert body is not None
-    assert "nonexistent instance" in body.get("error", "")
+    error = body.get("error", "")
+    assert error == "Plugin instance not found"
+    assert "nonexistent" not in error
 
 
 def test_plugin_page_without_instance_param_still_works(client):

--- a/tests/integration/test_plugin_update_now.py
+++ b/tests/integration/test_plugin_update_now.py
@@ -58,7 +58,10 @@ def test_update_now_ai_image_missing_key(client):
     assert resp.status_code == 400
     body = resp.get_json()
     assert body["code"] == "plugin_error"
-    assert "API Key not configured" in body["error"]
+    # JTN-326: plugin RuntimeError text is no longer echoed — the response is
+    # a generic message (py/stack-trace-exposure).  The actual reason is logged.
+    assert "API Key" not in body["error"]
+    assert body["error"] == "An internal error occurred"
 
 
 def test_update_now_apod_missing_key(client):
@@ -66,12 +69,19 @@ def test_update_now_apod_missing_key(client):
     assert resp.status_code == 400
     body = resp.get_json()
     assert body["code"] == "plugin_error"
-    assert body["error"] == "NASA API Key not configured."
+    # JTN-326: generic error — exception text is no longer exposed.
+    assert body["error"] == "An internal error occurred"
+    assert "NASA" not in body["error"]
 
 
-def test_update_now_returns_error_message_for_missing_key(client):
-    """Verify that /update_now surfaces the actual plugin error message."""
+def test_update_now_returns_generic_error_for_missing_key(client):
+    """JTN-326: /update_now must return a generic error, not the plugin
+    exception text (py/stack-trace-exposure, plugin.py:705)."""
     resp = client.post("/update_now", data={"plugin_id": "apod"})
     assert resp.status_code == 400
     body = resp.get_json()
-    assert body["error"] == "NASA API Key not configured."
+    assert body["error"] == "An internal error occurred"
+    assert body["code"] == "plugin_error"
+    # No fragment of the underlying RuntimeError leaks to the client.
+    assert "API Key" not in body["error"]
+    assert "NASA" not in body["error"]

--- a/tests/plugins/test_ai_text.py
+++ b/tests/plugins/test_ai_text.py
@@ -84,7 +84,9 @@ def test_ai_text_generate_image_missing_text_model(client, flask_app, monkeypatc
     body = resp.get_json()
     assert body["success"] is False
     assert body["code"] == "plugin_error"
-    assert "Text Model" in body["error"]
+    # JTN-326: plugin RuntimeError text is no longer surfaced by /update_now
+    # (py/stack-trace-exposure).  Response is a generic message.
+    assert body["error"] == "An internal error occurred"
 
 
 def test_ai_text_generate_image_missing_text_prompt(client, flask_app, monkeypatch):
@@ -103,7 +105,8 @@ def test_ai_text_generate_image_missing_text_prompt(client, flask_app, monkeypat
     body = resp.get_json()
     assert body["success"] is False
     assert body["code"] == "plugin_error"
-    assert "Text Prompt" in body["error"]
+    # JTN-326: generic message only — the RuntimeError detail is logged.
+    assert body["error"] == "An internal error occurred"
 
 
 @patch("plugins.ai_text.ai_text.OpenAI")
@@ -127,7 +130,8 @@ def test_ai_text_generate_image_openai_error(
     body = resp.get_json()
     assert body["success"] is False
     assert body["code"] == "plugin_error"
-    assert "API request failure" in body["error"]
+    # JTN-326: generic message only — upstream failure text is logged.
+    assert body["error"] == "An internal error occurred"
 
 
 @pytest.mark.parametrize(
@@ -203,7 +207,8 @@ def test_ai_text_generate_image_missing_key(client, flask_app, monkeypatch):
     body = resp.get_json()
     assert body["success"] is False
     assert body["code"] == "plugin_error"
-    assert body["error"] == "OpenAI API Key not configured."
+    # JTN-326: RuntimeError text is no longer echoed (py/stack-trace-exposure).
+    assert body["error"] == "An internal error occurred"
 
 
 @patch("plugins.ai_text.ai_text.OpenAI")


### PR DESCRIPTION
## Summary

Closes CodeQL security alerts in `src/blueprints/plugin.py`.  Follows the same pattern established in PR #422 (main blueprint).

### Alerts closed

| Rule | Line(s) | Endpoint / helper | Fix |
|---|---|---|---|
| `py/reflective-xss` | 90 | `show_plugin` — GET `/plugin/<id>?instance=` | Return generic "Plugin instance not found"; log tainted instance name via `sanitize_log_field` |
| `py/reflective-xss` | 304 | `update_instance` — PUT `/update_plugin_instance/<name>` | Generic message; log instance name |
| `py/reflective-xss` | 394 | `display_plugin_instance` | Generic "Playlist not found"; log playlist name (previously had NO sanitization — real XSS bug) |
| `py/reflective-xss` | 398 | `display_plugin_instance` | Generic "Plugin instance not found"; log instance name |
| `py/reflective-xss` | 429 | `force_retry_plugin_instance` | Generic 404 message + constant success message; log instance details |
| `py/reflective-xss` | 756 | `save_plugin_settings_alias` — POST `/plugin/<id>/save` | Generic "Plugin not found" in `_save_plugin_settings_common`; log URL path plugin_id |
| `py/stack-trace-exposure` | 705 | `_update_now_direct` RuntimeError branch | Stop echoing `str(e)`; return generic `"An internal error occurred"` with `code=plugin_error`.  `logger.exception` already captures the full traceback. |

### Approach

- Added module-level constants (`_ERR_PLUGIN_INSTANCE_NOT_FOUND`, `_ERR_PLUGIN_NOT_FOUND`, `_ERR_PLAYLIST_NOT_FOUND`, `_MSG_CIRCUIT_BREAKER_RESET`) so every error path returns a fixed string — no user input can reach the response body.
- Each site now calls `logger.warning(..., sanitize_log_field(...))` with the tainted value so operators still have diagnostic context.
- Dropped the now-unused `sanitize_response_value` import.
- Regression tests cover every alerted endpoint: script payloads in URL paths, form fields, and JSON bodies are not echoed back in any form (raw, HTML-escaped, fragmented).

### Precedent

Mirrors PR #422 (main.py) — `logger.exception` server-side + generic `json_error` client-side.

## Test plan

- [x] `scripts/lint.sh` — ruff, black, mypy strict subset, shellcheck all pass
- [x] `SKIP_BROWSER=1 pytest tests/` — 3981 passed, 5 skipped
- [x] Regression tests added/updated in `tests/integration/test_plugin_routes.py`, `tests/integration/test_api_json_errors.py`, `tests/integration/test_plugin_update_now.py`, `tests/plugins/test_ai_text.py`, `tests/integration/test_jtn_341_clock_preview.py`, `tests/integration/test_plugin_htmx.py`
- [ ] CodeQL check on PR confirms 7 alerts closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)