### PR TITLE
chore(quality): tighten helper typing and Ruff rules

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -18,10 +18,18 @@ ongoing feature work.
 |---|---|
 | `src/utils/http_utils.py` | JTN-525 |
 | `src/utils/security_utils.py` | JTN-525 |
+| `src/utils/client_endpoint.py` | Quality guards PR |
+| `src/utils/display_names.py` | Quality guards PR |
+| `src/utils/messages.py` | Quality guards PR |
+| `src/utils/output_validator.py` | Quality guards PR |
+| `src/utils/paths.py` | Quality guards PR |
+| `src/utils/time_utils.py` | Quality guards PR |
 
 `src/utils/http_cache.py` was deliberately deferred from the initial strict
-set because it was recently refactored (JTN-493) and is still settling.  It
-will be added in a follow-up once it stabilizes.
+set because it was recently refactored (JTN-493) and is still settling. It
+will be added in a follow-up once it stabilizes. This PR extends the strict
+subset with a low-churn helper cluster instead of broadening strict mode
+repo-wide.
 
 ## How to add a module to the strict subset
 
@@ -41,7 +49,10 @@ will be added in a follow-up once it stabilizes.
 3. **Add the file to the blocking check in `scripts/lint.sh`:**
 
    ```bash
-   mypy --strict src/utils/http_utils.py src/utils/security_utils.py src/utils/your_module.py
+   mypy --strict \
+     src/utils/http_utils.py \
+     src/utils/security_utils.py \
+     src/utils/your_module.py
    ```
 4. **Update the table above** with the module path and Linear issue reference.
 5. Open a PR — CI will enforce strictness from that point forward.

--- a/mypy.ini
+++ b/mypy.ini
@@ -53,3 +53,21 @@ strict = True
 
 [mypy-utils.security_utils]
 strict = True
+
+[mypy-utils.client_endpoint]
+strict = True
+
+[mypy-utils.display_names]
+strict = True
+
+[mypy-utils.messages]
+strict = True
+
+[mypy-utils.output_validator]
+strict = True
+
+[mypy-utils.paths]
+strict = True
+
+[mypy-utils.time_utils]
+strict = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ select = [
   "SIM",    # flake8-simplify
   "C4",     # flake8-comprehensions
   "PERF",   # perflint
+  "PIE",    # flake8-pie
+  "RSE",    # flake8-raise
 ]
 ignore = [
   "E501",   # line length handled by Black

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -46,14 +46,22 @@ else
 fi
 
 echo "Running mypy strict check (blocking — strict subset only)..."
-# Strict subset: src/utils/http_utils.py and src/utils/security_utils.py
+# Strict subset: curated low-churn helpers that are enforced at --strict.
 # See docs/typing.md for how to add more modules to this list.
-mypy --strict src/utils/http_utils.py src/utils/security_utils.py
+mypy --strict \
+    src/utils/http_utils.py \
+    src/utils/security_utils.py \
+    src/utils/client_endpoint.py \
+    src/utils/display_names.py \
+    src/utils/messages.py \
+    src/utils/output_validator.py \
+    src/utils/paths.py \
+    src/utils/time_utils.py
 MYPY_STRICT_EXIT=$?
 if [ $MYPY_STRICT_EXIT -ne 0 ]; then
-    echo "❌ mypy strict: http_utils + security_utils failed (exit code: $MYPY_STRICT_EXIT)"
+    echo "❌ mypy strict helper subset failed (exit code: $MYPY_STRICT_EXIT)"
 else
-    echo "✅ mypy strict: http_utils + security_utils clean"
+    echo "✅ mypy strict helper subset clean"
 fi
 
 # Shell scripts under install/ and scripts/ — must pass shellcheck.
@@ -86,7 +94,7 @@ else
 fi
 
 # Report summary — whole-codebase mypy is advisory only; the strict subset
-# (http_utils + security_utils) is blocking.  Ruff, Black, and shellcheck are blocking.
+# (typed helper subset) is blocking. Ruff, Black, and shellcheck are blocking.
 if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     echo ""
     echo "❌ Some checks failed:"
@@ -107,4 +115,3 @@ if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] 
 fi
 
 exit 0
-

--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -55,7 +55,7 @@ def _safe_next_url(raw: str | None) -> str:
     if any(ord(c) < 0x20 or ord(c) == 0x7F for c in raw):
         return "/"
     # Reject protocol-relative ('//evil.com') and backslash-authority tricks.
-    if not raw.startswith("/") or raw.startswith("//") or raw.startswith("/\\"):
+    if not raw.startswith("/") or raw.startswith(("//", "/\\")):
         return "/"
     # Parse with a dummy scheme+host so urlsplit routes the value through the
     # standard URL parser; we only consume the path+query components below.

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -125,7 +125,7 @@ class BasePlugin:
                 b64 = base64.b64encode(f.read()).decode("ascii")
             # Best-effort mime by extension
             mime = "image/png"
-            if path.endswith(".jpg") or path.endswith(".jpeg"):
+            if path.endswith((".jpg", ".jpeg")):
                 mime = "image/jpeg"
             elif path.endswith(".gif"):
                 mime = "image/gif"

--- a/src/plugins/weather/weather_data.py
+++ b/src/plugins/weather/weather_data.py
@@ -252,7 +252,7 @@ def parse_open_meteo_forecast(daily_data, tz, is_day, lat, plugin_dir):
 
     forecast = []
 
-    for i in range(0, len(times)):
+    for i in range(len(times)):
         dt = datetime.fromisoformat(times[i])
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=tz)

--- a/src/utils/client_endpoint.py
+++ b/src/utils/client_endpoint.py
@@ -9,6 +9,7 @@ parsed dict or an error response that the caller can return directly.
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from flask import Response, request
 
@@ -18,7 +19,7 @@ from utils.rate_limit import TokenBucket
 
 def parse_client_report(
     rate_limiter: TokenBucket, body_max: int
-) -> tuple[dict | None, Response | tuple[Response, int] | None]:
+) -> tuple[dict[str, Any] | None, Response | tuple[Response, int] | None]:
     """Validate body size, rate-limit, and parse JSON.
 
     Returns ``(data, None)`` on success or ``(None, error_response)`` on

--- a/src/utils/image_serving.py
+++ b/src/utils/image_serving.py
@@ -119,7 +119,7 @@ def _safe_join(root: str, filename: str) -> str:
     """
     joined = safe_join(root, filename)
     if joined is None or not os.path.isfile(joined):
-        raise NotFound()
+        raise NotFound
     return joined
 
 

--- a/src/utils/output_validator.py
+++ b/src/utils/output_validator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from PIL import Image
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,13 +34,13 @@ class OutputDimensionMismatch(Exception):
 
 
 def validate_image_dimensions(
-    image,
+    image: Image.Image,
     expected_width: int,
     expected_height: int,
     plugin_id: str = "<unknown>",
     *,
     auto_rotate: bool = True,
-) -> object:
+) -> Image.Image:
     """Validate that *image* matches the expected display resolution.
 
     Parameters

--- a/src/utils/time_utils.py
+++ b/src/utils/time_utils.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, tzinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from config import Config
@@ -20,7 +20,7 @@ def calculate_seconds(interval: int, unit: str) -> int:
     return seconds
 
 
-def get_timezone(tz_name: str | None):
+def get_timezone(tz_name: str | None) -> tzinfo:
     """Return a tzinfo for the provided timezone name using zoneinfo.
 
     Falls back to UTC if the timezone string is invalid or missing.
@@ -100,8 +100,6 @@ def get_next_occurrence(cron_expr: str, now: datetime | None = None) -> datetime
     dow = parse_cron_field(dow_f, 0, 6)
 
     candidate = now.replace(second=0, microsecond=0)
-    from datetime import timedelta
-
     for _ in range(60 * 24 * 366):  # up to 1 year search
         candidate += timedelta(minutes=1)
         if candidate.minute not in minutes:

--- a/tests/integration/test_settings_more.py
+++ b/tests/integration/test_settings_more.py
@@ -309,7 +309,6 @@ def test_api_logs_rate_limiting_disabled(monkeypatch):
 
     # This would normally work but we can't easily test the full flow without mocking more
     # The rate limit check happens before the main logic
-    pass
 
 
 def test_api_logs_exception_handling(client, monkeypatch):

--- a/tests/integration/test_weather_image_render.py
+++ b/tests/integration/test_weather_image_render.py
@@ -155,7 +155,7 @@ def test_weather_template_loads_images(client, device_config_dev, monkeypatch):
         loaded = 0
         for img in imgs:
             src = img.get_attribute("src") or ""
-            if src.startswith("file://") or src.startswith("data:"):
+            if src.startswith(("file://", "data:")):
                 # Wait for load and check naturalWidth
                 page.evaluate(
                     "img => new Promise(r => { if (img.complete) r(); else img.onload = () => r(); })",

--- a/tests/plugins/test_calendar.py
+++ b/tests/plugins/test_calendar.py
@@ -136,8 +136,8 @@ def test_parse_data_points_datetime_with_dtend():
         }
     )
     start, end, all_day = p.parse_data_points(event, tz)
-    assert start.endswith("-05:00") or start.endswith("-04:00")  # timezone adjusted
-    assert end.endswith("-05:00") or end.endswith("-04:00")
+    assert start.endswith(("-05:00", "-04:00"))  # timezone adjusted
+    assert end.endswith(("-05:00", "-04:00"))
     assert all_day is False
 
 

--- a/tests/unit/test_app_utils.py
+++ b/tests/unit/test_app_utils.py
@@ -100,7 +100,7 @@ def test_is_connected_true_false(monkeypatch):
 
     # False case: create_connection raises OSError
     def _raise(*_a, **_k):
-        raise OSError()
+        raise OSError
 
     monkeypatch.setattr(socket, "create_connection", _raise)
     assert app_utils.is_connected() is False

--- a/tests/unit/test_inkypi.py
+++ b/tests/unit/test_inkypi.py
@@ -355,7 +355,7 @@ def test_read_version_missing_both_sources_returns_unknown(monkeypatch):
 
     def _patched_open(path, *args, **kwargs):
         name = str(path)
-        if name.endswith("VERSION") or name.endswith("pyproject.toml"):
+        if name.endswith(("VERSION", "pyproject.toml")):
             raise FileNotFoundError("No such file")
         return _real_open(path, *args, **kwargs)
 

--- a/tests/unit/test_json_formatter.py
+++ b/tests/unit/test_json_formatter.py
@@ -64,7 +64,7 @@ def test_ts_is_iso8601_utc():
     data = json.loads(JsonFormatter().format(record))
     ts = data["ts"]
     assert "T" in ts
-    assert ts.endswith("+00:00") or ts.endswith("Z"), f"Expected UTC ts, got: {ts}"
+    assert ts.endswith(("+00:00", "Z")), f"Expected UTC ts, got: {ts}"
 
 
 def test_pid_is_integer():

--- a/tests/unit/test_time_utils.py
+++ b/tests/unit/test_time_utils.py
@@ -28,7 +28,7 @@ def test_calculate_seconds_default_value_for_unrecognized_unit():
 
 def test_parse_cron_field_wildcard():
     result = parse_cron_field("*", 0, 59)
-    assert result == set(range(0, 60))
+    assert result == set(range(60))
 
 
 def test_parse_cron_field_single_value():

--- a/tests/unit/test_time_utils_coverage.py
+++ b/tests/unit/test_time_utils_coverage.py
@@ -62,7 +62,7 @@ def test_now_device_tz_falls_back_on_exception():
 
 def test_parse_cron_field_wildcard():
     result = parse_cron_field("*", 0, 59)
-    assert result == set(range(0, 60))
+    assert result == set(range(60))
 
 
 def test_parse_cron_field_range():


### PR DESCRIPTION
## Summary
- expand the blocking mypy strict subset to a small low-churn helper cluster
- add targeted type annotations to helper modules promoted into the strict subset
- enable small Ruff ratchets (PIE and RSE) and fix the newly enforced findings

## What changed
- added strict mypy enforcement for helper modules in src/utils
- updated scripts/lint.sh and docs/typing.md to reflect the larger strict helper subset
- tightened helper annotations in client_endpoint, output_validator, and time_utils
- cleaned up straightforward Ruff findings in app code and tests

## Validation
- mypy --strict src/utils/http_utils.py src/utils/security_utils.py src/utils/client_endpoint.py src/utils/display_names.py src/utils/messages.py src/utils/output_validator.py src/utils/paths.py src/utils/time_utils.py
- ruff check src tests scripts
- python -m pytest -q tests/unit/test_time_utils.py tests/unit/test_time_utils_coverage.py tests/unit/test_output_validator.py tests/unit/test_app_utils.py
- CI=true scripts/lint.sh
