### PR TITLE
Fix reflected XSS alerts in API keys, client log, and playlists

### DIFF
--- a/src/blueprints/apikeys.py
+++ b/src/blueprints/apikeys.py
@@ -200,7 +200,7 @@ def save_apikeys():
         for entry in entries:
             key, value, err = _validate_api_key_entry(entry, existing_values)
             if err is not None:
-                return err
+                return json_error("Invalid API key entry", status=400)
             if not key:
                 continue
             valid_entries.append((key, value))

--- a/src/blueprints/apikeys.py
+++ b/src/blueprints/apikeys.py
@@ -25,6 +25,8 @@ _INTERNAL_KEYS: frozenset[str] = frozenset(
     }
 )
 
+API_KEY_VALIDATION_ERROR = "Invalid API key entry"
+
 
 # Path to .env file
 def get_env_path():
@@ -200,7 +202,7 @@ def save_apikeys():
         for entry in entries:
             key, value, err = _validate_api_key_entry(entry, existing_values)
             if err is not None:
-                return json_error("Invalid API key entry", status=400)
+                return json_error(API_KEY_VALIDATION_ERROR, status=400)
             if not key:
                 continue
             valid_entries.append((key, value))

--- a/tests/unit/test_input_validation_hardening.py
+++ b/tests/unit/test_input_validation_hardening.py
@@ -36,7 +36,7 @@ class TestApiKeySaveValidation:
         assert resp.status_code == 400
         data = resp.get_json()
         assert data["success"] is False
-        assert "string" in data["error"].lower()
+        assert data["error"]
 
     def test_non_dict_entry_returns_400(self, client, tmp_path, monkeypatch):
         env_path = tmp_path / "test.env"

--- a/tests/unit/test_input_validation_hardening.py
+++ b/tests/unit/test_input_validation_hardening.py
@@ -17,6 +17,8 @@ import json
 import subprocess
 from unittest.mock import MagicMock
 
+from blueprints.apikeys import API_KEY_VALIDATION_ERROR
+
 # ---------------------------------------------------------------------------
 # JTN-134: API key save endpoint input validation
 # ---------------------------------------------------------------------------
@@ -36,7 +38,7 @@ class TestApiKeySaveValidation:
         assert resp.status_code == 400
         data = resp.get_json()
         assert data["success"] is False
-        assert data["error"]
+        assert data["error"] == API_KEY_VALIDATION_ERROR
 
     def test_non_dict_entry_returns_400(self, client, tmp_path, monkeypatch):
         env_path = tmp_path / "test.env"


### PR DESCRIPTION
This PR consolidates the reflected XSS fixes for CodeQL alerts #27, #38, #39, #41, and #98.

What changed:
- API keys: keep the generic validation error path and the matching unit test assertion.
- Client log: sanitize request IDs before echoing them in JSON envelopes.
- Playlists: keep existing validation behavior and rely on the shared safe JSON envelope path.

Verification:
- uv run pytest tests/unit/test_input_validation_hardening.py -q
- uv run pytest tests/unit/test_http_utils.py tests/integration/test_client_log_xss.py tests/integration/test_playlist_xss.py tests/unit/test_playlist_blueprint.py -q