### PR TITLE
fix(security): close py/reflective-xss in history blueprint (JTN-326)

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -17,6 +17,7 @@ from flask import (
 )
 from werkzeug.exceptions import BadRequest
 
+from utils.form_utils import sanitize_log_field
 from utils.http_utils import json_error, json_internal_error, json_success
 from utils.image_serving import maybe_serve_webp
 from utils.security_utils import validate_file_path
@@ -29,8 +30,38 @@ history_bp = Blueprint("history", __name__)
 # Sonar S1192 — duplicate string constants
 _CONFIG_KEY = "DEVICE_CONFIG"
 _ERR_INVALID_FILENAME = "invalid filename"
+_ERR_FILE_NOT_FOUND = "File not found"
+_ERR_INVALID_JSON = "Invalid JSON payload"
+_ERR_BODY_NOT_OBJECT = "Request body must be a JSON object"
+_ERR_FILENAME_REQUIRED = "filename is required"
 _EXT_PNG = ".png"
 _EXT_JSON = ".json"
+
+# Helper return codes used in place of pre-built error responses so that
+# taint-tracking (CodeQL py/reflective-xss) sees only module-level constant
+# strings reaching ``json_error`` at call sites, never a value derived from
+# the request body.
+_ERRCODE_INVALID_JSON = "invalid_json"
+_ERRCODE_BODY_NOT_OBJECT = "body_not_object"
+_ERRCODE_FILENAME_REQUIRED = "filename_required"
+_ERRCODE_INVALID_FILENAME = "invalid_filename"
+_ERRCODE_FILE_NOT_FOUND = "file_not_found"
+
+
+def _filename_error_response(code: str):
+    """Map helper error codes to standard ``json_error`` responses.
+
+    All messages are module-level constants — no request data is interpolated.
+    """
+    if code == _ERRCODE_INVALID_JSON:
+        return json_error(_ERR_INVALID_JSON, status=400)
+    if code == _ERRCODE_BODY_NOT_OBJECT:
+        return json_error(_ERR_BODY_NOT_OBJECT, status=400)
+    if code == _ERRCODE_FILENAME_REQUIRED:
+        return json_error(_ERR_FILENAME_REQUIRED, status=400)
+    if code == _ERRCODE_FILE_NOT_FOUND:
+        return json_error(_ERR_FILE_NOT_FOUND, status=404)
+    return json_error(_ERR_INVALID_FILENAME, status=400)
 
 
 def _timestamp_from_history_filename(filename: str) -> float:
@@ -202,34 +233,44 @@ def _resolve_history_path(history_dir: str, filename: str) -> str:
 def _validate_and_resolve_history_file(history_dir, filename):
     """Validate and resolve a history filename to a safe absolute path.
 
-    Returns ``(safe_path, None)`` on success, or ``(None, error_response)`` when
-    the filename is invalid or the resolved file does not exist.  Callers should
-    check the second element before using the first.
+    Returns ``(safe_path, None)`` on success, or ``(None, err_code)`` where
+    ``err_code`` is one of the ``_ERRCODE_*`` sentinels. Callers convert the
+    code to a response via :func:`_filename_error_response` so that only
+    module-level constant strings flow into ``json_error`` (CodeQL
+    py/reflective-xss).
     """
     try:
         safe_path = _resolve_history_path(history_dir, filename)
     except ValueError:
-        return None, json_error(_ERR_INVALID_FILENAME, status=400)
+        logger.warning(
+            "history: invalid filename rejected filename=%s",
+            sanitize_log_field(filename),
+        )
+        return None, _ERRCODE_INVALID_FILENAME
     if not os.path.isfile(safe_path):
-        return None, json_error("File not found", status=404)
+        logger.warning(
+            "history: file not found filename=%s",
+            sanitize_log_field(filename),
+        )
+        return None, _ERRCODE_FILE_NOT_FOUND
     return safe_path, None
 
 
 def _parse_filename_from_request():
     """Parse and validate a ``filename`` field from a JSON POST body.
 
-    Returns ``(filename, None)`` on success, or ``(None, error_response)``
-    when the payload is malformed or the filename is missing/empty.
+    Returns ``(filename, None)`` on success, or ``(None, err_code)`` where
+    ``err_code`` is one of the ``_ERRCODE_*`` sentinels.
     """
     try:
         data = request.get_json(force=True)
     except BadRequest:
-        return None, json_error("Invalid JSON payload", status=400)
+        return None, _ERRCODE_INVALID_JSON
     if not isinstance(data, dict):
-        return None, json_error("Request body must be a JSON object", status=400)
+        return None, _ERRCODE_BODY_NOT_OBJECT
     filename = data.get("filename")
     if not isinstance(filename, str) or not filename.strip():
-        return None, json_error("filename is required", status=400)
+        return None, _ERRCODE_FILENAME_REQUIRED
     return filename, None
 
 
@@ -350,13 +391,13 @@ def history_redisplay():
     history_dir = device_config.history_image_dir
 
     try:
-        filename, err = _parse_filename_from_request()
-        if err is not None:
-            return err
+        filename, err_code = _parse_filename_from_request()
+        if err_code is not None:
+            return _filename_error_response(err_code)
 
-        safe_path, err = _validate_and_resolve_history_file(history_dir, filename)
-        if err is not None:
-            return err
+        safe_path, err_code = _validate_and_resolve_history_file(history_dir, filename)
+        if err_code is not None:
+            return _filename_error_response(err_code)
 
         display_manager.display_preprocessed_image(safe_path)
         return json_success("Display updated")
@@ -373,13 +414,13 @@ def history_delete():
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
     try:
-        filename, err = _parse_filename_from_request()
-        if err is not None:
-            return err
+        filename, err_code = _parse_filename_from_request()
+        if err_code is not None:
+            return _filename_error_response(err_code)
 
-        safe_path, err = _validate_and_resolve_history_file(history_dir, filename)
-        if err is not None:
-            return err
+        safe_path, err_code = _validate_and_resolve_history_file(history_dir, filename)
+        if err_code is not None:
+            return _filename_error_response(err_code)
 
         _base, ext = os.path.splitext(safe_path)
         if not ext.lower().endswith((_EXT_PNG, _EXT_JSON)):

--- a/tests/integration/test_history_xss.py
+++ b/tests/integration/test_history_xss.py
@@ -1,0 +1,97 @@
+"""Regression tests for CodeQL py/reflective-xss in ``history`` blueprint.
+
+Covers alerts previously raised at
+``src/blueprints/history.py`` lines 355, 359, 378, 382. Every POST route
+that accepts a user-controlled ``filename`` is hit with a selection of
+XSS payloads; the raw payload must never appear in the response body and
+the response must be ``application/json``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Payloads that would execute if reflected un-escaped into an HTML context.
+_XSS_PAYLOADS = [
+    "<script>alert(1)</script>",
+    '"><img src=x onerror=alert(1)>',
+    "<svg/onload=alert(1)>",
+    "javascript:alert(1)",
+    "<iframe srcdoc='<script>alert(1)</script>'></iframe>",
+]
+
+
+@pytest.mark.parametrize("payload", _XSS_PAYLOADS)
+def test_history_redisplay_rejects_xss_filename(client, payload):
+    resp = client.post("/history/redisplay", json={"filename": payload})
+    assert resp.status_code in (400, 404)
+    assert resp.mimetype == "application/json"
+    body = resp.get_data(as_text=True)
+    assert payload not in body
+    # Defence in depth: no raw HTML tag markers from the payloads should appear.
+    assert "<script" not in body.lower()
+    assert "onerror" not in body.lower()
+    assert "onload" not in body.lower()
+    assert "<iframe" not in body.lower()
+
+
+@pytest.mark.parametrize("payload", _XSS_PAYLOADS)
+def test_history_delete_rejects_xss_filename(client, payload):
+    resp = client.post("/history/delete", json={"filename": payload})
+    assert resp.status_code in (400, 404)
+    assert resp.mimetype == "application/json"
+    body = resp.get_data(as_text=True)
+    assert payload not in body
+    assert "<script" not in body.lower()
+    assert "onerror" not in body.lower()
+    assert "onload" not in body.lower()
+    assert "<iframe" not in body.lower()
+
+
+def test_history_redisplay_rejects_non_json_body(client):
+    # Non-JSON body exercises the ``BadRequest`` branch that used to build
+    # an error response inside the helper. Result must still be generic.
+    resp = client.post(
+        "/history/redisplay",
+        data="not json at all <script>",
+        content_type="text/plain",
+    )
+    assert resp.status_code == 400
+    assert resp.mimetype == "application/json"
+    body = resp.get_data(as_text=True)
+    assert "<script" not in body.lower()
+
+
+def test_history_delete_rejects_non_object_body(client):
+    resp = client.post("/history/delete", json=["<script>alert(1)</script>"])
+    assert resp.status_code == 400
+    assert resp.mimetype == "application/json"
+    body = resp.get_data(as_text=True)
+    assert "<script" not in body.lower()
+    assert "Request body must be a JSON object" in body
+
+
+def test_history_redisplay_missing_filename(client):
+    resp = client.post("/history/redisplay", json={})
+    assert resp.status_code == 400
+    assert resp.mimetype == "application/json"
+    body = resp.get_data(as_text=True)
+    assert "filename is required" in body
+
+
+def test_history_delete_empty_filename(client):
+    resp = client.post("/history/delete", json={"filename": "   "})
+    assert resp.status_code == 400
+    assert resp.mimetype == "application/json"
+    body = resp.get_data(as_text=True)
+    assert "filename is required" in body
+
+
+def test_history_image_invalid_filename_not_reflected(client):
+    # ``history_image`` uses ``_resolve_history_path`` directly and returns
+    # ``_ERR_INVALID_FILENAME``; confirm traversal attempts don't reflect.
+    resp = client.get("/history/image/%3Cscript%3Ealert(1)%3C%2Fscript%3E")
+    # Depending on routing, Flask may 400/404; either way, no reflection.
+    assert resp.status_code in (400, 404)
+    body = resp.get_data(as_text=True)
+    assert "<script>alert(1)</script>" not in body


### PR DESCRIPTION
## Summary

Closes CodeQL [`py/reflective-xss`](https://codeql.github.com/codeql-query-help/python/py-reflective-xss/) alerts in `src/blueprints/history.py`.

## Alerts closed

| # | Line | Site |
|---|---|---|
| 28 | 355 | `history_redisplay` — `return err` after `_parse_filename_from_request` |
| 29 | 359 | `history_redisplay` — `return err` after `_validate_and_resolve_history_file` |
| 30 | 378 | `history_delete` — `return err` after `_parse_filename_from_request` |
| 93 | 382 | `history_delete` — `return err` after `_validate_and_resolve_history_file` |

Every `json_error` message was already a module-level constant, but the helpers returned a *response object built inside a branch that had read `request`*, so CodeQL's taint tracker tied the response back to user input anyway.

## Fix

Refactor the two helpers (`_parse_filename_from_request`, `_validate_and_resolve_history_file`) to return plain string error-code sentinels (`_ERRCODE_*`) instead of pre-built `json_error` tuples. Callers translate the code to a response via a new `_filename_error_response(code)` helper whose every branch calls `json_error(...)` with a module-level constant.

This breaks the taint flow: the argument to `json_error` at each call site is now a literal constant reachable statically, with no conditional dependency on `request.get_json()`. Mirrors the pattern from PRs #422, #425, #426.

Tainted filenames are still logged server-side via `logger.warning(..., sanitize_log_field(filename))` so operators keep diagnostic context.

## Test plan

- [x] `tests/integration/test_history_xss.py` (new) — POSTs `<script>alert(1)</script>`, `"><img src=x onerror=alert(1)>`, `<svg/onload=alert(1)>`, `javascript:alert(1)`, iframe srcdoc against `/history/redisplay`, `/history/delete`, and `/history/image/<path>`; asserts raw payload not reflected and mimetype is `application/json`. Also covers non-JSON bodies, non-object JSON, missing/empty filename.
- [x] `SKIP_BROWSER=1 pytest -k history` → 166 passed.
- [x] `scripts/lint.sh` → ruff + black + shellcheck + mypy strict subset all pass.