### PR TITLE
test(ui-audit): Layer 1 static handler audit (JTN-678)

### DIFF
--- a/tests/ui_audit/__init__.py
+++ b/tests/ui_audit/__init__.py
@@ -1,0 +1,5 @@
+"""Layer 1 UI breakage detection net.
+
+Static audit of HTML templates and JS handler coverage. See
+`generic-prancing-lobster.md` plan (Layer 1) and Linear epic JTN-677 / JTN-678.
+"""

--- a/tests/ui_audit/allowlist.yml
+++ b/tests/ui_audit/allowlist.yml
@@ -1,0 +1,17 @@
+# UI audit allowlist. Each entry silences one finding from
+# tests/ui_audit/test_handler_audit.py.
+#
+# Schema:
+#   entries:
+#     - rule: missing-handler | orphan-button | dead-anchor
+#       template: repo-relative template path
+#       line: integer line number reported by the audit
+#       value: offending attribute value (action name, id, or href)
+#       reason: one-liner explaining why this is OK (REQUIRED)
+#
+# Keep this list small — empty is the goal. If something legitimately has no
+# JS handler (e.g. a form-submit button, a skip-link to a heading, a
+# third-party widget bootstrap), add it here with a reason instead of
+# loosening the audit rules.
+
+entries: []

--- a/tests/ui_audit/parsers.py
+++ b/tests/ui_audit/parsers.py
@@ -1,0 +1,254 @@
+"""HTML template + JS string-literal parsers for the UI handler audit.
+
+Intentionally uses only the standard library — no new dependency on
+``beautifulsoup4``. The scanning needs are narrow (locate clickable elements
+and their ``data-*-action`` attributes, pull ``id`` attributes, find ``href``
+values starting with ``#``) so ``html.parser`` is sufficient and keeps the
+audit cheap to run in CI.
+
+The JS side is equally pragmatic: extract every single-quoted, double-quoted
+or backtick-quoted string literal from a file, plus enumerate the dataset
+families any JS source mentions. We then check whether each action value
+referenced in a template appears as a literal inside a JS file that also
+references the matching family (via ``dataset.Xaction`` or
+``[data-x-action]``). This is a deliberately loose reachability test — false
+positives are cheap to allowlist, while false negatives would defeat the
+point of the audit.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from pathlib import Path
+
+# --- Template parsing --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Clickable:
+    """A single clickable element discovered in a template."""
+
+    template: str  # file path relative to repo root
+    line: int
+    tag: str  # "button" | "a" | other
+    attrs: tuple[tuple[str, str | None], ...]
+
+    def attr(self, name: str) -> str | None:
+        for key, value in self.attrs:
+            if key == name:
+                return value
+        return None
+
+    def has_attr(self, name: str) -> bool:
+        return any(key == name for key, _ in self.attrs)
+
+    def data_action_family(self) -> tuple[str, str] | None:
+        """Return (family, action_value) if this element has data-X-action.
+
+        ``family`` is the dataset-style name (``plugin`` for
+        ``data-plugin-action``). Returns ``None`` otherwise.
+        """
+
+        for key, value in self.attrs:
+            if not key.startswith("data-") or not key.endswith("-action"):
+                continue
+            # Ignore generic "data-action" (no family) — no template uses it today.
+            mid = key[len("data-") : -len("-action")]
+            if not mid:
+                continue
+            if value is None:
+                continue
+            return mid, value
+        return None
+
+
+@dataclass
+class TemplateScan:
+    """Everything the audit needs from a single template."""
+
+    path: Path
+    clickables: list[Clickable] = field(default_factory=list)
+    element_ids: set[str] = field(default_factory=set)
+
+
+class _TemplateParser(HTMLParser):
+    """Extract clickable elements + every ``id`` attribute."""
+
+    CLICKABLE_TAGS = frozenset({"button", "a"})
+
+    def __init__(self, template_rel: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.template_rel = template_rel
+        self.clickables: list[Clickable] = []
+        self.element_ids: set[str] = set()
+
+    def _record(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # Stash every id we see, not just clickables, so anchor-href lookups
+        # can succeed against <section id="...">, etc.
+        for key, value in attrs:
+            if key == "id" and value:
+                # Jinja placeholders inside ids (``id="btn-{{ img.filename }}"``)
+                # still count for orphan detection: strip any ``{{ ... }}`` so
+                # we have a canonical form to compare anchor hrefs against.
+                self.element_ids.add(_strip_jinja(value))
+
+        if tag not in self.CLICKABLE_TAGS:
+            # Non-<button>/<a> can still carry data-*-action attributes
+            # (e.g. playlist toggle <button> yes, but also sometimes <div>). We
+            # flag anything carrying any data-*-action attribute.
+            has_action = any(
+                key.startswith("data-") and key.endswith("-action") for key, _ in attrs
+            )
+            if not has_action:
+                return
+
+        line = self.getpos()[0]
+        self.clickables.append(
+            Clickable(
+                template=self.template_rel,
+                line=line,
+                tag=tag,
+                attrs=tuple(attrs),
+            )
+        )
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:  # noqa: D401 - HTMLParser override
+        self._record(tag, attrs)
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:  # noqa: D401 - HTMLParser override
+        self._record(tag, attrs)
+
+
+_JINJA_EXPR = re.compile(r"\{\{.*?\}\}")
+
+
+def _strip_jinja(value: str) -> str:
+    return _JINJA_EXPR.sub("", value).strip()
+
+
+def parse_template(path: Path, repo_root: Path) -> TemplateScan:
+    rel = path.relative_to(repo_root).as_posix()
+    parser = _TemplateParser(rel)
+    try:
+        parser.feed(path.read_text(encoding="utf-8"))
+    finally:
+        parser.close()
+    return TemplateScan(
+        path=path,
+        clickables=parser.clickables,
+        element_ids=parser.element_ids,
+    )
+
+
+# --- JS parsing --------------------------------------------------------------
+
+
+# Matches dataset reads of the form ``foo.dataset.pluginAction`` and captures
+# ``pluginAction`` so we can map back to the kebab family ``plugin``.
+_DATASET_READ = re.compile(r"dataset\.([a-zA-Z][a-zA-Z0-9]*)")
+
+# Matches explicit selector strings like ``[data-plugin-action]``.
+_SELECTOR = re.compile(r"\[data-([a-z0-9-]+)-action(?:[=\]~])")
+
+# Match any single/double/backtick string literal. We deliberately do not try
+# to parse template-literal interpolations — ``${action}`` stays inside the
+# captured text and we just check ``in`` membership, so it does not matter.
+_STRING_LITERAL = re.compile(
+    r"""
+    '(?P<sq>(?:\\.|[^'\\\n])*)' |
+    "(?P<dq>(?:\\.|[^"\\\n])*)" |
+    `(?P<bt>(?:\\.|[^`\\])*)`
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+@dataclass
+class ScriptScan:
+    path: Path
+    text: str
+    literals: frozenset[str]
+    dataset_families: frozenset[str]  # kebab form, e.g. "plugin", "history"
+    selector_families: frozenset[str]
+    getelementbyid_args: frozenset[str]
+    literal_calls_to: dict[str, frozenset[str]] = field(default_factory=dict)
+
+    @property
+    def action_families(self) -> frozenset[str]:
+        return self.dataset_families | self.selector_families
+
+
+def _camel_to_kebab(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+
+def parse_script(path: Path) -> ScriptScan:
+    text = path.read_text(encoding="utf-8")
+
+    literals: set[str] = set()
+    for match in _STRING_LITERAL.finditer(text):
+        literals.add(match.group("sq") or match.group("dq") or match.group("bt") or "")
+
+    dataset_fams: set[str] = set()
+    for match in _DATASET_READ.finditer(text):
+        camel = match.group(1)
+        if not camel.endswith("Action"):
+            continue
+        family_camel = camel[: -len("Action")]
+        if not family_camel:
+            continue
+        dataset_fams.add(_camel_to_kebab(family_camel))
+
+    selector_fams: set[str] = {m.group(1) for m in _SELECTOR.finditer(text)}
+
+    # getElementById("foo") arguments — used for orphan-button detection.
+    getid_args: set[str] = set()
+    for match in re.finditer(r"""getElementById\(\s*["'`]([^"'`]+)["'`]\s*\)""", text):
+        getid_args.add(match.group(1))
+    # querySelector("#foo") / querySelectorAll("#foo") — same idea.
+    for match in re.finditer(
+        r"""querySelector(?:All)?\(\s*["'`]#([A-Za-z_][\w-]*)["'`]\s*\)""", text
+    ):
+        getid_args.add(match.group(1))
+
+    return ScriptScan(
+        path=path,
+        text=text,
+        literals=frozenset(literals),
+        dataset_families=frozenset(dataset_fams),
+        selector_families=frozenset(selector_fams),
+        getelementbyid_args=frozenset(getid_args),
+    )
+
+
+# --- High-level audit helpers ------------------------------------------------
+
+
+def collect_scripts(scripts_dir: Path) -> list[ScriptScan]:
+    return [parse_script(p) for p in sorted(scripts_dir.rglob("*.js"))]
+
+
+def collect_templates(templates_dir: Path, repo_root: Path) -> list[TemplateScan]:
+    return [parse_template(p, repo_root) for p in sorted(templates_dir.rglob("*.html"))]
+
+
+def script_handles_family(script: ScriptScan, family: str) -> bool:
+    return family in script.action_families
+
+
+def family_handlers(scripts: list[ScriptScan], family: str) -> list[ScriptScan]:
+    return [s for s in scripts if script_handles_family(s, family)]
+
+
+def id_is_referenced(scripts: list[ScriptScan], element_id: str) -> bool:
+    if not element_id:
+        return False
+    return any(element_id in s.getelementbyid_args for s in scripts) or any(
+        element_id in s.literals for s in scripts
+    )

--- a/tests/ui_audit/test_handler_audit.py
+++ b/tests/ui_audit/test_handler_audit.py
@@ -1,0 +1,414 @@
+"""Layer 1 of the UI breakage detection net: static handler audit.
+
+Parses every template in ``src/templates/`` and every JS file in
+``src/static/scripts/`` and proves that each clickable element can reach at
+least one handler. Runs in well under 5 s and introduces no new Python
+dependencies (uses stdlib ``html.parser`` + regex).
+
+Rules enforced:
+
+1. **Rule 1 — missing data-action handler.** For any clickable element with
+   ``data-X-action="value"``, at least one JS file must reference the family
+   ``X`` (via ``dataset.Xaction`` or ``[data-x-action]`` selector) *and* the
+   action value must appear as a string literal in at least one JS file.
+   The second half is loose on purpose: handlers routinely delegate across
+   files (``plugin_page.js`` reads ``dataset.pluginAction`` and hands the
+   value to ``plugin_form.js``), so insisting the literal appears in the
+   same file as the dataset read produces false positives.
+
+2. **Rule 2 — orphan ``<button type="button">``.** A ``<button>`` whose
+   ``type`` is explicitly ``button`` (i.e. not a form-submit) with no
+   ``data-*-action``, no ``hx-*`` attribute, no recognised delegated
+   ``data-*`` marker, and no ``id``/``class`` referenced from JS is an
+   orphan — clicking it does nothing.
+
+3. **Rule 3 — dead anchor.** ``<a href="#foo">`` must either match an
+   ``id="foo"`` somewhere in the template family (same file or ``base.html``
+   it extends) or be wired up by JS.
+
+Findings can be silenced by adding an entry to
+``tests/ui_audit/allowlist.yml``. Each entry must carry a one-line ``reason``
+— the allowlist is a scalpel, not a sledgehammer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.ui_audit.parsers import (
+    ScriptScan,
+    TemplateScan,
+    _strip_jinja,
+    collect_scripts,
+    collect_templates,
+    family_handlers,
+    id_is_referenced,
+)
+
+# Attributes that indicate a button is wired up via a *delegated* handler
+# rather than by id/class lookup. We skip Rule 2 for buttons carrying any of
+# these — they are not orphans.
+_DELEGATED_MARKERS = frozenset(
+    {
+        "data-open-modal",
+        "data-close-modal",
+        "data-settings-tab",
+        "data-workflow-mode",
+        "data-playlist-toggle",
+        "data-collapsible-toggle",
+        "data-frame-option",
+        "data-repeater-add",
+        "data-repeater-remove",
+        # Playlist card controls use these attrs as inputs to class-bound
+        # handlers — the class selector covers the wiring, so carrying any
+        # of these is evidence of intentional wiring rather than orphanage.
+        "data-playlist",
+        "data-playlist-name",
+    }
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES_DIR = REPO_ROOT / "src" / "templates"
+SCRIPTS_DIR = REPO_ROOT / "src" / "static" / "scripts"
+ALLOWLIST_PATH = Path(__file__).with_name("allowlist.yml")
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule: str
+    template: str
+    line: int
+    value: str
+    detail: str
+
+    def matches_allowlist_entry(self, entry: dict) -> bool:
+        return (
+            entry.get("rule") == self.rule
+            and entry.get("template") == self.template
+            and int(entry.get("line", -1)) == self.line
+            and entry.get("value") == self.value
+        )
+
+    def as_table_row(self) -> str:
+        return (
+            f"  [{self.rule}] {self.template}:{self.line}  "
+            f"value={self.value!r}  — {self.detail}"
+        )
+
+
+def _load_allowlist() -> list[dict]:
+    if not ALLOWLIST_PATH.exists():
+        return []
+    raw = yaml.safe_load(ALLOWLIST_PATH.read_text(encoding="utf-8")) or {}
+    entries = raw.get("entries") or []
+    if not isinstance(entries, list):  # pragma: no cover - defensive
+        raise AssertionError(
+            f"{ALLOWLIST_PATH}: 'entries' must be a list (got {type(entries).__name__})"
+        )
+    for entry in entries:
+        if not entry.get("reason"):
+            raise AssertionError(
+                f"{ALLOWLIST_PATH}: every entry requires a 'reason' (got {entry!r})"
+            )
+    return entries
+
+
+def _rule1_findings(
+    templates: list[TemplateScan], scripts: list[ScriptScan]
+) -> list[Finding]:
+    out: list[Finding] = []
+    for t in templates:
+        for c in t.clickables:
+            fa = c.data_action_family()
+            if not fa:
+                continue
+            family, value = fa
+            handlers = family_handlers(scripts, family)
+            if not handlers:
+                out.append(
+                    Finding(
+                        rule="missing-handler",
+                        template=c.template,
+                        line=c.line,
+                        value=f"data-{family}-action={value}",
+                        detail=f"no JS file references dataset.{_dataset_camel(family)} or [data-{family}-action]",
+                    )
+                )
+                continue
+            if any(value in s.literals for s in scripts):
+                continue
+            out.append(
+                Finding(
+                    rule="missing-handler",
+                    template=c.template,
+                    line=c.line,
+                    value=f"data-{family}-action={value}",
+                    detail=(
+                        "family handlers present ("
+                        + ", ".join(s.path.name for s in handlers)
+                        + f") but the action literal {value!r} was not found "
+                        "in any JS file"
+                    ),
+                )
+            )
+    return out
+
+
+def _dataset_camel(family: str) -> str:
+    # plugin -> pluginAction, api-keys -> apiKeysAction
+    parts = family.split("-")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:]) + "Action"
+
+
+def _class_referenced(classes: Iterable[str], scripts: list[ScriptScan]) -> bool:
+    for cls in classes:
+        token = f".{cls}"
+        if any(token in s.text for s in scripts):
+            return True
+    return False
+
+
+def _rule2_findings(
+    templates: list[TemplateScan], scripts: list[ScriptScan]
+) -> list[Finding]:
+    out: list[Finding] = []
+    for t in templates:
+        for c in t.clickables:
+            if c.tag != "button":
+                continue
+            # Buttons without an explicit type default to type="submit" inside a
+            # <form>. Only audit explicit type="button" — submits are wired up
+            # by the form submit handler, not by clickjacking a listener onto
+            # the button itself.
+            btype = (c.attr("type") or "submit").lower()
+            if btype != "button":
+                continue
+            attr_keys = {k for k, _ in c.attrs}
+            if any(k.startswith("data-") and k.endswith("-action") for k in attr_keys):
+                continue
+            if any(k.startswith("hx-") for k in attr_keys):
+                continue
+            if attr_keys & _DELEGATED_MARKERS:
+                continue
+            btn_id = c.attr("id")
+            if btn_id:
+                canonical = _strip_jinja(btn_id)
+                if id_is_referenced(scripts, canonical):
+                    continue
+                out.append(
+                    Finding(
+                        rule="orphan-button",
+                        template=c.template,
+                        line=c.line,
+                        value=f"#{canonical}",
+                        detail="id not referenced by getElementById/querySelector or any JS literal",
+                    )
+                )
+                continue
+            classes = (c.attr("class") or "").split()
+            if _class_referenced(classes, scripts):
+                continue
+            out.append(
+                Finding(
+                    rule="orphan-button",
+                    template=c.template,
+                    line=c.line,
+                    value=f"<button class={' '.join(classes)!r}>",
+                    detail="no id, no data-*-action, no hx-*, no delegated marker, no class referenced from JS",
+                )
+            )
+    return out
+
+
+def _collect_all_ids(templates: list[TemplateScan]) -> set[str]:
+    # Anchors like href="#main-content" reference ids that may live in any
+    # template sharing the same base layout. base.html's skip link is the
+    # canonical example. Flattening ids across templates is a safe
+    # over-approximation — an id that exists nowhere still fails.
+    ids: set[str] = set()
+    for t in templates:
+        ids.update(t.element_ids)
+    return ids
+
+
+def _rule3_findings(
+    templates: list[TemplateScan], scripts: list[ScriptScan]
+) -> list[Finding]:
+    out: list[Finding] = []
+    all_ids = _collect_all_ids(templates)
+    for t in templates:
+        for c in t.clickables:
+            if c.tag != "a":
+                continue
+            href = c.attr("href") or ""
+            if not href.startswith("#"):
+                continue
+            anchor = href[1:]
+            if not anchor:
+                continue  # bare "#" is an intentional no-op (e.g. dropdown toggle)
+            canonical = _strip_jinja(anchor)
+            if not canonical:
+                continue
+            if canonical in t.element_ids or canonical in all_ids:
+                continue
+            if id_is_referenced(scripts, canonical):
+                continue
+            out.append(
+                Finding(
+                    rule="dead-anchor",
+                    template=c.template,
+                    line=c.line,
+                    value=href,
+                    detail="no matching id in any template and no JS handler",
+                )
+            )
+    return out
+
+
+@pytest.fixture(scope="module")
+def scanned_templates() -> list[TemplateScan]:
+    return collect_templates(TEMPLATES_DIR, REPO_ROOT)
+
+
+@pytest.fixture(scope="module")
+def scanned_scripts() -> list[ScriptScan]:
+    return collect_scripts(SCRIPTS_DIR)
+
+
+@pytest.fixture(scope="module")
+def allowlist() -> list[dict]:
+    return _load_allowlist()
+
+
+def test_templates_and_scripts_discoverable(
+    scanned_templates: list[TemplateScan], scanned_scripts: list[ScriptScan]
+) -> None:
+    """Fail fast if the audit is pointed at an empty/wrong directory."""
+
+    assert scanned_templates, f"no templates found under {TEMPLATES_DIR}"
+    assert scanned_scripts, f"no JS scripts found under {SCRIPTS_DIR}"
+
+
+def _partition(
+    findings: list[Finding], allowlist: list[dict]
+) -> tuple[list[Finding], list[dict]]:
+    unmatched_entries = list(allowlist)
+    live: list[Finding] = []
+    for f in findings:
+        hit = None
+        for entry in unmatched_entries:
+            if f.matches_allowlist_entry(entry):
+                hit = entry
+                break
+        if hit is None:
+            live.append(f)
+        else:
+            unmatched_entries.remove(hit)
+    return live, unmatched_entries
+
+
+def _format(findings: list[Finding]) -> str:
+    if not findings:
+        return "(none)"
+    return "\n".join(f.as_table_row() for f in findings)
+
+
+def test_no_dead_data_action_handlers(
+    scanned_templates: list[TemplateScan],
+    scanned_scripts: list[ScriptScan],
+    allowlist: list[dict],
+) -> None:
+    findings = _rule1_findings(scanned_templates, scanned_scripts)
+    live, _unused = _partition(findings, allowlist)
+    assert not live, (
+        "Rule 1 — every data-X-action value must reach a JS handler. "
+        "Dead handlers:\n" + _format(live)
+    )
+
+
+def test_no_orphan_buttons(
+    scanned_templates: list[TemplateScan],
+    scanned_scripts: list[ScriptScan],
+    allowlist: list[dict],
+) -> None:
+    findings = _rule2_findings(scanned_templates, scanned_scripts)
+    live, _unused = _partition(findings, allowlist)
+    assert not live, (
+        "Rule 2 — <button type=button> must have a handler wired via id, class, "
+        "data-*-action, hx-*, or a recognised delegated marker. Orphans:\n"
+        + _format(live)
+    )
+
+
+def test_no_dead_anchors(
+    scanned_templates: list[TemplateScan],
+    scanned_scripts: list[ScriptScan],
+    allowlist: list[dict],
+) -> None:
+    findings = _rule3_findings(scanned_templates, scanned_scripts)
+    live, _unused = _partition(findings, allowlist)
+    assert not live, (
+        "Rule 3 — every <a href='#anchor'> must resolve to an id in some "
+        "template or have a JS handler. Dead anchors:\n" + _format(live)
+    )
+
+
+def test_allowlist_is_tight(
+    scanned_templates: list[TemplateScan],
+    scanned_scripts: list[ScriptScan],
+    allowlist: list[dict],
+) -> None:
+    """Allowlist entries that no longer match anything should be removed."""
+
+    all_findings = (
+        _rule1_findings(scanned_templates, scanned_scripts)
+        + _rule2_findings(scanned_templates, scanned_scripts)
+        + _rule3_findings(scanned_templates, scanned_scripts)
+    )
+    _live, unused = _partition(all_findings, allowlist)
+    assert not unused, (
+        "allowlist.yml has stale entries that no longer match any finding — "
+        "delete them:\n" + "\n".join(f"  {e}" for e in unused)
+    )
+
+
+@pytest.fixture(scope="module")
+def findings_snapshot(
+    scanned_templates: list[TemplateScan], scanned_scripts: list[ScriptScan]
+) -> list[Finding]:
+    """Raw findings (pre-allowlist) — used by the inventory sanity check."""
+
+    return (
+        _rule1_findings(scanned_templates, scanned_scripts)
+        + _rule2_findings(scanned_templates, scanned_scripts)
+        + _rule3_findings(scanned_templates, scanned_scripts)
+    )
+
+
+def test_findings_inventory_matches_snapshot(findings_snapshot: list[Finding]) -> None:
+    """Human-readable guardrail: the current inventory of raw findings.
+
+    This test doubles as documentation for Agent B / Layer 2. If a new dead
+    handler appears, the snapshot changes and the test fails loudly; if
+    someone fixes one, they edit the snapshot down and the test stays honest.
+    """
+
+    expected_values: set[tuple[str, str, str]] = set()
+    # As of L1 landing, the static audit finds zero dead handlers. This is the
+    # baseline — any new entry here should be a deliberate, reasoned allowance
+    # during a regression window. See the epic (JTN-677) for context.
+    actual_values = {(f.rule, f.template, f.value) for f in findings_snapshot}
+    missing = expected_values - actual_values
+    unexpected = actual_values - expected_values
+    assert not missing and not unexpected, (
+        "Findings inventory drifted:\n"
+        f"  newly-appeared: {sorted(unexpected)}\n"
+        f"  no-longer-present: {sorted(missing)}\n"
+        "Full current inventory:\n" + _format(findings_snapshot)
+    )


### PR DESCRIPTION
## Summary

Ships **Layer 1** of the UI breakage detection net epic (JTN-677) — a stdlib-only pytest that statically audits every template against every JS file and proves every clickable element has a reachable handler.

## Rules enforced

1. **Rule 1 — `data-X-action="foo"` handler coverage.** Some JS file must read `dataset.Xaction` (or match `[data-x-action]`) AND the action literal `"foo"` must appear in some JS file. The second half is loose on purpose — handlers routinely delegate across files (e.g. `plugin_page.js` reads `dataset.pluginAction` then hands the value to `plugin_form.js`); insisting the literal lives in the *same* file produces false positives.

2. **Rule 2 — orphan `<button type="button">`.** A button whose `type` is explicitly `button` with no `data-*-action`, no `hx-*` attr, no recognised delegated `data-*` marker, and no `id`/`class` referenced from JS is an orphan — clicking it does nothing.

3. **Rule 3 — dead `<a href="#anchor">`.** The anchor must match an `id` in some template (flattened across the tree so base.html's skip-link resolves to child templates' `id="main-content"`) or be wired up by JS.

## Findings on current `main`

**Zero live findings.** Every `data-*-action` resolves, every typed button is wired, every anchor resolves. Full inventory is captured in `test_findings_inventory_matches_snapshot` — an empty set, so any regression fails loudly.

See "Findings list for Agent B" below.

## Design notes

- **No new Python deps.** Uses stdlib `html.parser` + regex instead of `beautifulsoup4`. Keeps `uv.lock` untouched and avoids lockfile drift CI noise.
- **Allowlist is empty** (`tests/ui_audit/allowlist.yml`) and has a `test_allowlist_is_tight` guard that fails if an entry no longer matches anything.
- **Runs in ~0.2 s** (plan target: <5 s).
- **Regression-tested interactively** before shipping:
  - Renaming `dataset.historyAction` in `history_page.js` → rule 1 fails with `[missing-handler] partials/history_grid.html:39 value='data-history-action=display' — no JS file references dataset.historyAction or [data-history-action]`.
  - Renaming `id="historyRefreshBtn"` → rule 2 fails with `[orphan-button] history.html:23 value='#historyRefreshBtn' — id not referenced by getElementById/querySelector or any JS literal`.

## What Layer 2 (Agent B) should do

L1 found **nothing** to fix statically. The user-reported bugs (settings buttons, daily-comic preview/history) are therefore either runtime-only failures (handler exists but throws/early-returns — L1 can't see this; L3+L4 are designed to catch it), live in plugin render templates that have no buttons today, or were already fixed in recent commits. Agent B should confirm with the user before opening L2 as an empty PR.

## Test plan

- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ui_audit/ -v` → 6 passed in 0.16 s
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck + strict mypy subset)
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no` → 4090 passed, 5 skipped, 0 new failures
- [x] Manually broke handlers to confirm rules 1 + 2 trip with clear output

Epic: JTN-677 · Issue: JTN-678

🤖 Generated with [Claude Code](https://claude.com/claude-code)