### PR TITLE
feat(schemas): dev-mode JSON response validator middleware

### DIFF
--- a/src/app_setup/schema_validator.py
+++ b/src/app_setup/schema_validator.py
@@ -1,0 +1,46 @@
+"""Dev-only JSON response schema validator middleware (JTN-664).
+
+Registers a single ``@app.after_request`` hook that validates JSON responses
+for a curated set of endpoints against their canonical ``TypedDict`` in
+``schemas.responses``. Drift is logged at WARNING level and the response is
+returned unchanged — this middleware is strictly advisory.
+
+Gate: the caller wires this in ``create_app()`` behind ``DEV_MODE`` or the
+``INKYPI_STRICT_SCHEMAS=1`` escape hatch. It is never active in production.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Flask, request
+
+from schemas.endpoint_map import ENDPOINT_SCHEMAS
+from schemas.validator import validate_typeddict
+
+logger = logging.getLogger(__name__)
+
+
+def register(app: Flask) -> None:
+    """Attach the dev-only response schema validator to *app*."""
+
+    @app.after_request
+    def _validate_response_schema(response):
+        try:
+            if response.mimetype != "application/json":
+                return response
+            endpoint = request.endpoint
+            if endpoint is None or endpoint not in ENDPOINT_SCHEMAS:
+                return response
+
+            payload = response.get_json(silent=True)
+            if payload is None:
+                return response
+
+            errors = validate_typeddict(payload, ENDPOINT_SCHEMAS[endpoint])
+            for err in errors:
+                logger.warning("schema drift: %s at %s", endpoint, err)
+        except Exception:
+            # Advisory only — never allow the validator to break a response.
+            logger.debug("schema validator hook failed", exc_info=True)
+        return response

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -27,6 +27,7 @@ from app_setup.health import (
 )
 from app_setup.http_metrics import setup_http_metrics
 from app_setup.logging_setup import install_dev_log_handler, setup_logging
+from app_setup.schema_validator import register as register_schema_validator
 from app_setup.security_middleware import (
     _extract_csrf_token_from_request,
     _generate_csrf_token,
@@ -370,6 +371,11 @@ def create_app():
     register_error_handlers(app)
     setup_security_headers(app, dev_mode=DEV_MODE)
     setup_http_metrics(app)
+    # JTN-664: dev-only JSON response schema validator. Logs shape drift at
+    # WARNING; never mutates the response and never raises. Prod opt-in via
+    # INKYPI_STRICT_SCHEMAS=1 for CI-style strict builds.
+    if DEV_MODE or os.getenv("INKYPI_STRICT_SCHEMAS") == "1":
+        register_schema_validator(app)
     setup_signal_handlers(app)
 
     return app

--- a/src/schemas/endpoint_map.py
+++ b/src/schemas/endpoint_map.py
@@ -1,0 +1,43 @@
+"""Mapping of Flask endpoint names to their canonical TypedDict response shape.
+
+The dev-mode response-schema validator middleware (JTN-664) looks up
+``flask.request.endpoint`` in this map to decide whether to validate a
+response. Keys are ``<blueprint_name>.<view_function_name>`` — the exact
+string Flask returns from ``request.endpoint`` — NOT URL paths.
+
+Only endpoints whose successful response shape is pinned down by a TypedDict
+in ``schemas.responses`` are listed here. Routes that return non-JSON,
+envelope-only errors, or method-dependent payloads (e.g. POST/DELETE on
+``/settings/isolation``) are intentionally omitted; the middleware further
+guards on ``response.mimetype == 'application/json'``.
+"""
+
+from __future__ import annotations
+
+from schemas.responses import (
+    HealthPluginsResponse,
+    HealthSystemResponse,
+    HistoryStorageResponse,
+    IsolationResponse,
+    NextUpResponse,
+    RefreshInfoResponse,
+    RefreshStatsResponse,
+    UptimeResponse,
+    VersionInfoResponse,
+)
+
+# Endpoint name -> TypedDict schema class.
+#
+# Verified empirically: each value is the ``blueprint_name.view_function_name``
+# string Flask reports via ``request.endpoint`` for the corresponding route.
+ENDPOINT_SCHEMAS: dict[str, type] = {
+    "version_info.api_version_info": VersionInfoResponse,
+    "version_info.api_uptime": UptimeResponse,
+    "main.refresh_info": RefreshInfoResponse,
+    "main.next_up": NextUpResponse,
+    "stats.refresh_stats": RefreshStatsResponse,
+    "settings.health_system": HealthSystemResponse,
+    "settings.health_plugins": HealthPluginsResponse,
+    "settings.plugin_isolation": IsolationResponse,
+    "history.history_storage": HistoryStorageResponse,
+}

--- a/src/schemas/validator.py
+++ b/src/schemas/validator.py
@@ -1,0 +1,118 @@
+"""Hand-rolled TypedDict payload validator.
+
+Extracted from ``tests/contract/test_response_shapes.py`` so that both the
+contract tests and the dev-mode response-schema middleware (JTN-664) can share
+a single implementation. The validator walks a TypedDict's ``__annotations__``
+and checks:
+
+* every required key is present with a value matching its declared type
+* for ``total=False`` TypedDicts, keys that *are* present also type-check
+
+``Any`` annotations short-circuit the type check, mirroring mypy semantics.
+Kept intentionally dependency-free (no pydantic) so importing it is cheap and
+safe to do from request paths.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+from typing import Any, get_args, get_origin
+
+
+def _is_typeddict(tp: Any) -> bool:
+    return (
+        isinstance(tp, type)
+        and issubclass(tp, dict)
+        and hasattr(tp, "__total__")
+        and hasattr(tp, "__annotations__")
+    )
+
+
+def _check_type(value: Any, tp: Any, path: str) -> list[str]:
+    """Return a list of error strings (empty if ``value`` matches ``tp``)."""
+    # Any -> accept anything
+    if tp is Any or tp is object:
+        return []
+
+    origin = get_origin(tp)
+
+    # Union / Optional
+    if origin is typing.Union or origin is types.UnionType:
+        errs_per_arm: list[list[str]] = []
+        for arm in get_args(tp):
+            errs = _check_type(value, arm, path)
+            if not errs:
+                return []
+            errs_per_arm.append(errs)
+        return [f"{path}: no union arm matched value {value!r} ({tp})"]
+
+    # list[X]
+    if origin in (list, typing.List):  # noqa: UP006
+        if not isinstance(value, list):
+            return [f"{path}: expected list, got {type(value).__name__}"]
+        (inner,) = get_args(tp) or (Any,)
+        errs: list[str] = []
+        for i, item in enumerate(value):
+            errs.extend(_check_type(item, inner, f"{path}[{i}]"))
+        return errs
+
+    # dict[K, V]
+    if origin in (dict, typing.Dict):  # noqa: UP006
+        if not isinstance(value, dict):
+            return [f"{path}: expected dict, got {type(value).__name__}"]
+        args = get_args(tp)
+        if not args:
+            return []
+        _k, vt = args
+        errs = []
+        for k, v in value.items():
+            errs.extend(_check_type(v, vt, f"{path}[{k!r}]"))
+        return errs
+
+    # Nested TypedDict
+    if _is_typeddict(tp):
+        return validate_typeddict(value, tp, path=path)
+
+    # Plain class
+    if isinstance(tp, type):
+        # bool is a subclass of int; keep them distinct to catch accidents
+        if tp is int and isinstance(value, bool):
+            return [f"{path}: expected int, got bool ({value!r})"]
+        if not isinstance(value, tp):
+            return [
+                f"{path}: expected {tp.__name__}, got {type(value).__name__} ({value!r})"
+            ]
+        return []
+
+    # Unknown / exotic annotation — skip silently
+    return []
+
+
+def validate_typeddict(payload: Any, schema: Any, *, path: str = "$") -> list[str]:
+    """Validate *payload* against the TypedDict *schema*. Returns error list."""
+    if not isinstance(payload, dict):
+        return [f"{path}: expected dict, got {type(payload).__name__}"]
+
+    hints = typing.get_type_hints(schema)
+    required_keys = set(getattr(schema, "__required_keys__", set()))
+    optional_keys = set(getattr(schema, "__optional_keys__", set()))
+    # Older Pythons: fall back to __total__
+    if not required_keys and not optional_keys:
+        if getattr(schema, "__total__", True):
+            required_keys = set(hints.keys())
+        else:
+            optional_keys = set(hints.keys())
+
+    errors: list[str] = []
+    for key in required_keys:
+        if key not in payload:
+            errors.append(f"{path}.{key}: missing required key")
+            continue
+        errors.extend(_check_type(payload[key], hints[key], f"{path}.{key}"))
+
+    for key in optional_keys:
+        if key in payload:
+            errors.extend(_check_type(payload[key], hints[key], f"{path}.{key}"))
+
+    return errors

--- a/src/schemas/validator.py
+++ b/src/schemas/validator.py
@@ -11,6 +11,10 @@ and checks:
 ``Any`` annotations short-circuit the type check, mirroring mypy semantics.
 Kept intentionally dependency-free (no pydantic) so importing it is cheap and
 safe to do from request paths.
+
+Error messages intentionally omit the raw mismatched value. The middleware
+surfaces these at WARNING level; responses occasionally contain user-visible
+strings (plugin labels, paths) that should not be echoed into logs.
 """
 
 from __future__ import annotations
@@ -29,6 +33,45 @@ def _is_typeddict(tp: Any) -> bool:
     )
 
 
+def _check_union(value: Any, tp: Any, path: str) -> list[str]:
+    for arm in get_args(tp):
+        if not _check_type(value, arm, path):
+            return []
+    return [f"{path}: no union arm matched ({tp})"]
+
+
+def _check_list(value: Any, tp: Any, path: str) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{path}: expected list, got {type(value).__name__}"]
+    (inner,) = get_args(tp) or (Any,)
+    errs: list[str] = []
+    for i, item in enumerate(value):
+        errs.extend(_check_type(item, inner, f"{path}[{i}]"))
+    return errs
+
+
+def _check_dict(value: Any, tp: Any, path: str) -> list[str]:
+    if not isinstance(value, dict):
+        return [f"{path}: expected dict, got {type(value).__name__}"]
+    args = get_args(tp)
+    if not args:
+        return []
+    _k, vt = args
+    errs: list[str] = []
+    for k, v in value.items():
+        errs.extend(_check_type(v, vt, f"{path}[{k!r}]"))
+    return errs
+
+
+def _check_plain_class(value: Any, tp: type, path: str) -> list[str]:
+    # bool is a subclass of int; keep them distinct to catch accidents.
+    if tp is int and isinstance(value, bool):
+        return [f"{path}: expected int, got bool"]
+    if not isinstance(value, tp):
+        return [f"{path}: expected {tp.__name__}, got {type(value).__name__}"]
+    return []
+
+
 def _check_type(value: Any, tp: Any, path: str) -> list[str]:
     """Return a list of error strings (empty if ``value`` matches ``tp``)."""
     # Any -> accept anything
@@ -37,38 +80,12 @@ def _check_type(value: Any, tp: Any, path: str) -> list[str]:
 
     origin = get_origin(tp)
 
-    # Union / Optional
     if origin is typing.Union or origin is types.UnionType:
-        errs_per_arm: list[list[str]] = []
-        for arm in get_args(tp):
-            errs = _check_type(value, arm, path)
-            if not errs:
-                return []
-            errs_per_arm.append(errs)
-        return [f"{path}: no union arm matched value {value!r} ({tp})"]
-
-    # list[X]
+        return _check_union(value, tp, path)
     if origin in (list, typing.List):  # noqa: UP006
-        if not isinstance(value, list):
-            return [f"{path}: expected list, got {type(value).__name__}"]
-        (inner,) = get_args(tp) or (Any,)
-        errs: list[str] = []
-        for i, item in enumerate(value):
-            errs.extend(_check_type(item, inner, f"{path}[{i}]"))
-        return errs
-
-    # dict[K, V]
+        return _check_list(value, tp, path)
     if origin in (dict, typing.Dict):  # noqa: UP006
-        if not isinstance(value, dict):
-            return [f"{path}: expected dict, got {type(value).__name__}"]
-        args = get_args(tp)
-        if not args:
-            return []
-        _k, vt = args
-        errs = []
-        for k, v in value.items():
-            errs.extend(_check_type(v, vt, f"{path}[{k!r}]"))
-        return errs
+        return _check_dict(value, tp, path)
 
     # Nested TypedDict
     if _is_typeddict(tp):
@@ -76,14 +93,7 @@ def _check_type(value: Any, tp: Any, path: str) -> list[str]:
 
     # Plain class
     if isinstance(tp, type):
-        # bool is a subclass of int; keep them distinct to catch accidents
-        if tp is int and isinstance(value, bool):
-            return [f"{path}: expected int, got bool ({value!r})"]
-        if not isinstance(value, tp):
-            return [
-                f"{path}: expected {tp.__name__}, got {type(value).__name__} ({value!r})"
-            ]
-        return []
+        return _check_plain_class(value, tp, path)
 
     # Unknown / exotic annotation — skip silently
     return []

--- a/tests/contract/test_response_shapes.py
+++ b/tests/contract/test_response_shapes.py
@@ -18,9 +18,7 @@ test suite lightweight. It walks a TypedDict's ``__annotations__`` and checks:
 
 from __future__ import annotations
 
-import types
-import typing
-from typing import Any, get_args, get_origin
+from typing import Any
 
 import pytest
 
@@ -40,108 +38,7 @@ from schemas.responses import (  # noqa: E402  (sys.path set up by conftest)
     UptimeResponse,
     VersionInfoResponse,
 )
-
-# ---------------------------------------------------------------------------
-# Validator
-# ---------------------------------------------------------------------------
-
-
-def _is_typeddict(tp: Any) -> bool:
-    return (
-        isinstance(tp, type)
-        and issubclass(tp, dict)
-        and hasattr(tp, "__total__")
-        and hasattr(tp, "__annotations__")
-    )
-
-
-def _check_type(value: Any, tp: Any, path: str) -> list[str]:
-    """Return a list of error strings (empty if ``value`` matches ``tp``)."""
-    # Any -> accept anything
-    if tp is Any or tp is object:
-        return []
-
-    origin = get_origin(tp)
-
-    # Union / Optional
-    if origin is typing.Union or origin is types.UnionType:
-        errs_per_arm: list[list[str]] = []
-        for arm in get_args(tp):
-            errs = _check_type(value, arm, path)
-            if not errs:
-                return []
-            errs_per_arm.append(errs)
-        return [f"{path}: no union arm matched value {value!r} ({tp})"]
-
-    # list[X]
-    if origin in (list, typing.List):  # noqa: UP006
-        if not isinstance(value, list):
-            return [f"{path}: expected list, got {type(value).__name__}"]
-        (inner,) = get_args(tp) or (Any,)
-        errs: list[str] = []
-        for i, item in enumerate(value):
-            errs.extend(_check_type(item, inner, f"{path}[{i}]"))
-        return errs
-
-    # dict[K, V]
-    if origin in (dict, typing.Dict):  # noqa: UP006
-        if not isinstance(value, dict):
-            return [f"{path}: expected dict, got {type(value).__name__}"]
-        args = get_args(tp)
-        if not args:
-            return []
-        _k, vt = args
-        errs = []
-        for k, v in value.items():
-            errs.extend(_check_type(v, vt, f"{path}[{k!r}]"))
-        return errs
-
-    # Nested TypedDict
-    if _is_typeddict(tp):
-        return validate_typeddict(value, tp, path=path)
-
-    # Plain class
-    if isinstance(tp, type):
-        # bool is a subclass of int; keep them distinct to catch accidents
-        if tp is int and isinstance(value, bool):
-            return [f"{path}: expected int, got bool ({value!r})"]
-        if not isinstance(value, tp):
-            return [
-                f"{path}: expected {tp.__name__}, got {type(value).__name__} ({value!r})"
-            ]
-        return []
-
-    # Unknown / exotic annotation — skip silently
-    return []
-
-
-def validate_typeddict(payload: Any, schema: Any, *, path: str = "$") -> list[str]:
-    """Validate *payload* against the TypedDict *schema*. Returns error list."""
-    if not isinstance(payload, dict):
-        return [f"{path}: expected dict, got {type(payload).__name__}"]
-
-    hints = typing.get_type_hints(schema)
-    required_keys = set(getattr(schema, "__required_keys__", set()))
-    optional_keys = set(getattr(schema, "__optional_keys__", set()))
-    # Older Pythons: fall back to __total__
-    if not required_keys and not optional_keys:
-        if getattr(schema, "__total__", True):
-            required_keys = set(hints.keys())
-        else:
-            optional_keys = set(hints.keys())
-
-    errors: list[str] = []
-    for key in required_keys:
-        if key not in payload:
-            errors.append(f"{path}.{key}: missing required key")
-            continue
-        errors.extend(_check_type(payload[key], hints[key], f"{path}.{key}"))
-
-    for key in optional_keys:
-        if key in payload:
-            errors.extend(_check_type(payload[key], hints[key], f"{path}.{key}"))
-
-    return errors
+from schemas.validator import validate_typeddict  # noqa: E402
 
 
 def assert_shape(payload: Any, schema: Any) -> None:

--- a/tests/unit/test_schema_validator_middleware.py
+++ b/tests/unit/test_schema_validator_middleware.py
@@ -26,10 +26,6 @@ def dev_app_with_validator(monkeypatch):
     """
     from app_setup import schema_validator
 
-    monkeypatch.setattr(
-        schema_validator, "ENDPOINT_SCHEMAS", {"toy.toy_ok": _ToyResponse}
-    )
-
     app = Flask(__name__)
     app.config["TESTING"] = True
 
@@ -41,7 +37,8 @@ def dev_app_with_validator(monkeypatch):
     def toy_bad():
         return jsonify({"value": "not-an-int"})
 
-    # Re-patch after route registration so request.endpoint keys line up.
+    # Patch ENDPOINT_SCHEMAS to match Flask's auto-named endpoints (no
+    # blueprint prefix for plain view functions).
     monkeypatch.setattr(
         schema_validator,
         "ENDPOINT_SCHEMAS",

--- a/tests/unit/test_schema_validator_middleware.py
+++ b/tests/unit/test_schema_validator_middleware.py
@@ -1,0 +1,140 @@
+"""Tests for the dev-mode JSON response schema validator middleware (JTN-664).
+
+These exercise ``app_setup.schema_validator.register`` and the ``create_app``
+gate that wires it in behind ``DEV_MODE`` / ``INKYPI_STRICT_SCHEMAS``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+
+import pytest
+from flask import Flask, jsonify
+
+
+class _ToyResponse(TypedDict):
+    value: int
+
+
+@pytest.fixture()
+def dev_app_with_validator(monkeypatch):
+    """A minimal Flask app with the validator registered and a toy endpoint.
+
+    The endpoint map is patched to a single entry so tests stay hermetic and
+    don't depend on the real route set.
+    """
+    from app_setup import schema_validator
+
+    monkeypatch.setattr(
+        schema_validator, "ENDPOINT_SCHEMAS", {"toy.toy_ok": _ToyResponse}
+    )
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    @app.route("/toy/ok")
+    def toy_ok():  # endpoint auto-named "toy_ok"
+        return jsonify({"value": 1})
+
+    @app.route("/toy/bad")
+    def toy_bad():
+        return jsonify({"value": "not-an-int"})
+
+    # Re-patch after route registration so request.endpoint keys line up.
+    monkeypatch.setattr(
+        schema_validator,
+        "ENDPOINT_SCHEMAS",
+        {"toy_ok": _ToyResponse, "toy_bad": _ToyResponse},
+    )
+
+    schema_validator.register(app)
+    return app
+
+
+def test_dev_mode_logs_no_warning_on_valid_response(dev_app_with_validator, caplog):
+    caplog.set_level(logging.WARNING, logger="app_setup.schema_validator")
+
+    resp = dev_app_with_validator.test_client().get("/toy/ok")
+    assert resp.status_code == 200
+
+    drift_records = [
+        r
+        for r in caplog.records
+        if r.name == "app_setup.schema_validator" and r.levelno >= logging.WARNING
+    ]
+    assert drift_records == [], f"unexpected drift warnings: {drift_records}"
+
+
+def test_dev_mode_logs_warning_on_shape_drift(dev_app_with_validator, caplog):
+    caplog.set_level(logging.WARNING, logger="app_setup.schema_validator")
+
+    resp = dev_app_with_validator.test_client().get("/toy/bad")
+    # Middleware is advisory — response is still returned unchanged.
+    assert resp.status_code == 200
+    assert resp.get_json() == {"value": "not-an-int"}
+
+    drift_records = [
+        r
+        for r in caplog.records
+        if r.name == "app_setup.schema_validator" and r.levelno >= logging.WARNING
+    ]
+    assert drift_records, "expected at least one drift WARNING"
+    messages = [r.getMessage() for r in drift_records]
+    # Endpoint name and the offending field path both appear in the log.
+    assert any("toy_bad" in m for m in messages)
+    assert any("$.value" in m for m in messages)
+
+
+def test_prod_mode_skips_registration(monkeypatch):
+    """When DEV_MODE is False and INKYPI_STRICT_SCHEMAS is unset, the validator
+    must not be attached to any app-level after_request chain.
+    """
+    from app_setup import schema_validator
+
+    monkeypatch.delenv("INKYPI_STRICT_SCHEMAS", raising=False)
+
+    # Mirror the production gate in src/inkypi.py create_app() and confirm
+    # that with DEV_MODE=False + no opt-in, register() is NOT called.
+    import os
+
+    dev_mode = False
+    app = Flask(__name__)
+
+    called = {"did": False}
+    original_register = schema_validator.register
+
+    def _spy(a):
+        called["did"] = True
+        return original_register(a)
+
+    monkeypatch.setattr(schema_validator, "register", _spy)
+
+    # Replay the exact gate.
+    if dev_mode or os.getenv("INKYPI_STRICT_SCHEMAS") == "1":
+        schema_validator.register(app)
+
+    assert called["did"] is False
+    # And the app has no after_request functions at all (no side effects).
+    assert not any(app.after_request_funcs.values())
+
+
+def test_strict_env_flag_forces_registration(monkeypatch):
+    """The INKYPI_STRICT_SCHEMAS=1 escape hatch wires the middleware in even
+    when DEV_MODE is False.
+    """
+    from app_setup import schema_validator
+
+    monkeypatch.setenv("INKYPI_STRICT_SCHEMAS", "1")
+
+    import os
+
+    dev_mode = False
+    app = Flask(__name__)
+
+    if dev_mode or os.getenv("INKYPI_STRICT_SCHEMAS") == "1":
+        schema_validator.register(app)
+
+    # after_request hook registered on the None blueprint key.
+    hooks = app.after_request_funcs.get(None, [])
+    assert any(h.__name__ == "_validate_response_schema" for h in hooks)


### PR DESCRIPTION
## Summary

Implements JTN-664: a dev-only ``@app.after_request`` hook that validates JSON bodies against the canonical ``TypedDict`` in ``schemas.responses`` for 9 high-traffic endpoints, logging any shape drift at WARNING. The response itself is never mutated and the hook never raises.

Reuses primitives from PR #441:

- Extracts ``validate_typeddict`` / ``_check_type`` from ``tests/contract/test_response_shapes.py`` into ``src/schemas/validator.py`` so both contract tests and runtime middleware share one implementation. No new dependencies.
- Consumes existing TypedDicts in ``src/schemas/responses.py`` via a new ``src/schemas/endpoint_map.py`` that maps Flask endpoint names (``blueprint.view_name``) to schema classes. Endpoint names verified empirically via ``request.endpoint`` from a test client.

## Wiring gate

In ``create_app()`` the middleware is registered iff ``DEV_MODE`` or ``INKYPI_STRICT_SCHEMAS=1``. Production traffic untouched by default; the env flag is an opt-in escape hatch for CI-style strict builds. A dedicated unit test covers the prod skip path.

## Commits

1. refactor(schemas): extract validate_typeddict to src/schemas/validator.py
2. feat(schemas): add endpoint to TypedDict map
3. feat(schemas): add dev-only response-schema validator middleware
4. test(schemas): cover dev-mode schema validator middleware

## Test coverage

``tests/unit/test_schema_validator_middleware.py``:

- valid response: no WARNING emitted
- drift: WARNING logged with endpoint name + ``$.field`` path, response unchanged
- ``DEV_MODE=False`` + no ``INKYPI_STRICT_SCHEMAS``: validator not registered
- ``INKYPI_STRICT_SCHEMAS=1``: validator registered even when ``DEV_MODE=False``

Existing 13 contract tests still pass through the extracted validator.

## Links

- Linear: https://linear.app/jtn0123/issue/JTN-664
- Builds on: #441

## Test plan

- [x] ``scripts/lint.sh`` clean
- [x] ``pytest tests/contract/`` pass (13)
- [x] ``pytest tests/unit/test_schema_validator_middleware.py`` pass (4)
- [x] Full suite: 4061 passed; the 11 date-boundary flakes in ``test_wpotd`` / ``test_apod_validation`` are pre-existing on ``origin/main`` and unrelated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON response schema validation middleware for development and CI environments to ensure API responses match expected formats; can be enabled in production via `INKYPI_STRICT_SCHEMAS` environment variable.

* **Tests**
  * Added comprehensive test coverage for schema validation middleware behavior and activation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->