### PR TITLE
Fix history path-expression alerts

### DIFF
--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -205,6 +205,65 @@ def _remove_sidecar_by_name(history_dir: str, expected_name: str) -> None:
         return
 
 
+def _remove_history_file_by_name(history_dir: str, expected_name: str) -> None:
+    """Delete a history entry in *history_dir* whose basename matches *expected_name*.
+
+    This mirrors :func:`_remove_sidecar_by_name` but is used for the primary
+    history file so the delete path never reconstructs a filesystem path from
+    user input.
+    """
+    try:
+        entries = os.listdir(history_dir)
+    except OSError:
+        return
+    real_history_dir = os.path.realpath(history_dir)
+    for entry in entries:
+        if entry != expected_name:
+            continue
+        full = os.path.join(history_dir, entry)
+        try:
+            real_full = os.path.realpath(full)
+        except OSError:
+            return
+        try:
+            common = os.path.commonpath([real_history_dir, real_full])
+        except ValueError:
+            return
+        if common != real_history_dir:
+            return
+        if os.path.isfile(real_full):
+            os.remove(real_full)
+        return
+
+
+def _find_history_file_by_name(history_dir: str, expected_name: str) -> str | None:
+    """Return the real path for *expected_name* if it exists in *history_dir*."""
+    try:
+        entries = os.scandir(history_dir)
+    except OSError:
+        return None
+
+    real_history_dir = os.path.realpath(history_dir)
+    with entries:
+        for entry in entries:
+            if entry.name != expected_name:
+                continue
+            if not entry.is_file(follow_symlinks=False):
+                return None
+            try:
+                real_full = os.path.realpath(entry.path)
+            except OSError:
+                return None
+            try:
+                common = os.path.commonpath([real_history_dir, real_full])
+            except ValueError:
+                return None
+            if common != real_history_dir:
+                return None
+            return real_full
+    return None
+
+
 def _resolve_history_path(history_dir: str, filename: str) -> str:
     """Resolve a requested filename under history_dir and enforce containment.
 
@@ -245,14 +304,15 @@ def _validate_and_resolve_history_file(history_dir, filename):
     py/reflective-xss).
     """
     try:
-        safe_path = _resolve_history_path(history_dir, filename)
+        _resolve_history_path(history_dir, filename)
     except ValueError:
         logger.warning(
             "history: invalid filename rejected filename=%s",
             sanitize_log_field(filename),
         )
         return None, _ERRCODE_INVALID_FILENAME
-    if not os.path.isfile(safe_path):
+    safe_path = _find_history_file_by_name(history_dir, filename)
+    if safe_path is None:
         logger.warning(
             "history: file not found filename=%s",
             sanitize_log_field(filename),
@@ -400,11 +460,11 @@ def history_redisplay():
         if err_code is not None:
             return _filename_error_response(err_code)
 
-        safe_path, err_code = _validate_and_resolve_history_file(history_dir, filename)
+        _safe_path, err_code = _validate_and_resolve_history_file(history_dir, filename)
         if err_code is not None:
             return _filename_error_response(err_code)
 
-        display_manager.display_preprocessed_image(safe_path)
+        display_manager.display_preprocessed_image(_safe_path)
         return json_success("Display updated")
     except Exception:
         logger.exception("Error redisplaying history image")
@@ -427,7 +487,7 @@ def history_delete():
         if err_code is not None:
             return _filename_error_response(err_code)
 
-        _base, ext = os.path.splitext(safe_path)
+        _base, ext = os.path.splitext(filename)
         if not ext.lower().endswith((_EXT_PNG, _EXT_JSON)):
             return json_error(
                 "unsupported file type",
@@ -442,9 +502,10 @@ def history_delete():
         # This way the value passed to ``os.remove`` originates from
         # ``os.listdir`` (which is not user-controlled) and CodeQL cannot
         # taint-track it back to the request body.
-        expected_stem = os.path.splitext(os.path.basename(safe_path))[0]
+        expected_stem = os.path.splitext(filename)[0]
         sidecar_ext = _EXT_JSON if ext.lower() == _EXT_PNG else _EXT_PNG
         expected_sidecar_name = expected_stem + sidecar_ext
+        _remove_history_file_by_name(history_dir, filename)
         _remove_sidecar_by_name(history_dir, expected_sidecar_name)
         return json_success("Deleted")
     except Exception:

--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -172,96 +172,51 @@ def _list_history_images(
     return result, total
 
 
-def _remove_sidecar_by_name(history_dir: str, expected_name: str) -> None:
-    """Delete an entry in *history_dir* whose basename equals *expected_name*.
+def _resolve_history_entry_path(history_dir: str, expected_name: str) -> str | None:
+    """Return the real path for *expected_name* if it exists in *history_dir*.
 
-    The value ultimately passed to :func:`os.remove` is constructed from
-    :func:`os.listdir`, not from caller-supplied input, which keeps the
-    operation safe even if the caller's ``expected_name`` were tainted.  A
-    final :func:`os.path.realpath` containment check defends against any
-    symlinked entry that points outside the history directory.
+    The lookup only considers entries that come from ``os.listdir`` and then
+    performs a containment check against the resolved history directory.  That
+    keeps downstream filesystem operations from reconstructing paths directly
+    from request data.
     """
     try:
         entries = os.listdir(history_dir)
-    except OSError:
-        return
-    real_history_dir = os.path.realpath(history_dir)
-    for entry in entries:
-        if entry != expected_name:
-            continue
-        full = os.path.join(history_dir, entry)
-        try:
-            real_full = os.path.realpath(full)
-        except OSError:
-            return
-        try:
-            common = os.path.commonpath([real_history_dir, real_full])
-        except ValueError:
-            return
-        if common != real_history_dir:
-            return
-        if os.path.isfile(real_full):
-            os.remove(real_full)
-        return
-
-
-def _remove_history_file_by_name(history_dir: str, expected_name: str) -> None:
-    """Delete a history entry in *history_dir* whose basename matches *expected_name*.
-
-    This mirrors :func:`_remove_sidecar_by_name` but is used for the primary
-    history file so the delete path never reconstructs a filesystem path from
-    user input.
-    """
-    try:
-        entries = os.listdir(history_dir)
-    except OSError:
-        return
-    real_history_dir = os.path.realpath(history_dir)
-    for entry in entries:
-        if entry != expected_name:
-            continue
-        full = os.path.join(history_dir, entry)
-        try:
-            real_full = os.path.realpath(full)
-        except OSError:
-            return
-        try:
-            common = os.path.commonpath([real_history_dir, real_full])
-        except ValueError:
-            return
-        if common != real_history_dir:
-            return
-        if os.path.isfile(real_full):
-            os.remove(real_full)
-        return
-
-
-def _find_history_file_by_name(history_dir: str, expected_name: str) -> str | None:
-    """Return the real path for *expected_name* if it exists in *history_dir*."""
-    try:
-        entries = os.scandir(history_dir)
     except OSError:
         return None
 
     real_history_dir = os.path.realpath(history_dir)
-    with entries:
-        for entry in entries:
-            if entry.name != expected_name:
-                continue
-            if not entry.is_file(follow_symlinks=False):
-                return None
-            try:
-                real_full = os.path.realpath(entry.path)
-            except OSError:
-                return None
-            try:
-                common = os.path.commonpath([real_history_dir, real_full])
-            except ValueError:
-                return None
-            if common != real_history_dir:
-                return None
+    for entry in entries:
+        if entry != expected_name:
+            continue
+        full = os.path.join(history_dir, entry)
+        try:
+            real_full = os.path.realpath(full)
+        except OSError:
+            return None
+        try:
+            common = os.path.commonpath([real_history_dir, real_full])
+        except ValueError:
+            return None
+        if common != real_history_dir:
+            return None
+        if os.path.isfile(real_full):
             return real_full
+        return None
     return None
+
+
+def _remove_history_entry_by_name(history_dir: str, expected_name: str) -> None:
+    """Delete a history entry by basename after resolving it safely."""
+    real_full = _resolve_history_entry_path(history_dir, expected_name)
+    if real_full is None:
+        return
+    os.remove(real_full)
+
+
+def _remove_sidecar_by_name(history_dir: str, expected_name: str) -> None:
+    """Delete an entry in *history_dir* whose basename equals *expected_name*."""
+    _remove_history_entry_by_name(history_dir, expected_name)
 
 
 def _resolve_history_path(history_dir: str, filename: str) -> str:
@@ -311,7 +266,7 @@ def _validate_and_resolve_history_file(history_dir, filename):
             sanitize_log_field(filename),
         )
         return None, _ERRCODE_INVALID_FILENAME
-    safe_path = _find_history_file_by_name(history_dir, filename)
+    safe_path = _resolve_history_entry_path(history_dir, filename)
     if safe_path is None:
         logger.warning(
             "history: file not found filename=%s",
@@ -487,7 +442,7 @@ def history_delete():
         if err_code is not None:
             return _filename_error_response(err_code)
 
-        _base, ext = os.path.splitext(filename)
+        _base, ext = os.path.splitext(safe_path)
         if not ext.lower().endswith((_EXT_PNG, _EXT_JSON)):
             return json_error(
                 "unsupported file type",
@@ -502,10 +457,10 @@ def history_delete():
         # This way the value passed to ``os.remove`` originates from
         # ``os.listdir`` (which is not user-controlled) and CodeQL cannot
         # taint-track it back to the request body.
-        expected_stem = os.path.splitext(filename)[0]
+        expected_stem = os.path.splitext(os.path.basename(safe_path))[0]
         sidecar_ext = _EXT_JSON if ext.lower() == _EXT_PNG else _EXT_PNG
         expected_sidecar_name = expected_stem + sidecar_ext
-        _remove_history_file_by_name(history_dir, filename)
+        _remove_history_entry_by_name(history_dir, os.path.basename(safe_path))
         _remove_sidecar_by_name(history_dir, expected_sidecar_name)
         return json_success("Deleted")
     except Exception:

--- a/tests/static/test_plugin_settings_polish.py
+++ b/tests/static/test_plugin_settings_polish.py
@@ -1,5 +1,6 @@
 """Tests for plugin settings UX polish (JTN-184, JTN-174, JTN-157, JTN-158, JTN-154)."""
 
+import re
 from pathlib import Path
 
 
@@ -14,10 +15,9 @@ def test_todo_remove_last_item_guarded():
 def test_calendar_repeater_has_descriptive_placeholder():
     """Calendar URL input should have a descriptive placeholder."""
     html = Path("src/templates/widgets/calendar_repeater.html").read_text()
-    # lgtm[py/incomplete-url-substring-sanitization] — not URL sanitization;
-    # asserting that a Jinja template's static placeholder contains an example
-    # hostname for UX. No URL is parsed or trusted here.
-    assert ".ics" in html or "calendar.google.com" in html
+    assert re.search(
+        r'placeholder="https://calendar\.google\.com/…/basic\.ics"', html
+    )
 
 
 def test_calendar_repeater_has_help_text():

--- a/tests/static/test_plugin_settings_polish.py
+++ b/tests/static/test_plugin_settings_polish.py
@@ -15,9 +15,7 @@ def test_todo_remove_last_item_guarded():
 def test_calendar_repeater_has_descriptive_placeholder():
     """Calendar URL input should have a descriptive placeholder."""
     html = Path("src/templates/widgets/calendar_repeater.html").read_text()
-    assert re.search(
-        r'placeholder="https://calendar\.google\.com/…/basic\.ics"', html
-    )
+    assert re.search(r'placeholder="https://calendar\.google\.com/…/basic\.ics"', html)
 
 
 def test_calendar_repeater_has_help_text():

--- a/tests/unit/test_history_helpers.py
+++ b/tests/unit/test_history_helpers.py
@@ -1,0 +1,77 @@
+"""Tests for the internal history path helpers."""
+
+from __future__ import annotations
+
+
+def test_resolve_history_entry_path_returns_real_file(tmp_path):
+    from blueprints.history import _resolve_history_entry_path
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+    image = history_dir / "display_20250101_000000.png"
+    image.write_bytes(b"png")
+
+    resolved = _resolve_history_entry_path(str(history_dir), image.name)
+
+    assert resolved == str(image)
+
+
+def test_resolve_history_entry_path_returns_none_for_missing_file(tmp_path):
+    from blueprints.history import _resolve_history_entry_path
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+
+    assert _resolve_history_entry_path(str(history_dir), "missing.png") is None
+
+
+def test_resolve_history_entry_path_returns_none_for_directory_entry(tmp_path):
+    from blueprints.history import _resolve_history_entry_path
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+    (history_dir / "nested").mkdir()
+
+    assert _resolve_history_entry_path(str(history_dir), "nested") is None
+
+
+def test_resolve_history_entry_path_returns_none_for_symlink_escape(tmp_path):
+    from blueprints.history import _resolve_history_entry_path
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"png")
+    link = history_dir / "escape.png"
+    link.symlink_to(outside)
+
+    assert _resolve_history_entry_path(str(history_dir), link.name) is None
+
+
+def test_resolve_history_entry_path_returns_none_when_listdir_fails(
+    tmp_path, monkeypatch
+):
+    from blueprints.history import _resolve_history_entry_path
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+
+    def raise_oserror(_path):
+        raise OSError("boom")
+
+    monkeypatch.setattr("blueprints.history.os.listdir", raise_oserror)
+
+    assert _resolve_history_entry_path(str(history_dir), "display.png") is None
+
+
+def test_remove_history_entry_by_name_deletes_file(tmp_path):
+    from blueprints.history import _remove_history_entry_by_name
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+    image = history_dir / "display_20250101_000000.png"
+    image.write_bytes(b"png")
+
+    _remove_history_entry_by_name(str(history_dir), image.name)
+
+    assert not image.exists()


### PR DESCRIPTION
## Summary
- Hardened history file lookup and deletion so the code resolves entries by enumerating `history_dir` instead of using a tainted path directly.
- Kept redisplay and delete behavior intact while preserving the existing containment checks.
- Updated the static plugin-settings test to use an exact regex match so CodeQL no longer treats it like URL sanitization logic.

## Changes
- `src/blueprints/history.py`: added directory-based history lookup/removal helpers and switched redisplay/delete to use them.
- `tests/static/test_plugin_settings_polish.py`: replaced the substring check with a precise regex assertion for the calendar placeholder.

## Test plan
- `uv run pytest tests/integration/test_history.py tests/integration/test_history_xss.py tests/integration/test_history_button_regressions.py tests/unit/test_history_cleanup.py tests/static/test_plugin_settings_polish.py -q`
