### PR TITLE
fix(update): remove lockfile before systemctl start, add EXIT trap (JTN-685)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -66,11 +66,21 @@ fi
 
 # JTN-666: Create the install-in-progress lockfile. inkypi.service's
 # ExecStartPre refuses to start while this file exists (defense-in-depth for
-# JTN-600's systemctl disable). The lockfile is removed once all update steps
-# succeed (see near end of script); on failure exit it is left in place so the
-# user must rerun update.sh (or manually rm it) before the service can start.
+# JTN-600's systemctl disable). The lockfile is removed just before
+# update_app_service() calls `systemctl start` (see below); on intentional
+# failure exit it is left in place so the user must rerun update.sh (or
+# manually rm it) before the service can start.
 mkdir -p "$LOCKFILE_DIR"
 touch "$LOCKFILE"
+
+# JTN-685: Defense-in-depth EXIT trap for abnormal exits (SIGTERM, SIGHUP,
+# unhandled errors).  Intentional failure paths (exit 1 after an error message)
+# set _lockfile_keep=1 before exiting so the lockfile is intentionally
+# preserved — forcing a manual rerun.  Signals and unexpected exits leave
+# _lockfile_keep unset, so the trap clears the lockfile and allows the service
+# to start after the interruption.
+_lockfile_keep=0
+trap '[[ "${_lockfile_keep:-0}" -eq 1 ]] || rm -f "$LOCKFILE"' EXIT
 
 # JTN-666: Stop and disable the service BEFORE touching files or venv so
 # systemd cannot restart a half-installed service and thrash the Pi.
@@ -81,12 +91,12 @@ if [ -f "$APT_REQUIREMENTS_FILE" ]; then
   echo "Installing system dependencies... "
   if ! xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null; then
     echo_error "ERROR: apt-get install failed — aborting update."
-    exit 1
+    _lockfile_keep=1; exit 1
   fi
   echo_success "Installed system dependencies."
 else
   echo_error "ERROR: System dependencies file $APT_REQUIREMENTS_FILE not found!"
-  exit 1
+  _lockfile_keep=1; exit 1
 fi
 
 # Setup zramswap on any modern Pi OS that ships zram-tools (Bullseye/Bookworm/Trixie).
@@ -104,7 +114,7 @@ setup_earlyoom_service
 # Check if virtual environment exists
 if [ ! -d "$VENV_PATH" ]; then
   echo_error "ERROR: Virtual environment not found at $VENV_PATH. Run the installation script first."
-  exit 1
+  _lockfile_keep=1; exit 1
 fi
 
 # JTN-668: /tmp on Pi OS Trixie is a 213 MB tmpfs — too small for numpy's
@@ -128,7 +138,7 @@ echo "Upgrading pip..."
 # JTN-669: --retries 5 --timeout 60 --no-cache-dir for JTN-534/JTN-602 parity.
 if ! "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 --no-cache-dir --upgrade pip setuptools wheel > /dev/null; then
   echo_error "ERROR: pip/setuptools upgrade failed — aborting update."
-  exit 1
+  _lockfile_keep=1; exit 1
 fi
 echo_success "Pip upgraded successfully."
 
@@ -189,7 +199,7 @@ if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
         -r "$PIP_REQUIREMENTS_FILE"; then
       cleanup_wheelhouse
       echo_error "ERROR: uv pip install failed — aborting update (service remains stopped)."
-      exit 1
+      _lockfile_keep=1; exit 1
     fi
   else
     # pip fallback: --require-hashes + --no-cache-dir preserve JTN-516/JTN-602 guarantees.
@@ -199,7 +209,7 @@ if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
         -r "$PIP_REQUIREMENTS_FILE"; then
       cleanup_wheelhouse
       echo_error "ERROR: pip install failed — aborting update (service remains stopped)."
-      exit 1
+      _lockfile_keep=1; exit 1
     fi
   fi
   cleanup_wheelhouse
@@ -207,7 +217,7 @@ if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
 else
   cleanup_wheelhouse
   echo_error "ERROR: Requirements file $PIP_REQUIREMENTS_FILE not found!"
-  exit 1
+  _lockfile_keep=1; exit 1
 fi
 
 # Clean up the pip build temp dir — it can be several hundred MB.
@@ -221,20 +231,25 @@ sudo chmod +x "$BINPATH/$APPNAME"
 echo "Update JS and CSS files"
 if ! bash "$SCRIPT_DIR/update_vendors.sh" > /dev/null; then
   echo_error "ERROR: Vendor JS/CSS download failed. Check network connectivity and re-run."
-  exit 1
+  _lockfile_keep=1; exit 1
 fi
 
 # JTN-674: use shared build_css_bundle from _common.sh
+# build_css_bundle calls exit 1 internally on failure — mark as intentional so
+# the lockfile is preserved and the user is forced to rerun.
+_lockfile_keep=1
 build_css_bundle
+_lockfile_keep=0
 
 update_cli
-update_app_service
 
-# JTN-666: All update steps succeeded — remove the install-in-progress lockfile
-# so the service is allowed to start. If update.sh exits early due to a failure
-# above, this line is never reached and the lockfile stays in place, forcing the
-# user to rerun update.sh (or manually rm the file) before the service can start.
+# JTN-685: Remove the lockfile BEFORE starting the service. The ordering bug
+# was: update_app_service() called `systemctl start` while the lockfile was
+# still present, causing ExecStartPre to reject the start attempt.  All
+# dep-install work above is complete; it is now safe to release the lock.
 rm -f "$LOCKFILE"
+
+update_app_service
 
 echo "Version: $(cat "$INSTALL_PATH/VERSION" 2>/dev/null || echo 'unknown')"
 echo_success "Update completed."

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1373,16 +1373,36 @@ class TestUpdateScript:
             touch_pos < stop_pos
         ), "Lockfile must be created before stop_service is called"
 
-    def test_update_lockfile_removed_on_success(self):
-        # JTN-666: The lockfile must be removed after all steps succeed so the
-        # service is allowed to start. On failure, it stays to require manual recovery.
+    def test_update_lockfile_removed_before_service_start(self):
+        # JTN-685: The lockfile must be removed BEFORE update_app_service() is
+        # called so that ExecStartPre does not see the lockfile and reject the
+        # `systemctl start` invocation.  The old ordering (rm after start) caused
+        # the first service-start after every update to fail.
         assert 'rm -f "$LOCKFILE"' in self.content
-        # rm must come after update_app_service call
-        update_service_pos = self.content.rindex("update_app_service")
+        # rm must come BEFORE update_app_service call (last occurrence, which is
+        # the actual call site — the function definition also has the identifier)
+        update_service_call_pos = self.content.rindex("\nupdate_app_service\n")
         rm_pos = self.content.rindex('rm -f "$LOCKFILE"')
         assert (
-            rm_pos > update_service_pos
-        ), "Lockfile removal must come after update_app_service to ensure service is running"
+            rm_pos < update_service_call_pos
+        ), "Lockfile removal must come BEFORE update_app_service call (JTN-685)"
+
+    def test_update_has_exit_trap_for_lockfile(self):
+        # JTN-685: Defense-in-depth EXIT trap so SIGTERM / unhandled exits clean
+        # up the lockfile and don't permanently block the service.  Intentional
+        # failure paths set _lockfile_keep=1 before exit so the lockfile is
+        # preserved (forcing a manual rerun) while unhandled exits clear it.
+        assert "trap " in self.content, "update.sh must set a trap for EXIT"
+        assert "_lockfile_keep" in self.content, (
+            "update.sh must use _lockfile_keep sentinel to distinguish "
+            "intentional failure exits (keep lockfile) from abnormal exits (clear it)"
+        )
+        # The trap must be set after the lockfile is created
+        lockfile_pos = self.content.index('touch "$LOCKFILE"')
+        trap_pos = self.content.index("trap ")
+        assert trap_pos > lockfile_pos, (
+            "EXIT trap must be set after the lockfile is created"
+        )
 
     def test_update_upgrades_pip_deps(self):
         assert "pip install" in self.content

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1400,9 +1400,9 @@ class TestUpdateScript:
         # The trap must be set after the lockfile is created
         lockfile_pos = self.content.index('touch "$LOCKFILE"')
         trap_pos = self.content.index("trap ")
-        assert trap_pos > lockfile_pos, (
-            "EXIT trap must be set after the lockfile is created"
-        )
+        assert (
+            trap_pos > lockfile_pos
+        ), "EXIT trap must be set after the lockfile is created"
 
     def test_update_upgrades_pip_deps(self):
         assert "pip install" in self.content


### PR DESCRIPTION
## Summary

- **Bug**: `install/update.sh` called `systemctl start inkypi` while the install-in-progress lockfile was still present. `ExecStartPre` in `inkypi.service` rejects any start attempt while the lockfile exists → first service start after every update failed.
- **Fix**: Move `rm -f "$LOCKFILE"` to just before `update_app_service()` so ExecStartPre sees no lockfile when `systemctl start` runs. The lockfile still guards the entire dep-install phase.
- **Defense-in-depth**: Add `trap ... EXIT` with a `_lockfile_keep` sentinel — abnormal exits (SIGTERM, unhandled errors) clear the lockfile automatically; intentional failure exits (`_lockfile_keep=1`) preserve it to force a manual rerun.

## Changes

- `install/update.sh` — move `rm -f "$LOCKFILE"` before `update_app_service()` call; add EXIT trap + `_lockfile_keep` pattern; annotate all intentional failure exits with `_lockfile_keep=1`
- `tests/unit/test_install_scripts.py` — update `test_update_lockfile_removed_on_success` → `test_update_lockfile_removed_before_service_start` to assert the correct (fixed) ordering; add `test_update_has_exit_trap_for_lockfile`

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Test plan

- [x] All existing tests pass (`tests/unit/test_install_scripts.py` — 196 passed)
- [x] New tests added for lockfile ordering and EXIT trap
- [x] `scripts/lint.sh` passes (shellcheck + ruff + black + mypy strict subset all green)
- [ ] On-device verification: run `do_update.sh` on Pi — service starts first attempt, no "Install in progress" in journal
- [ ] Simulate SIGTERM mid-run — confirm lockfile cleared afterward

Closes JTN-685