### PR TITLE
fix(tests): eliminate date-boundary flakes in apod/wpotd tests

### DIFF
--- a/tests/plugins/test_apod_validation.py
+++ b/tests/plugins/test_apod_validation.py
@@ -8,7 +8,18 @@ obviously cannot return future dates, so we now reject out-of-range values at
 save time and constrain the date input client-side via ``min``/``max``.
 """
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
+
+
+def _today_utc() -> date:
+    """Return today's date in UTC.
+
+    The APOD plugin resolves "today" via ``datetime.now(tz=UTC).date()`` so
+    tests must reference the same UTC-anchored date. Using the local
+    ``date.today()`` causes intermittent failures around UTC midnight when
+    the host timezone is not UTC (JTN-663: date-boundary flakes).
+    """
+    return datetime.now(tz=UTC).date()
 
 
 def _make_plugin():
@@ -44,16 +55,16 @@ def test_validate_settings_far_future_returns_error():
     plugin = _make_plugin()
     err = plugin.validate_settings({"customDate": "2099-12-31"})
     assert err is not None
-    today = date.today().isoformat()
+    today = _today_utc().isoformat()
     assert today in err
 
 
 def test_validate_settings_tomorrow_returns_error():
     plugin = _make_plugin()
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    tomorrow = (_today_utc() + timedelta(days=1)).isoformat()
     err = plugin.validate_settings({"customDate": tomorrow})
     assert err is not None
-    assert date.today().isoformat() in err
+    assert _today_utc().isoformat() in err
 
 
 def test_validate_settings_archive_start_boundary_returns_none():
@@ -63,7 +74,7 @@ def test_validate_settings_archive_start_boundary_returns_none():
 
 def test_validate_settings_today_boundary_returns_none():
     plugin = _make_plugin()
-    today = date.today().isoformat()
+    today = _today_utc().isoformat()
     assert plugin.validate_settings({"customDate": today}) is None
 
 
@@ -93,7 +104,7 @@ def test_settings_schema_advertises_min_and_max():
     assert custom_date_field is not None
     assert custom_date_field.get("type") == "date"
     assert custom_date_field.get("min") == "1995-06-16"
-    assert custom_date_field.get("max") == date.today().isoformat()
+    assert custom_date_field.get("max") == _today_utc().isoformat()
 
 
 def test_settings_template_renders_min_and_max(client):
@@ -102,7 +113,7 @@ def test_settings_template_renders_min_and_max(client):
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert 'min="1995-06-16"' in body
-    assert f'max="{date.today().isoformat()}"' in body
+    assert f'max="{_today_utc().isoformat()}"' in body
 
 
 def test_save_plugin_settings_rejects_pre_archive_date(client):
@@ -132,7 +143,7 @@ def test_save_plugin_settings_rejects_future_date(client):
     body = resp.get_json() or {}
     assert body.get("success") is False
     msg = body.get("error") or body.get("message") or ""
-    assert date.today().isoformat() in msg
+    assert _today_utc().isoformat() in msg
 
 
 def test_save_plugin_settings_accepts_valid_date(client):

--- a/tests/plugins/test_wpotd.py
+++ b/tests/plugins/test_wpotd.py
@@ -237,15 +237,20 @@ def test_wpotd_shrink_to_fit_disabled(device_config_dev, monkeypatch):
 
 
 def test_determine_date_today():
-    """Test _determine_date with no special settings (uses today)."""
-    from datetime import datetime
+    """Test _determine_date with no special settings (uses today).
+
+    The plugin resolves "today" via ``datetime.now(tz=UTC).date()``; the test
+    must use the same UTC anchor to avoid flakes around UTC midnight on
+    non-UTC hosts (JTN-663).
+    """
+    from datetime import UTC, datetime
 
     from plugins.wpotd.wpotd import Wpotd
 
     p = Wpotd({"id": "wpotd"})
     result = p._determine_date({})
 
-    assert result == datetime.today().date()
+    assert result == datetime.now(tz=UTC).date()
 
 
 def test_determine_date_random(monkeypatch):

--- a/tests/plugins/test_wpotd_validation.py
+++ b/tests/plugins/test_wpotd_validation.py
@@ -8,7 +8,18 @@ series runs from 2007-01-01 onward, so we now reject out-of-range values at
 save time and constrain the date input client-side via ``min``/``max``.
 """
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
+
+
+def _today_utc() -> date:
+    """Return today's date in UTC.
+
+    The WPOTD plugin resolves "today" via ``datetime.now(tz=UTC).date()`` so
+    tests must reference the same UTC-anchored date. Using the local
+    ``date.today()`` causes intermittent failures around UTC midnight when
+    the host timezone is not UTC (JTN-663: date-boundary flakes).
+    """
+    return datetime.now(tz=UTC).date()
 
 
 def _make_plugin():
@@ -44,16 +55,16 @@ def test_validate_settings_far_future_returns_error():
     plugin = _make_plugin()
     err = plugin.validate_settings({"customDate": "2099-12-31"})
     assert err is not None
-    today = date.today().isoformat()
+    today = _today_utc().isoformat()
     assert today in err
 
 
 def test_validate_settings_tomorrow_returns_error():
     plugin = _make_plugin()
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    tomorrow = (_today_utc() + timedelta(days=1)).isoformat()
     err = plugin.validate_settings({"customDate": tomorrow})
     assert err is not None
-    assert date.today().isoformat() in err
+    assert _today_utc().isoformat() in err
 
 
 def test_validate_settings_archive_start_boundary_returns_none():
@@ -63,7 +74,7 @@ def test_validate_settings_archive_start_boundary_returns_none():
 
 def test_validate_settings_today_boundary_returns_none():
     plugin = _make_plugin()
-    today = date.today().isoformat()
+    today = _today_utc().isoformat()
     assert plugin.validate_settings({"customDate": today}) is None
 
 
@@ -93,7 +104,7 @@ def test_settings_schema_advertises_min_and_max():
     assert custom_date_field is not None
     assert custom_date_field.get("type") == "date"
     assert custom_date_field.get("min") == "2007-01-01"
-    assert custom_date_field.get("max") == date.today().isoformat()
+    assert custom_date_field.get("max") == _today_utc().isoformat()
 
 
 def test_settings_template_renders_min_and_max(client):
@@ -102,7 +113,7 @@ def test_settings_template_renders_min_and_max(client):
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert 'min="2007-01-01"' in body
-    assert f'max="{date.today().isoformat()}"' in body
+    assert f'max="{_today_utc().isoformat()}"' in body
 
 
 def test_save_plugin_settings_rejects_pre_archive_date(client):
@@ -132,7 +143,7 @@ def test_save_plugin_settings_rejects_future_date(client):
     body = resp.get_json() or {}
     assert body.get("success") is False
     msg = body.get("error") or body.get("message") or ""
-    assert date.today().isoformat() in msg
+    assert _today_utc().isoformat() in msg
 
 
 def test_save_plugin_settings_accepts_valid_date(client):


### PR DESCRIPTION
## Root cause

The APOD and WPOTD plugins resolve "today" via `datetime.now(tz=UTC).date()` (see `src/plugins/apod/apod.py` `validate_settings` / `build_settings_schema`, and `src/plugins/wpotd/wpotd.py` `_determine_date` / `validate_settings` / `build_settings_schema`). That contract was hardened in PR #442 to kill naive `datetime` usage in plugin code.

The tests, however, were still comparing against the **local** `date.today()` / `datetime.today().date()`. Near UTC midnight on a non-UTC host, those two dates diverge by one day. A prior sub-agent running at ~UTC midnight observed ~11 failures; on a different host at midday, all 64 tests pass. Classic naive-local vs tz-aware-UTC mismatch; ruff DTZ skipped `tests/**` so the smell never landed a warning.

## Fix

No plugin bugs were found. The plugins' tz handling is correct.

Test-side fix only: introduce a `_today_utc()` helper in each validation test file and replace `date.today()` / `datetime.today()` with `datetime.now(tz=UTC).date()` so tests reference the same UTC anchor the plugins use.

## Classification

All flakes are **Type 1** (test uses naive `date.today()` vs plugin's tz-aware UTC date):

| File | Test | Classification |
|---|---|---|
| test_apod_validation.py | test_validate_settings_far_future_returns_error | Type 1 |
| test_apod_validation.py | test_validate_settings_tomorrow_returns_error | Type 1 |
| test_apod_validation.py | test_validate_settings_today_boundary_returns_none | Type 1 |
| test_apod_validation.py | test_settings_schema_advertises_min_and_max | Type 1 |
| test_apod_validation.py | test_settings_template_renders_min_and_max | Type 1 |
| test_apod_validation.py | test_save_plugin_settings_rejects_future_date | Type 1 |
| test_wpotd_validation.py | test_validate_settings_far_future_returns_error | Type 1 |
| test_wpotd_validation.py | test_validate_settings_tomorrow_returns_error | Type 1 |
| test_wpotd_validation.py | test_validate_settings_today_boundary_returns_none | Type 1 |
| test_wpotd_validation.py | test_settings_schema_advertises_min_and_max | Type 1 |
| test_wpotd_validation.py | test_settings_template_renders_min_and_max | Type 1 |
| test_wpotd_validation.py | test_save_plugin_settings_rejects_future_date | Type 1 |
| test_wpotd.py | test_determine_date_today | Type 1 |

(`test_wpotd_unit.py::test_determine_date_invalid_custom_date_falls_back` already uses a `FrozenDateTime` stub and is deterministic — no change needed.)

## Plugin bugs

**None.** Plugins are correct. Test-side-only fix.

## Boundary-time evidence

Target files run clean under each simulated UTC time (freezegun):

- `2025-01-15 00:30:00 UTC` (just past UTC midnight): 62 passed
- `2025-01-15 04:30:00 UTC` (US Eastern midnight): 62 passed
- `2025-01-15 08:30:00 UTC` (US Pacific midnight): 62 passed
- `2025-01-15 12:00:00 UTC` (no boundary): 62 passed

Target files run clean under each host TZ:

- `TZ=UTC`: 62 passed
- `TZ=America/Los_Angeles`: 62 passed
- `TZ=Asia/Tokyo`: 62 passed
- `TZ=Pacific/Kiritimati` (UTC+14): 62 passed

Full suite: **4072 passed, 5 skipped**. `scripts/lint.sh` clean.

## Links

- Originating context: PR #445 / JTN-663 (agent reported these flakes at ~UTC midnight)
- Related prior hardening: PR #442 (ruff DTZ)