### PR TITLE
fix(ci): prevent shell injection in workflows via env vars

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -70,9 +70,11 @@ jobs:
 
       - name: Resolve release tag
         id: tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          TAG="$RELEASE_TAG"
           if [ -z "$TAG" ]; then
             echo "ERROR: No release tag resolved" >&2
             exit 1

--- a/.github/workflows/build-wheelhouse.yml
+++ b/.github/workflows/build-wheelhouse.yml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Resolve tag
         id: tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          TAG="$RELEASE_TAG"
           if [ -z "$TAG" ]; then
             echo "ERROR: No release tag resolved" >&2
             exit 1

--- a/.github/workflows/os-drift-nightly.yml
+++ b/.github/workflows/os-drift-nightly.yml
@@ -58,11 +58,15 @@ jobs:
     steps:
       - name: Skip leg if not selected (workflow_dispatch)
         id: skip
+        env:
+          SELECTED_CODENAME: ${{ github.event.inputs.codename }}
+          EVENT_NAME: ${{ github.event_name }}
+          MATRIX_CODENAME: ${{ matrix.codename }}
         run: |
           set -euo pipefail
-          selected='${{ github.event.inputs.codename }}'
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$selected" ] && [ "$selected" != "${{ matrix.codename }}" ]; then
-            echo "Leg ${{ matrix.codename }} not selected; skipping."
+          selected="$SELECTED_CODENAME"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$selected" ] && [ "$selected" != "$MATRIX_CODENAME" ]; then
+            echo "Leg $MATRIX_CODENAME not selected; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -216,11 +220,15 @@ jobs:
 
       - name: Skip leg if not selected (workflow_dispatch)
         id: skip
+        env:
+          SELECTED_CODENAME: ${{ github.event.inputs.codename }}
+          EVENT_NAME: ${{ github.event_name }}
+          MATRIX_CODENAME: ${{ matrix.codename }}
         run: |
           set -euo pipefail
-          selected='${{ github.event.inputs.codename }}'
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$selected" ] && [ "$selected" != "${{ matrix.codename }}" ]; then
-            echo "Leg ${{ matrix.codename }} not selected; skipping."
+          selected="$SELECTED_CODENAME"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$selected" ] && [ "$selected" != "$MATRIX_CODENAME" ]; then
+            echo "Leg $MATRIX_CODENAME not selected; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes 4 GitHub code-scanning alerts (rule `yaml.github-actions.security.run-shell-injection`) by moving `${{ github.* }}` expression interpolations out of `run:` scripts and into `env:` blocks, then referencing them as normal shell variables.

| Alert | File | Line | Variable(s) moved |
|-------|------|------|-------------------|
| 108 | `.github/workflows/os-drift-nightly.yml` | 61 | `github.event.inputs.codename`, `github.event_name`, `matrix.codename` → `SELECTED_CODENAME`, `EVENT_NAME`, `MATRIX_CODENAME` |
| 109 | `.github/workflows/os-drift-nightly.yml` | 219 | same three expressions in the `install-sim` job's skip step |
| 110 | `.github/workflows/build-wheelhouse.yml` | 52 | `github.event.release.tag_name \|\| inputs.tag` → `RELEASE_TAG` |
| 111 | `.github/workflows/build-pi-image.yml` | 73 | `github.event.release.tag_name \|\| inputs.tag` → `RELEASE_TAG` |

No logic changes — only the interpolation mechanism. All existing quoting/escaping style preserved.

## Test plan

- [ ] Verify all 4 code-scanning alerts are resolved after merge
- [ ] Confirm `os-drift-nightly` workflow still skips unselected legs on `workflow_dispatch`
- [ ] Confirm `build-wheelhouse` and `build-pi-image` still resolve release tags correctly on `release` and `workflow_dispatch` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)