### PR TITLE
fix(install): gate service-enable on CSS build success (JTN-695)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -499,8 +499,12 @@ install_config
 if [[ -n "$WS_TYPE" ]]; then
   update_config
 fi
-install_app_service
 
+# JTN-695: Vendor download + CSS build must run BEFORE install_app_service so
+# that a failure in either step leaves the service untouched. Previously the
+# service was enabled first, and a subsequent vendor-download or CSS-build
+# failure left the unit enabled while `src/static/styles/main.css` was absent —
+# the user would boot into an unstyled web UI with no hint why.
 echo "Update JS and CSS files"
 # JTN-534: previously the exit code from update_vendors.sh was discarded — a
 # transient curl write error during vendor download silently produced a
@@ -512,6 +516,22 @@ fi
 
 # JTN-674: use shared build_css_bundle from _common.sh
 build_css_bundle
+
+# JTN-695: Explicit post-build assertion — main.css must exist AND be non-empty
+# before we enable the systemd unit. build_css_bundle already checks existence,
+# but a zero-byte file would still pass -f; guard against that too so a silent
+# truncation can't leave the service enabled against a blank stylesheet.
+MAIN_CSS="$SRC_PATH/static/styles/main.css"
+if [ ! -f "$MAIN_CSS" ] || [ ! -s "$MAIN_CSS" ]; then
+  echo_error "ERROR: CSS bundle assertion failed — $MAIN_CSS is missing or empty."
+  echo_error "Refusing to enable $APPNAME.service with an unusable stylesheet."
+  exit 1
+fi
+
+# JTN-695: Only now — after vendor download + CSS build + assertion all passed —
+# do we enable the systemd unit. A failure in any step above exits before
+# touching the service, so `systemctl is-enabled inkypi` reflects reality.
+install_app_service
 
 # JTN-607: All install steps succeeded — remove the install-in-progress
 # lockfile so the service is allowed to start. If install.sh exits early due

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -552,6 +552,62 @@ class TestInstallScript:
             "so a CSS build failure leaves the lockfile in place (JTN-607)"
         )
 
+    def test_service_enable_gated_on_css_build(self):
+        # JTN-695: systemctl enable / install_app_service must only run AFTER
+        # vendor download + CSS build both succeed. If either step fails, the
+        # service must be left untouched so `systemctl is-enabled inkypi`
+        # reflects reality (not "enabled but main.css missing").
+        main_start = self.content.index('parse_arguments "$@"')
+        main_body = self.content[main_start:]
+
+        # Use rindex for install_app_service so we locate the actual call site
+        # at the bottom of the script rather than an earlier comment/reference.
+        vendor_pos = main_body.index("update_vendors.sh")
+        css_pos = main_body.index("build_css_bundle")
+        install_app_pos = main_body.rindex("install_app_service")
+
+        assert vendor_pos < install_app_pos, (
+            "install.sh must invoke update_vendors.sh BEFORE install_app_service "
+            "so a vendor-download failure exits before the systemd unit is "
+            "enabled (JTN-695)"
+        )
+        assert css_pos < install_app_pos, (
+            "install.sh must call build_css_bundle BEFORE install_app_service "
+            "so a CSS build failure exits before the systemd unit is enabled "
+            "(JTN-695)"
+        )
+
+    def test_install_asserts_main_css_exists_before_service_enable(self):
+        # JTN-695: After build_css_bundle, install.sh must assert that
+        # src/static/styles/main.css exists AND is non-empty (`-s`) before the
+        # service is enabled. This catches silent truncation where the file
+        # exists (so `-f` passes) but is zero bytes — which would otherwise
+        # slip past build_css_bundle's existence-only check and leave the
+        # service enabled against an unusable stylesheet.
+        main_start = self.content.index('parse_arguments "$@"')
+        main_body = self.content[main_start:]
+
+        # A reference to main.css must appear in the main body, with an
+        # accompanying non-empty-file test (`-s`) on the same variable.
+        assert "main.css" in main_body, (
+            "install.sh main body must reference src/static/styles/main.css "
+            "for the post-build assertion (JTN-695)"
+        )
+        assert "-s " in main_body and '-s "$MAIN_CSS"' in main_body, (
+            "install.sh must assert the CSS bundle is non-empty via '-s' "
+            "before enabling the systemd unit (JTN-695)"
+        )
+
+        # Ordering: the main.css assertion must come AFTER build_css_bundle and
+        # BEFORE install_app_service so a zero-byte stylesheet blocks enable.
+        css_pos = main_body.index("build_css_bundle")
+        assert_pos = main_body.index("MAIN_CSS=")
+        install_app_pos = main_body.rindex("install_app_service")
+        assert css_pos < assert_pos < install_app_pos, (
+            "main.css existence/non-empty assertion must appear after "
+            "build_css_bundle and before install_app_service (JTN-695)"
+        )
+
     def test_install_lockfile_not_removed_by_error_trap(self):
         # JTN-607: On failure exit, the lockfile must be LEFT in place so the
         # user is forced to rerun install.sh (or manually rm the file) before


### PR DESCRIPTION
## Summary

Re-order `install/install.sh` so vendor download + CSS build run **before** `install_app_service`, and add an explicit post-build assertion that `src/static/styles/main.css` exists and is non-empty before enabling the systemd unit.

## Scenario (before this PR)

In the old ordering, `install_app_service` (which runs `systemctl enable inkypi.service`) ran before `update_vendors.sh` and `build_css_bundle`. If a vendor CDN timed out, or `build_css.py` crashed, install.sh exited non-zero — but the unit was already enabled. On reboot the user got an unstyled live service with no signal why.

## Changes

- **`install/install.sh`**: move the vendor download + `build_css_bundle` block above `install_app_service`. Add an explicit `-f` + `-s` gate on `\$SRC_PATH/static/styles/main.css` between the CSS build and the service enable. On any failure, exit before touching the service unit. Lockfile semantics from JTN-607 are preserved — `rm -f \"\$LOCKFILE\"` still follows both CSS build and service-enable, so any failure in the gating path leaves the lockfile in place for the user to retry.
- **`tests/unit/test_install_scripts.py`**: two new regression tests on the script ordering —
  - `test_service_enable_gated_on_css_build` — asserts `update_vendors.sh` and `build_css_bundle` appear before the `install_app_service` call.
  - `test_install_asserts_main_css_exists_before_service_enable` — asserts the `-s \"\$MAIN_CSS\"` non-empty check appears between `build_css_bundle` and `install_app_service`.

No conflict with JTN-704 — that branch edits `install/update.sh`, this one only edits `install/install.sh`.

## Linear

- https://linear.app/jtn0123/issue/JTN-695

## Test plan

- [x] `tests/unit/test_install_scripts.py` — 202/202 passing locally.
- [x] Full test suite — 4171 passed, 5 skipped.
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean (mypy advisory, no new issues).