### PR TITLE
fix(install): widen narrow git fetch refspec in do_update.sh (JTN-673)

### DIFF
--- a/install/do_update.sh
+++ b/install/do_update.sh
@@ -54,6 +54,28 @@ echo "$CURRENT_VERSION" > "$STATE_DIR/prev_version"
 echo "Current version: $CURRENT_VERSION"
 
 # ---------------------------------------------------------------------------
+# JTN-673: Ensure the origin remote has a full branch refspec before fetching.
+# Older installers pinned origin to a single-tag refspec such as
+#   +refs/tags/v0.28.1:refs/tags/v0.28.1
+# which causes `git fetch origin` to download only that one tag.  As a
+# result, `git branch -r` is empty, and `git checkout refs/tags/<new_tag>`
+# still works but leaves HEAD detached with no remote-tracking branches —
+# meaning the next do_update.sh run cannot re-resolve the latest semver tag
+# from `git tag --sort=-v:refname` after a fresh fetch of only the old tag.
+# More visibly: if any code path falls back to `git checkout main` it will
+# fail with "'origin/main' is not a commit".
+#
+# Fix: if the full branch glob is not already in the fetch refspec list, wipe
+# and re-add it so subsequent fetches download all branches.
+# ---------------------------------------------------------------------------
+if ! git -C "$REPO_DIR" config --get-all remote.origin.fetch 2>/dev/null \
+    | grep -qF '+refs/heads/*:refs/remotes/origin/*'; then
+  echo "Widening narrow git fetch refspec to include all branches..."
+  git -C "$REPO_DIR" config --unset-all remote.origin.fetch || true
+  git -C "$REPO_DIR" config --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+fi
+
+# ---------------------------------------------------------------------------
 # Fetch latest from origin
 # ---------------------------------------------------------------------------
 echo "Fetching latest from origin..."


### PR DESCRIPTION
## Summary

- Older installers could pin `remote.origin.fetch` to a single-tag refspec (e.g. `+refs/tags/v0.28.1:refs/tags/v0.28.1`), causing `git fetch origin` in `do_update.sh` to download only that one tag
- With a narrow refspec, `git branch -r` returns empty and `git checkout refs/tags/<new_tag>` can still work, but any code path that relies on remote-tracking branches (e.g. falling back to `git checkout main`) fails with `'origin/main' is not a commit`
- This blocked updates on `inkypi.local` (Pi Zero 2 W) today; any other Pi installed via an older release has the same silent breakage
- Fix: before `git fetch`, check whether the full branch glob `+refs/heads/*:refs/remotes/origin/*` is present in the refspec list; if not, wipe and re-add it

## Changes

- `install/do_update.sh`: add refspec-widening guard block (22 lines) immediately before the existing `git fetch origin --tags --prune` call

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync — this is a new fix against jtn0123/InkyPi main

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (145 pre-existing failures unchanged; 2378 passed)
- [x] No breaking API route/path changes (shell script only)
- [x] Lint (`scripts/lint.sh`) passes — ruff, black, shellcheck all clean

## Testing

- Manually tested logic: `git config --get-all remote.origin.fetch | grep -qF '+refs/heads/*:refs/remotes/origin/*'` correctly detects narrow vs. wide refspecs in a scratch repo
- Pi `inkypi.local` was previously fixed by hand by exactly this sequence of commands — this codifies it

Closes JTN-673