### PR TITLE
fix(playlist): return details.field from every validator (JTN-658)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -41,20 +41,33 @@ _MSG_TIME_OVERLAP = "Playlist time range overlaps with existing playlist"
 _MSG_INVALID_PLAYLIST_REQUEST = "Invalid playlist request"
 
 
-def _validate_playlist_name(name):
-    """Validate playlist name format. Returns (cleaned_name, error_response) tuple."""
+def _validate_playlist_name(name, field="playlist_name"):
+    """Validate playlist name format. Returns (cleaned_name, error_response) tuple.
+
+    ``field`` is the form field name echoed back in ``details.field`` so the
+    frontend can highlight the offending input.
+    """
     if not name or not name.strip():
-        return None, json_error(PLAYLIST_NAME_REQUIRED_ERROR, status=400)
+        return None, json_error(
+            PLAYLIST_NAME_REQUIRED_ERROR,
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": field},
+        )
     name = name.strip()
     if len(name) > _PLAYLIST_NAME_MAX_LEN:
         return None, json_error(
             f"Playlist name must be {_PLAYLIST_NAME_MAX_LEN} characters or fewer",
             status=400,
+            code=_CODE_VALIDATION,
+            details={"field": field},
         )
     if not _PLAYLIST_NAME_RE.match(name):
         return None, json_error(
             "Playlist name may only contain letters, numbers, spaces, hyphens, and underscores",
             status=400,
+            code=_CODE_VALIDATION,
+            details={"field": field},
         )
     return name, None
 
@@ -124,7 +137,12 @@ def _check_playlist_overlap(new_start, new_end, playlists, exclude_name=None):
         ps = _to_minutes(pl.start_time)
         pe = _to_minutes(pl.end_time)
         if _windows_overlap(new_start, new_end, ps, pe):
-            return json_error(_MSG_TIME_OVERLAP, status=400)
+            return json_error(
+                _MSG_TIME_OVERLAP,
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "start_time"},
+            )
     return None
 
 
@@ -302,13 +320,25 @@ def add_plugin():
             return json_error(
                 "refresh_settings is required",
                 status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "refresh_settings"},
             )
         try:
             refresh_settings = json.loads(raw_refresh)
         except (json.JSONDecodeError, ValueError):
-            return json_error("Invalid JSON in refresh_settings", status=400)
+            return json_error(
+                "Invalid JSON in refresh_settings",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "refresh_settings"},
+            )
         if not isinstance(refresh_settings, dict):
-            return json_error("refresh_settings must be a JSON object", status=400)
+            return json_error(
+                "refresh_settings must be a JSON object",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "refresh_settings"},
+            )
         plugin_id = plugin_settings.pop("plugin_id", None)
         if not plugin_id or not isinstance(plugin_id, str):
             return json_error(
@@ -335,7 +365,10 @@ def add_plugin():
         existing = playlist_manager.find_plugin(plugin_id, instance_name)
         if existing:
             return json_error(
-                f"Plugin instance '{instance_name}' already exists", status=400
+                f"Plugin instance '{instance_name}' already exists",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "instance_name"},
             )
 
         refresh_config, refresh_err = validate_plugin_refresh_settings(refresh_settings)
@@ -500,19 +533,60 @@ def _validate_playlist_times(start_time, end_time):
 
     Returns (start_min, end_min, error_response).
     """
-    if not start_time or not end_time:
+    if not start_time:
+        missing_field = "start_time"
+    elif not end_time:
+        missing_field = "end_time"
+    else:
+        missing_field = None
+    if missing_field is not None:
         return (
             None,
             None,
-            json_error("Start time and End time are required", status=400),
+            json_error(
+                "Start time and End time are required",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": missing_field},
+            ),
         )
     try:
         start_min = _to_minutes(start_time)
+    except Exception:
+        return (
+            None,
+            None,
+            json_error(
+                _MSG_INVALID_TIME_FORMAT,
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "start_time"},
+            ),
+        )
+    try:
         end_min = _to_minutes(end_time)
     except Exception:
-        return None, None, json_error(_MSG_INVALID_TIME_FORMAT, status=400)
+        return (
+            None,
+            None,
+            json_error(
+                _MSG_INVALID_TIME_FORMAT,
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "end_time"},
+            ),
+        )
     if start_min == end_min:
-        return None, None, json_error(_MSG_SAME_TIME, status=400)
+        return (
+            None,
+            None,
+            json_error(
+                _MSG_SAME_TIME,
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "end_time"},
+            ),
+        )
     return start_min, end_min, None
 
 
@@ -527,7 +601,7 @@ def create_playlist():
 
     playlist_name, name_err = _validate_playlist_name(data.get("playlist_name"))
     if name_err:
-        return reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
+        return name_err
     start_min, end_min, time_err = _validate_playlist_times(
         data.get("start_time"), data.get("end_time")
     )
@@ -537,7 +611,12 @@ def create_playlist():
     try:
         playlist = playlist_manager.get_playlist(playlist_name)
         if playlist:
-            return json_error("A playlist with that name already exists", status=400)
+            return json_error(
+                "A playlist with that name already exists",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "playlist_name"},
+            )
 
         # Prevent overlapping time windows
         try:
@@ -598,11 +677,18 @@ def _validate_cycle_minutes(cycle_minutes):
     try:
         cm = int(cycle_minutes)
     except (ValueError, TypeError):
-        return None, json_error("cycle_minutes must be an integer", status=400)
+        return None, json_error(
+            "cycle_minutes must be an integer",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "cycle_minutes"},
+        )
     if cm < _CYCLE_MINUTES_MIN or cm > _CYCLE_MINUTES_MAX:
         return None, json_error(
             f"cycle_minutes must be between {_CYCLE_MINUTES_MIN} and {_CYCLE_MINUTES_MAX}",
             status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "cycle_minutes"},
         )
     return cm, None
 
@@ -629,20 +715,31 @@ def update_playlist(playlist_name):
         return json_error("Invalid JSON data", status=400)
 
     new_name_raw = data.get("new_name")
-    new_name, name_err = _validate_playlist_name(new_name_raw)
+    new_name, name_err = _validate_playlist_name(new_name_raw, field="new_name")
     if name_err:
-        return reissue_json_error(name_err, _MSG_INVALID_PLAYLIST_REQUEST)
+        return name_err
     start_time = data.get("start_time")
     end_time = data.get("end_time")
     if not start_time or not end_time:
-        return json_error("Missing required fields", status=400)
+        missing_field = "start_time" if not start_time else "end_time"
+        return json_error(
+            "Missing required fields",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": missing_field},
+        )
     start_min, end_min, time_err = _validate_playlist_times(start_time, end_time)
     if time_err:
         return time_err
 
     playlist = playlist_manager.get_playlist(playlist_name)
     if not playlist:
-        return json_error("Playlist does not exist", status=400)
+        return json_error(
+            "Playlist does not exist",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "playlist_name"},
+        )
 
     # Prevent overlapping (exclude the playlist being updated)
     try:
@@ -690,11 +787,21 @@ def delete_playlist(playlist_name):
     playlist_manager = device_config.get_playlist_manager()
 
     if not playlist_name:
-        return json_error(PLAYLIST_NAME_REQUIRED_ERROR, status=400)
+        return json_error(
+            PLAYLIST_NAME_REQUIRED_ERROR,
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "playlist_name"},
+        )
 
     playlist = playlist_manager.get_playlist(playlist_name)
     if not playlist:
-        return json_error("Playlist does not exist", status=400)
+        return json_error(
+            "Playlist does not exist",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "playlist_name"},
+        )
 
     device_config.update_atomic(
         lambda cfg: playlist_manager.delete_playlist(playlist_name)
@@ -712,9 +819,19 @@ def update_device_cycle():
     try:
         m = int(minutes)
         if m < 1 or m > 1440:
-            return json_error("Minutes must be between 1 and 1440", status=400)
+            return json_error(
+                "Minutes must be between 1 and 1440",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "minutes"},
+            )
     except Exception:
-        return json_error("Invalid minutes", status=400)
+        return json_error(
+            "Invalid minutes",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "minutes"},
+        )
     try:
         device_config.update_value("plugin_cycle_interval_seconds", m * 60, write=True)
         try:
@@ -739,12 +856,29 @@ def reorder_plugins():
             return json_error("Invalid or missing JSON payload", status=400)
         playlist_name = data.get("playlist_name")
         ordered = data.get("ordered")  # list of {plugin_id, name}
-        if not playlist_name or not isinstance(ordered, list):
-            return json_error("playlist_name and ordered list are required", status=400)
+        if not playlist_name:
+            return json_error(
+                "playlist_name and ordered list are required",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "playlist_name"},
+            )
+        if not isinstance(ordered, list):
+            return json_error(
+                "playlist_name and ordered list are required",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "ordered"},
+            )
 
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error("Playlist not found", status=400)
+            return json_error(
+                "Playlist not found",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "playlist_name"},
+            )
 
         reorder_result: list[bool] = []
 
@@ -776,18 +910,33 @@ def display_next_in_playlist():
             return json_error("Invalid or missing JSON payload", status=400)
         playlist_name = data.get("playlist_name")
         if not playlist_name:
-            return json_error("playlist_name required", status=400)
+            return json_error(
+                "playlist_name required",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "playlist_name"},
+            )
 
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error("Playlist not found", status=400)
+            return json_error(
+                "Playlist not found",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "playlist_name"},
+            )
 
         # Determine current time and next eligible
         current_dt = _safe_now_device_tz(device_config)
 
         plugin_instance = playlist.get_next_eligible_plugin(current_dt)
         if not plugin_instance:
-            return json_error("No eligible instance in playlist", status=400)
+            return json_error(
+                "No eligible instance in playlist",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "playlist_name"},
+            )
 
         refresh_task.manual_update(
             PlaylistRefresh(playlist, plugin_instance, force=True)
@@ -822,7 +971,12 @@ def playlist_eta(playlist_name: str):
 
     pl = playlist_manager.get_playlist(playlist_name)
     if not pl:
-        return json_error("Playlist not found", status=404)
+        return json_error(
+            "Playlist not found",
+            status=404,
+            code=_CODE_VALIDATION,
+            details={"field": "playlist_name"},
+        )
 
     # Cache key is playlist name; invalidate once per minute
     now = _safe_now_device_tz(device_config)

--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -559,6 +559,31 @@
         return (globalThis.FormState && form) ? globalThis.FormState.attach(form) : null;
     }
 
+    /**
+     * Apply a server-side validation error (canonical JSON envelope
+     * `{ error, details: { field } }`) to the given FormState instance so the
+     * offending input gets `aria-invalid`, is focused, and scrolled into view.
+     * Falls back to `field_errors` maps for backwards compatibility, and
+     * silently no-ops when neither shape is present so callers can keep their
+     * generic toast fallback.
+     */
+    function applyFieldErrorFromResponse(fs, result) {
+        if (!fs || !result) return false;
+        if (result.field_errors && typeof result.field_errors === 'object') {
+            fs.setFieldErrors(result.field_errors);
+            return true;
+        }
+        const field = result.details && result.details.field;
+        if (field) {
+            const message = result.error || 'Invalid value';
+            fs.setFieldError(field, message);
+            return true;
+        }
+        return false;
+    }
+    // Export for tests / other modules.
+    globalThis.applyFieldErrorFromResponse = applyFieldErrorFromResponse;
+
     async function createPlaylist() {
         const fs = _scheduleFormState();
         if (fs) fs.clearErrors();
@@ -574,8 +599,8 @@
                     closeModal();
                     if (result.warning) { sessionStorage.setItem("storedMessage", JSON.stringify({ type: "warning", text: result.warning })); }
                     location.reload();
-                } else if (fs && result && result.field_errors) {
-                    fs.setFieldErrors(result.field_errors);
+                } else if (fs && result) {
+                    applyFieldErrorFromResponse(fs, result);
                 }
             } catch (error) { console.error("Error:", error); showResponseModal('failure', 'An error occurred while processing your request.'); }
         };
@@ -599,8 +624,8 @@
                     closeModal();
                     if (result.warning) { sessionStorage.setItem("storedMessage", JSON.stringify({ type: "warning", text: result.warning })); }
                     location.reload();
-                } else if (fs && result && result.field_errors) {
-                    fs.setFieldErrors(result.field_errors);
+                } else if (fs && result) {
+                    applyFieldErrorFromResponse(fs, result);
                 }
             } catch (error) { console.error("Error:", error); showResponseModal('failure', 'An error occurred while processing your request.'); }
         };

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -190,9 +190,11 @@
                 </div>
                 <div class="form-group">
                     <label for="start_time" class="form-label">Display from </label>
-                    <input type="time" id="start_time" name="start_time" class="form-input" step="60" value="09:00" aria-required="true" required>
+                    <input type="time" id="start_time" name="start_time" class="form-input" step="60" value="09:00" aria-required="true" aria-invalid="false" aria-describedby="start-time-error" required>
                     <label for="end_time" class="form-label"> to </label>
-                    <input type="time" id="end_time" name="end_time" class="form-input" step="60" value="17:00" aria-required="true" required>
+                    <input type="time" id="end_time" name="end_time" class="form-input" step="60" value="17:00" aria-required="true" aria-invalid="false" aria-describedby="end-time-error" required>
+                    <span id="start-time-error" class="validation-message" role="alert"></span>
+                    <span id="end-time-error" class="validation-message" role="alert"></span>
                 </div>
                 <div class="form-group">
                     <label for="cycle_minutes" class="form-label">Cycle override (minutes)</label>

--- a/tests/integration/test_playlist_more.py
+++ b/tests/integration/test_playlist_more.py
@@ -368,7 +368,12 @@ def test_create_playlist_missing_name(client):
         "/create_playlist", json={"start_time": "06:00", "end_time": "09:00"}
     )
     assert resp.status_code == 400
-    assert resp.get_json().get("error") == "Invalid playlist request"
+    data = resp.get_json()
+    # JTN-658: validator-owned messages are preserved end-to-end (they are
+    # static strings so safe) and carry ``details.field`` for frontend
+    # highlighting.
+    assert "required" in data["error"].lower()
+    assert data["details"]["field"] == "playlist_name"
 
 
 def test_create_playlist_missing_times(client):

--- a/tests/static/test_playlist_field_error_helper.py
+++ b/tests/static/test_playlist_field_error_helper.py
@@ -1,0 +1,40 @@
+"""JTN-658: playlist.js reads ``details.field`` from server validation errors
+and highlights the offending input via FormState.
+
+The helper ``applyFieldErrorFromResponse`` is a shared shim used by the
+create/update playlist flows so field-level attribution works even for
+back-ends that don't emit the legacy ``field_errors`` map.
+"""
+
+from __future__ import annotations
+
+
+def test_playlist_script_exposes_field_error_helper(client):
+    resp = client.get("/static/scripts/playlist.js")
+    assert resp.status_code == 200
+    js = resp.get_data(as_text=True)
+
+    # Helper symbol + callsite.
+    assert "applyFieldErrorFromResponse" in js
+    # Reads canonical envelope (details.field) with a field_errors fallback so
+    # older / newer deploys both work.
+    assert "result.details" in js
+    assert "result.field_errors" in js
+    # Uses FormState.setFieldError under the hood — that is where the
+    # aria-invalid + focus + scroll-into-view UX lives.
+    assert "setFieldError" in js
+
+
+def test_playlist_template_exposes_inline_time_errors(client):
+    """Start/end-time inputs must advertise an inline error region so
+    FormState.setFieldError can render the message inline rather than via a
+    toast the user can dismiss in under a second."""
+
+    resp = client.get("/playlist")
+    if resp.status_code != 200:
+        return  # auth redirect — tested elsewhere
+    body = resp.get_data(as_text=True)
+    assert 'id="start-time-error"' in body
+    assert 'id="end-time-error"' in body
+    assert 'aria-describedby="start-time-error"' in body
+    assert 'aria-describedby="end-time-error"' in body

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -733,19 +733,31 @@ class TestPlaylistEta:
 
 class TestPlaylistNameValidation:
     def test_create_playlist_name_too_long(self, client):
-        """Playlist name exceeding 64 characters should be rejected."""
+        """Playlist name exceeding 64 characters should be rejected with field attribution."""
         resp = _create_playlist(client, "A" * 65, "08:00", "12:00")
         assert resp.status_code == 400
-        assert resp.get_json()["error"] == "Invalid playlist request"
+        data = resp.get_json()
+        # Validator messages are safe static strings, so they are preserved
+        # (JTN-658) alongside the field attribution for frontend highlighting.
+        assert "64 characters" in data["error"]
+        assert data["details"]["field"] == "playlist_name"
+        assert data["code"] == "validation_error"
 
     def test_create_playlist_name_special_chars(self, client):
         """Playlist names containing script tags or path traversal should be rejected."""
         resp = _create_playlist(client, "<script>alert(1)</script>", "08:00", "12:00")
         assert resp.status_code == 400
-        assert resp.get_json()["error"] == "Invalid playlist request"
+        data = resp.get_json()
+        # Never reflect the raw input back; message is a static sanitised string.
+        assert "<script>" not in data["error"]
+        assert "only contain" in data["error"]
+        assert data["details"]["field"] == "playlist_name"
 
         resp = _create_playlist(client, "../etc/passwd", "08:00", "12:00")
         assert resp.status_code == 400
+        data = resp.get_json()
+        assert "../" not in data["error"]
+        assert data["details"]["field"] == "playlist_name"
 
     def test_create_playlist_name_valid_unicode(self, client, device_config_dev):
         r"""Unicode word characters (accented letters matched by \w) should be accepted."""
@@ -758,6 +770,230 @@ class TestPlaylistNameValidation:
         resp = _create_playlist(client, "My Playlist", "08:00", "12:00")
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Field-level error attribution (JTN-658)
+# ---------------------------------------------------------------------------
+
+
+class TestValidatorFieldAttribution:
+    """Every validator in playlist.py must return ``details.field`` so the
+    frontend can highlight the offending input (JTN-658)."""
+
+    def _assert_field(self, resp, field, *, status=400):
+        assert resp.status_code == status, resp.get_json()
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data.get("code") == "validation_error", data
+        assert data.get("details", {}).get("field") == field, data
+
+    # --- playlist name (create + update) ---
+
+    def test_create_missing_name(self, client):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": "", "start_time": "08:00", "end_time": "12:00"},
+        )
+        self._assert_field(resp, "playlist_name")
+
+    def test_create_whitespace_name(self, client):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": "   ", "start_time": "08:00", "end_time": "12:00"},
+        )
+        self._assert_field(resp, "playlist_name")
+
+    def test_create_duplicate_name(self, client):
+        _create_playlist(client, "Dup", "06:00", "08:00")
+        resp = _create_playlist(client, "Dup", "14:00", "16:00")
+        self._assert_field(resp, "playlist_name")
+
+    def test_update_name_invalid(self, client):
+        _create_playlist(client, "ToUpd", "06:00", "10:00")
+        resp = client.put(
+            "/update_playlist/ToUpd",
+            json={"new_name": "", "start_time": "06:00", "end_time": "10:00"},
+        )
+        self._assert_field(resp, "new_name")
+
+    def test_update_nonexistent_playlist(self, client):
+        resp = client.put(
+            "/update_playlist/Nope",
+            json={"new_name": "X", "start_time": "06:00", "end_time": "10:00"},
+        )
+        self._assert_field(resp, "playlist_name")
+
+    # --- time range ---
+
+    def test_missing_start_time(self, client):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": "T", "start_time": "", "end_time": "12:00"},
+        )
+        self._assert_field(resp, "start_time")
+
+    def test_missing_end_time(self, client):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": "T", "start_time": "08:00", "end_time": ""},
+        )
+        self._assert_field(resp, "end_time")
+
+    def test_invalid_start_time_format(self, client):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": "T", "start_time": "bogus", "end_time": "12:00"},
+        )
+        self._assert_field(resp, "start_time")
+
+    def test_invalid_end_time_format(self, client):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": "T", "start_time": "08:00", "end_time": "bogus"},
+        )
+        self._assert_field(resp, "end_time")
+
+    def test_same_start_end(self, client):
+        resp = _create_playlist(client, "Same", "10:00", "10:00")
+        self._assert_field(resp, "end_time")
+
+    def test_overlapping_windows(self, client):
+        _create_playlist(client, "First", "08:00", "12:00")
+        resp = _create_playlist(client, "Second", "10:00", "14:00")
+        self._assert_field(resp, "start_time")
+
+    def test_update_missing_time(self, client):
+        _create_playlist(client, "UpdT", "06:00", "10:00")
+        resp = client.put(
+            "/update_playlist/UpdT",
+            json={"new_name": "UpdT", "start_time": "", "end_time": "10:00"},
+        )
+        self._assert_field(resp, "start_time")
+
+    # --- cycle minutes ---
+
+    def test_cycle_minutes_non_integer(self, client):
+        _create_playlist(client, "Cyc", "06:00", "10:00")
+        resp = client.put(
+            "/update_playlist/Cyc",
+            json={
+                "new_name": "Cyc",
+                "start_time": "06:00",
+                "end_time": "10:00",
+                "cycle_minutes": "abc",
+            },
+        )
+        self._assert_field(resp, "cycle_minutes")
+
+    def test_cycle_minutes_out_of_range(self, client):
+        _create_playlist(client, "Cyc2", "06:00", "10:00")
+        resp = client.put(
+            "/update_playlist/Cyc2",
+            json={
+                "new_name": "Cyc2",
+                "start_time": "06:00",
+                "end_time": "10:00",
+                "cycle_minutes": 99999,
+            },
+        )
+        self._assert_field(resp, "cycle_minutes")
+
+    # --- delete ---
+
+    def test_delete_nonexistent(self, client):
+        resp = client.delete("/delete_playlist/Ghost")
+        self._assert_field(resp, "playlist_name")
+
+    # --- device cycle ---
+
+    def test_device_cycle_out_of_range(self, client):
+        resp = client.put("/update_device_cycle", json={"minutes": 0})
+        self._assert_field(resp, "minutes")
+
+    def test_device_cycle_invalid_type(self, client):
+        resp = client.put("/update_device_cycle", json={"minutes": "abc"})
+        self._assert_field(resp, "minutes")
+
+    # --- reorder ---
+
+    def test_reorder_missing_name(self, client):
+        resp = client.post(
+            "/reorder_plugins",
+            json={"ordered": []},
+        )
+        self._assert_field(resp, "playlist_name")
+
+    def test_reorder_missing_ordered(self, client):
+        resp = client.post(
+            "/reorder_plugins",
+            json={"playlist_name": "X"},
+        )
+        self._assert_field(resp, "ordered")
+
+    def test_reorder_playlist_not_found(self, client):
+        resp = client.post(
+            "/reorder_plugins",
+            json={"playlist_name": "Ghost", "ordered": []},
+        )
+        self._assert_field(resp, "playlist_name")
+
+    # --- display next ---
+
+    def test_display_next_missing_name(self, client):
+        resp = client.post("/display_next_in_playlist", json={})
+        self._assert_field(resp, "playlist_name")
+
+    def test_display_next_not_found(self, client):
+        resp = client.post("/display_next_in_playlist", json={"playlist_name": "Ghost"})
+        self._assert_field(resp, "playlist_name")
+
+    # --- ETA ---
+
+    def test_eta_not_found(self, client):
+        resp = client.get("/playlist/eta/Ghost")
+        self._assert_field(resp, "playlist_name", status=404)
+
+    # --- add_plugin ---
+
+    def test_add_plugin_missing_refresh(self, client):
+        resp = client.post(
+            "/add_plugin",
+            data={"plugin_id": "weather"},
+        )
+        self._assert_field(resp, "refresh_settings")
+
+    def test_add_plugin_invalid_refresh_json(self, client):
+        resp = client.post(
+            "/add_plugin",
+            data={"plugin_id": "weather", "refresh_settings": "not-json"},
+        )
+        self._assert_field(resp, "refresh_settings")
+
+    def test_add_plugin_missing_instance(self, client):
+        _create_playlist(client, "APIPlaylist", "08:00", "12:00")
+        resp = client.post(
+            "/add_plugin",
+            data={
+                "plugin_id": "weather",
+                "refresh_settings": json.dumps(
+                    {
+                        "playlist": "APIPlaylist",
+                        "instance_name": "",
+                        "refreshType": "interval",
+                        "unit": "minute",
+                        "interval": "10",
+                    }
+                ),
+            },
+        )
+        self._assert_field(resp, "instance_name", status=422)
+
+    def test_add_plugin_duplicate_instance(self, client):
+        _create_playlist(client, "Dup2", "08:00", "12:00")
+        _add_plugin_to_playlist(client, "Dup2", "Same", "weather")
+        resp = _add_plugin_to_playlist(client, "Dup2", "Same", "weather")
+        self._assert_field(resp, "instance_name")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes JTN-658. Every validation failure in `src/blueprints/playlist.py` now returns the canonical error envelope with `details.field` populated, so the frontend can highlight the offending input. Previously, only `validate_plugin_refresh_settings` did this; the rest emitted generic messages that `reissue_json_error` further flattened to "Invalid playlist request".

## Changes
- **Backend** (`src/blueprints/playlist.py`): every validator and inline validation branch now emits `code=\"validation_error\"` + `details={\"field\": ...}`. Stopped round-tripping validator errors through `reissue_json_error` — their messages are static strings, so they can be surfaced verbatim (the masking was the chief source of "can't tell which field broke" reports). Validators covered:
  - `_validate_playlist_name` (with field override for `new_name` path)
  - `_validate_playlist_times` (distinguishes `start_time` / `end_time`)
  - `_validate_cycle_minutes`
  - `_check_playlist_overlap`
  - Inline validators in `add_plugin`, `delete_playlist`, `update_device_cycle`, `reorder_plugins`, `display_next_in_playlist`, `playlist_eta`, and duplicate-name check in `create_playlist` / `update_playlist`.
- **Frontend** (`src/static/scripts/playlist.js`): new `applyFieldErrorFromResponse(fs, result)` helper reads `details.field`, falls back to legacy `field_errors` map, and defers to the existing `FormState.setFieldError` utility (aria-invalid, focus, scroll into view). Reused in both create and update submit paths.
- **Template** (`src/templates/playlist.html`): add inline `.validation-message` regions + `aria-describedby` for the `start_time` / `end_time` inputs so `FormState` can render server messages inline.
- **Tests**: new `TestValidatorFieldAttribution` class (22 cases) in `tests/unit/test_playlist_blueprint.py` asserting `details.field` on every validator path. New `tests/static/test_playlist_field_error_helper.py` verifying the helper is exported and the template wires the inline error regions. Updated two legacy assertions to match the new (better) message surface.

## Backwards compatibility
- JSON envelope is additive — older frontends ignoring `details.field` fall back to the `error` message as before.
- `reissue_json_error`'s detail-stripping behavior is unchanged for non-validator paths (e.g. unsupported media type); existing `test_http_utils.py::test_reissue_json_error_uses_fallback_message` still passes.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/` — 4,152 passed, 5 skipped
- [x] `scripts/lint.sh` — all blocking checks pass (ruff / black / mypy-strict / shellcheck)
- [ ] Manual smoke: submit invalid playlist create form, confirm the offending input is focused / outlined

🤖 Generated with [Claude Code](https://claude.com/claude-code)