### PR TITLE
test(ui): skip historyRefreshBtn in click sweep (JTN-682)

### DIFF
--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -20,7 +20,8 @@
                 </div>
                 <div class="header-actions history-toolbar">
                     <a href="{{ url_for('history.history_export_csv') }}" class="header-button" download>Export CSV</a>
-                    <button id="historyRefreshBtn" class="header-button" type="button">Refresh</button>
+                    {# JTN-682: Skip in click sweep — handler calls location.reload() which destabilises subsequent clicks. #}
+                    <button id="historyRefreshBtn" class="header-button" type="button" data-test-skip-click="true">Refresh</button>
                 </div>
             </div>
         </header>

--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -94,14 +94,6 @@ _XFAIL_PAGES: dict[str, str] = {
         "awaiting L2 batch fix in JTN-681 "
         "(clock face picker clicks show no DOM mutation)"
     ),
-    # JTN-682: historyRefreshBtn calls location.reload(); the sweep's
-    # markerPresent sentinel races with reload completion. L2 should either
-    # tag the button `data-test-skip-click="true"` or switch detection to
-    # `page.expect_event('framenavigated')`.
-    "history": (
-        "awaiting L2 batch fix in JTN-682 "
-        "(Refresh button reload not detected as observable change)"
-    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Tag `#historyRefreshBtn` with `data-test-skip-click="true"` in `src/templates/history.html` so the Layer-3 click sweep walks around it. The handler is `globalThis.location.reload()`, which restarts the page mid-sweep and destabilises subsequent clicks.
- Remove `history` from `_XFAIL_PAGES` in `tests/integration/test_click_sweep.py` now that the page passes cleanly.

Closes JTN-682.

## Test plan
- [x] `.venv/bin/python -m pytest tests/integration/test_click_sweep.py::test_click_sweep[history] -v` passes
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck + strict mypy subset)
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/` -> 4123 passed, 5 skipped

Generated with [Claude Code](https://claude.com/claude-code)