### PR TITLE
fix(install): make update.sh fail loudly on pip/apt errors (JTN-665)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -76,7 +76,11 @@ fi
 apt-get update -y > /dev/null &
 if [ -f "$APT_REQUIREMENTS_FILE" ]; then
   echo "Installing system dependencies... "
-  xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null && echo_success "Installed system dependencies."
+  if ! xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null; then
+    echo_error "ERROR: apt-get install failed — aborting update."
+    exit 1
+  fi
+  echo_success "Installed system dependencies."
 else
   echo_error "ERROR: System dependencies file $APT_REQUIREMENTS_FILE not found!"
   exit 1
@@ -103,12 +107,24 @@ source "$VENV_PATH/bin/activate"
 
 # Upgrade pip
 echo "Upgrading pip..."
-$VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null && echo_success "Pip upgraded successfully."
+# JTN-665: capture failure so a broken pip/setuptools upgrade does not silently
+# proceed to requirements install and leave the venv in a partially-broken state.
+if ! "$VENV_PATH/bin/python" -m pip install --upgrade pip setuptools wheel > /dev/null; then
+  echo_error "ERROR: pip/setuptools upgrade failed — aborting update."
+  exit 1
+fi
+echo_success "Pip upgraded successfully."
 
 # Install or update Python dependencies
 if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
   echo "Updating Python dependencies..."
-  $VENV_PATH/bin/python -m pip install --upgrade -r "$PIP_REQUIREMENTS_FILE" -qq > /dev/null && echo_success "Dependencies updated successfully."
+  # JTN-665: explicit exit-code check so a compile error (e.g. metadata-generation-failed)
+  # stops the update before CSS build + service restart, preventing a boot loop.
+  if ! "$VENV_PATH/bin/python" -m pip install --upgrade -r "$PIP_REQUIREMENTS_FILE"; then
+    echo_error "ERROR: pip install failed — aborting update (service remains stopped)."
+    exit 1
+  fi
+  echo_success "Dependencies updated successfully."
 else
   echo_error "ERROR: Requirements file $PIP_REQUIREMENTS_FILE not found!"
   exit 1
@@ -119,7 +135,10 @@ cp "$SCRIPT_DIR/inkypi" "$BINPATH/"
 sudo chmod +x "$BINPATH/$APPNAME"
 
 echo "Update JS and CSS files"
-bash "$SCRIPT_DIR/update_vendors.sh" > /dev/null
+if ! bash "$SCRIPT_DIR/update_vendors.sh" > /dev/null; then
+  echo_error "ERROR: Vendor JS/CSS download failed. Check network connectivity and re-run."
+  exit 1
+fi
 
 echo "Building minified CSS bundle"
 if ! "$VENV_PATH/bin/python" "$SCRIPT_DIR/../scripts/build_css.py" --minify; then


### PR DESCRIPTION
## Summary

- **Root cause**: `update.sh` used `&& echo_success` for apt-get install, pip upgrade, pip install, and `update_vendors.sh` — a non-zero exit code silently dropped the success message but let execution continue into CSS build and service restart.
- **Impact observed**: numpy compile error (`metadata-generation-failed`) during v0.38.0→v0.49.20 update caused a 4,091-restart boot loop (Flask absent from venv, service kept restarting).
- **Fix**: Replace all four silent-failure patterns with explicit `if ! cmd; then echo_error ...; exit 1; fi` guards, matching the hardened style already used in `install.sh` (lines 697–711).

## Changes

- `install/update.sh` — four guards added:
  - `apt-get install` (was `&& echo_success`)
  - `pip install --upgrade pip setuptools wheel` (was `&& echo_success`)
  - `pip install --upgrade -r requirements.txt` (was `&& echo_success` — **primary bug site**)
  - `bash update_vendors.sh` (was silently discarded with `> /dev/null`)

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a sync PR
- [x] No upstream behavior changes

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (17 pre-existing collection errors unrelated to this change — `prometheus_client` missing in local venv; same count on `main`)
- [x] No breaking API route/path changes
- [x] Install/update flow: shell script logic only — no Python changes

## Testing

- [x] `scripts/lint.sh` passes (ruff, black, shellcheck all green)
- [x] `bash -n install/update.sh` syntax check passes
- Verification path per JTN-665 AC: break venv (`rm -rf /usr/local/inkypi/venv_inkypi/lib`), run `update.sh`, confirm non-zero exit + no "Update completed ✔"

Closes JTN-665