### PR TITLE
refactor(install): factor shared helpers into _common.sh (JTN-674)

### DIFF
--- a/install/_common.sh
+++ b/install/_common.sh
@@ -3,24 +3,148 @@
 # =============================================================================
 # _common.sh — shared helpers sourced by install.sh and update.sh
 #
-# JTN-669: Extracted from install.sh so update.sh can also use the pre-built
-# wheelhouse (JTN-604), avoiding source-compilation of numpy/Pillow/cffi/etc.
-# on every update on low-RAM boards like the Pi Zero 2 W.
+# JTN-669: Extracted fetch_wheelhouse/cleanup_wheelhouse so update.sh can use
+# pre-built wheels (JTN-604), avoiding source-compilation on every update.
+#
+# JTN-674: Extended to cover all remaining duplicated logic so install.sh and
+# update.sh share a single source of truth:
+#   - Formatting helpers (echo_success / echo_error / echo_header / echo_blue /
+#     echo_override / show_loader)
+#   - get_os_version
+#   - setup_zramswap_service / setup_earlyoom_service
+#   - stop_service
+#   - build_css_bundle
 # =============================================================================
 
-# JTN-604: Fetch a pre-built wheelhouse bundle from the GitHub release for
-# the current VERSION so pip can install every dependency without compiling
-# wheels on-device. First-boot install on a Pi Zero 2 W drops from ~15 min
-# to ~2-3 min and peak memory pressure drops by ~200 MB (no native builds).
+# ---------------------------------------------------------------------------
+# Terminal formatting (requires tput; safe to call in non-interactive shells)
+# ---------------------------------------------------------------------------
+bold=$(tput bold 2>/dev/null || true)
+normal=$(tput sgr0 2>/dev/null || true)
+red=$(tput setaf 1 2>/dev/null || true)
+
+echo_success() {
+  echo -e "$1 [\e[32m\xE2\x9C\x94\e[0m]"
+}
+
+echo_override() {
+  echo -e "\r$1"
+}
+
+echo_header() {
+  echo -e "${bold}$1${normal}"
+}
+
+echo_error() {
+  echo -e "${red}$1${normal} [\e[31m\xE2\x9C\x98\e[0m]\n"
+}
+
+echo_blue() {
+  echo -e "\e[38;2;65;105;225m$1\e[0m"
+}
+
+show_loader() {
+  local pid=$!
+  local message="$1"
+  local delay=0.1
+  local spinstr="|/-\\"
+  printf "%s [%s] " "$message" "${spinstr:0:1}"
+  while kill -0 "$pid" 2>/dev/null; do
+    local temp=${spinstr#?}
+    printf "\r%s [%s] " "$message" "${temp:0:1}"
+    spinstr=${temp}${spinstr%"${temp}"}
+    sleep "${delay}"
+  done
+  if wait "$pid"; then
+    printf "\r%s [\e[32m\xE2\x9C\x94\e[0m]\n" "$message"
+  else
+    printf "\r%s [\e[31m\xE2\x9C\x98\e[0m]\n" "$message"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# OS helpers
+# ---------------------------------------------------------------------------
+
+# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie
+get_os_version() {
+  lsb_release -sr
+}
+
+# ---------------------------------------------------------------------------
+# Service helpers
+# ---------------------------------------------------------------------------
+
+# Stop and DISABLE (not just stop) the service so systemd cannot restart a
+# half-installed service during install/update. The caller is responsible for
+# re-enabling and starting the service once all steps succeed.
 #
-# The function is deliberately noisy-but-graceful: on ANY failure (missing
-# tarball, 404, checksum mismatch, network glitch, non-matching arch) it
-# cleans up and returns non-zero so the caller falls back to normal pip
-# install. Users can opt out entirely via INKYPI_SKIP_WHEELHOUSE=1.
+# Requires SERVICE_FILE and APPNAME to be set by the sourcing script.
+stop_service() {
+  echo "Checking if $SERVICE_FILE is running"
+  if /usr/bin/systemctl is-active --quiet "$SERVICE_FILE"; then
+    /usr/bin/systemctl stop "$SERVICE_FILE" > /dev/null &
+    show_loader "Stopping $APPNAME service"
+  else
+    echo_success "\t$SERVICE_FILE not running"
+  fi
+  # DISABLE (not just stop) during install/update so systemd cannot restart the
+  # half-installed service. The caller re-enables it at the end of the script.
+  /usr/bin/systemctl disable "$SERVICE_FILE" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Memory-pressure helpers
+# ---------------------------------------------------------------------------
+
+setup_zramswap_service() {
+  # If the OS already provides zram swap (e.g. Pi OS Trixie preinstalls
+  # zram-swap), skip zram-tools — they fight over /dev/zram0 and cause mkswap
+  # to fail.
+  if grep -q "^/dev/zram" /proc/swaps 2>/dev/null; then
+    echo "zram swap already active (likely from preinstalled zram-swap package) — skipping zram-tools install."
+    return 0
+  fi
+  echo "Enabling and starting zramswap service."
+  sudo apt-get install -y zram-tools > /dev/null
+  echo -e "ALGO=zstd\nPERCENT=60" | sudo tee /etc/default/zramswap > /dev/null
+  sudo systemctl enable --now zramswap
+}
+
+setup_earlyoom_service() {
+  echo "Enabling and starting earlyoom service."
+  sudo apt-get install -y earlyoom > /dev/null
+  sudo systemctl enable --now earlyoom
+}
+
+# ---------------------------------------------------------------------------
+# CSS build helper
 #
-# Sets WHEELHOUSE_DIR on success; caller passes it to pip via --find-links.
+# Requires VENV_PATH and SCRIPT_DIR to be set by the sourcing script.
+# ---------------------------------------------------------------------------
+
+build_css_bundle() {
+  echo "Building minified CSS bundle"
+  if ! "$VENV_PATH/bin/python" "$SCRIPT_DIR/../scripts/build_css.py" --minify; then
+    echo_error "ERROR: CSS build failed. The web UI will not render correctly."
+    exit 1
+  fi
+  local css_output="$SCRIPT_DIR/../src/static/styles/main.css"
+  if [ ! -f "$css_output" ]; then
+    echo_error "ERROR: CSS bundle was not generated at $css_output."
+    exit 1
+  fi
+  echo_success "CSS bundle built."
+}
+
+# ---------------------------------------------------------------------------
+# Wheelhouse helpers (JTN-604 / JTN-669)
 #
-# Requires SCRIPT_DIR and WHEELHOUSE_REPO to be set by the sourcing script.
+# fetch_wheelhouse / cleanup_wheelhouse — extracted in PR #450.
+# Require SCRIPT_DIR and WHEELHOUSE_REPO to be set (WHEELHOUSE_REPO defaults
+# below). Sets WHEELHOUSE_DIR on success so callers can pass --find-links.
+# ---------------------------------------------------------------------------
+
 WHEELHOUSE_DIR=""
 WHEELHOUSE_REPO="${INKYPI_WHEELHOUSE_REPO:-jtn0123/InkyPi}"
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -13,11 +13,6 @@
 #                               is assumed.
 # =============================================================================
 
-# Formatting stuff
-bold=$(tput bold)
-normal=$(tput sgr0)
-red=$(tput setaf 1)
-
 SOURCE=${BASH_SOURCE[0]}
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
@@ -57,6 +52,12 @@ PIP_REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 # as per the WS naming convention.
 WS_TYPE=""
 WS_REQUIREMENTS_FILE="$SCRIPT_DIR/ws-requirements.txt"
+
+# JTN-669/674: Source shared helpers (formatting, stop_service, zramswap,
+# earlyoom, get_os_version, build_css_bundle, fetch_wheelhouse, cleanup_wheelhouse)
+# so install.sh and update.sh share a single source of truth.
+# shellcheck source=install/_common.sh
+source "$SCRIPT_DIR/_common.sh"
 
 # Parse the arguments, looking for the -W option.
 parse_arguments() {
@@ -147,7 +148,7 @@ enable_interfaces(){
         echo "dtoverlay for spi0-2cs already specified"
     fi
   else
-    # TODO - check if really need the dtparam set for INKY as this seems to be 
+    # TODO - check if really need the dtparam set for INKY as this seems to be
     # only for the older screens (as per INKY docs)
     echo "Enabling single CS line for SPI interface in config.txt"
     if ! grep -E -q '^[[:space:]]*dtoverlay=spi0-0cs' "$config_txt"; then
@@ -155,53 +156,13 @@ enable_interfaces(){
     else
         echo "dtoverlay for spi0-0cs already specified"
     fi
-  fi 
-}
-
-show_loader() {
-  local pid=$!
-  local message="$1"
-  local delay=0.1
-  local spinstr="|/-\\"
-  printf "%s [%s] " "$message" "${spinstr:0:1}"
-  while kill -0 "$pid" 2>/dev/null; do
-    local temp=${spinstr#?}
-    printf "\r%s [%s] " "$message" "${temp:0:1}"
-    spinstr=${temp}${spinstr%"${temp}"}
-    sleep "${delay}"
-  done
-  if wait "$pid"; then
-    printf "\r%s [\e[32m\xE2\x9C\x94\e[0m]\n" "$message"
-  else
-    printf "\r%s [\e[31m\xE2\x9C\x98\e[0m]\n" "$message"
   fi
 }
-
-echo_success() {
-  echo -e "$1 [\e[32m\xE2\x9C\x94\e[0m]"
-}
-
-echo_override() {
-  echo -e "\r$1"
-}
-
-echo_header() {
-  echo -e "${bold}$1${normal}"
-}
-
-echo_error() {
-  echo -e "${red}$1${normal} [\e[31m\xE2\x9C\x98\e[0m]\n"
-}
-
-echo_blue() {
-  echo -e "\e[38;2;65;105;225m$1\e[0m"
-}
-
 
 install_debian_dependencies() {
   if [ -f "$APT_REQUIREMENTS_FILE" ]; then
     sudo apt-get update > /dev/null &
-    show_loader "Fetch available system dependencies updates. " 
+    show_loader "Fetch available system dependencies updates. "
 
     xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null &
     show_loader "Installing system dependencies. "
@@ -209,25 +170,6 @@ install_debian_dependencies() {
     echo "ERROR: System dependencies file $APT_REQUIREMENTS_FILE not found!"
     exit 1
   fi
-}
-
-setup_zramswap_service() {
-  # If the OS already provides zram swap (e.g. Pi OS Trixie preinstalls zram-swap),
-  # skip zram-tools — they fight over /dev/zram0 and cause mkswap to fail.
-  if grep -q "^/dev/zram" /proc/swaps 2>/dev/null; then
-    echo "zram swap already active (likely from preinstalled zram-swap package) — skipping zram-tools install."
-    return 0
-  fi
-  echo "Enabling and starting zramswap service."
-  sudo apt-get install -y zram-tools > /dev/null
-  echo -e "ALGO=zstd\nPERCENT=60" | sudo tee /etc/default/zramswap > /dev/null
-  sudo systemctl enable --now zramswap
-}
-
-setup_earlyoom_service() {
-  echo "Enabling and starting earlyoom service."
-  sudo apt-get install -y earlyoom > /dev/null
-  sudo systemctl enable --now earlyoom
 }
 
 maybe_disable_dphys_swapfile() {
@@ -266,13 +208,6 @@ configure_journal_size() {
     echo_success "Journal size limit configured."
   fi
 }
-
-# JTN-669: fetch_wheelhouse / cleanup_wheelhouse live in _common.sh so that
-# update.sh can also use the pre-built wheelhouse (JTN-604). Sourcing here
-# brings WHEELHOUSE_DIR, WHEELHOUSE_REPO, fetch_wheelhouse, and
-# cleanup_wheelhouse into scope — no logic change.
-# shellcheck source=install/_common.sh
-source "$SCRIPT_DIR/_common.sh"
 
 create_venv(){
   echo "Creating python virtual environment. "
@@ -411,7 +346,7 @@ update_config() {
       if grep -q '"display_type":' "$DEVICE_JSON"; then
           # Update existing display_type value
           sed -i "s/\"display_type\": \".*\"/\"display_type\": \"$WS_TYPE\"/" "$DEVICE_JSON"
-          echo "Updated display_type to: $WS_TYPE" 
+          echo "Updated display_type to: $WS_TYPE"
       else
           # Append display_type safely, ensuring proper comma placement
           if grep -q '}$' "$DEVICE_JSON"; then
@@ -424,21 +359,6 @@ update_config() {
   else
       echo "Config not updated as WS_TYPE flag is not set"
   fi
-}
-
-stop_service() {
-    echo "Checking if $SERVICE_FILE is running"
-    if /usr/bin/systemctl is-active --quiet "$SERVICE_FILE"
-    then
-      /usr/bin/systemctl stop "$SERVICE_FILE" > /dev/null &
-      show_loader "Stopping $APPNAME service"
-    else
-      echo_success "\t$SERVICE_FILE not running"
-    fi
-    # JTN-600: DISABLE (not just stop) during install so systemd cannot
-    # restart the half-installed service and thrash the Pi. install_app_service
-    # re-enables it at the end of the install.
-    /usr/bin/systemctl disable "$SERVICE_FILE" 2>/dev/null || true
 }
 
 start_service() {
@@ -477,11 +397,6 @@ get_ip_address() {
   local ip_address
   ip_address=$(hostname -I | awk '{print $1}')
   echo "$ip_address"
-}
-
-# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie
-get_os_version() {
-  lsb_release -sr
 }
 
 ask_for_reboot() {
@@ -589,17 +504,8 @@ if ! bash "$SCRIPT_DIR/update_vendors.sh"; then
   exit 1
 fi
 
-echo "Building minified CSS bundle"
-if ! "$VENV_PATH/bin/python" "$SCRIPT_DIR/../scripts/build_css.py" --minify; then
-  echo_error "ERROR: CSS build failed. The web UI will not render correctly."
-  exit 1
-fi
-CSS_OUTPUT="$SCRIPT_DIR/../src/static/styles/main.css"
-if [ ! -f "$CSS_OUTPUT" ]; then
-  echo_error "ERROR: CSS bundle was not generated at $CSS_OUTPUT."
-  exit 1
-fi
-echo_success "CSS bundle built."
+# JTN-674: use shared build_css_bundle from _common.sh
+build_css_bundle
 
 # JTN-607: All install steps succeeded — remove the install-in-progress
 # lockfile so the service is allowed to start. If install.sh exits early due

--- a/install/update.sh
+++ b/install/update.sh
@@ -31,73 +31,11 @@ SERVICE_FILE_TARGET="/etc/systemd/system/$SERVICE_FILE"
 APT_REQUIREMENTS_FILE="$SCRIPT_DIR/debian-requirements.txt"
 PIP_REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 
-echo_success() {
-  echo -e "$1 [\e[32m\xE2\x9C\x94\e[0m]"
-}
-
-echo_error() {
-  echo -e "$1 [\e[31m\xE2\x9C\x98\e[0m]\n"
-}
-
-show_loader() {
-  local pid=$!
-  local message="$1"
-  local delay=0.1
-  local spinstr="|/-\\"
-  printf "%s [%s] " "$message" "${spinstr:0:1}"
-  while kill -0 "$pid" 2>/dev/null; do
-    local temp=${spinstr#?}
-    printf "\r%s [%s] " "$message" "${temp:0:1}"
-    spinstr=${temp}${spinstr%"${temp}"}
-    sleep "${delay}"
-  done
-  if wait "$pid"; then
-    printf "\r%s [\e[32m\xE2\x9C\x94\e[0m]\n" "$message"
-  else
-    printf "\r%s [\e[31m\xE2\x9C\x98\e[0m]\n" "$message"
-  fi
-}
-
-# JTN-669: source shared wheelhouse helpers (fetch_wheelhouse / cleanup_wheelhouse)
-# so updates use the same pre-built binary wheels as fresh installs (JTN-604).
+# JTN-669/674: Source shared helpers (formatting, stop_service, zramswap,
+# earlyoom, get_os_version, build_css_bundle, fetch_wheelhouse, cleanup_wheelhouse)
+# so install.sh and update.sh share a single source of truth.
 # shellcheck source=install/_common.sh
 source "$SCRIPT_DIR/_common.sh"
-
-setup_zramswap_service() {
-  # If the OS already provides zram swap (e.g. Pi OS Trixie preinstalls zram-swap),
-  # skip zram-tools — they fight over /dev/zram0 and cause mkswap to fail.
-  if grep -q "^/dev/zram" /proc/swaps 2>/dev/null; then
-    echo "zram swap already active (likely from preinstalled zram-swap package) — skipping zram-tools install."
-    return 0
-  fi
-  echo "Enabling and starting zramswap service."
-  sudo apt-get install -y zram-tools > /dev/null
-  echo -e "ALGO=zstd\nPERCENT=60" | sudo tee /etc/default/zramswap > /dev/null
-  sudo systemctl enable --now zramswap
-}
-
-setup_earlyoom_service() {
-  echo "Enabling and starting earlyoom service."
-  sudo apt-get install -y earlyoom > /dev/null
-  sudo systemctl enable --now earlyoom
-}
-
-# JTN-666: Stop and DISABLE (not just stop) the service before touching the
-# venv or app files. This mirrors install.sh:539-552 (JTN-600). systemd cannot
-# restart a half-installed service during the update, preventing the load-14
-# thrash observed on Pi Zero 2 W.
-stop_service() {
-  echo "Checking if $SERVICE_FILE is running"
-  if /usr/bin/systemctl is-active --quiet "$SERVICE_FILE"; then
-    /usr/bin/systemctl stop "$SERVICE_FILE" > /dev/null &
-    show_loader "Stopping $APPNAME service"
-  else
-    echo_success "\t$SERVICE_FILE not running"
-  fi
-  # DISABLE (not just stop) during update so systemd cannot restart the
-  # half-installed service. update_app_service re-enables it at the end.
-  /usr/bin/systemctl disable "$SERVICE_FILE" 2>/dev/null || true
-}
 
 update_app_service() {
   echo "Updating $APPNAME systemd service."
@@ -119,12 +57,6 @@ update_cli() {
   cp -a "$SCRIPT_DIR/cli/." "$INSTALL_PATH/cli/"
   sudo chmod +x "$INSTALL_PATH/cli/"*
 }
-
-# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie
-get_os_version() {
-  lsb_release -sr
-}
-
 
 # Ensure script is run with sudo
 if [ "$EUID" -ne 0 ]; then
@@ -244,17 +176,8 @@ if ! bash "$SCRIPT_DIR/update_vendors.sh" > /dev/null; then
   exit 1
 fi
 
-echo "Building minified CSS bundle"
-if ! "$VENV_PATH/bin/python" "$SCRIPT_DIR/../scripts/build_css.py" --minify; then
-  echo_error "ERROR: CSS build failed. The web UI will not render correctly."
-  exit 1
-fi
-CSS_OUTPUT="$SCRIPT_DIR/../src/static/styles/main.css"
-if [ ! -f "$CSS_OUTPUT" ]; then
-  echo_error "ERROR: CSS bundle was not generated at $CSS_OUTPUT."
-  exit 1
-fi
-echo_success "CSS bundle built."
+# JTN-674: use shared build_css_bundle from _common.sh
+build_css_bundle
 
 update_cli
 update_app_service

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -146,6 +146,11 @@ class TestInstallScript:
     @pytest.fixture(autouse=True)
     def _load(self):
         self.content = _read("install.sh")
+        # JTN-674: shared helpers (stop_service, setup_zramswap_service,
+        # get_os_version, echo_*, show_loader) live in _common.sh and are
+        # sourced by install.sh.  Tests that verify these shared functions
+        # should use self.combined so they keep passing after the refactor.
+        self.combined = self.content + "\n" + _read("_common.sh")
 
     def test_install_enables_spi(self):
         assert "dtparam=spi=" in self.content
@@ -171,16 +176,17 @@ class TestInstallScript:
         # JTN-569: Pi OS Trixie preinstalls zram-swap which configures /dev/zram0 at
         # boot. Installing zram-tools on top fights over /dev/zram0 and makes
         # `systemctl start zramswap` exit 1. The guard must run before apt-get.
+        # JTN-674: setup_zramswap_service() now lives in _common.sh — check combined.
         guard = 'grep -q "^/dev/zram" /proc/swaps'
         apt_install = "apt-get install -y zram-tools"
-        assert guard in self.content
-        assert "skipping zram-tools install" in self.content
-        assert "return 0" in self.content
+        assert guard in self.combined
+        assert "skipping zram-tools install" in self.combined
+        assert "return 0" in self.combined
 
-        fn_start = self.content.index("setup_zramswap_service() {")
-        guard_pos = self.content.index(guard, fn_start)
-        return_pos = self.content.index("return 0", fn_start)
-        apt_pos = self.content.index(apt_install, fn_start)
+        fn_start = self.combined.index("setup_zramswap_service() {")
+        guard_pos = self.combined.index(guard, fn_start)
+        return_pos = self.combined.index("return 0", fn_start)
+        apt_pos = self.combined.index(apt_install, fn_start)
         assert guard_pos < return_pos < apt_pos
 
     def test_install_enables_zramswap_on_bookworm_and_trixie(self):
@@ -249,22 +255,24 @@ class TestInstallScript:
     def test_install_os_version_comment_lists_correct_codenames(self):
         # The comment near get_os_version should list 11/12/13 with correct
         # codenames — including the 'Trixie' typo fix from JTN-528.
-        assert "11=Bullseye" in self.content
-        assert "12=Bookworm" in self.content
-        assert "13=Trixie" in self.content
-        assert "Trixe" not in self.content  # typo guard
+        # JTN-674: get_os_version() now lives in _common.sh — check combined.
+        assert "11=Bullseye" in self.combined
+        assert "12=Bookworm" in self.combined
+        assert "13=Trixie" in self.combined
+        assert "Trixe" not in self.combined  # typo guard
 
     def test_zramswap_regex_matches_codename_comment_parity(self):
         # JTN-531: The codename comment near get_os_version() and the version
         # regex in the zramswap branch must list the same integer keys.
         # If someone adds 14=Forky to one without updating the other this test
         # will catch it.
+        # JTN-674: get_os_version() now lives in _common.sh — check combined.
 
         # Parse "# Get OS release number, e.g. 11=Bullseye, 12=Bookworm, 13=Trixie"
         # Capture every "<digit(s)>=<Codename>" pair from the comment line
         # immediately above the get_os_version() function definition.
         comment_versions = set()
-        lines = self.content.splitlines()
+        lines = self.combined.splitlines()
         for i, line in enumerate(lines):
             if "get_os_version" in line and line.strip().startswith("get_os_version"):
                 # Search backwards for the nearest preceding comment line with
@@ -276,8 +284,9 @@ class TestInstallScript:
 
         # Parse the regex alternation in the zramswap if-branch:
         # [[ "$os_version" =~ ^(11|12|13)$ ]]
+        # JTN-674: the regex lives in install.sh main body; check combined.
         regex_versions = set()
-        for line in self.content.splitlines():
+        for line in self.combined.splitlines():
             m = re.search(r"\^\(([0-9|]+)\)\$", line)
             if m:
                 for part in m.group(1).split("|"):
@@ -286,7 +295,7 @@ class TestInstallScript:
 
         assert (
             comment_versions
-        ), "Could not parse any version numbers from the get_os_version comment in install.sh"
+        ), "Could not parse any version numbers from the get_os_version comment in _common.sh"
         assert (
             regex_versions
         ), "Could not parse any version numbers from the zramswap regex in install.sh"
@@ -376,9 +385,10 @@ class TestInstallScript:
         # JTN-600: stop_service() must DISABLE (not just stop) the service so
         # systemd cannot auto-restart the half-installed service during the ~15 min
         # install window and cause a memory-thrash cascade on the Pi Zero 2 W.
-        fn_start = self.content.index("stop_service() {")
-        fn_end = self.content.index("\n}", fn_start)
-        fn_body = self.content[fn_start:fn_end]
+        # JTN-674: stop_service() now lives in _common.sh — check combined.
+        fn_start = self.combined.index("stop_service() {")
+        fn_end = self.combined.index("\n}", fn_start)
+        fn_body = self.combined[fn_start:fn_end]
         assert 'systemctl disable "$SERVICE_FILE"' in fn_body, (
             "stop_service() must call 'systemctl disable \"$SERVICE_FILE\"' to "
             "prevent systemd from restarting the half-installed service"
@@ -436,6 +446,8 @@ class TestInstallScript:
         # has succeeded, remove the lockfile so the service is allowed to
         # start. The removal must come AFTER install_app_service and the CSS
         # build so a failure in any earlier step leaves the lockfile in place.
+        # JTN-674: CSS build is now called via build_css_bundle (shared helper
+        # in _common.sh). The call site is still in install.sh's main body.
         main_start = self.content.index('parse_arguments "$@"')
         main_body = self.content[main_start:]
 
@@ -444,15 +456,17 @@ class TestInstallScript:
         ), "install.sh must remove the lockfile on success (JTN-607)"
 
         # Ordering: rm must come after install_app_service and after the CSS
-        # build so an earlier failure leaves the lockfile in place.
+        # build call so an earlier failure leaves the lockfile in place.
         rm_pos = main_body.index('rm -f "$LOCKFILE"')
         install_app_pos = main_body.index("install_app_service")
-        css_pos = main_body.index("CSS bundle built")
+        # JTN-674: CSS build is invoked via build_css_bundle; the inline
+        # "CSS bundle built" message now lives in _common.sh's function body.
+        css_pos = main_body.index("build_css_bundle")
         assert (
             install_app_pos < rm_pos
         ), 'rm -f "$LOCKFILE" must come after install_app_service (JTN-607)'
         assert css_pos < rm_pos, (
-            'rm -f "$LOCKFILE" must come after the CSS bundle build step '
+            'rm -f "$LOCKFILE" must come after the build_css_bundle call '
             "so a CSS build failure leaves the lockfile in place (JTN-607)"
         )
 
@@ -477,9 +491,10 @@ class TestInstallScript:
     def test_stop_service_disable_tolerates_already_disabled(self):
         # JTN-600: The disable call must not fail if the service is already
         # disabled (e.g. fresh install). Must use '|| true' or '2>/dev/null'.
-        fn_start = self.content.index("stop_service() {")
-        fn_end = self.content.index("\n}", fn_start)
-        fn_body = self.content[fn_start:fn_end]
+        # JTN-674: stop_service() now lives in _common.sh — check combined.
+        fn_start = self.combined.index("stop_service() {")
+        fn_end = self.combined.index("\n}", fn_start)
+        fn_body = self.combined[fn_start:fn_end]
         # Find the disable line and confirm it has an error-tolerant fallback.
         disable_lines = [
             line.strip() for line in fn_body.splitlines() if "systemctl disable" in line
@@ -1224,6 +1239,11 @@ class TestUpdateScript:
     @pytest.fixture(autouse=True)
     def _load(self):
         self.content = _read("update.sh")
+        # JTN-674: shared helpers (stop_service, setup_zramswap_service,
+        # get_os_version, echo_*, show_loader) live in _common.sh and are
+        # sourced by update.sh.  Tests that verify these shared functions
+        # should use self.combined so they keep passing after the refactor.
+        self.combined = self.content + "\n" + _read("_common.sh")
 
     def test_update_rebuilds_css(self):
         assert "build_css" in self.content
@@ -1238,17 +1258,18 @@ class TestUpdateScript:
     def test_update_stop_service_before_pip(self):
         # JTN-666: stop_service() must be called before pip install to prevent
         # systemd from restart-looping the half-installed venv during update.
+        # JTN-674: stop_service() now lives in _common.sh — check combined.
         assert "stop_service" in self.content
         # stop_service() must DISABLE (not just stop) so systemd cannot auto-restart.
-        fn_start = self.content.index("stop_service() {")
-        fn_end = self.content.index("}", fn_start) + 1
-        fn_body = self.content[fn_start:fn_end]
+        fn_start = self.combined.index("stop_service() {")
+        fn_end = self.combined.index("}", fn_start) + 1
+        fn_body = self.combined[fn_start:fn_end]
         assert (
             "systemctl disable" in fn_body
         ), "stop_service() must call 'systemctl disable' to prevent auto-restart mid-update"
         # stop_service call must appear before pip install in main script body
-        main_call = self.content.index("stop_service\n", fn_end)
-        pip_pos = self.content.index("pip install", fn_end)
+        main_call = self.content.index("stop_service\n")
+        pip_pos = self.content.index("pip install")
         assert (
             main_call < pip_pos
         ), "stop_service must be called before pip install to prevent mid-update thrash"
@@ -1297,22 +1318,24 @@ class TestUpdateScript:
     def test_update_skips_zramtools_when_zram_swap_already_active(self):
         # JTN-667: setup_zramswap_service in update.sh must guard against
         # Trixie's preinstalled zram-swap to avoid /dev/zram0 conflicts.
+        # JTN-674: setup_zramswap_service() now lives in _common.sh — check combined.
         guard = 'grep -q "^/dev/zram" /proc/swaps'
         apt_install = "apt-get install -y zram-tools"
-        assert guard in self.content
-        assert "skipping zram-tools install" in self.content
-        assert "return 0" in self.content
+        assert guard in self.combined
+        assert "skipping zram-tools install" in self.combined
+        assert "return 0" in self.combined
 
-        fn_start = self.content.index("setup_zramswap_service() {")
-        guard_pos = self.content.index(guard, fn_start)
-        return_pos = self.content.index("return 0", fn_start)
-        apt_pos = self.content.index(apt_install, fn_start)
+        fn_start = self.combined.index("setup_zramswap_service() {")
+        guard_pos = self.combined.index(guard, fn_start)
+        return_pos = self.combined.index("return 0", fn_start)
+        apt_pos = self.combined.index(apt_install, fn_start)
         assert guard_pos < return_pos < apt_pos
 
     def test_update_codename_comment_has_no_trixie_typo(self):
         # JTN-667: The comment near get_os_version must spell Trixie correctly.
-        assert "13=Trixie" in self.content
-        assert "Trixe" not in self.content  # typo guard
+        # JTN-674: get_os_version() now lives in _common.sh — check combined.
+        assert "13=Trixie" in self.combined
+        assert "Trixe" not in self.combined  # typo guard
 
     def test_update_sources_common(self):
         # JTN-669: update.sh must source _common.sh to gain access to


### PR DESCRIPTION
## Summary

- Move duplicated logic from `install.sh` and `update.sh` into `install/_common.sh` as a single source of truth (JTN-674)
- Shared helpers now in `_common.sh`: `echo_success`, `echo_error`, `echo_header`, `echo_blue`, `echo_override`, `show_loader`, `get_os_version`, `stop_service`, `setup_zramswap_service`, `setup_earlyoom_service`, and a new `build_css_bundle` helper
- Both scripts source `_common.sh` early (right after `SCRIPT_DIR` is set) so formatting helpers are available from the first function call
- `install.sh` retains only install-specific logic: `enable_interfaces`, `fetch_waveshare_driver`, `install_config`, `ask_for_reboot`, `wait_for_clock`
- `update.sh` retains only update-specific logic: `update_app_service`, `update_cli`, pip-upgrade and venv-activation block

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Relevant upstream behavior differences were documented in PR description

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (pre-existing `prometheus_client` import errors on 17 tests are unrelated to shell script changes — identical on `main`)
- [x] `scripts/lint.sh` passes (ruff, black, shellcheck all green)
- [x] No breaking API route/path changes (shell scripts only)
- [x] Error responses follow JSON contract — N/A (shell scripts only)

## Testing

- `scripts/lint.sh` passes clean including shellcheck
- `bash -n install/_common.sh install/install.sh install/update.sh` all pass syntax check
- Net: 153 insertions, 200 deletions — reduces total lines across the three files

PR #450 (JTN-669) previously extracted `fetch_wheelhouse`/`cleanup_wheelhouse` into `_common.sh`. This PR completes the JTN-674 scope by factoring the remaining ~6 duplicated function groups.