### PR TITLE
fix(install): update.sh uses uv + --require-hashes for supply-chain parity (JTN-670)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -208,9 +208,9 @@ pip_extra_args=()
 uv_extra_args=()
 if fetch_wheelhouse; then
   pip_extra_args+=(--find-links "$WHEELHOUSE_DIR" --prefer-binary)
-  # uv supports --find-links; --only-binary=:all: forces binary wheels to
-  # guarantee nothing is built from sdist on the Pi (equivalent intent to
-  # pip's --prefer-binary but stricter).
+  # uv supports --find-links; --find-links pointing at the pre-built wheelhouse
+  # already ensures binary wheels are preferred. We omit --only-binary=:all:
+  # to avoid blocking packages that only exist as sdists in the wheelhouse.
   uv_extra_args+=(--find-links "$WHEELHOUSE_DIR")
 fi
 

--- a/install/update.sh
+++ b/install/update.sh
@@ -205,22 +205,70 @@ echo_success "Pip upgraded successfully."
 # low-RAM boards like the Pi Zero 2 W (cuts ~15 min / OOM risk down to
 # ~2-3 min). Degrades gracefully: any failure falls back to normal pip.
 pip_extra_args=()
+uv_extra_args=()
 if fetch_wheelhouse; then
   pip_extra_args+=(--find-links "$WHEELHOUSE_DIR" --prefer-binary)
+  # uv supports --find-links; --only-binary=:all: forces binary wheels to
+  # guarantee nothing is built from sdist on the Pi (equivalent intent to
+  # pip's --prefer-binary but stricter).
+  uv_extra_args+=(--find-links "$WHEELHOUSE_DIR")
+fi
+
+# JTN-670 / JTN-605 parity: Install uv (Rust-based pip replacement) into the
+# venv so every update uses the same low-memory installer as fresh installs.
+# uv's resolver uses ~10-20 MB peak vs pip's ~100-150 MB — on a 512 MB Pi Zero
+# 2 W that difference is the swap cliff.  uv fully honors --require-hashes so
+# the JTN-516 supply-chain integrity guarantee is preserved on every update.
+#
+# We install uv via pip (into the venv) rather than curl-piping from astral.sh:
+#   (a) no extra network trust root — uses the same PyPI + hashes we already trust
+#   (b) uv is sandboxed inside the venv, not installed to /root/.local
+#   (c) if uv itself is unavailable for any reason, we cleanly fall back to pip
+use_uv=0
+if "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 --no-cache-dir uv > /dev/null 2>&1; then
+  if "$VENV_PATH/bin/python" -m uv --version > /dev/null 2>&1; then
+    use_uv=1
+    echo_success "  uv installed into venv — using uv for dependency install"
+  else
+    echo "  uv installed but not runnable — falling back to pip for dependency install"
+  fi
+else
+  echo "  uv could not be installed (unsupported arch?) — falling back to pip for dependency install"
 fi
 
 # Install or update Python dependencies
+# JTN-670: --require-hashes enforces supply-chain integrity on every update
+# (JTN-516 parity). Without this, existing Pis that update pull unverified
+# wheels even though fresh installs are hash-verified.
 if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
   echo "Updating Python dependencies..."
-  # JTN-665: explicit exit-code check so a compile error (e.g. metadata-generation-failed)
-  # stops the update before CSS build + service restart, preventing a boot loop.
-  # JTN-669: pass --find-links + --prefer-binary when wheelhouse is available.
-  if ! "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 --no-cache-dir --upgrade \
-      "${pip_extra_args[@]}" \
-      -r "$PIP_REQUIREMENTS_FILE"; then
-    cleanup_wheelhouse
-    echo_error "ERROR: pip install failed — aborting update (service remains stopped)."
-    exit 1
+  # JTN-665: explicit exit-code check so a compile error stops the update
+  # before CSS build + service restart, preventing a boot loop.
+  # JTN-670/JTN-605: prefer uv; fall back to pip. Both enforce --require-hashes.
+  if [[ "$use_uv" -eq 1 ]]; then
+    # uv equivalents: --no-cache (not --no-cache-dir), --require-hashes supported.
+    # `--python` pins uv to the venv's interpreter so packages land in the venv.
+    # UV_HTTP_TIMEOUT scoped to this invocation for flaky Wi-Fi resilience (JTN-534).
+    if ! UV_HTTP_TIMEOUT=60 "$VENV_PATH/bin/python" -m uv pip install \
+        --python "$VENV_PATH/bin/python" \
+        --no-cache \
+        "${uv_extra_args[@]}" \
+        --require-hashes \
+        -r "$PIP_REQUIREMENTS_FILE"; then
+      cleanup_wheelhouse
+      echo_error "ERROR: uv pip install failed — aborting update (service remains stopped)."
+      exit 1
+    fi
+  else
+    # pip fallback: --require-hashes + --no-cache-dir preserve JTN-516/JTN-602 guarantees.
+    if ! "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 --no-cache-dir \
+        "${pip_extra_args[@]}" \
+        --require-hashes \
+        -r "$PIP_REQUIREMENTS_FILE"; then
+      cleanup_wheelhouse
+      echo_error "ERROR: pip install failed — aborting update (service remains stopped)."
+      exit 1
+    fi
   fi
   cleanup_wheelhouse
   echo_success "Dependencies updated successfully."

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1351,6 +1351,146 @@ class TestUpdateScript:
                 "--no-cache-dir" in line
             ), f"JTN-602 parity — pip install in update.sh missing --no-cache-dir: {line!r}"
 
+    def test_update_installs_uv_into_venv(self):
+        # JTN-670 / JTN-605 parity: uv must be installed into the venv so that
+        # every update uses the low-memory uv resolver (~10-20 MB peak vs pip's
+        # ~100-150 MB). This prevents OOM thrashing on Pi Zero 2 W updates.
+        uv_install_lines = [
+            line
+            for line in self.content.splitlines()
+            if re.search(r"-m pip install", line)
+            and " uv" in line
+            and not line.strip().startswith("#")
+        ]
+        assert (
+            uv_install_lines
+        ), "update.sh must have a 'pip install ... uv' call (JTN-670)"
+        for line in uv_install_lines:
+            assert (
+                "--no-cache-dir" in line
+            ), f"pip install uv in update.sh missing --no-cache-dir: {line!r}"
+
+    def test_update_uses_uv_pip_install_for_requirements(self):
+        # JTN-670 / JTN-605 parity: update.sh must prefer uv pip install when uv
+        # is available, mirroring install.sh's create_venv() pattern.
+        assert (
+            "uv pip install" in self.content
+        ), "update.sh must use 'uv pip install' for dependency install (JTN-670)"
+
+    def test_update_uses_require_hashes(self):
+        # JTN-670 / JTN-516 parity: supply-chain integrity must be enforced on
+        # every update, not just fresh installs. Both the uv path and the pip
+        # fallback must carry --require-hashes.
+        lines = self.content.splitlines()
+        # Collect joined continuation blocks that are install commands referencing
+        # requirements (contains pip/uv install and PIP_REQUIREMENTS_FILE, but not
+        # a bare variable assignment like PIP_REQUIREMENTS_FILE="...").
+        install_blocks: list[str] = []
+        current: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            current.append(stripped.rstrip("\\").strip())
+            if not stripped.endswith("\\"):
+                block = " ".join(current)
+                if "PIP_REQUIREMENTS_FILE" in block and (
+                    "pip install" in block or "uv pip install" in block
+                ):
+                    install_blocks.append(block)
+                current = []
+
+        assert (
+            install_blocks
+        ), "update.sh must have an install invocation referencing PIP_REQUIREMENTS_FILE"
+        for block in install_blocks:
+            assert "--require-hashes" in block, (
+                f"update.sh requirements install block missing --require-hashes "
+                f"(JTN-670/JTN-516): {block!r}"
+            )
+
+    def test_update_uv_install_has_http_timeout(self):
+        # JTN-670 / JTN-534 parity: uv pip install invocations must prefix
+        # UV_HTTP_TIMEOUT=60 to survive flaky Wi-Fi on Pi Zero 2 W.
+        # uv doesn't accept --default-timeout as a CLI flag; the env var scopes
+        # the timeout to that subprocess only and doesn't leak.
+        lines = self.content.splitlines()
+        uv_install_indices = [
+            i for i, line in enumerate(lines) if "-m uv pip install" in line
+        ]
+        assert (
+            uv_install_indices
+        ), "update.sh must have at least one 'uv pip install' invocation (JTN-670)"
+        for idx in uv_install_indices:
+            prev = lines[idx - 1] if idx > 0 else ""
+            assert "UV_HTTP_TIMEOUT" in lines[idx] or "UV_HTTP_TIMEOUT" in prev, (
+                "uv pip install in update.sh must prefix UV_HTTP_TIMEOUT "
+                "for Wi-Fi resilience (JTN-534)"
+            )
+
+    def test_update_has_uv_pip_fallback_with_require_hashes(self):
+        # JTN-670 / JTN-605 parity: if uv is unavailable, update.sh must fall
+        # back to pip with --require-hashes preserved. The pip install and the
+        # -r <requirements> flag are on separate continuation lines, so join them.
+        assert (
+            "use_uv" in self.content
+        ), "update.sh must gate uv vs pip path on a use_uv flag (JTN-670)"
+        lines = self.content.splitlines()
+        # Collect joined continuation blocks: a block that contains `-m pip install`
+        # AND references the requirements file (via -r "$PIP_REQUIREMENTS_FILE"),
+        # but NOT via the uv installer.
+        current: list[str] = []
+        pip_fallback_blocks: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            current.append(stripped.rstrip("\\").strip())
+            if not stripped.endswith("\\"):
+                block = " ".join(current)
+                if (
+                    re.search(r"-m pip install", block)
+                    and "PIP_REQUIREMENTS_FILE" in block
+                    and "uv pip install" not in block
+                ):
+                    pip_fallback_blocks.append(block)
+                current = []
+
+        assert (
+            pip_fallback_blocks
+        ), "update.sh must retain a pip-based fallback install of PIP_REQUIREMENTS_FILE (JTN-670)"
+        for block in pip_fallback_blocks:
+            assert (
+                "--require-hashes" in block
+            ), "pip fallback in update.sh must preserve --require-hashes (JTN-670/JTN-516)"
+            assert (
+                "--no-cache-dir" in block
+            ), "pip fallback in update.sh must preserve --no-cache-dir (JTN-670/JTN-602)"
+
+    def test_update_uv_install_uses_no_cache(self):
+        # JTN-670 / JTN-602 parity: uv pip install must use --no-cache (uv's
+        # equivalent of pip's --no-cache-dir) to avoid wasting SD space on updates.
+        lines = self.content.splitlines()
+        current: list[str] = []
+        uv_req_blocks: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            current.append(stripped.rstrip("\\").strip())
+            if not stripped.endswith("\\"):
+                block = " ".join(current)
+                if "uv pip install" in block and "PIP_REQUIREMENTS_FILE" in block:
+                    uv_req_blocks.append(block)
+                current = []
+        assert (
+            uv_req_blocks
+        ), "update.sh must have a 'uv pip install ... -r PIP_REQUIREMENTS_FILE' block"
+        for block in uv_req_blocks:
+            assert (
+                "--no-cache" in block
+            ), f"uv pip install in update.sh missing --no-cache (JTN-602 parity): {block!r}"
+
 
 # ---- uninstall.sh ----
 


### PR DESCRIPTION
## Summary

- **Supply-chain fix (JTN-516 parity):** `update.sh` previously used bare `pip install --upgrade` without `--require-hashes`, meaning existing Pis that run `update.sh` pull unverified wheels — eroding the hash-verification guarantee that fresh installs already enforce.
- **Memory fix (JTN-605 parity):** Installs `uv` into the venv before the requirements update; `uv pip install` uses ~10–20 MB peak vs pip's ~100–150 MB, keeping the Pi Zero 2 W off the swap cliff during updates.
- **SD wear fix (JTN-602 parity):** Both `uv` path (`--no-cache`) and pip fallback path (`--no-cache-dir`) avoid writing to `/root/.cache/pip` during updates.
- **Wi-Fi resilience (JTN-534 parity):** `UV_HTTP_TIMEOUT=60` scoped to each `uv pip install` invocation; pip fallback uses `--retries 5 --timeout 60`.

## Changes

**`install/update.sh`** (+57 lines)
- Add `uv_extra_args=()` alongside existing `pip_extra_args` for wheelhouse path
- Install `uv` into the venv via `pip install --no-cache-dir uv`
- Branch on `use_uv` flag: run `uv pip install --require-hashes --no-cache` or pip fallback with `--require-hashes --no-cache-dir`
- Error paths cleaned up to always call `cleanup_wheelhouse` before exit

**`tests/unit/test_install_scripts.py`** (+140 lines, 6 new tests)
- `test_update_installs_uv_into_venv` — uv is installed via pip with `--no-cache-dir`
- `test_update_uses_uv_pip_install_for_requirements` — `uv pip install` present
- `test_update_uses_require_hashes` — every install block for requirements carries `--require-hashes`
- `test_update_uv_install_has_http_timeout` — `UV_HTTP_TIMEOUT` prefixed on every uv invocation
- `test_update_has_uv_pip_fallback_with_require_hashes` — pip fallback block has `--require-hashes` + `--no-cache-dir`
- `test_update_uv_install_uses_no_cache` — uv requirements block carries `--no-cache`

## Test plan

- [x] All 20 `TestUpdateScript` tests pass
- [x] Full test suite: 4090 passed, 5 skipped, 0 new failures
- [x] `scripts/lint.sh` clean (ruff ✅, black ✅, shellcheck ✅, mypy strict ✅)
- [x] Pre-existing failures (3 CSS static tests) are unrelated to this change

Part of epic JTN-529 (install path hardening). Closes JTN-670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation process now supports `uv` as a faster package installer with automatic fallback to pip for compatibility.
  * Enhanced hash verification enforcement during updates for improved security.
  * Improved error messaging to better communicate installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->