### PR TITLE
fix(security): nonce-based CSP eliminates inline script violations (JTN-687)

### DIFF
--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -319,6 +319,36 @@ def setup_rate_limiting(app: Flask) -> None:
 
 
 # ---------------------------------------------------------------------------
+# CSP nonce
+# ---------------------------------------------------------------------------
+
+
+def setup_csp_nonce(app: Flask) -> None:
+    """Generate a per-request CSP nonce and expose it to templates.
+
+    A fresh ``secrets.token_urlsafe(16)`` value is stored on ``flask.g`` at
+    the start of every request.  The same nonce is then embedded in the
+    ``Content-Security-Policy`` (or ``-Report-Only``) header by
+    ``_apply_csp_header`` and is available to Jinja templates via the
+    ``csp_nonce`` template variable so that inline ``<script>`` blocks can
+    carry the matching ``nonce`` attribute.
+
+    Inline ``<script nonce="{{ csp_nonce }}">`` blocks are the approved CSP
+    mechanism for authorising necessary server-rendered JS snippets that
+    pass Jinja data into static scripts (JTN-687).  ``'unsafe-inline'`` is
+    intentionally NOT used.
+    """
+
+    @app.before_request
+    def _generate_csp_nonce():
+        g.csp_nonce = secrets.token_urlsafe(16)
+
+    @app.context_processor
+    def _inject_csp_nonce():
+        return {"csp_nonce": getattr(g, "csp_nonce", "")}
+
+
+# ---------------------------------------------------------------------------
 # Security headers
 # ---------------------------------------------------------------------------
 
@@ -335,10 +365,10 @@ _STATIC_ASSET_EXTS = (
     ".woff2",
     ".ttf",
 )
-_DEFAULT_CSP = (
+_DEFAULT_CSP_TEMPLATE = (
     "default-src 'self'; img-src 'self' data: https:; "
     "style-src 'self' 'unsafe-inline' https://unpkg.com; "
-    "script-src 'self'; font-src 'self' data: https:"
+    "script-src 'self' 'nonce-{nonce}'; font-src 'self' data: https:"
 )
 
 
@@ -405,7 +435,9 @@ def _apply_hsts_header(response) -> None:
 
 def _apply_csp_header(response, *, dev_mode: bool) -> None:
     """Set the Content-Security-Policy header (report-only in dev mode)."""
-    csp_value = os.getenv("INKYPI_CSP") or _DEFAULT_CSP
+    nonce = getattr(g, "csp_nonce", "")
+    # Honour operator-supplied CSP verbatim (no nonce injection).
+    csp_value = os.getenv("INKYPI_CSP") or _DEFAULT_CSP_TEMPLATE.format(nonce=nonce)
     if "report-uri" not in csp_value:
         csp_value = csp_value.rstrip("; ") + "; report-uri /api/csp-report"
     report_only = dev_mode or _env_bool("INKYPI_CSP_REPORT_ONLY")

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -31,6 +31,8 @@ from app_setup.schema_validator import register as register_schema_validator
 from app_setup.security_middleware import (
     _extract_csrf_token_from_request,
     _generate_csrf_token,
+    setup_csp_nonce,
+    setup_csp_nonce as _setup_csp_nonce,
     setup_csrf_protection,
     setup_csrf_protection as _setup_csrf_protection,
     setup_https_redirect,
@@ -61,6 +63,7 @@ __all__ = [
     "pop_hot_reload_info",
     "_register_error_handlers",
     "_register_health_endpoints",
+    "_setup_csp_nonce",
     "_setup_csrf_protection",
     "_setup_https_redirect",
     "_setup_rate_limiting",
@@ -366,6 +369,7 @@ def create_app():
         except Exception:
             pass
 
+    setup_csp_nonce(app)
     setup_csrf_protection(app)
     setup_rate_limiting(app)
     register_error_handlers(app)

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -26,7 +26,7 @@
     <script src="{{ url_for('static', filename='vendor/htmx.min.js') }}" defer
             integrity="{{ sri_for('vendor/htmx.min.js') }}" crossorigin="anonymous"></script>
     {% block head %}{% endblock %}
-    <script>
+    <script nonce="{{ csp_nonce }}">
       if ("serviceWorker" in navigator && (location.protocol === "https:" || location.hostname === "localhost" || location.hostname === "127.0.0.1")) {
         window.addEventListener("load", () => navigator.serviceWorker.register("/sw.js").catch(() => {}));
       }

--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -138,7 +138,7 @@
          data-delete-url="{{ url_for('history.history_delete') }}"
          data-redisplay-url="{{ url_for('history.history_redisplay') }}"
          data-storage-url="{{ url_for('history.history_storage') }}"></div>
-    <script>
+    <script nonce="{{ csp_nonce }}">
         document.addEventListener('DOMContentLoaded', () => {
             var el = document.getElementById('historyBootData');
             if (!el || !window.InkyPiHistoryPage) return;

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -150,7 +150,7 @@
         </section>
     </div>
     {% include 'response_modal.html' %}
-<script>
+<script nonce="{{ csp_nonce }}">
     window.__INKYPI_DASHBOARD_BOOT__ = {
         displayNextUrl: {{ url_for('main.display_next') | tojson }},
         imageHash: {{ refresh_info.get('image_hash')|tojson }},

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -2,7 +2,7 @@
 {% block title %}InkyPi - Playlists{% endblock %}
 {% block head %}
     <script src="{{ url_for('static', filename='scripts/refresh_settings_manager.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
         window.PLAYLIST_CTX = {
             create_playlist_url: {{ url_for('playlist.create_playlist') | tojson }},
             delete_playlist_base_url: {{ url_for('playlist.delete_playlist', playlist_name='') | tojson }},

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -7,7 +7,7 @@
     <script src="{{ url_for('static', filename='scripts/plugin_schema.js') }}" defer></script>
 
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
         const pluginSettings = window.pluginSettings = {{ (plugin_settings | default({})) | tojson }};
         const pluginInstanceName = window.pluginInstanceName = {{ (plugin_instance | default('')) | tojson }};
         const hasPluginSettings = !!(pluginSettings && Object.keys(pluginSettings).length);
@@ -376,7 +376,7 @@
     </div>
     <script src="{{ url_for('static', filename='scripts/ui_helpers.js') }}"></script>
     <script src="{{ url_for('static', filename='scripts/plugin_page.js') }}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
         window.__INKYPI_PLUGIN_BOOT__ = {
             deviceFrameUrl: {{ url_for('plugin.image', plugin_id='base_plugin', filename='frames/device_frame.png') | tojson }},
             displayInstancePayload: {

--- a/src/templates/refresh_settings_form.html
+++ b/src/templates/refresh_settings_form.html
@@ -21,7 +21,7 @@
 </div>
 <p id="{{ prefix }}-scheduled-help" class="form-help-text" style="display:none;" aria-live="polite">Pick a time of day for the refresh.</p>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener('DOMContentLoaded', () => {
     // Interval group
     const groupInterval = document.getElementById('{{ prefix }}-group-interval');

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -392,7 +392,7 @@
     <!-- Success/Error Modal -->
     {% include 'response_modal.html' %}
     </main>
-    <script>
+    <script nonce="{{ csp_nonce }}">
         window.__INKYPI_SETTINGS_BOOT__ = {
             downloadLogsUrl: {{ url_for('settings.download_logs', hours=24) | tojson }},
             exportSettingsUrl: {{ url_for('settings.export_settings') | tojson }},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,7 +327,10 @@ def flask_app(device_config_dev, monkeypatch):
         return {"csrf_token": _generate_csrf_token}
 
     from app_setup.http_metrics import setup_http_metrics
+    from app_setup.security_middleware import setup_csp_nonce
     from utils.sri import init_sri
+
+    setup_csp_nonce(app)
 
     # Register routes
     app.register_blueprint(main_bp)
@@ -400,9 +403,13 @@ def flask_app(device_config_dev, monkeypatch):
             pass
         # Content Security Policy (Report-Only by default)
         try:
-            csp_value = (
-                os.getenv("INKYPI_CSP")
-                or "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' data:"
+            from flask import g as _g
+
+            _nonce = getattr(_g, "csp_nonce", "")
+            csp_value = os.getenv("INKYPI_CSP") or (
+                "default-src 'self'; img-src 'self' data: https:; "
+                "style-src 'self' 'unsafe-inline'; "
+                f"script-src 'self' 'nonce-{_nonce}'; font-src 'self' data:"
             )
             report_only = os.getenv("INKYPI_CSP_REPORT_ONLY", "1").strip().lower() in (
                 "1",

--- a/tests/unit/test_security_headers_csp_hsts.py
+++ b/tests/unit/test_security_headers_csp_hsts.py
@@ -48,6 +48,51 @@ def test_csp_enforcement_and_report_only(monkeypatch):
     assert r3.headers.get(header_name, "").startswith("default-src 'none'")
 
 
+def test_csp_nonce_present_and_unique_per_request(monkeypatch):
+    """Each request generates a unique nonce that appears in the CSP header."""
+    mod = _reload_inkypi(monkeypatch)
+    app = mod.app
+    client = app.test_client()
+
+    monkeypatch.setenv("INKYPI_CSP_REPORT_ONLY", "0")
+
+    r1 = client.get("/healthz")
+    r2 = client.get("/healthz")
+
+    csp1 = r1.headers.get("Content-Security-Policy", "")
+    csp2 = r2.headers.get("Content-Security-Policy", "")
+
+    # Both responses must carry a nonce in script-src.
+    assert "nonce-" in csp1, f"nonce missing in CSP: {csp1}"
+    assert "nonce-" in csp2, f"nonce missing in CSP: {csp2}"
+
+    # Nonces must differ between requests (collision probability ~2^-96).
+    import re
+
+    def _extract_nonce(csp):
+        m = re.search(r"nonce-([A-Za-z0-9_=-]+)", csp)
+        return m.group(1) if m else None
+
+    assert _extract_nonce(csp1) != _extract_nonce(csp2), (
+        "CSP nonce must be unique per request"
+    )
+
+
+def test_csp_nonce_not_injected_when_custom_csp_set(monkeypatch):
+    """Custom INKYPI_CSP values are used verbatim — no nonce is injected."""
+    mod = _reload_inkypi(monkeypatch, env={"INKYPI_CSP_REPORT_ONLY": "0"})
+    app = mod.app
+    client = app.test_client()
+
+    monkeypatch.setenv("INKYPI_CSP", "default-src 'none'")
+    r = client.get("/healthz")
+    csp = r.headers.get("Content-Security-Policy", "")
+    # The custom value starts verbatim (report-uri may be appended).
+    assert csp.startswith("default-src 'none'"), f"Unexpected CSP: {csp}"
+    # No nonce should appear in a custom policy (operator's responsibility).
+    assert "nonce-" not in csp
+
+
 def test_hsts_only_under_https_or_forward_proto(monkeypatch):
     mod = _reload_inkypi(monkeypatch)
     app = mod.app

--- a/tests/unit/test_security_headers_csp_hsts.py
+++ b/tests/unit/test_security_headers_csp_hsts.py
@@ -73,9 +73,9 @@ def test_csp_nonce_present_and_unique_per_request(monkeypatch):
         m = re.search(r"nonce-([A-Za-z0-9_=-]+)", csp)
         return m.group(1) if m else None
 
-    assert _extract_nonce(csp1) != _extract_nonce(csp2), (
-        "CSP nonce must be unique per request"
-    )
+    assert _extract_nonce(csp1) != _extract_nonce(
+        csp2
+    ), "CSP nonce must be unique per request"
 
 
 def test_csp_nonce_not_injected_when_custom_csp_set(monkeypatch):


### PR DESCRIPTION
## Summary

- Replaces bare `script-src 'self'` with `script-src 'self' 'nonce-{nonce}'` — a unique 128-bit nonce generated per request via `secrets.token_urlsafe(16)` stored on `flask.g.csp_nonce`.
- Every inline `<script>` block across all affected templates now carries `nonce="{{ csp_nonce }}"` so the browser permits them without `'unsafe-inline'`.
- Operator-supplied `INKYPI_CSP` overrides are honoured verbatim (no nonce injected).
- Two new unit tests assert nonce presence and per-request uniqueness.

Closes JTN-687.

## Changes

**`src/app_setup/security_middleware.py`**
- Renamed `_DEFAULT_CSP` → `_DEFAULT_CSP_TEMPLATE` with `{nonce}` placeholder.
- New `setup_csp_nonce(app)`: `before_request` hook generates nonce on `g.csp_nonce`; `context_processor` exposes it as `csp_nonce` in Jinja.
- `_apply_csp_header` reads `g.csp_nonce` to fill the template.

**`src/inkypi.py`**
- Imports and calls `setup_csp_nonce(app)` before `setup_csrf_protection`.

**Templates (all inline `<script>` blocks)**
- `src/templates/base.html` — service-worker registration
- `src/templates/inky.html` — dashboard boot data
- `src/templates/plugin.html` — plugin config data (2 blocks)
- `src/templates/settings.html` — settings boot data
- `src/templates/history.html` — history page init
- `src/templates/playlist.html` — playlist context
- `src/templates/refresh_settings_form.html` — refresh-mode form logic

**`tests/conftest.py`**
- Calls `setup_csp_nonce(app)` in the test fixture so templates render with a nonce.
- Updates the inline CSP string to include the per-request nonce.

**`tests/unit/test_security_headers_csp_hsts.py`**
- `test_csp_nonce_present_and_unique_per_request` — verifies nonce appears and differs across requests.
- `test_csp_nonce_not_injected_when_custom_csp_set` — verifies custom `INKYPI_CSP` is used verbatim.

## Test plan
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no -q` → 4125 passed, 5 skipped
- [x] `scripts/lint.sh` → ✅ All checks passed
- [x] Zero `'unsafe-inline'` added — nonce approach is correct CSP hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)