### PR TITLE
chore(typing): split advisory mypy into src and tests passes

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -63,12 +63,38 @@ repo-wide.
 4. **Update the table above** with the module path and Linear issue reference.
 5. Open a PR — CI will enforce strictness from that point forward.
 
-## Advisory whole-codebase check
+## Advisory checks: split `src/` vs `tests/`
 
-`scripts/lint.sh` also runs `mypy src tests` (non-strict) over the entire
-codebase.  Failures there are printed with a `⚠️` warning but do **not** block
-the lint step.  This keeps visibility into type drift without blocking PRs on
-pre-existing issues.
+`scripts/lint.sh` runs the advisory (non-strict) mypy pass as **two separate
+invocations** instead of one:
+
+1. `mypy src/` — production code
+2. `mypy tests/` — test suite
+
+Both are non-blocking — failures are printed with a `⚠️` warning and the
+error counts are reported separately. The strict subset above is the only
+mypy check that blocks CI.
+
+### Why the split?
+
+The test suite carries far more advisory typing noise than `src/` (fixtures,
+monkeypatching, duck-typed stubs). When both were combined into a single
+`mypy src tests` run, a small regression in production code was invisible —
+drowned out by thousands of test-only errors. Splitting the counts makes
+**`src/` type drift legible so we can ratchet it downward** and eventually
+promote more modules into the strict subset.
+
+### What to do if the `src/` count goes up
+
+1. Run `mypy src/` locally and look at the diff in errors vs `main`.
+2. If your PR introduced the new errors, fix them before merging — even
+   though the check is advisory, rising `src/` counts block our ability to
+   grow the strict subset.
+3. If the increase is unrelated to your change (e.g. a dependency bump),
+   open a follow-up issue and call it out in the PR description.
+
+Increases in the `tests/` count are lower priority but still worth a glance —
+prefer fixing them opportunistically in the same area you're already editing.
 
 ## Coding guidelines for typed modules
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -43,36 +43,59 @@ fi
 # below is CI-blocking. See docs/typing.md.
 count_mypy_errors() {
     # Parse "Found N errors" / "Success: ..." lines from captured output.
+    # Returns "?" when mypy exited non-zero without a recognizable summary
+    # (config error, import failure, crash) so callers don't misreport "0".
     local output="$1"
+    local exit_code="${2:-0}"
     local n
-    n=$(printf '%s\n' "$output" | grep -Eo 'Found [0-9]+ error' | grep -Eo '[0-9]+' | tail -1)
+    n=$(printf '%s\n' "$output" | sed -nE 's/.*Found ([0-9]+) errors?.*/\1/p' | tail -1)
     if [ -z "$n" ]; then
-        n=0
+        if printf '%s\n' "$output" | grep -q '^Success:'; then
+            n=0
+        elif [ "$exit_code" -ne 0 ]; then
+            # Non-zero exit, no summary — treat as a failed run with unknown count
+            n="?"
+        else
+            n=0
+        fi
     fi
     echo "$n"
 }
 
-echo "Running mypy type checker (advisory — src/ only)..."
-MYPY_SRC_OUTPUT="$(mypy src 2>&1)"
-MYPY_SRC_EXIT=$?
-echo "$MYPY_SRC_OUTPUT"
-MYPY_SRC_COUNT=$(count_mypy_errors "$MYPY_SRC_OUTPUT")
-if [ $MYPY_SRC_EXIT -ne 0 ]; then
-    echo "⚠️  mypy src/: advisory only — ${MYPY_SRC_COUNT} issue(s) found"
-else
-    echo "✅ mypy src/ advisory type check passed"
-fi
+# Run mypy on a directory as an advisory (non-blocking) check.
+# Sets globals MYPY_<UPPER_LABEL>_EXIT and MYPY_<UPPER_LABEL>_COUNT so the
+# outer script can reference them in the summary block below.
+run_advisory_mypy() {
+    local dir_path="$1"
+    local label="$2"
+    local var_key="$3"   # e.g. SRC or TESTS — used to build global var names
+    local output
+    local exit_code
+    local count
 
-echo "Running mypy type checker (advisory — tests/ only)..."
-MYPY_TESTS_OUTPUT="$(mypy tests 2>&1)"
-MYPY_TESTS_EXIT=$?
-echo "$MYPY_TESTS_OUTPUT"
-MYPY_TESTS_COUNT=$(count_mypy_errors "$MYPY_TESTS_OUTPUT")
-if [ $MYPY_TESTS_EXIT -ne 0 ]; then
-    echo "⚠️  mypy tests/: advisory only — ${MYPY_TESTS_COUNT} issue(s) found"
-else
-    echo "✅ mypy tests/ advisory type check passed"
-fi
+    echo "Running mypy type checker (advisory — ${label} only)..."
+    output="$(mypy "$dir_path" 2>&1)"
+    exit_code=$?
+    echo "$output"
+    count=$(count_mypy_errors "$output" "$exit_code")
+
+    if [ "$exit_code" -ne 0 ]; then
+        if [ "$count" = "?" ]; then
+            echo "⚠️  mypy ${label}: failed (see output above)"
+        else
+            echo "⚠️  mypy ${label}: advisory only — ${count} issue(s) found"
+        fi
+    else
+        echo "✅ mypy ${label} advisory type check passed"
+    fi
+
+    # Write through to globals for the final summary.
+    printf -v "MYPY_${var_key}_EXIT" '%s' "$exit_code"
+    printf -v "MYPY_${var_key}_COUNT" '%s' "$count"
+}
+
+run_advisory_mypy src "src/" SRC
+run_advisory_mypy tests "tests/" TESTS
 
 echo "Running mypy strict check (blocking — strict subset only)..."
 # Strict subset: curated low-churn helpers that are enforced at --strict.
@@ -143,8 +166,20 @@ else
     echo ""
     echo "✅ All checks passed!"
 fi
-[ $MYPY_SRC_EXIT -ne 0 ] && echo "⚠️  mypy src/: advisory only — ${MYPY_SRC_COUNT} issue(s) remain (non-blocking)"
-[ $MYPY_TESTS_EXIT -ne 0 ] && echo "⚠️  mypy tests/: advisory only — ${MYPY_TESTS_COUNT} issue(s) remain (non-blocking)"
+if [ $MYPY_SRC_EXIT -ne 0 ]; then
+    if [ "$MYPY_SRC_COUNT" = "?" ]; then
+        echo "⚠️  mypy src/: failed without summary (non-blocking — see output above)"
+    else
+        echo "⚠️  mypy src/: advisory only — ${MYPY_SRC_COUNT} issue(s) remain (non-blocking)"
+    fi
+fi
+if [ $MYPY_TESTS_EXIT -ne 0 ]; then
+    if [ "$MYPY_TESTS_COUNT" = "?" ]; then
+        echo "⚠️  mypy tests/: failed without summary (non-blocking — see output above)"
+    else
+        echo "⚠️  mypy tests/: advisory only — ${MYPY_TESTS_COUNT} issue(s) remain (non-blocking)"
+    fi
+fi
 
 if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     exit 1

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -14,7 +14,8 @@ fi
 # Track failures
 RUFF_EXIT=0
 BLACK_EXIT=0
-MYPY_EXIT=0
+MYPY_SRC_EXIT=0
+MYPY_TESTS_EXIT=0
 MYPY_STRICT_EXIT=0
 SHELLCHECK_EXIT=0
 
@@ -36,13 +37,41 @@ else
     echo "✅ Black formatting check passed"
 fi
 
-echo "Running mypy type checker (advisory — whole codebase)..."
-mypy src tests
-MYPY_EXIT=$?
-if [ $MYPY_EXIT -ne 0 ]; then
-    echo "⚠️  mypy: advisory only (except strict subset) — $MYPY_EXIT issue(s) found"
+# Advisory mypy is split into two passes (src/ and tests/) so that
+# production-code type drift stays visible even when test-only typing
+# noise dominates. Both passes are non-blocking; only the strict subset
+# below is CI-blocking. See docs/typing.md.
+count_mypy_errors() {
+    # Parse "Found N errors" / "Success: ..." lines from captured output.
+    local output="$1"
+    local n
+    n=$(printf '%s\n' "$output" | grep -Eo 'Found [0-9]+ error' | grep -Eo '[0-9]+' | tail -1)
+    if [ -z "$n" ]; then
+        n=0
+    fi
+    echo "$n"
+}
+
+echo "Running mypy type checker (advisory — src/ only)..."
+MYPY_SRC_OUTPUT="$(mypy src 2>&1)"
+MYPY_SRC_EXIT=$?
+echo "$MYPY_SRC_OUTPUT"
+MYPY_SRC_COUNT=$(count_mypy_errors "$MYPY_SRC_OUTPUT")
+if [ $MYPY_SRC_EXIT -ne 0 ]; then
+    echo "⚠️  mypy src/: advisory only — ${MYPY_SRC_COUNT} issue(s) found"
 else
-    echo "✅ mypy advisory type check passed"
+    echo "✅ mypy src/ advisory type check passed"
+fi
+
+echo "Running mypy type checker (advisory — tests/ only)..."
+MYPY_TESTS_OUTPUT="$(mypy tests 2>&1)"
+MYPY_TESTS_EXIT=$?
+echo "$MYPY_TESTS_OUTPUT"
+MYPY_TESTS_COUNT=$(count_mypy_errors "$MYPY_TESTS_OUTPUT")
+if [ $MYPY_TESTS_EXIT -ne 0 ]; then
+    echo "⚠️  mypy tests/: advisory only — ${MYPY_TESTS_COUNT} issue(s) found"
+else
+    echo "✅ mypy tests/ advisory type check passed"
 fi
 
 echo "Running mypy strict check (blocking — strict subset only)..."
@@ -114,7 +143,8 @@ else
     echo ""
     echo "✅ All checks passed!"
 fi
-[ $MYPY_EXIT -ne 0 ] && echo "⚠️  mypy: advisory only (except strict subset) — issues remain (non-blocking)"
+[ $MYPY_SRC_EXIT -ne 0 ] && echo "⚠️  mypy src/: advisory only — ${MYPY_SRC_COUNT} issue(s) remain (non-blocking)"
+[ $MYPY_TESTS_EXIT -ne 0 ] && echo "⚠️  mypy tests/: advisory only — ${MYPY_TESTS_COUNT} issue(s) remain (non-blocking)"
 
 if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     exit 1


### PR DESCRIPTION
## Summary
- Replaces the single `mypy src tests` advisory invocation in `scripts/lint.sh` with two labeled, non-blocking passes: one for `src/` and one for `tests/`, each reporting its own error count.
- Updates `docs/typing.md` with a new "Advisory checks: split src/ vs tests/" section explaining why the split exists (keep production type drift legible so we can ratchet the strict subset) and how contributors should respond when the `src/` count rises.
- Leaves the blocking strict subset untouched — same modules, still `mypy --strict`, still CI-blocking.
- No `mypy.ini` schema changes were needed; both passes work with the existing config.

## Validation
Ran locally from the worktree:

```
CI=true bash scripts/lint.sh
```

Result (tail):
- `mypy src/`: advisory only — **1397** issue(s)
- `mypy tests/`: advisory only — **6028** issue(s)
- `mypy --strict` (subset): `Success: no issues found in 14 source files`
- Ruff, Black, shellcheck: all passed
- Overall: `All checks passed!` (advisory warnings preserved as non-blocking)

## Test plan
- [ ] CI runs `scripts/lint.sh` and shows both `mypy src/` and `mypy tests/` advisory lines with separate counts.
- [ ] Strict mypy subset remains blocking and clean.
- [ ] Ruff / Black / shellcheck unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated typing-check documentation with comprehensive guidance for handling and tracking type-check errors across source and test code separately.

* **Chores**
  * Refactored type-checking script to perform independent checks for source and test directories with separate error reporting and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->