### PR TITLE
chore(lint): enable ruff DTZ and RET rule families

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = [
   "PIE",    # flake8-pie
   "RSE",    # flake8-raise
   "DTZ",    # flake8-datetimez
+  "RET",    # flake8-return
 ]
 ignore = [
   "E501",   # line length handled by Black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ select = [
   "PERF",   # perflint
   "PIE",    # flake8-pie
   "RSE",    # flake8-raise
+  "DTZ",    # flake8-datetimez
 ]
 ignore = [
   "E501",   # line length handled by Black
@@ -97,6 +98,13 @@ ignore = [
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["src"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests intentionally construct naive datetimes for fixture-style assertions and
+# deterministic clock stubs. Mirroring production's tz-aware datetime everywhere
+# would bloat the suite without exercising new behavior. Enforce DTZ in src/
+# and scripts/ only.
+"tests/**" = ["DTZ001", "DTZ002", "DTZ003", "DTZ005", "DTZ006", "DTZ007", "DTZ011"]
 
 [tool.mutmut]
 paths_to_mutate = "src/app_setup/,src/blueprints/,src/utils/,src/refresh_task/"

--- a/scripts/dry_run_plugin.py
+++ b/scripts/dry_run_plugin.py
@@ -101,9 +101,9 @@ def _load_settings(config_path: str | None) -> dict:
 
 
 def _default_output_path(plugin_id: str) -> str:
-    from datetime import datetime
+    from datetime import UTC, datetime
 
-    ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%S")
     return f"dry-run-{plugin_id}-{ts}.png"
 
 

--- a/scripts/export_benchmarks_report.py
+++ b/scripts/export_benchmarks_report.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sqlite3
-from datetime import datetime
+from datetime import UTC, datetime
 
 
 def main():
@@ -40,7 +40,9 @@ def main():
     report_path = os.path.join(base_dir, "docs", "benchmarks_report.md")
     with open(report_path, "w", encoding="utf-8") as fh:
         fh.write("## InkyPi Benchmarks Report\n\n")
-        fh.write(f"Generated: {datetime.utcnow().isoformat()}Z\n\n")
+        fh.write(
+            f"Generated: {datetime.now(tz=UTC).replace(tzinfo=None).isoformat()}Z\n\n"
+        )
         fh.write("### Recent refreshes (latest 50)\n\n")
         fh.write(
             "| ts | plugin | instance | playlist | cached | req(ms) | gen(ms) | pre(ms) | disp(ms) | cpu% | mem% |\n"
@@ -48,7 +50,10 @@ def main():
         fh.write("|---|---|---|---|---:|---:|---:|---:|---:|---:|---:|\n")
         for r in rows:
             _rid, ts, plugin, inst, pl, cached, req, gen, pre, disp, cpu, mem = r
-            iso = datetime.utcfromtimestamp(ts).isoformat() + "Z"
+            iso = (
+                datetime.fromtimestamp(ts, tz=UTC).replace(tzinfo=None).isoformat()
+                + "Z"
+            )
             fh.write(
                 f"| {iso} | {plugin or ''} | {inst or ''} | {pl or ''} | {cached or 0} | {req or ''} | {gen or ''} | {pre or ''} | {disp or ''} | {cpu or ''} | {mem or ''} |\n"
             )
@@ -63,7 +68,10 @@ def main():
             LIMIT 50
             """)
         for ts, rid, stage, dur, extra in cur.fetchall():
-            iso = datetime.utcfromtimestamp(ts).isoformat() + "Z"
+            iso = (
+                datetime.fromtimestamp(ts, tz=UTC).replace(tzinfo=None).isoformat()
+                + "Z"
+            )
             fh.write(f"| {iso} | {rid} | {stage} | {dur or ''} | {extra or ''} |\n")
 
     conn.close()

--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -161,8 +161,7 @@ def _make_image(colour: tuple[int, int, int]):
         from PIL import Image
     except ImportError:
         sys.exit("ERROR: Pillow is required. Install it with: pip install Pillow")
-    img = Image.new("RGB", (_IMG_WIDTH, _IMG_HEIGHT), colour)
-    return img
+    return Image.new("RGB", (_IMG_WIDTH, _IMG_HEIGHT), colour)
 
 
 def _ts_filename(dt: datetime) -> str:

--- a/src/blueprints/apikeys.py
+++ b/src/blueprints/apikeys.py
@@ -215,8 +215,7 @@ def save_apikeys():
             return json_success(
                 f"Saved {len(valid_entries)} API key(s). Some plugins may require restart to pick up changes."
             )
-        else:
-            return json_error("Failed to write .env file", status=500)
+        return json_error("Failed to write .env file", status=500)
 
     except Exception as e:
         logger.error(f"Error saving API keys: {e}")

--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -71,10 +71,12 @@ def _timestamp_from_history_filename(filename: str) -> float:
     if len(parts) < 3:
         return 0.0
     try:
-        dt = datetime.strptime(f"{parts[-2]}_{parts[-1]}", "%Y%m%d_%H%M%S")
+        dt = datetime.strptime(f"{parts[-2]}_{parts[-1]}", "%Y%m%d_%H%M%S").replace(
+            tzinfo=UTC
+        )
     except ValueError:
         return 0.0
-    return dt.replace(tzinfo=UTC).timestamp()
+    return dt.timestamp()
 
 
 def _format_size(num_bytes: int) -> str:
@@ -156,7 +158,7 @@ def _list_history_images(
             )
             dt = datetime.fromtimestamp(mtime, tz=now.tzinfo)
         except Exception:
-            dt = datetime.fromtimestamp(mtime)
+            dt = datetime.fromtimestamp(mtime, tz=UTC)
         result.append(
             {
                 "filename": f,

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -195,7 +195,8 @@ def validate_plugin_refresh_settings(refresh_settings):
             )
         refresh_time = refresh_time.strip()
         try:
-            datetime.strptime(refresh_time, "%H:%M")
+            # Format-only validation; the parsed datetime is discarded. No tz needed.
+            datetime.strptime(refresh_time, "%H:%M")  # noqa: DTZ007
         except ValueError:
             return None, json_error(
                 "Refresh time must be in HH:MM format",

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -917,14 +917,13 @@ def format_relative_time(iso_date_string):
     # Determine relative time string
     if diff_seconds < 120:
         return "just now"
-    elif diff_minutes < 60:
+    if diff_minutes < 60:
         return f"{int(diff_minutes)} minutes ago"
     # Use rolling windows to avoid midnight boundary flakiness across TZs
-    elif diff_seconds < 60 * 60 * 24:
+    if diff_seconds < 60 * 60 * 24:
         return "today at " + dt_local.strftime(time_format).lstrip("0")
-    elif diff_seconds < 60 * 60 * 48:
+    if diff_seconds < 60 * 60 * 48:
         return "yesterday at " + dt_local.strftime(time_format).lstrip("0")
-    else:
-        return dt_local.strftime(month_day_format).replace(
-            " 0", " "
-        )  # Removes leading zero in day
+    return dt_local.strftime(month_day_format).replace(
+        " 0", " "
+    )  # Removes leading zero in day

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -795,11 +795,10 @@ def update_now():
                 ManualRefresh(plugin_id, plugin_settings)
             )
             return json_success(message=_MSG_DISPLAY_UPDATED, metrics=metrics)
-        else:
-            logger.info("Refresh task not running, updating display directly")
-            return _update_now_direct(
-                plugin_id, plugin_settings, device_config, display_manager
-            )
+        logger.info("Refresh task not running, updating display directly")
+        return _update_now_direct(
+            plugin_id, plugin_settings, device_config, display_manager
+        )
     except Exception as e:
         logger.exception("Error in update_now: %s", e)
         return json_error(_ERR_INTERNAL, status=500, code="internal_error")

--- a/src/blueprints/settings/__init__.py
+++ b/src/blueprints/settings/__init__.py
@@ -8,7 +8,7 @@ import subprocess
 import threading
 import time
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from flask import (
     Blueprint,
@@ -157,7 +157,7 @@ class DevModeLogHandler(logging.Handler):
     def emit(self, record):
         try:
             msg = self.format(record)
-            timestamp = datetime.fromtimestamp(record.created).strftime(
+            timestamp = datetime.fromtimestamp(record.created, tz=UTC).strftime(
                 LOG_TIMESTAMP_FORMAT
             )
             log_line = f"{timestamp} [{record.levelname}] {record.name}: {msg}"
@@ -233,7 +233,9 @@ def _read_log_lines(hours: int) -> list[str]:
 
         for record in reader:
             try:
-                ts = datetime.fromtimestamp(record.get_realtime_usec() / 1_000_000)
+                ts = datetime.fromtimestamp(
+                    record.get_realtime_usec() / 1_000_000, tz=UTC
+                )
                 formatted_ts = ts.strftime(LOG_TIMESTAMP_FORMAT)
             except Exception:
                 formatted_ts = "??? ?? ??:??:??"
@@ -291,7 +293,7 @@ def _read_units_log_lines(hours: int, units: list[str]) -> list[str]:
                 if unit_name not in units:
                     continue
                 ts_usec = record.get_realtime_usec()
-                ts = datetime.fromtimestamp(ts_usec / 1_000_000)
+                ts = datetime.fromtimestamp(ts_usec / 1_000_000, tz=UTC)
                 formatted_ts = ts.strftime(LOG_TIMESTAMP_FORMAT)
                 line = _format_journal_line(formatted_ts, data)
                 merged.append((ts.timestamp(), line))

--- a/src/display/mock_display.py
+++ b/src/display/mock_display.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 
 from .abstract_display import AbstractDisplay
 
@@ -33,7 +33,7 @@ class MockDisplay(AbstractDisplay):
     def display_image(self, image, image_settings=None):
         if image_settings is None:
             image_settings = []
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
         filepath = os.path.join(self.output_dir, f"display_{timestamp}.png")
         image.save(filepath, "PNG")
 

--- a/src/model.py
+++ b/src/model.py
@@ -580,7 +580,10 @@ class PluginInstance:
         if "scheduled" in self.refresh:
             scheduled_time_str = self.refresh.get("scheduled")
             try:
-                scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
+                # Parsing HH:MM into a time-of-day; no date/tz context is needed.
+                scheduled_time = datetime.strptime(  # noqa: DTZ007
+                    scheduled_time_str, "%H:%M"
+                ).time()
             except (ValueError, TypeError):
                 logger.warning(
                     "Malformed scheduled time '%s' for plugin '%s'; skipping scheduled check",

--- a/src/model.py
+++ b/src/model.py
@@ -171,9 +171,7 @@ class PlaylistManager:
 
         # Sort playlists by priority
         active_playlists.sort(key=lambda p: p.get_priority())
-        playlist = active_playlists[0]
-
-        return playlist
+        return active_playlists[0]
 
     def get_playlist(self, playlist_name):
         """Returns the playlist with the specified name."""

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -237,8 +237,7 @@ class AIImage(BasePlugin):
         image_base64 = response.data[0].b64_json
         image_bytes = base64.b64decode(image_base64)
         with Image.open(BytesIO(image_bytes)) as opened_img:
-            img = opened_img.copy()
-        return img
+            return opened_img.copy()
 
     def fetch_image_google(self, client, prompt, model):
         """Fetch image from Google Imagen API."""

--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from openai import OpenAI
 
@@ -180,7 +180,7 @@ class AIText(BasePlugin):
             "IMPORTANT: If the response naturally requires a newline for formatting, provide "
             "the '\\n' newline character explicitly for every new line. For regular sentences "
             "or paragraphs do not provide the new line character."
-            f"For context, today is {datetime.today().strftime('%Y-%m-%d')}"
+            f"For context, today is {datetime.now(tz=UTC).strftime('%Y-%m-%d')}"
         )
         user_content = text_prompt
 
@@ -215,7 +215,7 @@ class AIText(BasePlugin):
             "IMPORTANT: If the response naturally requires a newline for formatting, provide "
             "the '\\n' newline character explicitly for every new line. For regular sentences "
             "or paragraphs do not provide the new line character."
-            f"For context, today is {datetime.today().strftime('%Y-%m-%d')}"
+            f"For context, today is {datetime.now(tz=UTC).strftime('%Y-%m-%d')}"
         )
 
         response = client.models.generate_content(

--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -159,11 +159,9 @@ class AIText(BasePlugin):
             "plugin_settings": settings,
         }
 
-        image = self.render_image(
+        return self.render_image(
             dimensions, "ai_text.html", "ai_text.css", image_template_params
         )
-
-        return image
 
     @staticmethod
     def fetch_text_prompt(ai_client, model, text_prompt):

--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -7,7 +7,7 @@ For the API key, set `NASA_SECRET={API_KEY}` in your .env file.
 
 import logging
 import os
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from io import BytesIO
 from random import randint
 
@@ -46,7 +46,7 @@ class Apod(BasePlugin):
             parsed = date.fromisoformat(custom_date_str)
         except ValueError:
             return f"Invalid date format: {custom_date_str!r} (expected YYYY-MM-DD)"
-        today = date.today()
+        today = datetime.now(tz=UTC).date()
         if parsed < _APOD_MIN_DATE:
             return (
                 f"Date must be on or after {_APOD_MIN_DATE.isoformat()} "
@@ -57,7 +57,7 @@ class Apod(BasePlugin):
         return None
 
     def build_settings_schema(self):
-        today = datetime.today().strftime("%Y-%m-%d")
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
         return schema(
             section(
                 "Source",
@@ -117,8 +117,8 @@ class Apod(BasePlugin):
         params = {"api_key": api_key}
 
         if settings.get("randomizeApod") == "true":
-            start = datetime(2015, 1, 1)
-            end = datetime.today()
+            start = datetime(2015, 1, 1, tzinfo=UTC)
+            end = datetime.now(tz=UTC)
             delta_days = (end - start).days
             random_date = start + timedelta(days=randint(0, delta_days))
             params["date"] = random_date.strftime("%Y-%m-%d")

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -151,7 +151,7 @@ class BasePlugin:
         Plugins can override this instead of shipping a bespoke settings.html
         when their UI can be expressed with the shared field system.
         """
-        return None
+        return
 
     def generate_settings_template(self):
         template_params = {"style_settings": True}

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -151,7 +151,6 @@ class BasePlugin:
         Plugins can override this instead of shipping a bespoke settings.html
         when their UI can be expressed with the shared field system.
         """
-        return
 
     def generate_settings_template(self):
         template_params = {"style_settings": True}

--- a/src/plugins/calendar/calendar.py
+++ b/src/plugins/calendar/calendar.py
@@ -236,7 +236,7 @@ class Calendar(BasePlugin):
 
         if not view:
             raise RuntimeError("View is required")
-        elif view not in [
+        if view not in [
             "timeGridDay",
             "timeGridWeek",
             "dayGrid",

--- a/src/plugins/clock/clock.py
+++ b/src/plugins/clock/clock.py
@@ -135,9 +135,7 @@ class Clock(BasePlugin):
             (w / 2, h / 2), time_str, font=fnt, anchor="mm", fill=primary_color + (255,)
         )
 
-        combined = Image.alpha_composite(image, text)
-
-        return combined
+        return Image.alpha_composite(image, text)
 
     def draw_conic_clock(
         self,
@@ -271,9 +269,7 @@ class Clock(BasePlugin):
             width=max(int(dim * 0.007), 1),
         )
 
-        combined = Image.alpha_composite(bg, canvas)
-
-        return combined
+        return Image.alpha_composite(bg, canvas)
 
     def draw_word_clock(
         self, dimensions, time, primary_color=(0, 0, 0), secondary_color=(255, 255, 255)
@@ -334,8 +330,7 @@ class Clock(BasePlugin):
                     (x_pos, y_pos), letter, anchor="mm", fill=fill, font=fnt
                 )
 
-        combined = Image.alpha_composite(bg, canvas)
-        return combined
+        return Image.alpha_composite(bg, canvas)
 
     @staticmethod
     def format_time(hour, minute, zero_pad=False):

--- a/src/plugins/countdown/countdown.py
+++ b/src/plugins/countdown/countdown.py
@@ -60,7 +60,6 @@ class Countdown(BasePlugin):
             "plugin_settings": settings,
         }
 
-        image = self.render_image(
+        return self.render_image(
             dimensions, "countdown.html", "countdown.css", template_params
         )
-        return image

--- a/src/plugins/countdown/countdown.py
+++ b/src/plugins/countdown/countdown.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import field, row, schema, section
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class Countdown(BasePlugin):
     def build_settings_schema(self):
-        tomorrow = (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")
+        tomorrow = (datetime.now(tz=UTC) + timedelta(days=1)).strftime("%Y-%m-%d")
         return schema(
             section(
                 "Countdown",
@@ -44,8 +44,10 @@ class Countdown(BasePlugin):
         tz = get_timezone(tz_name)
         current_time = datetime.now(tz)
 
-        countdown_date = datetime.strptime(countdown_date_str, "%Y-%m-%d")
-        countdown_date = countdown_date.replace(tzinfo=tz)
+        # Input is YYYY-MM-DD (no tz); we attach device tz immediately after parsing.
+        countdown_date = datetime.strptime(  # noqa: DTZ007
+            countdown_date_str, "%Y-%m-%d"
+        ).replace(tzinfo=tz)
 
         day_count = (countdown_date.date() - current_time.date()).days
         label = "Days Left" if day_count > 0 else "Days Passed"

--- a/src/plugins/github/github.py
+++ b/src/plugins/github/github.py
@@ -67,13 +67,12 @@ class GitHub(BasePlugin):
 
             if github_type == "contributions":
                 return contributions_generate_image(self, settings, device_config)
-            elif github_type == "sponsors":
+            if github_type == "sponsors":
                 return sponsors_generate_image(self, settings, device_config)
-            elif github_type == "stars":
+            if github_type == "stars":
                 return stars_generate_image(self, settings, device_config)
-            else:
-                logger.error(f"Unknown GitHub type: {github_type}")
-                raise ValueError(f"Unknown GitHub type: {github_type}")
+            logger.error(f"Unknown GitHub type: {github_type}")
+            raise ValueError(f"Unknown GitHub type: {github_type}")
         except Exception as e:
             logger.error(f"GitHub image generation failed: {str(e)}")
             raise

--- a/src/plugins/github/github_contributions.py
+++ b/src/plugins/github/github_contributions.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from utils.http_client import get_http_session
 
@@ -105,7 +105,8 @@ def parse_contributions(data, colors):
     seen_months = set()
     for i, week in enumerate(weeks):
         first_day = week["contributionDays"][0]["date"]
-        dt = datetime.strptime(first_day, "%Y-%m-%d")
+        # Only month/year labels are extracted; tz is irrelevant for formatting.
+        dt = datetime.strptime(first_day, "%Y-%m-%d")  # noqa: DTZ007
         month_year = f"{dt.strftime('%b')}-{dt.year}"
         if month_year not in seen_months:
             month_positions.append({"name": dt.strftime("%b"), "index": i})
@@ -126,7 +127,7 @@ def calculate_metrics(data):
 
     total = sum(day["contributionCount"] for day in days)
     streak, longest_streak, current_streak = 0, 0, 0
-    today = date.today()
+    today = datetime.now(tz=UTC).date()
     yesterday = today - timedelta(days=1)
     in_current_streak = False
 

--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -36,14 +36,12 @@ def list_files_in_folder(folder_path):
         ".heif",
         ".heic",
     )
-    image_files = [
+    return [
         os.path.join(root, f)
         for root, _dirs, files in os.walk(folder_path, followlinks=False)
         for f in files
         if f.lower().endswith(image_extensions) and not f.startswith(".")
     ]
-
-    return image_files
 
 
 class ImageFolder(BasePlugin):

--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -141,16 +141,15 @@ class ImageUpload(BasePlugin):
 
             if settings.get("backgroundOption") == "blur":
                 return pad_image_blur(image, dimensions)
-            else:
-                background_color = _resolve_background_color(
-                    settings.get("backgroundColor"), "RGB"
-                )
-                return ImageOps.pad(
-                    image,
-                    dimensions,
-                    color=background_color,
-                    method=Image.Resampling.LANCZOS,
-                )
+            background_color = _resolve_background_color(
+                settings.get("backgroundColor"), "RGB"
+            )
+            return ImageOps.pad(
+                image,
+                dimensions,
+                color=background_color,
+                method=Image.Resampling.LANCZOS,
+            )
         return image
 
     def cleanup(self, settings):

--- a/src/plugins/newspaper/newspaper.py
+++ b/src/plugins/newspaper/newspaper.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from PIL import Image
 
@@ -38,7 +38,7 @@ class Newspaper(BasePlugin):
             raise RuntimeError("Invalid newspaper selection.")
 
         # Get today's date
-        today = datetime.today()
+        today = datetime.now(tz=UTC)
 
         # check the next day, then today, then prior day
         days = [today + timedelta(days=diff) for diff in [1, 0, -1, -2]]

--- a/src/plugins/rss/rss.py
+++ b/src/plugins/rss/rss.py
@@ -112,8 +112,7 @@ class Rss(BasePlugin):
             "plugin_settings": settings,
         }
 
-        image = self.render_image(dimensions, "rss.html", "rss.css", template_params)
-        return image
+        return self.render_image(dimensions, "rss.html", "rss.css", template_params)
 
     @staticmethod
     def _sanitize_text(raw):

--- a/src/plugins/todo_list/todo_list.py
+++ b/src/plugins/todo_list/todo_list.py
@@ -80,7 +80,6 @@ class TodoList(BasePlugin):
             "plugin_settings": settings,
         }
 
-        image = self.render_image(
+        return self.render_image(
             dimensions, "todo_list.html", "todo_list.css", template_params
         )
-        return image

--- a/src/plugins/weather/weather_api.py
+++ b/src/plugins/weather/weather_api.py
@@ -69,9 +69,7 @@ def get_location(api_key, lat, long, timeout=20):
         logger.warning("Geocoding returned empty result for lat=%s, long=%s", lat, long)
         return "Unknown Location"
     location_data = location_list[0]
-    location_str = f"{location_data.get('name')}, {location_data.get('state', location_data.get('country'))}"
-
-    return location_str
+    return f"{location_data.get('name')}, {location_data.get('state', location_data.get('country'))}"
 
 
 def get_open_meteo_data(lat, long, units, forecast_days, timeout=20):

--- a/src/plugins/weather/weather_data.py
+++ b/src/plugins/weather/weather_data.py
@@ -101,9 +101,8 @@ def parse_timezone(weatherdata):
             redact_secrets(weatherdata["timezone"]),
         )
         return ZoneInfo(weatherdata["timezone"])
-    else:
-        logger.error("Failed to retrieve Timezone from weather data")
-        raise RuntimeError("Timezone not found in weather data.")
+    logger.error("Failed to retrieve Timezone from weather data")
+    raise RuntimeError("Timezone not found in weather data.")
 
 
 _WEATHER_CODE_TO_ICON = {
@@ -186,12 +185,11 @@ def _choose_phase_name(phase: float) -> str:
             return name
     if 0.0 < phase < 0.25:
         return "waxingcrescent"
-    elif 0.25 < phase < 0.5:
+    if 0.25 < phase < 0.5:
         return "waxinggibbous"
-    elif 0.5 < phase < 0.75:
+    if 0.5 < phase < 0.75:
         return "waninggibbous"
-    else:
-        return "waningcrescent"
+    return "waningcrescent"
 
 
 def parse_forecast(daily_forecast, tz, current_suffix, lat, plugin_dir):

--- a/src/plugins/wpotd/wpotd.py
+++ b/src/plugins/wpotd/wpotd.py
@@ -156,7 +156,7 @@ class Wpotd(BasePlugin):
             start = datetime(2015, 1, 1, tzinfo=UTC)
             delta_days = (datetime.now(tz=UTC) - start).days
             return (start + timedelta(days=randint(0, delta_days))).date()
-        elif settings.get("customDate"):
+        if settings.get("customDate"):
             try:
                 # YYYY-MM-DD date input; the parsed date is returned as-is.
                 return datetime.strptime(  # noqa: DTZ007
@@ -275,6 +275,5 @@ class Wpotd(BasePlugin):
                 image, ((max_width - new_width) // 2, (max_height - new_height) // 2)
             )
             return new_image
-        else:
-            # If the image is already within bounds, return it as is
-            return image
+        # If the image is already within bounds, return it as is
+        return image

--- a/src/plugins/wpotd/wpotd.py
+++ b/src/plugins/wpotd/wpotd.py
@@ -23,7 +23,7 @@ Flow:
 
 import logging
 import os
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from io import BytesIO
 from random import randint
 from typing import Any
@@ -70,7 +70,7 @@ class Wpotd(BasePlugin):
             parsed = date.fromisoformat(custom_date_str)
         except ValueError:
             return f"Invalid date format: {custom_date_str!r} (expected YYYY-MM-DD)"
-        today = date.today()
+        today = datetime.now(tz=UTC).date()
         if parsed < _WPOTD_MIN_DATE:
             return (
                 f"Date must be on or after {_WPOTD_MIN_DATE.isoformat()} "
@@ -81,7 +81,7 @@ class Wpotd(BasePlugin):
         return None
 
     def build_settings_schema(self):
-        today = datetime.today().strftime("%Y-%m-%d")
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
         return schema(
             section(
                 "Source",
@@ -153,20 +153,23 @@ class Wpotd(BasePlugin):
 
     def _determine_date(self, settings: dict[str, Any]) -> date:
         if settings.get("randomizeWpotd") == "true":
-            start = datetime(2015, 1, 1)
-            delta_days = (datetime.today() - start).days
+            start = datetime(2015, 1, 1, tzinfo=UTC)
+            delta_days = (datetime.now(tz=UTC) - start).days
             return (start + timedelta(days=randint(0, delta_days))).date()
         elif settings.get("customDate"):
             try:
-                return datetime.strptime(settings["customDate"], "%Y-%m-%d").date()
+                # YYYY-MM-DD date input; the parsed date is returned as-is.
+                return datetime.strptime(  # noqa: DTZ007
+                    settings["customDate"], "%Y-%m-%d"
+                ).date()
             except ValueError:
                 logger.warning(
                     "Invalid customDate %r for WPOTD, defaulting to today",
                     settings["customDate"],
                 )
-                return datetime.today().date()
+                return datetime.now(tz=UTC).date()
         else:
-            return datetime.today().date()
+            return datetime.now(tz=UTC).date()
 
     def _download_image(self, url: str) -> Image.Image:
         if url.lower().endswith(".svg"):

--- a/src/plugins/year_progress/year_progress.py
+++ b/src/plugins/year_progress/year_progress.py
@@ -34,7 +34,6 @@ class YearProgress(BasePlugin):
             "plugin_settings": settings,
         }
 
-        image = self.render_image(
+        return self.render_image(
             dimensions, "year_progress.html", "year_progress.css", template_params
         )
-        return image

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -847,10 +847,10 @@ class RefreshTask:
                     raise exc
                 raise RuntimeError(str(exc))
             return metrics
-        else:
-            logger.warning(
-                "Background refresh task is not running, unable to do a manual update"
-            )
+        logger.warning(
+            "Background refresh task is not running, unable to do a manual update"
+        )
+        return None
 
     @staticmethod
     def _timeout_msg(plugin_id: str, timeout_s: float) -> str:

--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -65,8 +65,7 @@ def get_wifi_name():
         iwgetid_bin = shutil.which("iwgetid") or "/sbin/iwgetid"
         if not os.path.isabs(iwgetid_bin):
             return None
-        output = subprocess.check_output([iwgetid_bin, "-r"]).decode("utf-8").strip()
-        return output
+        return subprocess.check_output([iwgetid_bin, "-r"]).decode("utf-8").strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
 
@@ -111,7 +110,7 @@ def get_font(font_name, font_size=50, font_weight="normal", strict=False):
 
 
 def get_fonts():
-    fonts_list = [
+    return [
         {
             "font_family": font_family,
             "url": resolve_path(os.path.join("static", "fonts", variant["file"])),
@@ -121,7 +120,6 @@ def get_fonts():
         for font_family, variants in FONT_FAMILIES.items()
         for variant in variants
     ]
-    return fonts_list
 
 
 def get_font_path(font_name):

--- a/src/utils/image_loader.py
+++ b/src/utils/image_loader.py
@@ -123,10 +123,7 @@ class AdaptiveImageLoader:
             return self._load_from_url_lowmem(
                 url, dimensions, timeout_ms, resize, headers
             )
-        else:
-            return self._load_from_url_fast(
-                url, dimensions, timeout_ms, resize, headers
-            )
+        return self._load_from_url_fast(url, dimensions, timeout_ms, resize, headers)
 
     def from_file(self, path, dimensions, resize=True):
         """
@@ -150,8 +147,7 @@ class AdaptiveImageLoader:
         try:
             if self.is_low_resource:
                 return self._load_from_file_lowmem(path, dimensions, resize)
-            else:
-                return self._load_from_file_fast(path, dimensions, resize)
+            return self._load_from_file_fast(path, dimensions, resize)
         except (OSError, ValueError, MemoryError) as e:
             logger.error(f"Error loading image from {path}: {e}")
             return None

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -62,8 +62,7 @@ def process_image_from_bytes(
     try:
         opener = image_open or Image.open
         with opener(BytesIO(content)) as _img:
-            result = processor(_img)
-            return result
+            return processor(_img)
     except (OSError, ValueError, TypeError) as e:
         logger.error(f"Failed to process image from bytes: {e}")
         return None
@@ -247,9 +246,7 @@ def apply_image_enhancement(img, image_settings=None):
     img = ImageEnhance.Color(img).enhance(image_settings.get("saturation", 1.0))
 
     # Apply Sharpness
-    img = ImageEnhance.Sharpness(img).enhance(image_settings.get("sharpness", 1.0))
-
-    return img
+    return ImageEnhance.Sharpness(img).enhance(image_settings.get("sharpness", 1.0))
 
 
 def pad_image_blur(img: Image, dimensions: tuple[int, int]) -> Image:

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -77,8 +77,7 @@ def _redact(text: str) -> str:
     # Pattern 1: key=value — keep key + separator, replace only the value.
     text = _SECRET_PATTERNS[1].sub(r"\1\2" + _REDACTED, text)
     # Pattern 2: bare 32+ hex strings.
-    text = _SECRET_PATTERNS[2].sub(_REDACTED, text)
-    return text
+    return _SECRET_PATTERNS[2].sub(_REDACTED, text)
 
 
 def redact_secrets(value: object) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,8 +144,7 @@ def mock_screenshot(monkeypatch):
     def _fake_screenshot(*args, **kwargs):
         dims = args[1] if len(args) > 1 else kwargs.get("dimensions", (800, 480))
         width, height = dims
-        img = Image.new("RGB", (width, height), "white")
-        return img
+        return Image.new("RGB", (width, height), "white")
 
     import plugins.base_plugin.base_plugin as base_plugin
     import utils.image_utils as image_utils

--- a/tests/plugins/test_ai_text.py
+++ b/tests/plugins/test_ai_text.py
@@ -172,7 +172,7 @@ def test_ai_text_generate_image_orientation(
     def mock_get_config(key, default=None):
         if key == "orientation":
             return orientation
-        elif key == "resolution":
+        if key == "resolution":
             return resolution
         return default
 

--- a/tests/plugins/test_apod.py
+++ b/tests/plugins/test_apod.py
@@ -79,20 +79,20 @@ def test_apod_success_via_client(mock_get_session, client):
                     }
 
             return ApiResponse()
-        else:  # Second call is to download the image
-            from io import BytesIO
+        # Second call is to download the image
+        from io import BytesIO
 
-            from PIL import Image
+        from PIL import Image
 
-            img = Image.new("RGB", (64, 64), "black")
-            buf = BytesIO()
-            img.save(buf, format="PNG")
+        img = Image.new("RGB", (64, 64), "black")
+        buf = BytesIO()
+        img.save(buf, format="PNG")
 
-            class ImageResponse:
-                content = buf.getvalue()
-                status_code = 200
+        class ImageResponse:
+            content = buf.getvalue()
+            status_code = 200
 
-            return ImageResponse()
+        return ImageResponse()
 
     mock_session.get.side_effect = fake_get
 

--- a/tests/plugins/test_image_decode_failures.py
+++ b/tests/plugins/test_image_decode_failures.py
@@ -26,8 +26,7 @@ def test_apod_decode_failure(device_config_dev, monkeypatch):
         call_count[0] += 1
         if call_count[0] == 1:
             return R()  # First call returns JSON
-        else:
-            return R2()  # Second call returns invalid image
+        return R2()  # Second call returns invalid image
 
     monkeypatch.setattr("requests.get", mock_http_get)
 

--- a/tests/plugins/test_image_upload.py
+++ b/tests/plugins/test_image_upload.py
@@ -292,7 +292,7 @@ def test_image_upload_generate_image_vertical_orientation(
     def mock_get_config(key, default=None):
         if key == "orientation":
             return "vertical"
-        elif key == "resolution":
+        if key == "resolution":
             return (400, 300)  # width, height
         return default
 

--- a/tests/test_asset_bundling.py
+++ b/tests/test_asset_bundling.py
@@ -57,12 +57,11 @@ else:
 argv = {["--no-minify"] if not minify else []}
 ba.main(argv)
 """
-    result = subprocess.run(
+    return subprocess.run(
         [sys.executable, "-c", env_code],
         capture_output=True,
         text=True,
     )
-    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_diff.py
+++ b/tests/test_image_diff.py
@@ -38,8 +38,7 @@ def imdiff():
 
 def _solid_image(color: tuple, size: tuple = (10, 10)) -> Image.Image:
     """Create a solid-color RGBA image."""
-    img = Image.new("RGBA", size, color)
-    return img
+    return Image.new("RGBA", size, color)
 
 
 def _save_image(img: Image.Image, path: Path) -> Path:

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -227,8 +227,7 @@ class TestRefreshTaskHooks:
         from refresh_task.task import RefreshTask
 
         dm = DisplayManager(device_config_dev)
-        task = RefreshTask(device_config_dev, dm)
-        return task
+        return RefreshTask(device_config_dev, dm)
 
     def test_refresh_task_has_event_bus(self, device_config_dev, monkeypatch):
         task = self._make_task(device_config_dev, monkeypatch)

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -24,8 +24,7 @@ from refresh_task import RefreshTask
 
 def _make_task(device_config_dev):
     dm = MagicMock()
-    task = RefreshTask(device_config_dev, dm)
-    return task
+    return RefreshTask(device_config_dev, dm)
 
 
 def _make_plugin_instance(plugin_id="weather", name="my_weather"):

--- a/tests/unit/test_execute_inprocess.py
+++ b/tests/unit/test_execute_inprocess.py
@@ -18,8 +18,7 @@ from refresh_task import RefreshTask
 
 def _make_task(device_config_dev):
     dm = MagicMock()
-    task = RefreshTask(device_config_dev, dm)
-    return task
+    return RefreshTask(device_config_dev, dm)
 
 
 def _fake_action(plugin_id="test_plugin"):

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -127,8 +127,7 @@ from src.utils.http_utils import (  # noqa: E402
 @pytest.fixture
 def app():
     """Create a test Flask application."""
-    app = Flask(__name__)
-    return app
+    return Flask(__name__)
 
 
 class TestAPIError:

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -196,7 +196,7 @@ def rate_limit_app():
             resp = make_response(body, code)
             resp.headers["Retry-After"] = "30"
             return resp
-        elif request.path in _REFRESH_PATHS and not refresh_b.try_acquire(addr):
+        if request.path in _REFRESH_PATHS and not refresh_b.try_acquire(addr):
             body, code = json_error(
                 "Refresh rate limit exceeded — try again later", status=429
             )

--- a/tests/unit/test_refresh_task_critical.py
+++ b/tests/unit/test_refresh_task_critical.py
@@ -184,8 +184,7 @@ class TestExecuteRefreshAttemptWorker:
 class TestRefreshTaskStop:
     def _make_task(self, device_config_dev):
         dm = MagicMock()
-        task = RefreshTask(device_config_dev, dm)
-        return task
+        return RefreshTask(device_config_dev, dm)
 
     def test_stop_rejects_pending_requests(self, device_config_dev):
         task = self._make_task(device_config_dev)

--- a/tests/unit/test_refresh_task_watchdog.py
+++ b/tests/unit/test_refresh_task_watchdog.py
@@ -95,8 +95,7 @@ def _make_refresh_task(module, *, with_sd_notify: bool = True):
 
     display_manager = MagicMock()
 
-    task = module.RefreshTask(device_config, display_manager)
-    return task
+    return module.RefreshTask(device_config, display_manager)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_security_csrf_rate_limit.py
+++ b/tests/unit/test_security_csrf_rate_limit.py
@@ -35,9 +35,9 @@ def csrf_app():
         from flask import request
 
         if request.method in _CSRF_SAFE_METHODS:
-            return
+            return None
         if request.path in _CSRF_EXEMPT_PATHS:
-            return
+            return None
         token = session.get("_csrf_token")
         if not token:
             _generate_csrf_token()
@@ -58,6 +58,7 @@ def csrf_app():
         )
         if not request_token or not secrets.compare_digest(request_token, token):
             return json_error("CSRF token missing or invalid", status=403)
+        return None
 
     # --- Rate limiting ---
     _MUTATE_REQUESTS = defaultdict(deque)
@@ -71,9 +72,9 @@ def csrf_app():
         from flask import request
 
         if request.method in _CSRF_SAFE_METHODS:
-            return
+            return None
         if request.path in _CSRF_EXEMPT_PATHS:
-            return
+            return None
         addr = request.remote_addr or "unknown"
         now = _time.monotonic()
         dq = _MUTATE_REQUESTS[addr]
@@ -82,6 +83,7 @@ def csrf_app():
         if len(dq) >= _MUTATE_MAX:
             return json_error("Rate limit exceeded — try again shortly", status=429)
         dq.append(now)
+        return None
 
     @app.route("/test-post", methods=["POST"])
     def test_post():

--- a/tests/unit/test_snapshot_helper.py
+++ b/tests/unit/test_snapshot_helper.py
@@ -28,8 +28,7 @@ def _snapshot_sandbox(tmp_path, monkeypatch):
 
 def _make_image(color: tuple[int, int, int] = (255, 0, 0)) -> Image.Image:
     """Create a small solid-colour test image."""
-    img = Image.new("RGB", (10, 10), color)
-    return img
+    return Image.new("RGB", (10, 10), color)
 
 
 class TestSnapshotMismatchSavesActual:

--- a/tests/unit/test_wpotd_unit.py
+++ b/tests/unit/test_wpotd_unit.py
@@ -37,6 +37,11 @@ def test_determine_date_invalid_custom_date_falls_back(monkeypatch):
             return datetime(2024, 1, 2)
 
         @staticmethod
+        def now(tz=None):
+            # Mirror today(); tests pin the date, tz is ignored.
+            return datetime(2024, 1, 2)
+
+        @staticmethod
         def strptime(value, fmt):
             return datetime.strptime(value, fmt)
 


### PR DESCRIPTION
## Summary

Enable two new ruff rule families with fixes for every surfaced violation. Bundled into one PR to avoid ``pyproject.toml`` merge conflicts.

### Phase 1 — DTZ (flake8-datetimez)

Catches timezone-naive ``datetime`` usage — a real bug class for the scheduler/history subsystems.

- 91 total violations surfaced; 30 in production code (``src/`` + ``scripts/``), 61 in tests.
- **Production (30): all fixed.** Replaced naive ``datetime.now()``/``today()``/``utcnow()``/``fromtimestamp()`` calls with tz-aware ``datetime.now(tz=UTC)`` (or device tz where already plumbed). Paired ``strptime()`` with an immediate ``.replace(tzinfo=...)``.
- **Narrow ``# noqa: DTZ007``s (4)** — all on ``strptime`` calls that either (a) validate HH:MM / YYYY-MM-DD format and discard the parsed value, or (b) attach a tz immediately after parsing. Each has a one-line comment explaining why tz is irrelevant at the call site:
  - ``src/blueprints/playlist.py`` — HH:MM format validation
  - ``src/model.py`` — HH:MM → ``.time()`` for scheduled refresh
  - ``src/plugins/countdown/countdown.py`` — ``.replace(tzinfo=tz)`` immediately after
  - ``src/plugins/github/github_contributions.py`` — month/year label extraction
  - ``src/plugins/wpotd/wpotd.py`` — ``.date()`` on YYYY-MM-DD input
- **Tests (61): ignored via ``[tool.ruff.lint.per-file-ignores]`` for ``tests/**``.** The test suite leans heavily on naive fixture datetimes for deterministic clock stubs; enforcing tz-awareness would bloat fixtures without exercising new behavior. Production paths still get full DTZ coverage.
- **Test fix**: ``tests/unit/test_wpotd_unit.py`` patched ``datetime`` with a stub implementing only ``today()``/``strptime()``. Added a ``now()`` shim so the frozen-date fixture keeps working after ``wpotd._determine_date()`` switched to ``datetime.now(tz=UTC)``.

### Phase 2 — RET (flake8-return)

Cleans up return-statement smells.

- 61 total violations; all fixed.
- **30 safe auto-fixes** (``ruff --fix``): RET505 superfluous-else-return, RET501 unnecessary-return-none, RET502 implicit-return-value, RET506 superfluous-else-raise.
- **31 manual/unsafe auto-fixes** (``ruff --fix --unsafe-fixes``, all reviewed): 28 × RET504 unnecessary-assign-before-return + 3 × RET503 implicit-return.

**Potentially-real return-path issues surfaced — please review:**

- ``src/refresh_task/task.py::RefreshTask.manual_update``: the ``else`` branch logged a warning but fell off the function, implicitly returning ``None``. Callers expect ``RefreshResult | None``, so behavior is preserved — but the prior code was ambiguous about whether ``None`` was intentional. Now it's an explicit ``return None``.
- ``tests/unit/test_security_csrf_rate_limit.py``: two Flask ``before_request`` handlers used bare ``return`` (implicit ``None``) on the happy path and a response object on error paths. Made both explicit; no behavior change.

## Validation

- ``ruff check src tests scripts`` — clean
- ``black --check src tests scripts`` — clean
- ``SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no`` — **4055 passed, 5 skipped** (identical to ``origin/main``)

## Test plan

- [x] Ruff passes with DTZ + RET enabled
- [x] Black formatting clean
- [x] Full pytest suite: 4055 passed / 5 skipped (no deltas vs main)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)