### PR TITLE
chore(quality): tighten refresh task typing

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -25,6 +25,9 @@ ongoing feature work.
 | `src/utils/paths.py` | Quality guards PR |
 | `src/utils/refresh_info.py` | Quality guards follow-up PR |
 | `src/utils/refresh_stats.py` | Quality guards follow-up PR |
+| `src/refresh_task/actions.py` | Refresh guards PR |
+| `src/refresh_task/context.py` | Refresh guards PR |
+| `src/refresh_task/worker.py` | Refresh guards PR |
 | `src/utils/sri.py` | Quality guards follow-up PR |
 | `src/utils/time_utils.py` | Quality guards PR |
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -80,3 +80,12 @@ strict = True
 
 [mypy-utils.time_utils]
 strict = True
+
+[mypy-refresh_task.actions]
+strict = True
+
+[mypy-refresh_task.context]
+strict = True
+
+[mypy-refresh_task.worker]
+strict = True

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -58,6 +58,9 @@ mypy --strict \
     src/utils/paths.py \
     src/utils/refresh_info.py \
     src/utils/refresh_stats.py \
+    src/refresh_task/actions.py \
+    src/refresh_task/context.py \
+    src/refresh_task/worker.py \
     src/utils/sri.py \
     src/utils/time_utils.py
 MYPY_STRICT_EXIT=$?

--- a/src/refresh_task/actions.py
+++ b/src/refresh_task/actions.py
@@ -3,12 +3,53 @@
 import logging
 import os
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Protocol
+
+from PIL import Image
 
 from utils.image_utils import load_image_from_path
 
 logger = logging.getLogger(__name__)
+
+
+Metrics = dict[str, object]
+RefreshInfo = dict[str, str]
+
+
+class PluginLike(Protocol):
+    """Minimum plugin interface required by refresh actions."""
+
+    def generate_image(
+        self, settings: Mapping[str, object], device_config: object
+    ) -> Image.Image: ...
+
+
+class DeviceConfigLike(Protocol):
+    """Config surface needed by refresh actions."""
+
+    plugin_image_dir: str
+
+
+class PlaylistLike(Protocol):
+    """Playlist surface needed to report refresh metadata."""
+
+    name: str
+
+
+class PluginInstanceLike(Protocol):
+    """Playlist plugin-instance surface required for execution."""
+
+    plugin_id: str
+    name: str
+    settings: Mapping[str, object]
+    latest_refresh_time: str | None
+
+    def get_image_path(self) -> str: ...
+
+    def should_refresh(self, current_dt: datetime) -> bool: ...
 
 
 @dataclass
@@ -16,7 +57,7 @@ class ManualUpdateRequest:
     request_id: str
     refresh_action: "RefreshAction"
     done: threading.Event = field(default_factory=threading.Event)
-    metrics: dict | None = None
+    metrics: Metrics | None = None
     exception: BaseException | None = None
 
 
@@ -27,17 +68,19 @@ class RefreshAction:
     and return the resulting image.
     """
 
-    def execute(self, plugin, device_config, current_dt):
+    def execute(
+        self, plugin: PluginLike, device_config: DeviceConfigLike, current_dt: datetime
+    ) -> Image.Image:
         """Execute the refresh operation and return the updated image."""
         raise NotImplementedError("Subclasses must implement the execute method.")
 
-    def get_refresh_info(self):
+    def get_refresh_info(self) -> RefreshInfo:
         """Return refresh metadata as a dictionary."""
         raise NotImplementedError(
             "Subclasses must implement the get_refresh_info method."
         )
 
-    def get_plugin_id(self):
+    def get_plugin_id(self) -> str:
         """Return the plugin ID associated with this refresh."""
         raise NotImplementedError("Subclasses must implement the get_plugin_id method.")
 
@@ -47,22 +90,24 @@ class ManualRefresh(RefreshAction):
 
     Attributes:
         plugin_id (str): The ID of the plugin to refresh.
-        plugin_settings (dict): The settings for the manual refresh.
+        plugin_settings (dict[str, object]): The settings for the manual refresh.
     """
 
-    def __init__(self, plugin_id: str, plugin_settings: dict):
+    def __init__(self, plugin_id: str, plugin_settings: Mapping[str, object]) -> None:
         self.plugin_id = plugin_id
-        self.plugin_settings = plugin_settings
+        self.plugin_settings = dict(plugin_settings)
 
-    def execute(self, plugin, device_config, current_dt: datetime):
+    def execute(
+        self, plugin: PluginLike, device_config: DeviceConfigLike, current_dt: datetime
+    ) -> Image.Image:
         """Performs a manual refresh using the stored plugin ID and settings."""
         return plugin.generate_image(self.plugin_settings, device_config)
 
-    def get_refresh_info(self):
+    def get_refresh_info(self) -> RefreshInfo:
         """Return refresh metadata as a dictionary."""
         return {"refresh_type": "Manual Update", "plugin_id": self.plugin_id}
 
-    def get_plugin_id(self):
+    def get_plugin_id(self) -> str:
         """Return the plugin ID associated with this refresh."""
         return self.plugin_id
 
@@ -75,12 +120,17 @@ class PlaylistRefresh(RefreshAction):
         plugin_instance: The plugin instance to refresh.
     """
 
-    def __init__(self, playlist, plugin_instance, force=False):
+    def __init__(
+        self,
+        playlist: PlaylistLike,
+        plugin_instance: PluginInstanceLike,
+        force: bool = False,
+    ) -> None:
         self.playlist = playlist
         self.plugin_instance = plugin_instance
         self.force = force
 
-    def get_refresh_info(self):
+    def get_refresh_info(self) -> RefreshInfo:
         """Return refresh metadata as a dictionary."""
         return {
             "refresh_type": "Playlist",
@@ -89,11 +139,13 @@ class PlaylistRefresh(RefreshAction):
             "plugin_instance": self.plugin_instance.name,
         }
 
-    def get_plugin_id(self):
+    def get_plugin_id(self) -> str:
         """Return the plugin ID associated with this refresh."""
         return self.plugin_instance.plugin_id
 
-    def execute(self, plugin, device_config, current_dt: datetime):
+    def execute(
+        self, plugin: PluginLike, device_config: DeviceConfigLike, current_dt: datetime
+    ) -> Image.Image:
         """Performs a refresh for the specified plugin instance within its playlist context."""
         # Determine the file path for the plugin's image
         plugin_image_path = os.path.join(

--- a/src/refresh_task/context.py
+++ b/src/refresh_task/context.py
@@ -10,6 +10,24 @@ was fragile, especially under ``forkserver`` / ``spawn`` start methods.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from config import Config
+
+
+class SupportsRefreshConfig(Protocol):
+    """Config interface needed to snapshot and restore refresh state."""
+
+    config_file: str
+    current_image_file: str
+    processed_image_file: str
+    plugin_image_dir: str
+    history_image_dir: str
+
+    def get_resolution(self) -> tuple[int, int]: ...
+
+    def get_config(self, key: str, default: object = ...) -> object: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,7 +57,7 @@ class RefreshContext:
     timezone: str
 
     @classmethod
-    def from_config(cls, device_config) -> RefreshContext:
+    def from_config(cls, device_config: SupportsRefreshConfig) -> RefreshContext:
         """Build a ``RefreshContext`` from a live :class:`Config` instance.
 
         This is the canonical factory used at the application boundary
@@ -60,7 +78,8 @@ class RefreshContext:
 
         tz = "UTC"
         try:
-            tz = device_config.get_config("timezone", default="UTC") or "UTC"
+            raw_tz = device_config.get_config("timezone", default="UTC")
+            tz = str(raw_tz or "UTC")
         except Exception:
             pass
 
@@ -76,7 +95,7 @@ class RefreshContext:
             timezone=str(tz),
         )
 
-    def restore_child_config(self):
+    def restore_child_config(self) -> Config:
         """Rebuild the ``Config`` singleton inside a subprocess from this snapshot.
 
         Sets the class-level path attributes on ``Config`` before

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -5,13 +5,53 @@ import logging
 import multiprocessing
 import sys
 import traceback
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 from plugins.plugin_registry import get_plugin_instance
+from refresh_task.actions import PluginLike, RefreshAction
+from refresh_task.context import RefreshContext, SupportsRefreshConfig
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from config import Config
 
-def _get_mp_context():
+
+class LegacyConfigLike(Protocol):
+    """Legacy pickled config shape accepted by the worker."""
+
+    config_file: str
+    current_image_file: str
+    processed_image_file: str
+    plugin_image_dir: str
+    history_image_dir: str
+
+
+class WorkerSuccessPayload(TypedDict):
+    ok: bool
+    image_bytes: bytes
+    plugin_meta: object
+
+
+class WorkerErrorPayload(TypedDict):
+    ok: bool
+    error_type: str
+    error_message: str
+    traceback: str
+
+
+WorkerPayload = WorkerSuccessPayload | WorkerErrorPayload
+
+
+class ResultQueueLike(Protocol):
+    """Queue interface shared by queue.Queue and multiprocessing.Queue."""
+
+    def put(self, item: WorkerPayload) -> object: ...
+
+
+def _get_mp_context() -> multiprocessing.context.BaseContext:
     """Return the best available multiprocessing start context for this platform.
 
     Prefers ``forkserver`` on Linux (lower memory overhead on constrained
@@ -34,7 +74,9 @@ def _get_mp_context():
     return multiprocessing.get_context()
 
 
-def _restore_child_config(device_config):
+def _restore_child_config(
+    device_config: RefreshContext | LegacyConfigLike,
+) -> "Config | SupportsRefreshConfig":
     """Re-initialise the Config singleton inside a subprocess from a serialised snapshot.
 
     Accepts either a :class:`RefreshContext` dataclass (preferred) or a
@@ -50,8 +92,6 @@ def _restore_child_config(device_config):
     Returns:
         A new :class:`Config` instance initialised from the snapshot paths.
     """
-    from refresh_task.context import RefreshContext
-
     if isinstance(device_config, RefreshContext):
         return device_config.restore_child_config()
 
@@ -94,12 +134,12 @@ def _remote_exception(error_type: str, error_message: str) -> BaseException:
 
 
 def _execute_refresh_attempt_worker(
-    result_queue,
-    plugin_config: dict,
-    refresh_action,
-    refresh_context,
-    current_dt,
-):
+    result_queue: ResultQueueLike,
+    plugin_config: Mapping[str, object],
+    refresh_action: RefreshAction,
+    refresh_context: RefreshContext | LegacyConfigLike,
+    current_dt: datetime,
+) -> None:
     """Entry point for a plugin execution subprocess.
 
     Intended to be the ``target`` of a ``multiprocessing.Process``.
@@ -119,11 +159,16 @@ def _execute_refresh_attempt_worker(
     """
     try:
         child_config = _restore_child_config(refresh_context)
-        plugin = get_plugin_instance(plugin_config)
+        plugin_loader = cast(
+            Callable[[Mapping[str, object]], PluginLike],
+            get_plugin_instance,
+        )
+        plugin = plugin_loader(plugin_config)
         image = refresh_action.execute(plugin, child_config, current_dt)
         plugin_meta = None
         if hasattr(plugin, "get_latest_metadata"):
-            plugin_meta = plugin.get_latest_metadata()
+            metadata_getter = cast(Callable[[], object], plugin.get_latest_metadata)
+            plugin_meta = metadata_getter()
         if image is None:
             raise RuntimeError("Plugin returned None image")
         image_bytes = io.BytesIO()


### PR DESCRIPTION
## Summary
- add `src/refresh_task/actions.py`, `src/refresh_task/context.py`, and `src/refresh_task/worker.py` to the blocking strict mypy subset
- tighten the refresh action/context/worker interfaces with explicit protocols and payload typing
- document and enforce the new strict refresh-task subset in typing docs and lint

## Validation
- `python -m mypy --strict src/refresh_task/actions.py src/refresh_task/context.py src/refresh_task/worker.py`
- `ruff check src/refresh_task/actions.py src/refresh_task/context.py src/refresh_task/worker.py`
- `CI=true scripts/lint.sh`

## Notes
- `pytest -q tests/unit/test_refresh_context.py tests/unit/test_refresh_task_critical.py tests/unit/test_refresh_task_stress.py` currently fails during import in this worktree because `prometheus_client` is not installed.
