### PR TITLE
Fix remaining reflected XSS alerts in playlist and client log

### DIFF
--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -47,6 +47,19 @@ def _cap(value: object, max_len: int) -> str:
     return str(value)[:max_len]
 
 
+def _reissue_json_error(error_response, fallback_message: str):
+    """Rebuild an error response with a server-controlled envelope."""
+    response, status = error_response
+    payload = response.get_json(silent=True) or {}
+    message = payload.get("error") or fallback_message
+    return json_error(
+        message,
+        status=status,
+        code=payload.get("code"),
+        details=payload.get("details"),
+    )
+
+
 @client_log_bp.route("/api/client-log", methods=["POST"])
 def receive_client_log() -> tuple[Response, int] | Response:
     """Accept a browser console.warn/error report and emit it as a WARNING log entry.
@@ -56,7 +69,7 @@ def receive_client_log() -> tuple[Response, int] | Response:
     """
     data, error = parse_client_report(_rate_limiter, _BODY_MAX)
     if error is not None:
-        return error
+        return _reissue_json_error(error, "Invalid client log report")
 
     level = data.get("level", "")
     if level not in _ACCEPTED_LEVELS:

--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -19,7 +19,7 @@ from flask import Blueprint, Response
 
 from utils.client_endpoint import parse_client_report, strip_newlines
 from utils.form_utils import sanitize_log_field
-from utils.http_utils import json_error
+from utils.http_utils import json_error, reissue_json_error
 from utils.rate_limit import TokenBucket
 
 logger = logging.getLogger(__name__)
@@ -47,19 +47,6 @@ def _cap(value: object, max_len: int) -> str:
     return str(value)[:max_len]
 
 
-def _reissue_json_error(error_response, fallback_message: str):
-    """Rebuild an error response with a server-controlled envelope."""
-    response, status = error_response
-    payload = response.get_json(silent=True) or {}
-    message = payload.get("error") or fallback_message
-    return json_error(
-        message,
-        status=status,
-        code=payload.get("code"),
-        details=payload.get("details"),
-    )
-
-
 @client_log_bp.route("/api/client-log", methods=["POST"])
 def receive_client_log() -> tuple[Response, int] | Response:
     """Accept a browser console.warn/error report and emit it as a WARNING log entry.
@@ -69,7 +56,7 @@ def receive_client_log() -> tuple[Response, int] | Response:
     """
     data, error = parse_client_report(_rate_limiter, _BODY_MAX)
     if error is not None:
-        return _reissue_json_error(error, "Invalid client log report")
+        return reissue_json_error(error, "Invalid client log report")
 
     level = data.get("level", "")
     if level not in _ACCEPTED_LEVELS:

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -33,6 +33,20 @@ _CODE_VALIDATION = "validation_error"
 _MSG_INVALID_TIME_FORMAT = "Invalid start/end time format"
 _MSG_SAME_TIME = "Start time and End time cannot be the same"
 _MSG_TIME_OVERLAP = "Playlist time range overlaps with existing playlist"
+_MSG_INVALID_PLAYLIST_REQUEST = "Invalid playlist request"
+
+
+def _reissue_json_error(error_response, fallback_message: str):
+    """Rebuild an error response with a server-controlled envelope."""
+    response, status = error_response
+    payload = response.get_json(silent=True) or {}
+    message = payload.get("error") or fallback_message
+    return json_error(
+        message,
+        status=status,
+        code=payload.get("code"),
+        details=payload.get("details"),
+    )
 
 
 def _validate_playlist_name(name):
@@ -516,11 +530,11 @@ def create_playlist():
 
     data, err = _parse_playlist_request_data()
     if err:
-        return err
+        return _reissue_json_error(err, _MSG_INVALID_PLAYLIST_REQUEST)
 
     playlist_name, name_err = _validate_playlist_name(data.get("playlist_name"))
     if name_err:
-        return name_err
+        return _reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
     start_min, end_min, time_err = _validate_playlist_times(
         data.get("start_time"), data.get("end_time")
     )
@@ -624,7 +638,7 @@ def update_playlist(playlist_name):
     new_name_raw = data.get("new_name")
     new_name, name_err = _validate_playlist_name(new_name_raw)
     if name_err:
-        return name_err
+        return _reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
     start_time = data.get("start_time")
     end_time = data.get("end_time")
     if not start_time or not end_time:

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -17,7 +17,12 @@ from flask import (
 from model import Playlist
 from refresh_task import PlaylistRefresh
 from utils.app_utils import handle_request_files, parse_form
-from utils.http_utils import json_error, json_internal_error, json_success
+from utils.http_utils import (
+    json_error,
+    json_internal_error,
+    json_success,
+    reissue_json_error,
+)
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 from utils.time_utils import calculate_seconds, now_device_tz
 
@@ -34,19 +39,6 @@ _MSG_INVALID_TIME_FORMAT = "Invalid start/end time format"
 _MSG_SAME_TIME = "Start time and End time cannot be the same"
 _MSG_TIME_OVERLAP = "Playlist time range overlaps with existing playlist"
 _MSG_INVALID_PLAYLIST_REQUEST = "Invalid playlist request"
-
-
-def _reissue_json_error(error_response, fallback_message: str):
-    """Rebuild an error response with a server-controlled envelope."""
-    response, status = error_response
-    payload = response.get_json(silent=True) or {}
-    message = payload.get("error") or fallback_message
-    return json_error(
-        message,
-        status=status,
-        code=payload.get("code"),
-        details=payload.get("details"),
-    )
 
 
 def _validate_playlist_name(name):
@@ -530,11 +522,11 @@ def create_playlist():
 
     data, err = _parse_playlist_request_data()
     if err:
-        return _reissue_json_error(err, _MSG_INVALID_PLAYLIST_REQUEST)
+        return reissue_json_error(err, _MSG_INVALID_PLAYLIST_REQUEST)
 
     playlist_name, name_err = _validate_playlist_name(data.get("playlist_name"))
     if name_err:
-        return _reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
+        return reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
     start_min, end_min, time_err = _validate_playlist_times(
         data.get("start_time"), data.get("end_time")
     )
@@ -638,7 +630,7 @@ def update_playlist(playlist_name):
     new_name_raw = data.get("new_name")
     new_name, name_err = _validate_playlist_name(new_name_raw)
     if name_err:
-        return _reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
+        return reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
     start_time = data.get("start_time")
     end_time = data.get("end_time")
     if not start_time or not end_time:

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -159,6 +159,28 @@ def json_success(
         return body, status
 
 
+def reissue_json_error(
+    error_response: tuple[FlaskResponse | dict[str, Any], int],
+    fallback_message: str,
+) -> tuple[FlaskResponse | dict[str, Any], int]:
+    """Rebuild an error response using a server-controlled message.
+
+    This preserves status, code, and details from the upstream response, but
+    never reuses the upstream error text itself.
+    """
+    response, status = error_response
+    if isinstance(response, dict):
+        payload = response
+    else:
+        payload = response.get_json(silent=True) or {}
+    return json_error(
+        fallback_message,
+        status=status,
+        code=payload.get("code"),
+        details=payload.get("details"),
+    )
+
+
 def json_internal_error(
     context: str,
     *,

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -165,19 +165,19 @@ def reissue_json_error(
 ) -> tuple[FlaskResponse | dict[str, Any], int]:
     """Rebuild an error response using a server-controlled message.
 
-    This preserves status, code, and details from the upstream response, but
-    never reuses the upstream error text itself.
+    This preserves only the HTTP status and never reuses upstream payload
+    fields. The returned message is always server-controlled.
     """
-    response, status = error_response
-    if isinstance(response, dict):
-        payload = response
-    else:
-        payload = response.get_json(silent=True) or {}
+    _, status = error_response
+    try:
+        safe_status = int(status)
+    except (TypeError, ValueError):
+        safe_status = 400
+    if safe_status < 400 or safe_status > 599:
+        safe_status = 400
     return json_error(
         fallback_message,
-        status=status,
-        code=payload.get("code"),
-        details=payload.get("details"),
+        status=safe_status,
     )
 
 

--- a/tests/integration/test_client_log_xss.py
+++ b/tests/integration/test_client_log_xss.py
@@ -58,7 +58,8 @@ def test_invalid_level_not_reflected(client, payload: str) -> None:
     assert payload not in body
     # Response must declare JSON content-type (defence-in-depth).
     assert resp.content_type.startswith("application/json")
-    # The generic error message is still present for UX.
+    # The level validation message remains specific, but the tainted payload
+    # itself must never be reflected.
     parsed = json.loads(body)
     assert "Invalid level" in parsed.get("error", "")
 

--- a/tests/integration/test_playlist_more.py
+++ b/tests/integration/test_playlist_more.py
@@ -368,7 +368,7 @@ def test_create_playlist_missing_name(client):
         "/create_playlist", json={"start_time": "06:00", "end_time": "09:00"}
     )
     assert resp.status_code == 400
-    assert "Playlist name is required" in resp.get_json().get("error", "")
+    assert resp.get_json().get("error") == "Invalid playlist request"
 
 
 def test_create_playlist_missing_times(client):

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -119,6 +119,7 @@ from src.utils.http_utils import (  # noqa: E402
     json_error,
     json_internal_error,
     json_success,
+    reissue_json_error,
     wants_json,
 )
 
@@ -180,6 +181,25 @@ class TestJsonError:
             data = response.get_json()
             assert data.get("error") == "oops"
             assert data.get("request_id") == "abc-123"
+
+    def test_reissue_json_error_uses_fallback_message(self, app):
+        """reissue_json_error should ignore upstream error text."""
+        with app.test_request_context("/"):
+            upstream, status = json_error(
+                "tainted upstream text",
+                status=422,
+                code="validation_error",
+                details={"field": "level"},
+            )
+            response, returned_status = reissue_json_error(
+                (upstream, status), "safe fallback message"
+            )
+
+            assert returned_status == 422
+            data = response.get_json()
+            assert data["error"] == "safe fallback message"
+            assert data["code"] == "validation_error"
+            assert data["details"] == {"field": "level"}
 
 
 def test_http_get_timeout_tuple_from_env(monkeypatch):

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -184,7 +184,7 @@ class TestJsonError:
 
     def test_reissue_json_error_uses_fallback_message(self, app):
         """reissue_json_error should ignore upstream error text."""
-        with app.test_request_context("/"):
+        with app.app_context():
             upstream, status = json_error(
                 "tainted upstream text",
                 status=422,
@@ -198,8 +198,8 @@ class TestJsonError:
             assert returned_status == 422
             data = response.get_json()
             assert data["error"] == "safe fallback message"
-            assert data["code"] == "validation_error"
-            assert data["details"] == {"field": "level"}
+            assert "code" not in data
+            assert "details" not in data
 
 
 def test_http_get_timeout_tuple_from_env(monkeypatch):

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -736,16 +736,13 @@ class TestPlaylistNameValidation:
         """Playlist name exceeding 64 characters should be rejected."""
         resp = _create_playlist(client, "A" * 65, "08:00", "12:00")
         assert resp.status_code == 400
-        assert "64" in resp.get_json()["error"]
+        assert resp.get_json()["error"] == "Invalid playlist request"
 
     def test_create_playlist_name_special_chars(self, client):
         """Playlist names containing script tags or path traversal should be rejected."""
         resp = _create_playlist(client, "<script>alert(1)</script>", "08:00", "12:00")
         assert resp.status_code == 400
-        assert (
-            "letters" in resp.get_json()["error"].lower()
-            or "alphanumeric" in resp.get_json()["error"].lower()
-        )
+        assert resp.get_json()["error"] == "Invalid playlist request"
 
         resp = _create_playlist(client, "../etc/passwd", "08:00", "12:00")
         assert resp.status_code == 400


### PR DESCRIPTION
This PR consolidates the remaining reflected XSS fixes for CodeQL alerts #38, #39, #41, and #98.

What changed:
- `src/blueprints/playlist.py`: route handlers now reissue helper validation errors through a server-controlled JSON envelope instead of returning helper-built responses directly.
- `src/blueprints/client_log.py`: invalid client-log parse errors are reissued the same way, which avoids reflecting request-derived data back to the client.

Why:
- CodeQL flagged direct returns of helper-built error responses as reflected-XSS sinks.
- The helpers themselves still perform the same validation; this change only hardens the route boundary.

Verification:
- `uv run pytest tests/integration/test_client_log_xss.py tests/integration/test_playlist_xss.py tests/integration/test_playlist_more.py tests/unit/test_playlist_blueprint.py tests/unit/test_http_utils.py -q`
- `uv run pytest tests/integration/test_client_log_xss.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error responses for invalid client logs and playlist requests with standardized formatting.

* **Refactor**
  * Implemented centralized error response handler to improve consistency in error message formatting and fallback messaging across API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->