### PR TITLE
fix(install): copy inkypi-failure.service in update.sh (JTN-686)

### DIFF
--- a/install/_common.sh
+++ b/install/_common.sh
@@ -138,6 +138,28 @@ build_css_bundle() {
 }
 
 # ---------------------------------------------------------------------------
+# Systemd unit helpers (JTN-686)
+#
+# install_failure_service_unit — copy inkypi-failure.service to
+# /etc/systemd/system/. Called by both install.sh and update.sh so every code
+# path that refreshes the main inkypi.service unit also refreshes the
+# OnFailure= sentinel unit.  Not enabled (it is activated via OnFailure=).
+#
+# Requires SCRIPT_DIR to be set by the sourcing script.
+# ---------------------------------------------------------------------------
+
+install_failure_service_unit() {
+  local src="$SCRIPT_DIR/inkypi-failure.service"
+  local dst="/etc/systemd/system/inkypi-failure.service"
+  if [ -f "$src" ]; then
+    cp "$src" "$dst"
+  else
+    echo_error "ERROR: Failure service file $src not found!"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Wheelhouse helpers (JTN-604 / JTN-669)
 #
 # fetch_wheelhouse / cleanup_wheelhouse — extracted in PR #450.

--- a/install/install.sh
+++ b/install/install.sh
@@ -313,18 +313,10 @@ install_app_service() {
     exit 1
   fi
 
-  # JTN-671: Install the failure-sentinel helper unit. OnFailure= in
-  # inkypi.service activates this when the start-limit is hit; it writes
-  # /var/lib/inkypi/.start-limit-hit so status checks can detect a broken
-  # install without parsing journalctl.
-  FAILURE_SERVICE_SOURCE="$SCRIPT_DIR/inkypi-failure.service"
-  FAILURE_SERVICE_TARGET="/etc/systemd/system/inkypi-failure.service"
-  if [ -f "$FAILURE_SERVICE_SOURCE" ]; then
-    cp "$FAILURE_SERVICE_SOURCE" "$FAILURE_SERVICE_TARGET"
-  else
-    echo_error "ERROR: Failure service file $FAILURE_SERVICE_SOURCE not found!"
-    exit 1
-  fi
+  # JTN-671/686: Install the failure-sentinel helper unit via shared helper in
+  # _common.sh so install.sh and update.sh always copy inkypi-failure.service
+  # together with inkypi.service — keeps OnFailure= from dangling after updates.
+  install_failure_service_unit
 
   sudo systemctl daemon-reload
   sudo systemctl enable $SERVICE_FILE

--- a/install/update.sh
+++ b/install/update.sh
@@ -41,6 +41,9 @@ update_app_service() {
   echo "Updating $APPNAME systemd service."
   if [ -f "$SERVICE_FILE_SOURCE" ]; then
     sudo cp "$SERVICE_FILE_SOURCE" "$SERVICE_FILE_TARGET"
+    # JTN-686: Also refresh inkypi-failure.service so the OnFailure= directive
+    # in inkypi.service never dangles on pre-JTN-671 installs that are updating.
+    install_failure_service_unit
     sudo systemctl daemon-reload
     sudo systemctl enable "$SERVICE_FILE"
     echo "Starting $APPNAME service."


### PR DESCRIPTION
## Summary

- `update.sh` was not copying `inkypi-failure.service` to `/etc/systemd/system/`, causing `inkypi.service`'s `OnFailure=inkypi-failure.service` to dangle on every update with: *"Unit inkypi-failure.service not found"*
- Added `install_failure_service_unit` helper to `install/_common.sh` (JTN-674 pattern) that copies `inkypi-failure.service` to `/etc/systemd/system/`
- Refactored `install.sh`'s inline copy block to call the shared helper
- `update.sh`'s `update_app_service()` now calls the same helper, so every update path refreshes both units together before `daemon-reload`

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [ ] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [ ] Docs updated for new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

## Testing

- `scripts/lint.sh` passes (ruff + black + shellcheck + mypy strict)
- After `do_update.sh`, both `/etc/systemd/system/inkypi.service` and `/etc/systemd/system/inkypi-failure.service` will be present
- No "Unit inkypi-failure.service not found" in journal after update
- No `enable` call added — `inkypi-failure.service` is activated exclusively via `OnFailure=`

Fixes JTN-686