### PR TITLE
fix(security): close py/reflective-xss at main.py:280 (JTN-326)

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -277,11 +277,11 @@ def save_plugin_order():
         return json_error("Order must not contain duplicate plugin IDs", status=400)
     invalid_ids = [pid for pid in order if pid not in registered_ids]
     if invalid_ids:
-        return json_error(f"Unknown plugin IDs: {', '.join(invalid_ids)}", status=400)
+        return json_error("Order contains unknown plugin IDs", status=400)
     missing_ids = registered_ids.difference(order)
     if missing_ids:
         return json_error(
-            f"Order must include every plugin ID exactly once; missing: {', '.join(sorted(missing_ids))}",
+            "Order must include every plugin ID exactly once",
             status=400,
         )
     device_config.set_plugin_order(order)

--- a/tests/unit/test_blueprint_coverage.py
+++ b/tests/unit/test_blueprint_coverage.py
@@ -90,7 +90,9 @@ def test_plugin_order_unknown_id_returns_400(client):
     )
     assert resp.status_code == 400
     body = resp.get_json()
-    assert "Unknown plugin IDs" in body["error"]
+    assert "unknown plugin ids" in body["error"].lower()
+    # Payload value must not be reflected (py/reflective-xss hardening).
+    assert "nonexistent_plugin_id_xyz" not in body["error"]
 
 
 def test_plugin_order_non_string_entries_returns_400(client):

--- a/tests/unit/test_main_blueprint_coverage.py
+++ b/tests/unit/test_main_blueprint_coverage.py
@@ -309,3 +309,24 @@ def test_plugin_order_missing_items(client, device_config_dev):
     resp = client.post("/api/plugin_order", json={"order": [plugins[0]["id"]]})
     assert resp.status_code == 400
     assert "include every plugin id exactly once" in resp.get_json()["error"].lower()
+
+
+def test_plugin_order_unknown_ids_not_reflected(client):
+    """Regression test for CodeQL py/reflective-xss at main.py:280.
+
+    User-supplied plugin IDs must not be echoed back in the error response,
+    even via JSON content type, so that a stray browser content-type sniff
+    cannot execute injected markup.
+    """
+    xss_payloads = [
+        "<script>alert(1)</script>",
+        '"><img src=x onerror=alert(1)>',
+        "<svg/onload=alert(1)>",
+        "javascript:alert(1)",
+    ]
+    for payload in xss_payloads:
+        resp = client.post("/api/plugin_order", json={"order": [payload]})
+        assert resp.status_code == 400
+        body_text = resp.get_data(as_text=True)
+        assert payload not in body_text, f"Payload reflected: {payload!r}"
+        assert resp.headers.get("Content-Type", "").startswith("application/json")


### PR DESCRIPTION
## Summary
Closes CodeQL `py/reflective-xss` alert in `src/blueprints/main.py:280` (`save_plugin_order`). User-supplied plugin IDs (`invalid_ids`, `missing_ids`) were echoed back via f-string into `json_error` messages. Replaced with generic messages — same pattern as PRs #425/#426.

Although `json_error` returns `application/json` (minimising practical XSS), removing the reflection closes the alert at its root and hardens against future content-type regressions.

## Alerts closed
- `py/reflective-xss` at `src/blueprints/main.py:280`
- Also cleans L283-L286 (`missing_ids`) for consistency

## Test plan
- [x] New regression test `test_plugin_order_unknown_ids_not_reflected` posts `<script>`, `"><img onerror>`, `<svg/onload>`, `javascript:` payloads and asserts none appear in response body; content-type remains JSON.
- [x] Existing `/api/plugin_order` suite still green (message for `missing_ids` still matches the `"include every plugin id exactly once"` assertion).
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck + mypy strict subset).
- [x] All `-k main` tests green: 61 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)