### PR TITLE
chore(quality): expand strict helper subset

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -23,6 +23,9 @@ ongoing feature work.
 | `src/utils/messages.py` | Quality guards PR |
 | `src/utils/output_validator.py` | Quality guards PR |
 | `src/utils/paths.py` | Quality guards PR |
+| `src/utils/refresh_info.py` | Quality guards follow-up PR |
+| `src/utils/refresh_stats.py` | Quality guards follow-up PR |
+| `src/utils/sri.py` | Quality guards follow-up PR |
 | `src/utils/time_utils.py` | Quality guards PR |
 
 `src/utils/http_cache.py` was deliberately deferred from the initial strict

--- a/mypy.ini
+++ b/mypy.ini
@@ -69,5 +69,14 @@ strict = True
 [mypy-utils.paths]
 strict = True
 
+[mypy-utils.refresh_info]
+strict = True
+
+[mypy-utils.refresh_stats]
+strict = True
+
+[mypy-utils.sri]
+strict = True
+
 [mypy-utils.time_utils]
 strict = True

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -56,6 +56,9 @@ mypy --strict \
     src/utils/messages.py \
     src/utils/output_validator.py \
     src/utils/paths.py \
+    src/utils/refresh_info.py \
+    src/utils/refresh_stats.py \
+    src/utils/sri.py \
     src/utils/time_utils.py
 MYPY_STRICT_EXIT=$?
 if [ $MYPY_STRICT_EXIT -ne 0 ]; then

--- a/src/utils/refresh_info.py
+++ b/src/utils/refresh_info.py
@@ -5,10 +5,13 @@ main config god-object.
 """
 
 import logging
+from typing import Any, cast
 
 from model import RefreshInfo
 
 logger = logging.getLogger(__name__)
+
+RefreshInfoDict = dict[str, Any]
 
 
 class RefreshInfoRepository:
@@ -18,7 +21,7 @@ class RefreshInfoRepository:
     sub-key) and exposes the resulting model object.
     """
 
-    def __init__(self, raw_data: dict | None = None):
+    def __init__(self, raw_data: RefreshInfoDict | None = None):
         self.refresh_info = self._load(raw_data)
 
     # ------------------------------------------------------------------
@@ -33,16 +36,16 @@ class RefreshInfoRepository:
         """Replace the current :class:`RefreshInfo`."""
         self.refresh_info = refresh_info
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> RefreshInfoDict:
         """Serialise the current state for inclusion in the config file."""
-        return self.refresh_info.to_dict()
+        return cast(RefreshInfoDict, self.refresh_info.to_dict())
 
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _load(data: dict | None) -> RefreshInfo:
+    def _load(data: RefreshInfoDict | None) -> RefreshInfo:
         """Parse *data* into a :class:`RefreshInfo`, falling back to defaults."""
         data = data if isinstance(data, dict) else {}
         try:

--- a/src/utils/refresh_stats.py
+++ b/src/utils/refresh_stats.py
@@ -34,7 +34,10 @@ logger = logging.getLogger(__name__)
 
 _CACHE_TTL_SECONDS = 60
 
-_cache: dict[tuple[str, int], tuple[float, dict]] = {}
+RefreshStatsRecord = dict[str, Any]
+RefreshStatsResult = dict[str, Any]
+
+_cache: dict[tuple[str, int], tuple[float, RefreshStatsResult]] = {}
 
 
 def _now() -> float:
@@ -50,13 +53,13 @@ def _percentile(sorted_values: list[float], pct: float) -> int:
     return int(sorted_values[idx])
 
 
-def _load_sidecars(history_dir: str, since: float) -> list[dict[str, Any]]:
+def _load_sidecars(history_dir: str, since: float) -> list[RefreshStatsRecord]:
     """Read all JSON sidecar files from *history_dir* whose timestamp >= *since*.
 
     Only reads files that end with ``.json``.  Malformed or unreadable files are
     silently skipped.
     """
-    records: list[dict[str, Any]] = []
+    records: list[RefreshStatsRecord] = []
     try:
         names = os.listdir(history_dir)
     except OSError:
@@ -94,7 +97,7 @@ def _load_sidecars(history_dir: str, since: float) -> list[dict[str, Any]]:
     return records
 
 
-def _compute_window(records: list[dict[str, Any]]) -> dict:
+def _compute_window(records: list[RefreshStatsRecord]) -> RefreshStatsResult:
     """Build the stats dict for a pre-filtered list of sidecar records."""
     total = len(records)
     success = sum(1 for r in records if r.get("status") == "success")
@@ -133,7 +136,7 @@ def _compute_window(records: list[dict[str, Any]]) -> dict:
     }
 
 
-def compute_stats(history_dir: str, window_seconds: int) -> dict:
+def compute_stats(history_dir: str, window_seconds: int) -> RefreshStatsResult:
     """Return refresh aggregates for the last *window_seconds* seconds.
 
     Results are cached for 60 seconds per (history_dir, window_seconds) pair.

--- a/src/utils/sri.py
+++ b/src/utils/sri.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import logging
 from pathlib import Path
+from typing import cast
 
 from flask import Flask
 
@@ -26,7 +27,9 @@ _CDN_MANIFEST_PATH = _STATIC_ROOT / "cdn_manifest.json"
 
 # Per-process caches — avoids recomputing hashes on every request.
 _sri_cache: dict[str, str] = {}
-_cdn_manifest_cache: dict[str, dict] | None = None
+CDNManifestEntry = dict[str, str]
+CDNManifest = dict[str, CDNManifestEntry]
+_cdn_manifest_cache: CDNManifest | None = None
 _cdn_manifest_loaded: bool = False
 
 
@@ -77,7 +80,7 @@ def sri_for(static_rel_path: str) -> str:
     return result
 
 
-def _load_cdn_manifest() -> dict[str, dict]:
+def _load_cdn_manifest() -> CDNManifest:
     """Return the CDN manifest dict, loading from disk on first call."""
     global _cdn_manifest_cache, _cdn_manifest_loaded
     if _cdn_manifest_loaded:
@@ -85,9 +88,8 @@ def _load_cdn_manifest() -> dict[str, dict]:
     _cdn_manifest_loaded = True
     if _CDN_MANIFEST_PATH.is_file():
         try:
-            _cdn_manifest_cache = json.loads(
-                _CDN_MANIFEST_PATH.read_text(encoding="utf-8")
-            )
+            raw_manifest = json.loads(_CDN_MANIFEST_PATH.read_text(encoding="utf-8"))
+            _cdn_manifest_cache = cast(CDNManifest, raw_manifest)
             logger.debug("Loaded CDN manifest from %s", _CDN_MANIFEST_PATH)
         except Exception as exc:
             logger.warning("Failed to parse CDN manifest: %s", exc)
@@ -107,7 +109,8 @@ def cdn_sri(key: str) -> str:
     """
     manifest = _load_cdn_manifest()
     entry = manifest.get(key, {})
-    return entry.get("integrity", "")
+    integrity = entry.get("integrity", "")
+    return integrity if isinstance(integrity, str) else ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- extend the blocking mypy strict subset with three more low-churn utility modules
- add explicit dict/result typing in refresh metadata and SRI helpers
- keep the ratchet focused on modules that are already close to strict-clean

## What changed
- promoted src/utils/refresh_info.py into the strict subset
- promoted src/utils/refresh_stats.py into the strict subset
- promoted src/utils/sri.py into the strict subset
- updated scripts/lint.sh and docs/typing.md to reflect the larger helper subset

## Validation
- python -m mypy --strict src/utils/http_utils.py src/utils/security_utils.py src/utils/client_endpoint.py src/utils/display_names.py src/utils/messages.py src/utils/output_validator.py src/utils/paths.py src/utils/refresh_info.py src/utils/refresh_stats.py src/utils/sri.py src/utils/time_utils.py
- python -m pytest -q tests/test_refresh_stats.py tests/test_sri.py
- python -m ruff check src tests scripts
- CI=true scripts/lint.sh
