### PR TITLE
fix(install): add libffi-dev + libsystemd-dev to debian-requirements (JTN-675)

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -13,4 +13,6 @@ earlyoom
 swig
 liblgpio-dev
 libheif-dev
+libffi-dev
+libsystemd-dev
 jq

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1623,6 +1623,41 @@ def test_requirements_files_exist():
     assert (INSTALL_DIR / "debian-requirements.txt").exists()
 
 
+def test_debian_requirements_includes_build_headers_for_pinned_python_deps():
+    """Regression: JTN-675.
+
+    `install/requirements.txt` pins `cffi` and `cysystemd`, which need native
+    headers when built from source (piwheels has no prebuilt wheels for
+    Python 3.13 armv7 / Trixie). Without `libffi-dev` / `libsystemd-dev` in the
+    apt preflight list, `pip install` dies with:
+
+        fatal error: ffi.h: No such file or directory
+        fatal error: systemd/sd-daemon.h: No such file or directory
+
+    Keep these two apt packages wired to their Python dependencies so we don't
+    regress this on a future requirements refresh.
+    """
+    py_reqs = (INSTALL_DIR / "requirements.txt").read_text()
+    deb_reqs = (INSTALL_DIR / "debian-requirements.txt").read_text().splitlines()
+    deb_pkgs = {
+        line.strip() for line in deb_reqs if line.strip() and not line.startswith("#")
+    }
+
+    # cffi needs libffi-dev
+    if re.search(r"(?m)^cffi(==|>=|~=|\s|$)", py_reqs):
+        assert "libffi-dev" in deb_pkgs, (
+            "install/requirements.txt pins `cffi` but install/debian-requirements.txt "
+            "is missing `libffi-dev` — source builds will fail on armv7/py3.13."
+        )
+
+    # cysystemd needs libsystemd-dev
+    if re.search(r"(?m)^cysystemd(==|>=|~=|\s|;|$)", py_reqs):
+        assert "libsystemd-dev" in deb_pkgs, (
+            "install/requirements.txt pins `cysystemd` but install/debian-requirements.txt "
+            "is missing `libsystemd-dev` — source builds will fail on armv7/py3.13."
+        )
+
+
 def test_service_exec_matches_cli_wrapper():
     service = _read("inkypi.service")
     # ExecStart references /usr/local/bin/inkypi


### PR DESCRIPTION
## Summary
- `install/requirements.txt` pins `cffi` and `cysystemd`, both of which need native headers when built from source.
- On Python 3.13 armv7 (Pi Zero 2 W / Trixie) piwheels has no prebuilt wheels, so pip falls back to source builds and dies with `fatal error: ffi.h: No such file or directory` and `fatal error: systemd/sd-daemon.h: No such file or directory`.
- Add `libffi-dev` and `libsystemd-dev` to `install/debian-requirements.txt` so the apt preflight covers both.

## Regression test
Added `test_debian_requirements_includes_build_headers_for_pinned_python_deps` in `tests/unit/test_install_scripts.py`. It reads both files and asserts that whenever `cffi` / `cysystemd` are pinned in `requirements.txt`, the matching `-dev` apt package is listed. Verified it fails against the pre-fix `debian-requirements.txt` and passes with the fix.

## Verification
Reproduced on inkypi.local during `v0.38.0 -> v0.49.20` update. After `apt install -y libffi-dev libsystemd-dev`, both wheels built with no other changes.

## Test plan
- [x] New regression test fails before the fix, passes after
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck + mypy-strict)
- [x] Full suite: `SKIP_BROWSER=1 pytest tests/` — only 3 pre-existing static-frontend failures remain (reproduced on main; unrelated to this PR)

Closes JTN-675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system dependencies for Debian-based installations with additional build dependencies to support proper compilation of Python packages requiring native libraries.

* **Tests**
  * Added test validation to ensure required system build dependencies are correctly specified for applicable Python packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->