### PR TITLE
fix(scripts): use defusedxml in coverage_gate.py

### DIFF
--- a/install/requirements-dev.in
+++ b/install/requirements-dev.in
@@ -51,6 +51,9 @@ waitress>=3.0,<4
 jsonschema>=4.0,<5
 astral>=3.0,<4
 
+# Security — safe XML parsing (replaces stdlib xml.etree.ElementTree)
+defusedxml>=0.7,<1
+
 # Audit / compliance
 pip-audit>=2.0,<3
 cyclonedx-bom>=6.0,<7

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from pathlib import Path
 
 THRESHOLDS: dict[str, tuple[float, float]] = {

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import argparse
 import sys
-import defusedxml.ElementTree as ET
 from pathlib import Path
+
+import defusedxml.ElementTree as ET
 
 THRESHOLDS: dict[str, tuple[float, float]] = {
     "refresh_task/task.py": (0.65, 0.50),


### PR DESCRIPTION
## Summary

- Replaces `xml.etree.ElementTree` with `defusedxml.ElementTree` in `scripts/coverage_gate.py` (line 18) to resolve Semgrep alert #113 (`python.lang.security.use-defused-xml-parse.use-defused-xml-parse`, error severity).
- The `defusedxml` API is fully drop-in compatible with `xml.etree.ElementTree`; no behaviour change.
- Adds `defusedxml>=0.7,<1` to `install/requirements-dev.in` (the source-of-truth constraints file); it was already present in the compiled `requirements-dev.txt` as a transitive dependency.

## Test plan

- [ ] `python -c "import defusedxml.ElementTree"` passes in the project venv
- [ ] `scripts/coverage_gate.py` continues to parse coverage XML correctly (no API change)
- [ ] CI lint and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new development dependency for XML processing.
  * Updated internal code coverage tooling to use the new dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->