### PR TITLE
test(ui): responsive mobile click-sweep (JTN-693)

### DIFF
--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -104,6 +104,19 @@ _XFAIL_PAGES: dict[str, str] = {
     ),
 }
 
+# Viewports to sweep. Desktop is the original coverage; mobile (360×800)
+# catches buttons/handlers that only break at narrow widths where menus
+# collapse, sidebars become drawers, and clickables may overlap or hide.
+_VIEWPORTS: tuple[tuple[str, str], ...] = (
+    ("desktop", "browser_page"),
+    ("mobile", "mobile_page"),
+)
+
+# Per-(label, viewport) xfails for mobile-only regressions. Keep empty
+# until a mobile-specific break is triaged into Linear — new entries must
+# link to a JTN issue so they get cleaned up.
+_MOBILE_XFAIL_PAGES: dict[str, str] = {}
+
 
 _ENUMERATE_JS = """
 (skipSelectors) => {
@@ -298,13 +311,28 @@ def _reset_page_state(page, base_url: str, sweep: SweepPage) -> None:
     _install_observer(page)
 
 
+@pytest.mark.parametrize(
+    "viewport,page_fixture",
+    _VIEWPORTS,
+    ids=[vp[0] for vp in _VIEWPORTS],
+)
 @pytest.mark.parametrize("sweep", PAGES_TO_SWEEP, ids=lambda sweep: sweep.label)
-def test_click_sweep(live_server, browser_page, sweep: SweepPage):
-    """Click every visible clickable on the page; assert no silent failures."""
+def test_click_sweep(
+    live_server, request, sweep: SweepPage, viewport: str, page_fixture: str
+):
+    """Click every visible clickable on the page; assert no silent failures.
+
+    Parametrized over viewport: ``desktop`` (1280×900) and ``mobile``
+    (360×800). Mobile reflows can hide or overlap controls and catch
+    handlers that only break at narrow widths.
+    """
     if sweep.label in _XFAIL_PAGES:
         pytest.xfail(_XFAIL_PAGES[sweep.label])
+    mobile_key = f"{sweep.label}:{viewport}"
+    if viewport == "mobile" and mobile_key in _MOBILE_XFAIL_PAGES:
+        pytest.xfail(_MOBILE_XFAIL_PAGES[mobile_key])
 
-    page = browser_page
+    page = request.getfixturevalue(page_fixture)
     stub_leaflet(page)
     collector = RuntimeCollector(page, live_server)
 


### PR DESCRIPTION
## Summary
- Parametrize `tests/integration/test_click_sweep.py::test_click_sweep` over viewport: `desktop` (1280×900) and `mobile` (360×800). Reuses the existing `mobile_page` fixture in `tests/integration/conftest.py` via indirect fixture lookup — no duplication of sweep logic.
- Adds `_MOBILE_XFAIL_PAGES = {}` as the parking spot for mobile-only regressions. Existing `_XFAIL_PAGES` continue to apply to both viewports.
- No mobile-only breaks were discovered during local runs — mobile failures exactly mirror desktop failures, which are caused by a pre-existing local env issue (missing compiled `styles/main.css`) unrelated to this change.

Linear: [JTN-693](https://linear.app/jtn0123/issue/JTN-693/testui-responsive-mobile-click-sweep)

## Test plan
- [ ] `SKIP_BROWSER=0 .venv/bin/python -m pytest tests/integration/test_click_sweep.py -q` — 6 new mobile-variant test cases run alongside the original 6 desktop cases; existing xfails (`plugin_clock`, `history`) still applied in both viewports.
- [ ] `scripts/lint.sh` passes.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)