### PR TITLE
Potential fix for code scanning alert no. 99: Uncontrolled data used in path expression

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -223,6 +223,11 @@ def _resolve_history_path(history_dir: str, filename: str) -> str:
     # silently drops the base on POSIX, which would mask traversal intent.
     if os.path.isabs(filename):
         raise ValueError(_ERR_INVALID_FILENAME)
+    # Accept only plain filenames (no directory components).
+    if os.path.basename(filename) != filename:
+        raise ValueError(_ERR_INVALID_FILENAME)
+    if filename in {".", ".."}:
+        raise ValueError(_ERR_INVALID_FILENAME)
     candidate = os.path.join(history_dir, filename)
     try:
         return validate_file_path(candidate, history_dir)


### PR DESCRIPTION
Potential fix for [https://github.com/jtn0123/InkyPi/security/code-scanning/99](https://github.com/jtn0123/InkyPi/security/code-scanning/99)

Use stricter validation in `src/blueprints/history.py` so only simple file names (no directory components) are accepted before path resolution.

Best fix (without changing intended functionality): in `_resolve_history_path`, reject any `filename` where `os.path.basename(filename) != filename`, and reject `"."` / `".."` explicitly. This ensures user input cannot include path separators at all, while keeping normal history file access working. Keep the existing `validate_file_path` containment check as defense-in-depth.

Concretely:
- Edit `src/blueprints/history.py` in `_resolve_history_path` (around lines 220–226).
- Add checks after absolute-path rejection:
  - `if os.path.basename(filename) != filename: raise ValueError(...)`
  - `if filename in {".", ".."}: raise ValueError(...)`
- No new imports are required (`os` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened file path validation to reject directory traversal attempts and invalid filename patterns, improving security when processing file inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->