### PR TITLE
fix(benchmarks): parameterize/validate SQL identifiers in benchmark_storage

### DIFF
--- a/src/benchmarks/benchmark_storage.py
+++ b/src/benchmarks/benchmark_storage.py
@@ -130,18 +130,58 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+_ALLOWED_TABLES = frozenset({"refresh_events", "stage_events"})
+_ALLOWED_COLUMN_TYPES = frozenset({"TEXT", "INTEGER", "REAL", "BLOB", "NUMERIC"})
+_IDENTIFIER_RE = __import__("re").compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(value: str, label: str) -> str:
+    """Return *value* unchanged after confirming it is a safe SQL identifier.
+
+    SQL identifiers (table/column names) cannot be bound via parameterised
+    queries, so we validate against an explicit allow-list (tables) or a strict
+    regex (columns/types) before interpolating into the statement.  Any value
+    that fails validation raises ValueError so callers surface the bug at
+    development time rather than silently executing unsafe SQL.
+    """
+    if not _IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"Unsafe SQL identifier for {label!r}: {value!r} "
+            "(must match ^[A-Za-z_][A-Za-z0-9_]*$)"
+        )
+    return value
+
+
 def _ensure_optional_columns(
     conn: sqlite3.Connection,
     table_name: str,
     expected_columns: dict[str, str],
 ) -> None:
+    # table_name and column names are SQL identifiers that cannot be bound via
+    # query parameters.  Validate against an allow-list / strict regex before
+    # interpolating so that callers can never inject arbitrary SQL.
+    if table_name not in _ALLOWED_TABLES:
+        raise ValueError(f"Unknown benchmark table: {table_name!r}")
+    safe_table = _validate_identifier(table_name, "table_name")
+
     existing = {
-        row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        # Safe: safe_table is validated above against the allow-list.
+        row[1]
+        for row in conn.execute(
+            f"PRAGMA table_info({safe_table})"
+        ).fetchall()  # noqa: S608
     }
     for column_name, column_type in expected_columns.items():
         if column_name in existing:
             continue
-        conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type}")
+        safe_col = _validate_identifier(column_name, "column_name")
+        if column_type not in _ALLOWED_COLUMN_TYPES:
+            raise ValueError(f"Unknown column type: {column_type!r}")
+        # Safe: safe_table validated against allow-list; safe_col validated via
+        # regex; column_type validated against allow-list of SQLite type keywords.
+        conn.execute(  # noqa: S608
+            f"ALTER TABLE {safe_table} ADD COLUMN {safe_col} {column_type}"
+        )
 
 
 def save_refresh_event(device_config, refresh_event: dict[str, Any]) -> None:

--- a/tests/unit/test_benchmark_storage.py
+++ b/tests/unit/test_benchmark_storage.py
@@ -438,3 +438,85 @@ def test_save_stage_event_silently_fails_on_error(monkeypatch):
 
     # Should not raise
     save_stage_event(BadConfig(), refresh_id="fail", stage="test")
+
+
+# --- _validate_identifier tests ---
+
+
+def test_validate_identifier_accepts_valid_names():
+    """Valid SQL identifiers are returned unchanged."""
+    from benchmarks.benchmark_storage import _validate_identifier
+
+    assert _validate_identifier("refresh_events", "table") == "refresh_events"
+    assert _validate_identifier("column_name", "col") == "column_name"
+    assert _validate_identifier("_underscore_start", "col") == "_underscore_start"
+    assert _validate_identifier("CamelCase123", "col") == "CamelCase123"
+
+
+def test_validate_identifier_rejects_bad_input():
+    """Invalid SQL identifiers raise ValueError."""
+    import pytest
+
+    from benchmarks.benchmark_storage import _validate_identifier
+
+    bad_inputs = [
+        "drop table users",
+        "'; DROP TABLE refresh_events; --",
+        "1_starts_with_digit",
+        "has-hyphen",
+        "has space",
+        "has.dot",
+        "",
+    ]
+    for bad in bad_inputs:
+        with pytest.raises(ValueError, match="Unsafe SQL identifier"):
+            _validate_identifier(bad, "test_label")
+
+
+# --- _ensure_optional_columns tests ---
+
+
+def test_ensure_optional_columns_rejects_unknown_table(tmp_path):
+    """_ensure_optional_columns raises ValueError for unknown table names."""
+    import pytest
+
+    from benchmarks.benchmark_storage import _ensure_optional_columns
+
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    with pytest.raises(ValueError, match="Unknown benchmark table"):
+        _ensure_optional_columns(conn, "unknown_table", {"col": "TEXT"})
+    conn.close()
+
+
+def test_ensure_optional_columns_adds_missing_columns(tmp_path):
+    """Adds columns that don't yet exist in the table."""
+    from benchmarks.benchmark_storage import _ensure_optional_columns
+
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    conn.execute(
+        "CREATE TABLE refresh_events (id INTEGER PRIMARY KEY, refresh_id TEXT)"
+    )
+    conn.commit()
+
+    _ensure_optional_columns(conn, "refresh_events", {"new_col": "TEXT"})
+
+    cursor = conn.execute("PRAGMA table_info(refresh_events)")
+    columns = {row[1] for row in cursor.fetchall()}
+    conn.close()
+
+    assert "new_col" in columns
+
+
+def test_ensure_optional_columns_skips_existing_columns(tmp_path):
+    """Does not fail when column already exists."""
+    from benchmarks.benchmark_storage import _ensure_optional_columns
+
+    conn = sqlite3.connect(str(tmp_path / "test.db"))
+    conn.execute(
+        "CREATE TABLE refresh_events (id INTEGER PRIMARY KEY, existing_col TEXT)"
+    )
+    conn.commit()
+
+    # Should not raise even though existing_col already exists
+    _ensure_optional_columns(conn, "refresh_events", {"existing_col": "TEXT"})
+    conn.close()


### PR DESCRIPTION
## Summary

Fixes code-scanning alerts **#119, #120, #121, #122** in `src/benchmarks/benchmark_storage.py`.

**Rule violations addressed:**
- `python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query`
- `python.lang.security.audit.formatted-sql-query.formatted-sql-query`

**Root cause:** Lines 139 and 144 interpolated `table_name`, `column_name`, and `column_type` directly into SQL strings (`PRAGMA table_info(...)` and `ALTER TABLE ... ADD COLUMN ...`). SQL identifiers cannot be bound via query parameters, but unvalidated interpolation is still a security risk.

**Fix approach:**
- Added `_ALLOWED_TABLES` frozenset — table name is validated against the known allow-list before use.
- Added `_IDENTIFIER_RE` regex (`^[A-Za-z_][A-Za-z0-9_]*$`) — column names are validated before interpolation.
- Added `_ALLOWED_COLUMN_TYPES` frozenset — column type keywords validated against SQLite type allow-list.
- Added `_validate_identifier()` helper with clear docstring explaining why interpolation is safe post-validation.
- Both interpolated sites have `# noqa: S608` suppressing the Bandit/semgrep hint since the code is now demonstrably safe.

## Test plan

- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ -k benchmark` — 58 passed, 0 failed
- [x] `scripts/lint.sh` — all blocking checks pass (ruff, black, mypy strict subset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)