### PR TITLE
fix(security): pin DNS for plugin URL fetches to block rebinding SSRF (JTN-656)

### DIFF
--- a/src/plugins/image_album/image_album.py
+++ b/src/plugins/image_album/image_album.py
@@ -6,25 +6,41 @@ from PIL import Image, ImageColor, ImageOps
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import field, option, row, schema, section
 from utils.http_client import get_http_session
+from utils.http_utils import pinned_dns
 from utils.image_utils import pad_image_blur
-from utils.security_utils import validate_url
+from utils.security_utils import validate_url_with_ips
 
 logger = logging.getLogger(__name__)
 
 
 class ImmichProvider:
-    def __init__(self, base_url: str, key: str, image_loader):
+    def __init__(
+        self,
+        base_url: str,
+        key: str,
+        image_loader,
+        pinned_ips: tuple[str, ...] | None = None,
+    ):
         self.base_url = base_url
         self.key = key
         self.headers = {"x-api-key": self.key}
         self.image_loader = image_loader
         self.session = get_http_session()
+        self.pinned_ips: tuple[str, ...] = tuple(pinned_ips or ())
+        import urllib.parse as _urlparse
+
+        self._pin_hostname = _urlparse.urlparse(base_url).hostname or ""
+
+    def _pin(self):
+        """Context manager that pins DNS to the validated IPs for this base URL."""
+        return pinned_dns(self._pin_hostname, self.pinned_ips)
 
     def get_album_id(self, album: str) -> str:
         logger.debug(f"Fetching albums from {self.base_url}")
-        r = self.session.get(
-            f"{self.base_url}/api/albums", headers=self.headers, timeout=10
-        )
+        with self._pin():
+            r = self.session.get(
+                f"{self.base_url}/api/albums", headers=self.headers, timeout=10
+            )
         r.raise_for_status()
         albums = r.json()
 
@@ -43,12 +59,13 @@ class ImmichProvider:
         logger.debug(f"Fetching assets from album {album_id}")
         while page_items:
             body = {"albumIds": [album_id], "size": 1000, "page": page}
-            r2 = self.session.post(
-                f"{self.base_url}/api/search/metadata",
-                json=body,
-                headers=self.headers,
-                timeout=10,
-            )
+            with self._pin():
+                r2 = self.session.post(
+                    f"{self.base_url}/api/search/metadata",
+                    json=body,
+                    headers=self.headers,
+                    timeout=10,
+                )
             r2.raise_for_status()
             assets_data = r2.json()
 
@@ -97,9 +114,14 @@ class ImmichProvider:
 
         # Use adaptive image loader for memory-efficient processing
         # Let loader resize when requested (when no padding will be applied)
-        img = self.image_loader.from_url(
-            asset_url, dimensions, timeout_ms=40000, resize=resize, headers=self.headers
-        )
+        with self._pin():
+            img = self.image_loader.from_url(
+                asset_url,
+                dimensions,
+                timeout_ms=40000,
+                resize=resize,
+                headers=self.headers,
+            )
 
         if not img:
             logger.error(f"Failed to load image {asset_id} from Immich")
@@ -202,7 +224,7 @@ class ImageAlbum(BasePlugin):
             raise RuntimeError("Immich URL is required.")
 
         try:
-            validate_url(url)
+            _validated_url, pinned_ips = validate_url_with_ips(url)
         except ValueError as e:
             raise RuntimeError(f"Invalid URL: {e}") from e
 
@@ -214,7 +236,7 @@ class ImageAlbum(BasePlugin):
         logger.info(f"Immich URL: {url}")
         logger.info(f"Album: {album}")
 
-        provider = ImmichProvider(url, key, self.image_loader)
+        provider = ImmichProvider(url, key, self.image_loader, pinned_ips=pinned_ips)
         img = provider.get_image(album, dimensions, resize=not use_padding)
 
         if not img:

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -41,9 +41,13 @@ Rules of thumb
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
+import socket
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 
@@ -476,3 +480,155 @@ def _reset_shared_session_for_tests() -> None:
     """Reset the shared session (testing only)."""
     if hasattr(_thread_local, "session"):
         delattr(_thread_local, "session")
+
+
+# ---- DNS pinning (SSRF mitigation, JTN-656) --------------------------------
+#
+# ``validate_url`` resolves DNS up-front to reject private targets, but the
+# subsequent HTTP call resolves DNS *again* inside ``urllib3``.  A hostile
+# authoritative server can flip the second answer to a private IP (DNS
+# rebinding) — bypassing the guard entirely.
+#
+# The countermeasure here is to pin the resolver to the exact IPs observed at
+# validation time for the duration of the fetch.  We do this by monkey-patching
+# ``socket.getaddrinfo`` with a thin wrapper keyed on hostname.  The URL
+# itself is unchanged, so TLS SNI and certificate verification still happen
+# against the original hostname (we are *not* rewriting the URL host to an
+# IP, which would break HTTPS vhost routing and cert matching).
+#
+# The swap is bounded by a context manager: on entry we stash the currently
+# installed ``socket.getaddrinfo`` and replace it with our wrapper; on exit
+# we restore exactly what we stashed.  This nests cleanly and plays well
+# with test monkeypatches of ``socket.getaddrinfo`` that are set either
+# before or after the pin is established.
+#
+# Concurrency note: ``socket.getaddrinfo`` is a module-level attribute, so
+# replacing it affects every thread.  We serialise entry/exit through a
+# lock and use a re-entrant pin store so only threads that have actually
+# called ``pinned_dns`` see rewritten results.  Other threads' lookups pass
+# through unchanged.
+
+_dns_pin_global_lock = threading.Lock()
+_dns_pin_depth: int = 0
+_dns_pin_saved: Any = None
+_dns_pin_local = threading.local()
+
+
+def _pin_store() -> dict[str, tuple[str, ...]]:
+    store: dict[str, tuple[str, ...]] | None = getattr(_dns_pin_local, "pins", None)
+    if store is None:
+        store = {}
+        _dns_pin_local.pins = store
+    return store
+
+
+def _make_patched_getaddrinfo(original: Any) -> Any:
+    """Return a getaddrinfo wrapper that consults the thread-local pin store.
+
+    *original* is the resolver to delegate to for unpinned hostnames (or
+    when the calling thread has no active pins).
+    """
+
+    def _patched_getaddrinfo(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
+        pins = _pin_store()
+        if not pins:
+            return original(host, port, *args, **kwargs)
+        if isinstance(host, (bytes, bytearray)):
+            try:
+                host_str = host.decode("idna")
+            except Exception:
+                host_str = host.decode("ascii", errors="replace")
+        else:
+            host_str = host
+        key = host_str.lower() if isinstance(host_str, str) else host_str
+        ips = pins.get(key) if isinstance(key, str) else None
+        if not ips:
+            return original(host, port, *args, **kwargs)
+        results: list[Any] = []
+        norm_port = port if port is not None else 0
+        try:
+            port_int = int(norm_port) if norm_port != "" else 0
+        except (TypeError, ValueError):
+            port_int = 0
+        for ip in ips:
+            try:
+                addr = ipaddress.ip_address(ip)
+            except ValueError:
+                continue
+            if isinstance(addr, ipaddress.IPv6Address):
+                family = socket.AF_INET6
+                sockaddr: tuple[Any, ...] = (ip, port_int, 0, 0)
+            else:
+                family = socket.AF_INET
+                sockaddr = (ip, port_int)
+            results.append(
+                (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+            )
+        if not results:
+            # Shouldn't happen (we vet IPs before pinning) — fall back.
+            return original(host, port, *args, **kwargs)
+        return results
+
+    return _patched_getaddrinfo
+
+
+@contextmanager
+def pinned_dns(hostname: str, ips: tuple[str, ...] | list[str]) -> Iterator[None]:
+    """Context manager that pins ``socket.getaddrinfo(hostname, ...)`` to *ips*.
+
+    Only threads that entered ``pinned_dns`` see rewritten results; other
+    threads fall through to the underlying resolver.  Intended to bracket
+    an HTTP request whose hostname was already validated via
+    :func:`utils.security_utils.validate_url_with_ips`.
+    """
+    global _dns_pin_depth, _dns_pin_saved
+
+    if not hostname:
+        yield
+        return
+
+    key = hostname.lower()
+    store = _pin_store()
+    previous_pin = store.get(key)
+    store[key] = tuple(ips)
+
+    # Install the wrapper on first entry across all threads; subsequent
+    # nested ``pinned_dns`` calls just bump the depth.
+    installed_here = False
+    with _dns_pin_global_lock:
+        if _dns_pin_depth == 0:
+            _dns_pin_saved = socket.getaddrinfo
+            socket.getaddrinfo = _make_patched_getaddrinfo(_dns_pin_saved)
+            installed_here = True
+        _dns_pin_depth += 1
+
+    try:
+        yield
+    finally:
+        with _dns_pin_global_lock:
+            _dns_pin_depth -= 1
+            if _dns_pin_depth == 0 and installed_here:
+                socket.getaddrinfo = _dns_pin_saved
+                _dns_pin_saved = None
+        if previous_pin is None:
+            store.pop(key, None)
+        else:
+            store[key] = previous_pin
+
+
+def safe_http_get(url: str, **kwargs: Any) -> requests.Response:
+    """Validate *url* for SSRF and perform an ``http_get`` with DNS pinned.
+
+    The hostname is resolved once during validation; the resulting IPs are
+    pinned for the subsequent fetch so a DNS-rebinding attack cannot flip
+    the answer to a private address between the two resolutions (JTN-656).
+    """
+    # Local import to avoid a circular dependency during module initialisation.
+    from utils.security_utils import validate_url_with_ips
+
+    validated_url, ips = validate_url_with_ips(url)
+    import urllib.parse as _urlparse
+
+    hostname = _urlparse.urlparse(validated_url).hostname or ""
+    with pinned_dns(hostname, ips):
+        return http_get(validated_url, **kwargs)

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -522,6 +522,43 @@ def _pin_store() -> dict[str, tuple[str, ...]]:
     return store
 
 
+def _normalize_host(host: Any) -> str | None:
+    """Return *host* as a lowercase string, or None if not a decodable host."""
+    if isinstance(host, (bytes, bytearray)):
+        try:
+            host_str: Any = host.decode("idna")
+        except Exception:
+            host_str = host.decode("ascii", errors="replace")
+    else:
+        host_str = host
+    return host_str.lower() if isinstance(host_str, str) else None
+
+
+def _coerce_port(port: Any) -> int:
+    """Best-effort conversion of *port* to an int; returns 0 on failure."""
+    if port is None or port == "":
+        return 0
+    try:
+        return int(port)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _addrinfo_for_pinned_ip(ip: str, port_int: int) -> tuple[Any, ...] | None:
+    """Build an addrinfo tuple for *ip*, or None if *ip* is not parseable."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    if isinstance(addr, ipaddress.IPv6Address):
+        family = socket.AF_INET6
+        sockaddr: tuple[Any, ...] = (ip, port_int, 0, 0)
+    else:
+        family = socket.AF_INET
+        sockaddr = (ip, port_int)
+    return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+
+
 def _make_patched_getaddrinfo(original: Any) -> Any:
     """Return a getaddrinfo wrapper that consults the thread-local pin store.
 
@@ -531,39 +568,16 @@ def _make_patched_getaddrinfo(original: Any) -> Any:
 
     def _patched_getaddrinfo(host, port, *args, **kwargs):  # type: ignore[no-untyped-def]
         pins = _pin_store()
-        if not pins:
-            return original(host, port, *args, **kwargs)
-        if isinstance(host, (bytes, bytearray)):
-            try:
-                host_str = host.decode("idna")
-            except Exception:
-                host_str = host.decode("ascii", errors="replace")
-        else:
-            host_str = host
-        key = host_str.lower() if isinstance(host_str, str) else host_str
-        ips = pins.get(key) if isinstance(key, str) else None
+        key = _normalize_host(host) if pins else None
+        ips = pins.get(key) if key else None
         if not ips:
             return original(host, port, *args, **kwargs)
-        results: list[Any] = []
-        norm_port = port if port is not None else 0
-        try:
-            port_int = int(norm_port) if norm_port != "" else 0
-        except (TypeError, ValueError):
-            port_int = 0
-        for ip in ips:
-            try:
-                addr = ipaddress.ip_address(ip)
-            except ValueError:
-                continue
-            if isinstance(addr, ipaddress.IPv6Address):
-                family = socket.AF_INET6
-                sockaddr: tuple[Any, ...] = (ip, port_int, 0, 0)
-            else:
-                family = socket.AF_INET
-                sockaddr = (ip, port_int)
-            results.append(
-                (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
-            )
+        port_int = _coerce_port(port)
+        results: list[Any] = [
+            info
+            for info in (_addrinfo_for_pinned_ip(ip, port_int) for ip in ips)
+            if info is not None
+        ]
         if not results:
             # Shouldn't happen (we vet IPs before pinning) — fall back.
             return original(host, port, *args, **kwargs)

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -11,7 +11,8 @@ from typing import Any
 from PIL import Image
 from PIL.Image import Resampling
 
-from utils.http_utils import http_get
+from utils.http_utils import http_get, pinned_dns
+from utils.security_utils import validate_url_with_ips
 
 # ImageEnhance / ImageFilter / ImageOps are imported lazily from the
 # functions that use them (JTN-606).  Keeping them at module scope inflated
@@ -85,6 +86,9 @@ def load_image_from_path(
 def get_image(image_url, timeout_seconds: float = 10.0):
     """Fetch an image from a URL and return a PIL Image, or None on failure.
 
+    The hostname is validated and DNS-pinned for the duration of the fetch
+    to mitigate DNS-rebinding SSRF (JTN-656).
+
     Args:
         image_url: The URL of the image to fetch.
         timeout_seconds: Request timeout in seconds (default 10).
@@ -94,11 +98,22 @@ def get_image(image_url, timeout_seconds: float = 10.0):
         the response body cannot be decoded as an image.
     """
     try:
-        try:
-            response = http_get(image_url, timeout=timeout_seconds)
-        except TypeError:
-            # Fallback for tests that simulate environments without timeout support
-            response = http_get(image_url)
+        validated_url, pinned_ips = validate_url_with_ips(image_url)
+    except ValueError as exc:
+        logger.error(f"Rejected image URL {image_url}: {exc}")
+        return None
+
+    import urllib.parse as _urlparse
+
+    hostname = _urlparse.urlparse(validated_url).hostname or ""
+
+    try:
+        with pinned_dns(hostname, pinned_ips):
+            try:
+                response = http_get(validated_url, timeout=timeout_seconds)
+            except TypeError:
+                # Fallback for tests that simulate environments without timeout support
+                response = http_get(validated_url)
     except Exception as e:
         logger.error(f"Failed to fetch image from {image_url}: {str(e)}")
         return None
@@ -121,10 +136,25 @@ def fetch_and_resize_remote_image(
     dimensions: tuple[int, int],
     timeout_seconds: float = 40.0,
 ) -> Image.Image | None:
-    """Fetch a remote image and return a resized detached copy."""
+    """Fetch a remote image and return a resized detached copy.
+
+    The hostname is validated and DNS-pinned for the duration of the fetch
+    to mitigate DNS-rebinding SSRF (JTN-656).
+    """
     try:
-        response = http_get(image_url, timeout=timeout_seconds)
-        response.raise_for_status()
+        validated_url, pinned_ips = validate_url_with_ips(image_url)
+    except ValueError as exc:
+        logger.error(f"Rejected remote image URL {image_url}: {exc}")
+        return None
+
+    import urllib.parse as _urlparse
+
+    hostname = _urlparse.urlparse(validated_url).hostname or ""
+
+    try:
+        with pinned_dns(hostname, pinned_ips):
+            response = http_get(validated_url, timeout=timeout_seconds)
+            response.raise_for_status()
     except Exception as e:
         logger.error(f"Failed to fetch remote image from {image_url}: {e}")
         return None

--- a/src/utils/security_utils.py
+++ b/src/utils/security_utils.py
@@ -25,6 +25,26 @@ def validate_url(url: str) -> str:
         If the URL is empty, uses a disallowed scheme, targets localhost,
         or resolves to a private/reserved IP address.
     """
+    url_out, _ips = validate_url_with_ips(url)
+    return url_out
+
+
+def validate_url_with_ips(url: str) -> tuple[str, tuple[str, ...]]:
+    """Validate *url* and return ``(url, resolved_ips)``.
+
+    The returned IP tuple is the exact set of addresses the URL's hostname
+    resolved to at validation time.  Callers should pin DNS to these IPs for
+    the subsequent HTTP fetch (see :func:`utils.http_utils.pinned_dns`) to
+    mitigate DNS-rebinding SSRF where an attacker-controlled DNS server flips
+    the answer to a private IP between validation and the actual request
+    (JTN-656).
+
+    Raises
+    ------
+    ValueError
+        If the URL is empty, uses a disallowed scheme, targets localhost,
+        or resolves to a private/reserved IP address.
+    """
     if not url:
         raise ValueError("URL must not be empty")
 
@@ -44,6 +64,8 @@ def validate_url(url: str) -> str:
     try:
         addr = ipaddress.ip_address(hostname)
         _reject_private_ip(addr, hostname)
+        # Literal IP — no DNS required; the "resolved" set is the literal.
+        return url, (hostname,)
     except ValueError:
         # hostname is not a literal IP — fall through to DNS resolution
         pass
@@ -54,12 +76,18 @@ def validate_url(url: str) -> str:
     except socket.gaierror as exc:
         raise ValueError("Cannot resolve hostname") from exc
 
+    resolved: list[str] = []
     for info in addr_infos:
-        ip_str = info[4][0]
+        ip_str = str(info[4][0])
         addr = ipaddress.ip_address(ip_str)
         _reject_private_ip(addr, hostname)
+        if ip_str not in resolved:
+            resolved.append(ip_str)
 
-    return url
+    if not resolved:
+        raise ValueError("Cannot resolve hostname")
+
+    return url, tuple(resolved)
 
 
 def _reject_private_ip(

--- a/tests/unit/test_image_utils.py
+++ b/tests/unit/test_image_utils.py
@@ -198,6 +198,8 @@ def test_resize_image_zero_desired_height():
 
 def test_get_image_returns_correct_size(monkeypatch):
     """get_image returns an image with the correct dimensions."""
+    import socket
+
     buf = BytesIO()
     Image.new("RGB", (5, 5), "white").save(buf, format="PNG")
     png_bytes = buf.getvalue()
@@ -206,8 +208,15 @@ def test_get_image_returns_correct_size(monkeypatch):
         status_code = 200
         content = png_bytes
 
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ],
+    )
     monkeypatch.setattr("utils.image_utils.http_get", lambda url, **kwargs: Resp())
-    img = image_utils.get_image("http://example/img.png")
+    img = image_utils.get_image("http://example.com/img.png")
     assert img is not None
     assert img.size == (5, 5)
 

--- a/tests/unit/test_image_utils_edge.py
+++ b/tests/unit/test_image_utils_edge.py
@@ -12,6 +12,8 @@ def _png_bytes(size=(5, 5), color="white"):
 
 
 def test_get_image_timeout_fallback_success(monkeypatch):
+    import socket
+
     import utils.image_utils as image_utils
 
     calls = {"n": 0}
@@ -28,8 +30,15 @@ def test_get_image_timeout_fallback_success(monkeypatch):
             raise TypeError("timeout arg not supported")
         return Resp()
 
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ],
+    )
     monkeypatch.setattr("utils.image_utils.http_get", fake_get)
-    img = image_utils.get_image("http://example/img.png")
+    img = image_utils.get_image("http://example.com/img.png")
     assert img is not None
     assert img.size == (5, 5)
 

--- a/tests/unit/test_ssrf_dns_rebind.py
+++ b/tests/unit/test_ssrf_dns_rebind.py
@@ -1,0 +1,327 @@
+# pyright: reportMissingImports=false
+"""Regression tests for DNS-rebinding SSRF mitigation (JTN-656).
+
+``validate_url`` resolves DNS up-front to reject private targets, but the
+subsequent HTTP fetch resolves DNS *again* inside ``urllib3``.  A hostile
+authoritative server can flip the second answer to a private IP.  The
+mitigation introduced in JTN-656 pins DNS (via
+``utils.http_utils.pinned_dns``) to the IPs observed at validation time so
+the fetch socket connects to exactly one of the vetted addresses.
+
+These tests simulate the rebind by swapping ``socket.getaddrinfo`` between
+the validation call and the fetch, and assert the pinned IP is what the
+socket layer ends up using.
+"""
+
+from __future__ import annotations
+
+import socket
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ainfo(ip: str, port: int = 0) -> list:
+    """Build a minimal addrinfo tuple list for *ip* at *port*."""
+    try:
+        socket.inet_aton(ip)
+        family = socket.AF_INET
+        sockaddr: tuple = (ip, port)
+    except OSError:
+        family = socket.AF_INET6
+        sockaddr = (ip, port, 0, 0)
+    return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)]
+
+
+class _RebindingResolver:
+    """Callable that returns a public IP on first call, private IP afterward."""
+
+    def __init__(self, first: str, rebound: str) -> None:
+        self.first = first
+        self.rebound = rebound
+        self.calls: list[str] = []
+
+    def __call__(self, host, port=0, *args, **kwargs):
+        self.calls.append(host)
+        # First call (validation) → benign public IP
+        if len(self.calls) == 1:
+            return _ainfo(self.first, port or 0)
+        # Every subsequent call → private/metadata IP (the rebind)
+        return _ainfo(self.rebound, port or 0)
+
+
+# ---------------------------------------------------------------------------
+# validate_url_with_ips returns the exact IPs observed
+# ---------------------------------------------------------------------------
+
+
+def test_validate_url_with_ips_returns_resolved_addresses(monkeypatch):
+    from utils.security_utils import validate_url_with_ips
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: _ainfo("93.184.216.34"),
+    )
+    url, ips = validate_url_with_ips("https://example.com/path")
+    assert url == "https://example.com/path"
+    assert ips == ("93.184.216.34",)
+
+
+def test_validate_url_with_ips_literal_ip_shortcuts_dns(monkeypatch):
+    """A literal public IP should validate without DNS."""
+    from utils.security_utils import validate_url_with_ips
+
+    def _should_not_be_called(*a, **kw):  # pragma: no cover - guard only
+        raise AssertionError("getaddrinfo should not be invoked for literal IPs")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _should_not_be_called)
+    url, ips = validate_url_with_ips("http://93.184.216.34/page")
+    assert ips == ("93.184.216.34",)
+
+
+# ---------------------------------------------------------------------------
+# pinned_dns overrides getaddrinfo for the pinned hostname only
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_dns_forces_getaddrinfo_to_return_pinned_ip(monkeypatch):
+    from utils import http_utils
+
+    # Baseline resolver always claims a private IP — rebind in effect.
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: _ainfo("192.168.10.5"))
+
+    with http_utils.pinned_dns("example.com", ("93.184.216.34",)):
+        result = socket.getaddrinfo("example.com", 443)
+
+    assert (
+        result[0][4][0] == "93.184.216.34"
+    ), "pinned_dns must short-circuit DNS for the pinned hostname"
+
+
+def test_pinned_dns_does_not_affect_other_hostnames(monkeypatch):
+    from utils import http_utils
+
+    seen: dict[str, int] = {}
+
+    def real_resolver(host, port=0, *a, **kw):
+        seen[host] = seen.get(host, 0) + 1
+        return _ainfo("8.8.8.8", port or 0)
+
+    monkeypatch.setattr(socket, "getaddrinfo", real_resolver)
+
+    with http_utils.pinned_dns("pinned.example.com", ("93.184.216.34",)):
+        other = socket.getaddrinfo("other.example.net", 80)
+
+    assert other[0][4][0] == "8.8.8.8"
+    assert seen.get("other.example.net") == 1
+
+
+def test_pinned_dns_restores_previous_resolver_on_exit(monkeypatch):
+    from utils import http_utils
+
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: _ainfo("192.168.10.5"))
+    with http_utils.pinned_dns("example.com", ("93.184.216.34",)):
+        pass
+    # After exit the pin is removed — outer resolver takes over again
+    result = socket.getaddrinfo("example.com", 80)
+    assert result[0][4][0] == "192.168.10.5"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a DNS rebind between validate and fetch cannot escape the pin
+# ---------------------------------------------------------------------------
+
+
+def test_safe_http_get_pins_ip_across_dns_rebind(monkeypatch):
+    """Simulate an attacker flipping DNS between validate and fetch.
+
+    ``safe_http_get`` must use the IP resolved at validation time, not the
+    private IP the second resolution would return.
+    """
+    from utils import http_utils
+
+    http_utils._reset_shared_session_for_tests()
+
+    resolver = _RebindingResolver(first="93.184.216.34", rebound="169.254.169.254")
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+
+    seen_sockaddrs: list[tuple] = []
+
+    # Stand-in for urllib3's connect step: resolve the hostname through the
+    # same socket.getaddrinfo hook that requests/urllib3 would use.  We skip
+    # actually dialing a socket; the test asserts the resolver pick.
+    def fake_session_get(self, url, **kwargs):
+        import urllib.parse as _urlparse
+
+        host = _urlparse.urlparse(url).hostname or ""
+        addrs = socket.getaddrinfo(host, 443)
+        seen_sockaddrs.append(addrs[0][4])
+
+        class R:
+            status_code = 200
+            content = b""
+            headers: dict[str, str] = {}
+
+            def raise_for_status(self) -> None:
+                return None
+
+        return R()
+
+    import requests
+
+    monkeypatch.setattr(requests.Session, "get", fake_session_get, raising=True)
+
+    http_utils.safe_http_get("https://example.com/data")
+
+    assert seen_sockaddrs, "fetch step was not exercised"
+    fetched_ip = seen_sockaddrs[0][0]
+    assert (
+        fetched_ip == "93.184.216.34"
+    ), f"DNS-rebinding not prevented: fetch resolved to {fetched_ip}"
+    # Sanity: the validation step did resolve the hostname at least once.
+    # Subsequent resolutions are intercepted by ``pinned_dns`` and therefore
+    # never reach the attacker-controlled resolver — that *is* the fix.
+    assert resolver.calls[0] == "example.com"
+
+
+def test_fetch_and_resize_remote_image_pins_across_rebind(monkeypatch):
+    """fetch_and_resize_remote_image must not be tricked by a DNS flip."""
+    import utils.http_utils as http_utils
+    import utils.image_utils as image_utils
+
+    http_utils._reset_shared_session_for_tests()
+
+    resolver = _RebindingResolver(first="93.184.216.34", rebound="127.0.0.1")
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+
+    observed_ips: list[str] = []
+
+    def fake_http_get(url, **kwargs):
+        import urllib.parse as _urlparse
+
+        host = _urlparse.urlparse(url).hostname or ""
+        observed_ips.append(socket.getaddrinfo(host, 443)[0][4][0])
+
+        class R:
+            status_code = 200
+            # Invalid image bytes on purpose — we only care about the resolve.
+            content = b""
+
+            def raise_for_status(self) -> None:
+                return None
+
+        return R()
+
+    monkeypatch.setattr(image_utils, "http_get", fake_http_get)
+
+    image_utils.fetch_and_resize_remote_image(
+        "https://example.com/pic.jpg", (10, 10), timeout_seconds=1.0
+    )
+
+    assert observed_ips == ["93.184.216.34"], observed_ips
+
+
+def test_get_image_pins_across_rebind(monkeypatch):
+    """get_image must resolve through the pinned IP even if DNS flips."""
+    import utils.http_utils as http_utils
+    import utils.image_utils as image_utils
+
+    http_utils._reset_shared_session_for_tests()
+
+    resolver = _RebindingResolver(first="93.184.216.34", rebound="10.0.0.5")
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+
+    observed_ips: list[str] = []
+
+    def fake_http_get(url, **kwargs):
+        import urllib.parse as _urlparse
+
+        host = _urlparse.urlparse(url).hostname or ""
+        observed_ips.append(socket.getaddrinfo(host, 80)[0][4][0])
+
+        class R:
+            status_code = 500  # short-circuits decode path
+            content = b""
+
+        return R()
+
+    monkeypatch.setattr(image_utils, "http_get", fake_http_get)
+
+    image_utils.get_image("http://example.com/img.png")
+
+    assert observed_ips == ["93.184.216.34"], observed_ips
+
+
+def test_safe_http_get_rejects_private_ip_even_when_first_resolution_is_private(
+    monkeypatch,
+):
+    """If the *first* DNS answer is already private, validation rejects it."""
+    from utils import http_utils
+
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: _ainfo("192.168.1.1"))
+
+    try:
+        http_utils.safe_http_get("http://evil.example.com/x")
+    except ValueError as exc:
+        assert "private" in str(exc).lower() or "loopback" in str(exc).lower()
+    else:  # pragma: no cover - regression guard
+        raise AssertionError("safe_http_get should refuse a private-resolving host")
+
+
+# ---------------------------------------------------------------------------
+# Plugin-level: image_album pins DNS for Immich API calls
+# ---------------------------------------------------------------------------
+
+
+def test_image_album_immich_uses_pinned_ip_across_rebind(monkeypatch):
+    """ImageAlbum + Immich must pin DNS for the base URL across the fetch."""
+    from unittest.mock import MagicMock
+
+    import utils.http_utils as http_utils
+
+    http_utils._reset_shared_session_for_tests()
+
+    resolver = _RebindingResolver(first="93.184.216.34", rebound="127.0.0.1")
+    monkeypatch.setattr(socket, "getaddrinfo", resolver)
+
+    observed_hosts: list[str] = []
+
+    def _resolve_during_call(url: str, **_kwargs) -> MagicMock:
+        import urllib.parse as _urlparse
+
+        host = _urlparse.urlparse(url).hostname or ""
+        observed_hosts.append(socket.getaddrinfo(host, 443)[0][4][0])
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = []
+        return resp
+
+    session = MagicMock()
+    session.get = MagicMock(side_effect=_resolve_during_call)
+    session.post = MagicMock(side_effect=_resolve_during_call)
+
+    monkeypatch.setattr(
+        "plugins.image_album.image_album.get_http_session", lambda: session
+    )
+
+    from plugins.image_album.image_album import ImmichProvider
+    from utils.security_utils import validate_url_with_ips
+
+    url = "https://immich.example.com"
+    _, pinned_ips = validate_url_with_ips(url)
+
+    provider = ImmichProvider(
+        url, key="k", image_loader=MagicMock(), pinned_ips=pinned_ips
+    )
+
+    # DNS has now flipped to private — the pin must hold.
+    try:
+        provider.get_album_id("no-such-album")
+    except RuntimeError:
+        # Expected: empty album list → not found.  We only care about the
+        # host that was resolved during the call.
+        pass
+
+    assert observed_hosts == ["93.184.216.34"], observed_hosts


### PR DESCRIPTION
## Summary

- `validate_url` used to resolve DNS, check private ranges, then return. The subsequent `http_get` / `session.get` call re-resolved — a hostile authoritative server could flip the answer to `127.0.0.1`, `169.254.169.254`, `192.168.x`, etc. between the two lookups, bypassing the SSRF guard (classic DNS-rebinding).
- Fix: resolve **once**, pin the validated IPs for the actual fetch via a new `pinned_dns(hostname, ips)` context manager that wraps `socket.getaddrinfo`. The URL is unchanged so TLS SNI and certificate verification still happen against the original hostname.
- Propagated through `utils.image_utils` (image_url plugin) and `ImmichProvider` (image_album plugin). `safe_http_get` is available as a one-shot helper that validates + pins.

## Pinning approach

`socket.getaddrinfo` is monkey-patched for the duration of the request by a context manager. When the pinned hostname is queried, the wrapper returns pre-validated IPs; all other hostnames fall through to the normal resolver. This keeps the URL intact, so `requests`/`urllib3` still sets the correct `Host` header, TLS SNI, and certificate match against the hostname — which is critical for HTTPS. Alternatives (rewriting URL host to IP, subclassing `HTTPAdapter` to override `get_connection`) either broke TLS or required touching urllib3 internals.

## Tests

New file `tests/unit/test_ssrf_dns_rebind.py` — 10 tests:

- `test_validate_url_with_ips_returns_resolved_addresses`
- `test_validate_url_with_ips_literal_ip_shortcuts_dns`
- `test_pinned_dns_forces_getaddrinfo_to_return_pinned_ip`
- `test_pinned_dns_does_not_affect_other_hostnames`
- `test_pinned_dns_restores_previous_resolver_on_exit`
- `test_safe_http_get_pins_ip_across_dns_rebind` — swaps the resolver between validation and fetch and asserts the fetch still hits the original IP
- `test_fetch_and_resize_remote_image_pins_across_rebind`
- `test_get_image_pins_across_rebind`
- `test_safe_http_get_rejects_private_ip_even_when_first_resolution_is_private`
- `test_image_album_immich_uses_pinned_ip_across_rebind`

## Test plan

- [x] `scripts/lint.sh` — all blocking checks pass (Ruff, Black, mypy-strict, shellcheck)
- [x] Full suite: 4103 passed, 5 skipped, 3 pre-existing CSS failures unrelated to this change
- [x] New SSRF rebinding tests: 10/10 pass
- [ ] Smoke test image_url / image_album / screenshot plugins against a real public host

Closes JTN-656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)