### PR TITLE
test(ui): per-plugin Update Preview smoke (JTN-691)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ UI_BROWSER_TESTS = {
     "test_jtn_681_clock_face_picker.py",
     "test_toggle_reflection.py",
     "test_layout_overlap.py",
+    "test_plugin_preview_smoke.py",
 }
 A11Y_BROWSER_TESTS = {
     "test_axe_a11y.py",

--- a/tests/integration/fixtures/plugin_inputs.py
+++ b/tests/integration/fixtures/plugin_inputs.py
@@ -1,0 +1,73 @@
+# pyright: reportMissingImports=false
+"""Per-plugin minimum-viable form inputs for the Update Preview smoke test.
+
+Each entry maps a plugin id to the happy-path inputs required to make the
+``/update_now`` POST succeed end-to-end (plugin ``generate_image`` returns an
+image) without requiring external API keys, network round-trips, or file
+uploads. Keep payloads tiny — this is a smoke test, not a plugin config harness.
+
+Adding a plugin: drop a new ``"<plugin_id>": { ... }`` entry below. Inputs are
+applied in-order; ``fill_form_inputs`` below maps them to ``input``,
+``select``, and ``textarea`` elements inside ``#settingsForm``. Plugins that
+require API keys, uploads, or network calls should stay out of this dict
+until their fixtures can be stubbed in a follow-up.
+"""
+
+from __future__ import annotations
+
+# plugin_id -> { form_field_name: value }
+#
+# Scope is deliberately narrow: three plugins that render offline with no
+# external dependencies. Extending coverage is a one-line dict entry once the
+# pattern is proven.
+PLUGIN_FORM_INPUTS: dict[str, dict[str, str]] = {
+    # Clock renders entirely from local settings; no API key required.
+    # JTN-681 showed the face-picker handler can silently no-op — this smoke
+    # test catches the equivalent regression at the Update Preview level.
+    "clock": {
+        "selectedClockFace": "Gradient Clock",
+        "primaryColor": "#db3246",
+        "secondaryColor": "#000000",
+    },
+    # Year Progress needs no inputs — it computes from the current date.
+    "year_progress": {},
+    # Todo List renders from optional fields only; empty list is valid input.
+    "todo_list": {
+        "title": "Smoke test",
+        "fontSize": "normal",
+        "listStyle": "disc",
+    },
+}
+
+
+def fill_form_inputs(page, inputs: dict[str, str]) -> None:
+    """Fill ``#settingsForm`` fields from an inputs dict.
+
+    Uses ``page.evaluate`` so the call site stays synchronous with Playwright
+    and we can dispatch ``input``/``change`` events the plugin form handlers
+    listen for (e.g. the clock face picker's click-driven hidden input).
+    """
+    if not inputs:
+        return
+    page.evaluate(
+        """
+        (values) => {
+          const form = document.getElementById('settingsForm');
+          if (!form) return;
+          for (const [name, value] of Object.entries(values)) {
+            const el = form.querySelector(
+              `[name="${name}"], #${CSS.escape(name)}`
+            );
+            if (!el) continue;
+            // Native setter so React/Alpine-style frameworks pick up the
+            // change (InkyPi is vanilla JS but this keeps the helper portable).
+            const proto = Object.getPrototypeOf(el);
+            const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+            if (desc && desc.set) desc.set.call(el, value); else el.value = value;
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+          }
+        }
+        """,
+        inputs,
+    )

--- a/tests/integration/test_plugin_preview_smoke.py
+++ b/tests/integration/test_plugin_preview_smoke.py
@@ -1,0 +1,144 @@
+# pyright: reportMissingImports=false
+"""Per-plugin Update Preview smoke test (JTN-691).
+
+For each plugin in :data:`PLUGIN_FORM_INPUTS` this test:
+
+1. Navigates to ``/plugin/<plugin_id>``.
+2. Fills minimum-viable inputs from the per-plugin fixture dict.
+3. Clicks the primary ``data-plugin-action="update_now"`` button
+   ("Update Preview").
+4. Asserts the ``#previewImage`` ``src`` actually changed after the click —
+   the client-side ``refreshPreviewImage()`` cache-busts with ``?t=<ts>`` on
+   successful ``/update_now``, so an unchanged src means the handler silently
+   no-opped.
+5. Inherits the client-log tripwire from ``conftest.py`` — any
+   ``console.warn``/``console.error`` during the test automatically fails it.
+
+This layer catches the class of bug surfaced in JTN-681 (clock face picker
+click produced 200 responses but no visible change), which the existing
+click-sweep missed because its DOM-mutation heuristic xfails on the clock
+page.
+
+Scope is deliberately small (3 plugins). Add coverage by extending
+``PLUGIN_FORM_INPUTS`` in ``fixtures/plugin_inputs.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from tests.integration.browser_helpers import RuntimeCollector, stub_leaflet
+from tests.integration.fixtures.plugin_inputs import (
+    PLUGIN_FORM_INPUTS,
+    fill_form_inputs,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("SKIP_UI", "").lower() in ("1", "true"),
+    reason="UI interactions skipped by env",
+)
+
+
+# Playwright wait budgets. The update_now POST is synchronous on the dev
+# server path (refresh task off), so the preview src flip happens ~250 ms
+# after the POST returns (see plugin_page.js::handleAction).
+_UPDATE_PREVIEW_TIMEOUT_MS = 15000
+
+
+def _preview_src(page) -> str | None:
+    """Return the current ``#previewImage`` src (or None if missing)."""
+    return page.evaluate(
+        "() => document.getElementById('previewImage')?.getAttribute('src') || null"
+    )
+
+
+@pytest.mark.parametrize(
+    "plugin_id",
+    sorted(PLUGIN_FORM_INPUTS.keys()),
+    ids=lambda pid: pid,
+)
+def test_update_preview_changes_image_src(
+    live_server, browser_page, flask_app, monkeypatch, plugin_id: str
+):
+    """Update Preview must flip ``#previewImage`` src for each plugin.
+
+    We force the refresh task OFF so ``/update_now`` takes the direct path
+    and stub the display driver so no physical hardware is touched. The
+    plugin's real ``generate_image`` still runs, which is the whole point —
+    we are verifying the plugin-level preview loop produces an observable
+    UI change, not mocking it away.
+    """
+    # Direct update_now path — skip the background refresh queue.
+    flask_app.config["REFRESH_TASK"].running = False
+
+    # Stub the physical display so the real DisplayManager._save_history_entry
+    # still runs (sidecar JSON, preview file write) without hitting hardware.
+    dm = flask_app.config["DISPLAY_MANAGER"]
+    monkeypatch.setattr(dm.display, "display_image", lambda *a, **kw: None)
+
+    page = browser_page
+    stub_leaflet(page)
+    collector = RuntimeCollector(page, live_server)
+
+    page.goto(
+        f"{live_server}/plugin/{plugin_id}",
+        wait_until="domcontentloaded",
+        timeout=30000,
+    )
+    page.wait_for_selector("#settingsForm", timeout=10000)
+    page.wait_for_selector("#previewImage", timeout=10000)
+
+    fill_form_inputs(page, PLUGIN_FORM_INPUTS[plugin_id])
+
+    before_src = _preview_src(page)
+    assert (
+        before_src is not None
+    ), f"{plugin_id}: #previewImage missing src attribute on load"
+
+    update_btn = page.locator('[data-plugin-action="update_now"]').first
+    assert (
+        update_btn.count() > 0
+    ), f"{plugin_id}: no Update Preview button on /plugin/{plugin_id}"
+    update_btn.wait_for(state="visible", timeout=5000)
+    # Click with `force=True` in case the workflow-mode panel keeps the
+    # button briefly covered by a transition — matches the click-sweep
+    # pattern and avoids flakes on slow CI boxes.
+    update_btn.click(timeout=5000, force=True)
+
+    # Wait for refreshPreviewImage() to swap in the cache-busted src.
+    # The handler posts to /update_now, then on success schedules a 250 ms
+    # setTimeout before updating the src — budget generously for CI.
+    page.wait_for_function(
+        """
+        (prev) => {
+          const img = document.getElementById('previewImage');
+          return img && img.getAttribute('src') !== prev;
+        }
+        """,
+        arg=before_src,
+        timeout=_UPDATE_PREVIEW_TIMEOUT_MS,
+    )
+
+    after_src = _preview_src(page)
+    assert after_src and after_src != before_src, (
+        f"{plugin_id}: #previewImage src did not change after Update Preview "
+        f"(before={before_src!r}, after={after_src!r}) — handler likely "
+        "silently no-opped."
+    )
+
+    # Runtime tripwires: no JS errors / 5xx during the click. The autouse
+    # client_log_capture fixture in conftest.py handles console.warn/error.
+    assert not collector.page_errors, (
+        f"{plugin_id}: pageerror during Update Preview: " f"{collector.page_errors[:3]}"
+    )
+    assert not collector.console_errors, (
+        f"{plugin_id}: console.error during Update Preview: "
+        f"{collector.console_errors[:3]}"
+    )
+    server_5xx = [
+        r for r in collector.response_failures if 500 <= int(r.get("status", 0)) < 600
+    ]
+    assert not server_5xx, (
+        f"{plugin_id}: Update Preview triggered 5xx response(s): " f"{server_5xx[:3]}"
+    )


### PR DESCRIPTION
## Summary

- Adds a Playwright integration test that exercises each plugin's **Update Preview** flow end-to-end: navigate to `/plugin/<id>`, fill minimum-viable inputs from a fixture dict, click `[data-plugin-action="update_now"]`, and assert `#previewImage` `src` actually changed after the POST.
- Inherits the autouse client-log tripwire from `tests/integration/conftest.py`, so any `console.warn` / `console.error` during the flow fails the test automatically.
- Closes the plugin-level correctness blind spot surfaced in JTN-681 (clock face picker handler silently no-opped — the click sweep's DOM-mutation heuristic xfailed on the clock page and never caught it).

## Scope

Initial coverage (parametrized, one-per-plugin):

- `clock`
- `year_progress`
- `todo_list`

These three render entirely offline (no API keys, no uploads, no network). Extending coverage is a one-line entry in `tests/integration/fixtures/plugin_inputs.py`.

## Files

- `tests/integration/test_plugin_preview_smoke.py` (new)
- `tests/integration/fixtures/plugin_inputs.py` (new) — per-plugin form-input dict + helper
- `tests/integration/fixtures/__init__.py` (new)

## Follow-up

- The `plugin_clock` xfail at `tests/integration/test_click_sweep.py:93` is now effectively shadowed by per-plugin preview coverage and should be revisited in a follow-up PR. Deliberately **not** removed here to keep this PR scoped.

## Test plan

- [x] `SKIP_BROWSER=0 .venv/bin/python -m pytest tests/integration/test_plugin_preview_smoke.py -q` — 3 passed
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no` — 4126 passed, 5 skipped
- [x] `scripts/lint.sh` — ruff + black + mypy-strict + shellcheck clean

Linear: [JTN-691](https://linear.app/jtn0123/issue/JTN-691/testui-per-plugin-update-preview-smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)