### PR TITLE
fix(security): close py/reflective-xss in client_log blueprint (JTN-326)

### DIFF
--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -18,6 +18,7 @@ import logging
 from flask import Blueprint, Response
 
 from utils.client_endpoint import parse_client_report, strip_newlines
+from utils.form_utils import sanitize_log_field
 from utils.http_utils import json_error
 from utils.rate_limit import TokenBucket
 
@@ -59,8 +60,16 @@ def receive_client_log() -> tuple[Response, int] | Response:
 
     level = data.get("level", "")
     if level not in _ACCEPTED_LEVELS:
+        # Log the rejected value (sanitized) for debugging but do not echo
+        # it back to the client — that would be a reflective-xss sink
+        # (CodeQL py/reflective-xss). Response carries a generic message.
+        logger.warning(
+            "client log rejected: invalid level %s (accepted: %s)",
+            sanitize_log_field(level),
+            sorted(_ACCEPTED_LEVELS),
+        )
         return json_error(
-            f"Invalid level '{level}': must be one of {sorted(_ACCEPTED_LEVELS)}",
+            f"Invalid level: must be one of {sorted(_ACCEPTED_LEVELS)}",
             status=400,
         )
 

--- a/tests/integration/test_client_log_xss.py
+++ b/tests/integration/test_client_log_xss.py
@@ -1,0 +1,92 @@
+# pyright: reportMissingImports=false
+"""Regression tests: /api/client-log must not reflect tainted input in
+response bodies (CodeQL py/reflective-xss, JTN-326).
+
+The blueprint validates the ``level`` field against a small allow-list. A
+previous implementation echoed the rejected value back inside an f-string
+error message, which CodeQL flagged as a reflective-xss sink even though
+``json_error`` emits ``application/json``. These tests post crafted
+payloads and assert the raw value never appears in the response body.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+def _make_app() -> Flask:
+    import blueprints.client_log as cl_mod
+
+    # Reload to reset the per-module rate limiter between tests.
+    importlib.reload(cl_mod)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(cl_mod.client_log_bp)
+    return app
+
+
+@pytest.fixture()
+def client():
+    return _make_app().test_client()
+
+
+_XSS_PAYLOADS = [
+    "<script>alert(1)</script>",
+    "<img src=x onerror=alert(1)>",
+    "<svg onload=alert(1)>",
+    "javascript:alert(1)",
+    '"><script>alert(1)</script>',
+    "'><script>alert(1)</script>",
+]
+
+
+@pytest.mark.parametrize("payload", _XSS_PAYLOADS)
+def test_invalid_level_not_reflected(client, payload: str) -> None:
+    """An invalid ``level`` value must not appear verbatim in the response."""
+    resp = client.post(
+        "/api/client-log",
+        data=json.dumps({"level": payload, "message": "x"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    body = resp.get_data(as_text=True)
+    assert payload not in body
+    # Response must declare JSON content-type (defence-in-depth).
+    assert resp.content_type.startswith("application/json")
+    # The generic error message is still present for UX.
+    parsed = json.loads(body)
+    assert "Invalid level" in parsed.get("error", "")
+
+
+def test_invalid_level_missing_still_rejected(client) -> None:
+    """Empty level (default) triggers the same branch without reflection."""
+    resp = client.post(
+        "/api/client-log",
+        data=json.dumps({"message": "x"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert resp.content_type.startswith("application/json")
+
+
+def test_invalid_level_logs_sanitized_value(client, caplog) -> None:
+    """The rejected value is logged (sanitized) for debugging."""
+    import logging
+
+    payload = "<script>alert(1)</script>"
+    with caplog.at_level(logging.WARNING, logger="blueprints.client_log"):
+        resp = client.post(
+            "/api/client-log",
+            data=json.dumps({"level": payload}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+    # Sanitized form reaches the log (SecretRedactionFilter / sanitize_log_field
+    # strip control chars but leave printable HTML intact — the point is that
+    # the string never reaches the HTTP response body).
+    assert any("invalid level" in rec.getMessage().lower() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Close CodeQL `py/reflective-xss` alerts in `src/blueprints/client_log.py` (lines 58 and 62).
- The invalid-level branch of `POST /api/client-log` echoed the rejected `level` value inside an f-string. Replace with a generic response message and route the raw value to `logger.warning` via `sanitize_log_field`.
- Mirrors the pattern established in #425 (playlist) and #426 (plugin).

## Rule
- CodeQL `py/reflective-xss` — user input reaching a response body.

## Change sites
- `src/blueprints/client_log.py:60-73` — error message no longer contains `level`; sanitized value is logged instead.

## Test plan
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck).
- [x] `pytest tests/integration/ tests/unit/ -k 'client_log or clientlog'` — 26 passed.
- [x] New `tests/integration/test_client_log_xss.py` posts six XSS payloads and asserts:
  - Raw payload never appears in the response body.
  - Response carries `application/json`.
  - Sanitized value is logged as a WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated client log endpoint error responses to provide generic "Invalid level" messages instead of reflecting rejected input values.

* **Tests**
  * Added integration tests for the client log endpoint covering invalid level submissions, missing parameters, and response validation to ensure proper error handling and consistent message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->