### PR TITLE
fix(ci): wire build-wheelhouse to Release workflow_run (JTN-683)

### DIFF
--- a/.github/workflows/build-wheelhouse.yml
+++ b/.github/workflows/build-wheelhouse.yml
@@ -5,13 +5,26 @@ name: Build release wheelhouse
 # available, dropping first-boot install time on a Pi Zero 2 W from ~15 min
 # down to ~2-3 min (no on-device wheel compilation for numpy/Pillow/cffi/etc).
 #
-# Triggers only when a release is published (e.g. by semantic-release). The
-# workflow itself is not exercised in PR CI — install.sh carries a graceful
-# fallback so a missing bundle is a no-op.
+# JTN-683 FIX: The original `on: release: types: [published]` trigger never
+# fired because semantic-release creates releases using GITHUB_TOKEN, and
+# GitHub intentionally prevents GITHUB_TOKEN-created events from triggering
+# downstream workflow event listeners (a documented security boundary).
+#
+# Fix: added `workflow_run` trigger watching the "Release" workflow. This is
+# a first-party mechanism that explicitly allows cross-workflow chaining
+# regardless of which token the upstream workflow used. Gated on
+# `conclusion == 'success'` so we only build wheels when a real release
+# was actually cut. The release event trigger is kept for forward
+# compatibility (in case we ever switch to a PAT-based release flow).
 
 on:
   release:
     types: [published]
+  # Fires when the Release workflow completes successfully — works even when
+  # semantic-release uses GITHUB_TOKEN (which suppresses the release event).
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   # Manual trigger so maintainers can rebuild wheels for an existing tag
   # without cutting a new release.
   workflow_dispatch:
@@ -25,12 +38,68 @@ permissions:
   contents: write
 
 concurrency:
-  group: build-wheelhouse-${{ github.event.release.tag_name || inputs.tag }}
+  group: build-wheelhouse-${{ github.event.release.tag_name || inputs.tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
+  # Guard job: for workflow_run events, skip if the upstream run did not
+  # succeed (e.g. it was cancelled or failed with no new release).
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+      tag: ${{ steps.gate.outputs.tag }}
+    steps:
+      - name: Evaluate trigger and resolve tag
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+          WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            release)
+              TAG="$RELEASE_TAG"
+              ;;
+            workflow_dispatch)
+              TAG="$DISPATCH_TAG"
+              ;;
+            workflow_run)
+              if [ "$WF_CONCLUSION" != "success" ]; then
+                echo "Upstream Release workflow did not succeed (conclusion=$WF_CONCLUSION) — skipping."
+                echo "should-run=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              # Find the most recent release tag created by the Release workflow.
+              # semantic-release always creates a tag that matches vMAJOR.MINOR.PATCH.
+              TAG=$(gh release list --repo "$REPO" --limit 1 \
+                --json tagName --jq '.[0].tagName')
+              if [ -z "$TAG" ]; then
+                echo "ERROR: Could not resolve latest release tag after workflow_run" >&2
+                exit 1
+              fi
+              echo "Resolved tag from latest release: $TAG"
+              ;;
+            *)
+              echo "ERROR: Unexpected event name: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [ -z "$TAG" ]; then
+            echo "ERROR: No release tag resolved" >&2
+            exit 1
+          fi
+          echo "should-run=true" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
   build-wheels:
     name: Build wheels (${{ matrix.arch }})
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -45,12 +114,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ needs.check-trigger.outputs.tag }}
 
       - name: Resolve tag
         id: tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_TAG: ${{ needs.check-trigger.outputs.tag }}
         run: |
           TAG="$RELEASE_TAG"
           if [ -z "$TAG" ]; then
@@ -126,7 +195,7 @@ jobs:
           ls -la "$TARBALL" "${TARBALL}.sha256"
 
       - name: Attach wheelhouse to release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_run'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## Summary

- **Root cause confirmed**: `on: release: types: [published]` in `build-wheelhouse.yml` never triggered because GitHub intentionally blocks GITHUB_TOKEN-created events from firing downstream workflow listeners. The `release.yml` workflow uses `secrets.GITHUB_TOKEN` for semantic-release, so the `release.published` event is invisible to other workflows.
- **Fix**: Added `workflow_run: workflows: ["Release"] types: [completed]` trigger — this is GitHub's first-party cross-workflow chaining mechanism and works regardless of which token the upstream workflow used.
- **Guard job**: New `check-trigger` job evaluates the event type, skips if upstream run didn't succeed (`conclusion != 'success'`), and resolves the release tag correctly for all three trigger paths.
- **Upload condition**: Updated `Attach wheelhouse to release` step to also fire on `workflow_run` events (not just `release`), so wheels attach to the GitHub release in the automated path.
- **Kept `release` trigger**: Retained for forward compatibility in case we ever switch to a PAT-based release flow.

## Changes

- `.github/workflows/build-wheelhouse.yml` — add `workflow_run` trigger, new `check-trigger` guard job, fix upload conditions

## Why `workflow_run` instead of alternatives

| Option | Pros | Cons |
|--------|------|------|
| `workflow_run` trigger (chosen) | No secrets needed, first-party, no changes to release.yml | Tag resolved via `gh release list` (tiny race window, inconsequential) |
| PAT for semantic-release | Cleanest trigger path | Requires creating + rotating a fine-grained PAT; adds secret management overhead |
| `gh workflow run` from release.yml | Explicit push from upstream | Couples release.yml to wheelhouse workflow; adds `actions: write` permission |

`workflow_run` is the lowest-friction, zero-new-secrets fix.

## Test plan

- [ ] After merge, confirm next release (or re-run via `workflow_dispatch`) triggers the wheelhouse build
- [ ] Backfill v0.51.1 manually: `gh workflow run build-wheelhouse.yml -f tag=v0.51.1 --repo jtn0123/InkyPi`
- [ ] Verify `inkypi-wheels-0.51.1-linux_armv7l.tar.gz` and `linux_aarch64` appear in the v0.51.1 release assets
- [ ] SSH to Pi and confirm update prints "using wheelhouse" instead of "falling back to source install"

## Follow-up (not in this PR)

Backfill wheels for v0.51.1 via `workflow_dispatch` — documented in test plan above. This PR only fixes the trigger; it does not retroactively run for past releases.

Closes JTN-683