### PR TITLE
fix(install): check systemctl is-active after start in update_app_service (JTN-684)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -45,6 +45,29 @@ update_app_service() {
     sudo systemctl enable "$SERVICE_FILE"
     echo "Starting $APPNAME service."
     sudo systemctl start "$SERVICE_FILE"
+    # JTN-684: Explicitly verify the service reached active state.
+    # systemctl start exits 0 even when the service subsequently fails
+    # (e.g. ExecStart returns non-zero), so we poll is-active with a short
+    # retry loop to give systemd a moment to settle before declaring failure.
+    local attempts=0
+    local max_attempts=3
+    local active=0
+    while [ "$attempts" -lt "$max_attempts" ]; do
+      if sudo systemctl is-active --quiet "$SERVICE_FILE"; then
+        active=1
+        break
+      fi
+      attempts=$(( attempts + 1 ))
+      [ "$attempts" -lt "$max_attempts" ] && sleep 1
+    done
+    if [ "$active" -eq 0 ]; then
+      echo_error "ERROR: $SERVICE_FILE failed to start (not active after $max_attempts attempt(s))."
+      echo "Service status:" >&2
+      sudo systemctl show -p ActiveState,SubState,Result "$SERVICE_FILE" >&2 || true
+      echo "Last 20 journal lines:" >&2
+      sudo journalctl -u "$APPNAME" -n 20 --no-pager >&2 || true
+      exit 1
+    fi
   else
     echo_error "ERROR: Service file $SERVICE_FILE_SOURCE not found!"
     exit 1

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1596,6 +1596,48 @@ class TestUpdateScript:
                 "--no-cache" in block
             ), f"uv pip install in update.sh missing --no-cache (JTN-602 parity): {block!r}"
 
+    def test_update_app_service_checks_is_active_after_start(self):
+        # JTN-684: update_app_service() must verify the service reached active
+        # state after systemctl start. systemctl start exits 0 even when the
+        # service subsequently fails, so an explicit is-active check is required.
+        fn_start = self.content.index("update_app_service() {")
+        fn_end = self.content.index("\n}", fn_start) + 2
+        fn_body = self.content[fn_start:fn_end]
+        assert (
+            "systemctl start" in fn_body
+        ), "update_app_service must call systemctl start"
+        start_pos = fn_body.index("systemctl start")
+        assert (
+            "is-active" in fn_body
+        ), "update_app_service must check 'systemctl is-active' after start (JTN-684)"
+        is_active_pos = fn_body.index("is-active")
+        assert (
+            is_active_pos > start_pos
+        ), "'systemctl is-active' check must appear after 'systemctl start' (JTN-684)"
+
+    def test_update_app_service_exits_nonzero_on_start_failure(self):
+        # JTN-684: if the service is not active after starting, the script must
+        # exit non-zero so callers know the update failed.
+        fn_start = self.content.index("update_app_service() {")
+        fn_end = self.content.index("\n}", fn_start) + 2
+        fn_body = self.content[fn_start:fn_end]
+        assert (
+            "exit 1" in fn_body
+        ), "update_app_service must 'exit 1' when service fails to start (JTN-684)"
+
+    def test_update_app_service_dumps_journal_on_start_failure(self):
+        # JTN-684: on service-start failure, the user must see journal output
+        # instead of a misleading "Update completed" success message.
+        fn_start = self.content.index("update_app_service() {")
+        fn_end = self.content.index("\n}", fn_start) + 2
+        fn_body = self.content[fn_start:fn_end]
+        assert (
+            "journalctl" in fn_body
+        ), "update_app_service must dump journalctl output when service fails to start (JTN-684)"
+        assert (
+            "--no-pager" in fn_body
+        ), "journalctl in update_app_service must use --no-pager for non-interactive output (JTN-684)"
+
 
 # ---- uninstall.sh ----
 


### PR DESCRIPTION
## Summary

- **Bug**: `update_app_service()` in `install/update.sh` called `sudo systemctl start` without verifying the service reached the active state. `systemctl start` exits 0 even when the unit's ExecStart subsequently fails, so the script would print "Update completed ✔" and exit 0 while `inkypi.service` sat in a failed/inactive state.
- **Fix**: After `systemctl start`, add a retry loop (3 attempts × 1 s sleep) that checks `systemctl is-active --quiet`. On failure: dump `systemctl show` ActiveState/SubState/Result and the last 20 journal lines (via `journalctl -u inkypi -n 20 --no-pager`) to stderr, print a clear error message, and exit 1. On success, the existing flow is unchanged.
- **Tests**: Three new tests in `TestUpdateScript` assert that `update_app_service()` contains a `systemctl is-active` check, an `exit 1` branch, and a `--no-pager` journalctl call.

## Changes

- `install/update.sh` — added post-start `is-active` polling loop + failure handling inside `update_app_service()`
- `tests/unit/test_install_scripts.py` — three new `TestUpdateScript` tests covering JTN-684 acceptance criteria

## Test plan

- [x] `shellcheck --severity=warning install/update.sh` passes
- [x] `scripts/lint.sh` passes (ruff + black + shellcheck all green)
- [x] All 23 `TestUpdateScript` tests pass (including 3 new ones)
- [x] Pre-existing test count unchanged (146 failed, 2414 passed — same as main; failures are unrelated `prometheus_client` import errors)
- [ ] Manual: induce failure with `ExecStart=/bin/false` → confirm exit non-zero + journal tail printed, no "Update completed ✔"
- [ ] Manual: healthy update on `inkypi.local` → confirm success path unchanged

Fixes JTN-684. Follow-up to JTN-665 (pip exit-code check).