### PR TITLE
fix(clock): activate face picker handler when color fields are outside widget (JTN-681)

### DIFF
--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -132,16 +132,32 @@
 
   function initClockFacePicker(widget, config) {
     const hidden = widget.querySelector("#selected-clock-face");
-    const primary = widget.querySelector("[name='primaryColor']");
-    const secondary = widget.querySelector("[name='secondaryColor']");
     const options = Array.from(widget.querySelectorAll(".image-option"));
-    if (!hidden || !primary || !secondary || !options.length) return;
+    if (!hidden || !options.length) return;
+
+    // primaryColor/secondaryColor fields live in a sibling schema section on
+    // the plugin form, not inside the picker widget — scope the lookup to the
+    // whole schema root (or document as a last resort) so the face picker
+    // still activates when the colour fields are hoisted out of the widget.
+    const scope = widget.closest("[data-settings-schema]") ||
+      widget.closest("form") || document;
+    const primary = scope.querySelector("[name='primaryColor']");
+    const secondary = scope.querySelector("[name='secondaryColor']");
+
+    const setColor = (input, value) => {
+      if (!input || !value) return;
+      input.value = value;
+      // Keep any color-preview swatches bound to the input in sync — they
+      // listen for `input`/`change`, not direct assignment.
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    };
 
     const selectOption = (option) => {
       options.forEach((item) => item.classList.toggle("selected", item === option));
       hidden.value = option.dataset.faceName || "";
-      if (option.dataset.primaryColor) primary.value = option.dataset.primaryColor;
-      if (option.dataset.secondaryColor) secondary.value = option.dataset.secondaryColor;
+      setColor(primary, option.dataset.primaryColor);
+      setColor(secondary, option.dataset.secondaryColor);
     };
 
     options.forEach((option) => {
@@ -152,8 +168,8 @@
     const initial = options.find((option) => option.dataset.faceName === currentValue) || options[0];
     selectOption(initial);
 
-    if (config.primaryColor) primary.value = config.primaryColor;
-    if (config.secondaryColor) secondary.value = config.secondaryColor;
+    if (config.primaryColor) setColor(primary, config.primaryColor);
+    if (config.secondaryColor) setColor(secondary, config.secondaryColor);
   }
 
   function initNewspaperSearch(widget, config) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ UI_BROWSER_TESTS = {
     "test_collapsible_sections_e2e.py",
     "test_cross_page_navigation_e2e.py",
     "test_click_sweep.py",
+    "test_jtn_681_clock_face_picker.py",
 }
 A11Y_BROWSER_TESTS = {
     "test_axe_a11y.py",

--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -85,16 +85,7 @@ _SKIP_SELECTORS: tuple[str, ...] = (
 # Pages where the initial sweep surfaced bugs that the L2 batch-fix PR will
 # address. Marked xfail so the harness ships green today and starts locking
 # in once the fixes land. Each entry MUST link to a tracking Linear issue.
-_XFAIL_PAGES: dict[str, str] = {
-    # JTN-681: clock face picker buttons don't produce observable DOM
-    # mutations in the sweep — either initClockFacePicker isn't firing or
-    # MutationObserver misses the classList.toggle. Remove once JTN-681 is
-    # fixed in the L2 batch PR.
-    "plugin_clock": (
-        "awaiting L2 batch fix in JTN-681 "
-        "(clock face picker clicks show no DOM mutation)"
-    ),
-}
+_XFAIL_PAGES: dict[str, str] = {}
 
 
 _ENUMERATE_JS = """

--- a/tests/integration/test_jtn_681_clock_face_picker.py
+++ b/tests/integration/test_jtn_681_clock_face_picker.py
@@ -1,0 +1,96 @@
+# pyright: reportMissingImports=false
+"""Regression test for JTN-681 — clock face picker silent click handler.
+
+The Layer-3 click sweep (:mod:`tests.integration.test_click_sweep`) flagged
+all four `.image-option` buttons on `/plugin/clock` as producing no observable
+DOM change. Root cause: ``initClockFacePicker`` scoped its lookup of the
+``primaryColor`` / ``secondaryColor`` inputs to the widget wrapper, but those
+fields live in a sibling schema section on the plugin form. The early-return
+guard (``if (!hidden || !primary || !secondary || !options.length) return``)
+fired, so no click handler was ever attached and the initial ``.selected``
+state was never applied.
+
+This test exercises the handler directly so the regression is caught even if
+the click sweep's observer heuristics ever drift.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from tests.integration.browser_helpers import stub_leaflet
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("SKIP_UI", "").lower() in ("1", "true"),
+    reason="UI interactions skipped by env",
+)
+
+
+def test_clock_face_picker_applies_selected_and_updates_colors(
+    live_server, browser_page
+):
+    """Clicking a clock face button toggles `.selected` and syncs color inputs."""
+    page = browser_page
+    stub_leaflet(page)
+    page.goto(
+        f"{live_server}/plugin/clock",
+        wait_until="domcontentloaded",
+        timeout=30000,
+    )
+    page.wait_for_selector("#settingsForm", timeout=10000)
+    page.wait_for_timeout(300)
+
+    # Initial state: the hidden input should match the default face AND the
+    # matching `.image-option` should carry the `.selected` class. Prior to
+    # the fix neither was true because initClockFacePicker bailed out early.
+    state = page.evaluate("""() => {
+            const opts = document.querySelectorAll('#clock-face-selection .image-option');
+            const hidden = document.querySelector('#selected-clock-face');
+            return {
+                hiddenValue: hidden?.value,
+                selectedLabels: Array.from(opts)
+                    .filter(o => o.classList.contains('selected'))
+                    .map(o => o.dataset.faceName),
+            };
+        }""")
+    assert state["hiddenValue"], "hidden selectedClockFace input has no value"
+    assert state["selectedLabels"] == [state["hiddenValue"]], (
+        "on load, the clock-face button matching the hidden input should be "
+        f"marked .selected; got {state['selectedLabels']}"
+    )
+
+    # Clicking a different face must: toggle the `.selected` class over, sync
+    # the hidden input value, AND push the face's preset colors into the
+    # primaryColor/secondaryColor inputs that live in a sibling section.
+    result = page.evaluate("""() => {
+            const opts = Array.from(document.querySelectorAll('#clock-face-selection .image-option'));
+            const target = opts.find(o => !o.classList.contains('selected'));
+            if (!target) return {error: 'no unselected target'};
+            target.click();
+            return {
+                targetFace: target.dataset.faceName,
+                expectedPrimary: target.dataset.primaryColor,
+                expectedSecondary: target.dataset.secondaryColor,
+                selectedAfter: opts
+                    .filter(o => o.classList.contains('selected'))
+                    .map(o => o.dataset.faceName),
+                hiddenAfter: document.querySelector('#selected-clock-face')?.value,
+                primaryAfter: document.querySelector("[name='primaryColor']")?.value,
+                secondaryAfter: document.querySelector("[name='secondaryColor']")?.value,
+            };
+        }""")
+
+    assert "error" not in result, result
+    assert result["selectedAfter"] == [result["targetFace"]], (
+        "clicking a face button must move the .selected class exclusively to "
+        f"that option; got {result['selectedAfter']}"
+    )
+    assert result["hiddenAfter"] == result["targetFace"]
+    # Color inputs normalize hex values to lowercase; compare case-insensitively.
+    assert (
+        result["primaryAfter"].lower() == result["expectedPrimary"].lower()
+    ), f"primaryColor not synced: {result}"
+    assert (
+        result["secondaryAfter"].lower() == result["expectedSecondary"].lower()
+    ), f"secondaryColor not synced: {result}"


### PR DESCRIPTION
## Summary
- Clicking any `.image-option` button on `/plugin/clock` was a no-op — `initClockFacePicker` early-returned because it looked up `primaryColor` / `secondaryColor` inside the widget wrapper, but those fields live in a sibling schema section.
- Scope the colour-field lookup to `[data-settings-schema]` (with `form` / `document` fallbacks) and drop the colour inputs from the required-input guard. Also dispatch `input`/`change` events when syncing values so bound preview swatches stay in sync.
- Remove `plugin_clock` from `_XFAIL_PAGES` in the Layer-3 click sweep and add a dedicated regression test (`test_jtn_681_clock_face_picker.py`) asserting both initial selection and post-click class + hidden-input + colour-input sync.

Closes JTN-681.

## Root cause
Hypothesis 3: the handler genuinely no-ops. `widget.querySelector("[name='primaryColor']")` returned `null` because the widget wrapper only contains the picker — the colour fields are rendered in the sibling "Colors" section. The guard `if (!hidden || !primary || !secondary || !options.length) return;` fired, so:
- no `click` listeners were attached
- the initial `selectOption(initial)` call was never reached, leaving every option without `.selected`

## Test plan
- [x] `tests/integration/test_click_sweep.py::test_click_sweep[plugin_clock]` passes (was xfail)
- [x] New `test_jtn_681_clock_face_picker.py` passes
- [x] Full suite: `SKIP_BROWSER=1 pytest tests/` → 4124 passed, 5 skipped
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clock face picker widget to properly synchronize color preview UI when selecting different clock face designs. The color configuration is now derived from a broader lookup scope for better integration with the settings interface.

* **Tests**
  * Added new UI regression test for clock face picker selection and color synchronization behavior.
  * Integrated test into the test suite and removed associated expected-failure marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->