### PR TITLE
fix(update): stop + disable inkypi.service before venv update (JTN-666)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -13,6 +13,17 @@ INSTALL_PATH="/usr/local/$APPNAME"
 BINPATH="/usr/local/bin"
 VENV_PATH="$INSTALL_PATH/venv_$APPNAME"
 
+# JTN-666: Defense-in-depth for JTN-600 parity. While update.sh is running,
+# create /var/lib/inkypi/.install-in-progress. inkypi.service's ExecStartPre
+# refuses to start if this file exists, so even if someone manually runs
+# `systemctl start inkypi.service` or systemd tries to auto-restart, the
+# service cannot thrash the Pi mid-update. The lockfile is removed once all
+# update steps succeed (see end of script). On failure exit the file is
+# deliberately left in place so the user MUST rerun update.sh (or manually
+# remove it) before the service can start.
+LOCKFILE_DIR="/var/lib/inkypi"
+LOCKFILE="$LOCKFILE_DIR/.install-in-progress"
+
 SERVICE_FILE="$APPNAME.service"
 SERVICE_FILE_SOURCE="$SCRIPT_DIR/$SERVICE_FILE"
 SERVICE_FILE_TARGET="/etc/systemd/system/$SERVICE_FILE"
@@ -28,7 +39,32 @@ echo_error() {
   echo -e "$1 [\e[31m\xE2\x9C\x98\e[0m]\n"
 }
 
+show_loader() {
+  local pid=$!
+  local message="$1"
+  local delay=0.1
+  local spinstr="|/-\\"
+  printf "%s [%s] " "$message" "${spinstr:0:1}"
+  while kill -0 "$pid" 2>/dev/null; do
+    local temp=${spinstr#?}
+    printf "\r%s [%s] " "$message" "${temp:0:1}"
+    spinstr=${temp}${spinstr%"${temp}"}
+    sleep "${delay}"
+  done
+  if wait "$pid"; then
+    printf "\r%s [\e[32m\xE2\x9C\x94\e[0m]\n" "$message"
+  else
+    printf "\r%s [\e[31m\xE2\x9C\x98\e[0m]\n" "$message"
+  fi
+}
+
 setup_zramswap_service() {
+  # If the OS already provides zram swap (e.g. Pi OS Trixie preinstalls zram-swap),
+  # skip zram-tools — they fight over /dev/zram0 and cause mkswap to fail.
+  if grep -q "^/dev/zram" /proc/swaps 2>/dev/null; then
+    echo "zram swap already active (likely from preinstalled zram-swap package) — skipping zram-tools install."
+    return 0
+  fi
   echo "Enabling and starting zramswap service."
   sudo apt-get install -y zram-tools > /dev/null
   echo -e "ALGO=zstd\nPERCENT=60" | sudo tee /etc/default/zramswap > /dev/null
@@ -41,13 +77,31 @@ setup_earlyoom_service() {
   sudo systemctl enable --now earlyoom
 }
 
+# JTN-666: Stop and DISABLE (not just stop) the service before touching the
+# venv or app files. This mirrors install.sh:539-552 (JTN-600). systemd cannot
+# restart a half-installed service during the update, preventing the load-14
+# thrash observed on Pi Zero 2 W.
+stop_service() {
+  echo "Checking if $SERVICE_FILE is running"
+  if /usr/bin/systemctl is-active --quiet "$SERVICE_FILE"; then
+    /usr/bin/systemctl stop "$SERVICE_FILE" > /dev/null &
+    show_loader "Stopping $APPNAME service"
+  else
+    echo_success "\t$SERVICE_FILE not running"
+  fi
+  # DISABLE (not just stop) during update so systemd cannot restart the
+  # half-installed service. update_app_service re-enables it at the end.
+  /usr/bin/systemctl disable "$SERVICE_FILE" 2>/dev/null || true
+}
+
 update_app_service() {
   echo "Updating $APPNAME systemd service."
   if [ -f "$SERVICE_FILE_SOURCE" ]; then
     sudo cp "$SERVICE_FILE_SOURCE" "$SERVICE_FILE_TARGET"
-    echo "Restarting $APPNAME service."
     sudo systemctl daemon-reload
-    sudo systemctl restart "$SERVICE_FILE"
+    sudo systemctl enable "$SERVICE_FILE"
+    echo "Starting $APPNAME service."
+    sudo systemctl start "$SERVICE_FILE"
   else
     echo_error "ERROR: Service file $SERVICE_FILE_SOURCE not found!"
     exit 1
@@ -61,7 +115,7 @@ update_cli() {
   sudo chmod +x "$INSTALL_PATH/cli/"*
 }
 
-# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixe
+# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie
 get_os_version() {
   lsb_release -sr
 }
@@ -73,6 +127,18 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
+# JTN-666: Create the install-in-progress lockfile. inkypi.service's
+# ExecStartPre refuses to start while this file exists (defense-in-depth for
+# JTN-600's systemctl disable). The lockfile is removed once all update steps
+# succeed (see near end of script); on failure exit it is left in place so the
+# user must rerun update.sh (or manually rm it) before the service can start.
+mkdir -p "$LOCKFILE_DIR"
+touch "$LOCKFILE"
+
+# JTN-666: Stop and disable the service BEFORE touching files or venv so
+# systemd cannot restart a half-installed service and thrash the Pi.
+stop_service
+
 apt-get update -y > /dev/null &
 if [ -f "$APT_REQUIREMENTS_FILE" ]; then
   echo "Installing system dependencies... "
@@ -82,12 +148,15 @@ else
   exit 1
 fi
 
-# check OS version for Bookworm to setup zramswap
-if [[ $(get_os_version) = "12" ]] ; then
-  echo "OS version is Bookworm - setting up zramswap"
+# Setup zramswap on any modern Pi OS that ships zram-tools (Bullseye/Bookworm/Trixie).
+# This is critical on low-RAM boards like the Pi Zero 2 W (512 MB) — without
+# zramswap, pip install of numpy/Pillow/playwright will OOM during the update step.
+os_version=$(get_os_version)
+if [[ "$os_version" =~ ^(11|12|13)$ ]] ; then
+  echo "OS version is $os_version (Bullseye/Bookworm/Trixie) - setting up zramswap"
   setup_zramswap_service
 else
-  echo "OS version is not Bookworm - skipping zramswap setup."
+  echo "OS version is $os_version - skipping zramswap setup (zram-tools not available on this release)."
 fi
 setup_earlyoom_service
 
@@ -133,8 +202,14 @@ if [ ! -f "$CSS_OUTPUT" ]; then
 fi
 echo_success "CSS bundle built."
 
-update_app_service
 update_cli
+update_app_service
+
+# JTN-666: All update steps succeeded — remove the install-in-progress lockfile
+# so the service is allowed to start. If update.sh exits early due to a failure
+# above, this line is never reached and the lockfile stays in place, forcing the
+# user to rerun update.sh (or manually rm the file) before the service can start.
+rm -f "$LOCKFILE"
 
 echo "Version: $(cat "$INSTALL_PATH/VERSION" 2>/dev/null || echo 'unknown')"
 echo_success "Update completed."

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1217,11 +1217,90 @@ class TestUpdateScript:
         assert "build_css" in self.content
 
     def test_update_restarts_service(self):
+        # JTN-666: update.sh now stops first then starts (not restart), because
+        # stop_service is called before any file changes and update_app_service
+        # re-enables + starts the service at the end.
         assert "systemctl" in self.content
-        assert "restart" in self.content
+        assert "systemctl start" in self.content
+
+    def test_update_stop_service_before_pip(self):
+        # JTN-666: stop_service() must be called before pip install to prevent
+        # systemd from restart-looping the half-installed venv during update.
+        assert "stop_service" in self.content
+        # stop_service() must DISABLE (not just stop) so systemd cannot auto-restart.
+        fn_start = self.content.index("stop_service() {")
+        fn_end = self.content.index("}", fn_start) + 1
+        fn_body = self.content[fn_start:fn_end]
+        assert (
+            "systemctl disable" in fn_body
+        ), "stop_service() must call 'systemctl disable' to prevent auto-restart mid-update"
+        # stop_service call must appear before pip install in main script body
+        main_call = self.content.index("stop_service\n", fn_end)
+        pip_pos = self.content.index("pip install", fn_end)
+        assert (
+            main_call < pip_pos
+        ), "stop_service must be called before pip install to prevent mid-update thrash"
+
+    def test_update_lockfile_created_before_stop_service(self):
+        # JTN-666: The install-in-progress lockfile (JTN-607 parity) must be
+        # created before stop_service is called, providing defense-in-depth so
+        # that even a manual `systemctl start` cannot start mid-update.
+        assert 'LOCKFILE_DIR="/var/lib/inkypi"' in self.content
+        assert 'LOCKFILE="$LOCKFILE_DIR/.install-in-progress"' in self.content
+        # Use the stop_service call position to find main body start
+        stop_call_pos = self.content.rindex("stop_service\n")
+        main_body = self.content[self.content.rindex("EUID", 0, stop_call_pos) :]
+        assert 'mkdir -p "$LOCKFILE_DIR"' in main_body
+        assert 'touch "$LOCKFILE"' in main_body
+        touch_pos = main_body.index('touch "$LOCKFILE"')
+        stop_pos = main_body.index("stop_service\n")
+        assert (
+            touch_pos < stop_pos
+        ), "Lockfile must be created before stop_service is called"
+
+    def test_update_lockfile_removed_on_success(self):
+        # JTN-666: The lockfile must be removed after all steps succeed so the
+        # service is allowed to start. On failure, it stays to require manual recovery.
+        assert 'rm -f "$LOCKFILE"' in self.content
+        # rm must come after update_app_service call
+        update_service_pos = self.content.rindex("update_app_service")
+        rm_pos = self.content.rindex('rm -f "$LOCKFILE"')
+        assert (
+            rm_pos > update_service_pos
+        ), "Lockfile removal must come after update_app_service to ensure service is running"
 
     def test_update_upgrades_pip_deps(self):
         assert "pip install" in self.content
+
+    def test_update_enables_zramswap_on_bullseye_bookworm_trixie(self):
+        # JTN-667: update.sh must use the same multi-release zramswap guard as
+        # install.sh — previously it only matched Bookworm (12) so Trixie (13)
+        # and Bullseye (11) users would OOM during pip install on update.
+        assert "os_version=$(get_os_version)" in self.content
+        assert '[[ "$os_version" =~ ^(11|12|13)$ ]]' in self.content
+        assert "setup_zramswap_service" in self.content
+        # The skip branch should still exist for unknown future releases.
+        assert "skipping zramswap setup" in self.content
+
+    def test_update_skips_zramtools_when_zram_swap_already_active(self):
+        # JTN-667: setup_zramswap_service in update.sh must guard against
+        # Trixie's preinstalled zram-swap to avoid /dev/zram0 conflicts.
+        guard = 'grep -q "^/dev/zram" /proc/swaps'
+        apt_install = "apt-get install -y zram-tools"
+        assert guard in self.content
+        assert "skipping zram-tools install" in self.content
+        assert "return 0" in self.content
+
+        fn_start = self.content.index("setup_zramswap_service() {")
+        guard_pos = self.content.index(guard, fn_start)
+        return_pos = self.content.index("return 0", fn_start)
+        apt_pos = self.content.index(apt_install, fn_start)
+        assert guard_pos < return_pos < apt_pos
+
+    def test_update_codename_comment_has_no_trixie_typo(self):
+        # JTN-667: The comment near get_os_version must spell Trixie correctly.
+        assert "13=Trixie" in self.content
+        assert "Trixe" not in self.content  # typo guard
 
 
 # ---- uninstall.sh ----


### PR DESCRIPTION
## Summary

- **Root cause of Pi Zero 2 W thrash-to-power-cycle**: `update.sh` never stopped the inkypi service before pip install. systemd kept restart-looping the half-installed venv every 60s, turning the 512 MB board into a load-14 thrash box requiring physical power-cycling.
- Port `stop_service()` from `install.sh` (JTN-600 parity): stops + **disables** the service so systemd cannot auto-restart mid-update; `update_app_service` re-enables + starts at the end.
- Add `/var/lib/inkypi/.install-in-progress` lockfile (JTN-607 parity): `inkypi.service`'s `ExecStartPre` blocks start while this file exists; removed only on success so failed updates require explicit recovery.
- Fix `setup_zramswap_service` OS-version guard to cover Bullseye/Bookworm/Trixie (11/12/13) — was only matching Bookworm (12).
- Guard `setup_zramswap_service` against Trixie's preinstalled `zram-swap` to avoid `/dev/zram0` conflicts.

## Changes

- `install/update.sh` — add `stop_service()`, `show_loader()`, lockfile logic, fix zramswap OS guard, fix Trixie typo
- `tests/unit/test_install_scripts.py` — 4 new tests covering stop_service ordering, lockfile creation/removal, zramswap guards

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [x] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (177/177 install script tests pass)
- [x] No breaking API route/path changes (shell script only)
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI (N/A)
- [x] **Frontend changes**: N/A — install script only

## Testing

- All 177 `test_install_scripts.py` tests pass
- `scripts/lint.sh` clean (ruff, black, shellcheck all pass)
- Pre-existing test collection errors (17 errors from missing `prometheus_client` module) exist on `main` before this PR

Closes JTN-666
Epic: JTN-529 (install path hardening)