### PR TITLE
fix(install): verify wheelhouse integrity after extraction (JTN-697)

### DIFF
--- a/.github/workflows/build-wheelhouse.yml
+++ b/.github/workflows/build-wheelhouse.yml
@@ -191,8 +191,14 @@ jobs:
           TARBALL="inkypi-wheels-${VERSION}-${ARCH}.tar.gz"
           tar -czf "$TARBALL" -C dist/wheels .
           sha256sum "$TARBALL" > "${TARBALL}.sha256"
+          # JTN-697: Per-wheel sha256 manifest so install.sh can detect a
+          # truncated/corrupt individual wheel inside an otherwise-valid
+          # tarball (e.g. 0-byte numpy-*.whl). Format: one `sha256sum` line
+          # per wheel with basenames only, so verification can `cd` into the
+          # extracted wheelhouse dir and run `sha256sum -c` directly.
+          ( cd dist/wheels && sha256sum *.whl ) > "${TARBALL}.manifest.sha256"
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
-          ls -la "$TARBALL" "${TARBALL}.sha256"
+          ls -la "$TARBALL" "${TARBALL}.sha256" "${TARBALL}.manifest.sha256"
 
       - name: Attach wheelhouse to release
         if: github.event_name == 'release' || github.event_name == 'workflow_run'
@@ -202,6 +208,7 @@ jobs:
           files: |
             ${{ steps.package.outputs.tarball }}
             ${{ steps.package.outputs.tarball }}.sha256
+            ${{ steps.package.outputs.tarball }}.manifest.sha256
           fail_on_unmatched_files: true
 
       - name: Upload workflow artifact (workflow_dispatch)
@@ -212,4 +219,5 @@ jobs:
           path: |
             ${{ steps.package.outputs.tarball }}
             ${{ steps.package.outputs.tarball }}.sha256
+            ${{ steps.package.outputs.tarball }}.manifest.sha256
           if-no-files-found: error

--- a/install/_common.sh
+++ b/install/_common.sh
@@ -210,10 +210,12 @@ fetch_wheelhouse() {
   local tarball="inkypi-wheels-${version}-${arch}.tar.gz"
   local url="https://github.com/${WHEELHOUSE_REPO}/releases/download/v${version}/${tarball}"
   local sha_url="${url}.sha256"
-  local tmp_dir tmp_tarball tmp_sha
+  local manifest_url="https://github.com/${WHEELHOUSE_REPO}/releases/download/v${version}/${tarball}.manifest.sha256"
+  local tmp_dir tmp_tarball tmp_sha tmp_manifest
   tmp_dir=$(mktemp -d -t inkypi-wheels.XXXXXX) || return 1
   tmp_tarball="${tmp_dir}/${tarball}"
   tmp_sha="${tmp_dir}/${tarball}.sha256"
+  tmp_manifest="${tmp_dir}/${tarball}.manifest.sha256"
 
   echo "  Fetching pre-built wheelhouse for ${arch} (v${version})..."
   if ! curl --fail --silent --show-error --location \
@@ -258,6 +260,66 @@ fetch_wheelhouse() {
     echo "  Wheelhouse tarball contained no wheel files — falling back."
     rm -rf "$tmp_dir"
     return 1
+  fi
+
+  # JTN-697: Integrity-verify every extracted wheel. A tarball can decompress
+  # cleanly and pass the outer sha256 check yet still contain a zero-byte
+  # numpy-*.whl (e.g. if the producer truncated mid-write). pip happily
+  # "installs" those and the ImportError only surfaces on first refresh.
+  #
+  # Two layers:
+  #   1. If a per-wheel sha256 manifest was published (preferred), verify
+  #      every wheel's hash against the manifest. Any mismatch → fall back.
+  #   2. Structural fallback for older releases without a manifest: reject
+  #      empty files and anything that isn't a readable zip archive.
+  local sha256_cmd=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256_cmd="sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    sha256_cmd="shasum -a 256"
+  fi
+
+  local have_manifest=0
+  if curl --fail --silent --show-error --location \
+        --retry 2 --connect-timeout 10 --max-time 30 \
+        --output "$tmp_manifest" "$manifest_url" 2>/dev/null; then
+    if [ -s "$tmp_manifest" ] && [ -n "$sha256_cmd" ]; then
+      have_manifest=1
+    fi
+  fi
+
+  local whl
+  while IFS= read -r -d '' whl; do
+    # Guard 1: wheel must be non-empty. A truncated tarball can leave a
+    # 0-byte placeholder even after tar reports success.
+    if [ ! -s "$whl" ]; then
+      echo "  Wheelhouse integrity check failed: empty wheel $(basename "$whl") — falling back."
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+    # Guard 2: wheel must be a readable zip (pip won't install otherwise).
+    # We deliberately use python -m zipfile rather than unzip because the
+    # install base always has python available but unzip is not guaranteed.
+    if command -v python3 >/dev/null 2>&1; then
+      if ! python3 -m zipfile -l "$whl" >/dev/null 2>&1; then
+        echo "  Wheelhouse integrity check failed: $(basename "$whl") is not a valid zip — falling back."
+        rm -rf "$tmp_dir"
+        return 1
+      fi
+    fi
+  done < <(find "$extract_dir" -name '*.whl' -type f -print0)
+
+  # Guard 3 (preferred): verify each wheel against the published manifest.
+  # Manifest format is `sha256sum` output: "<hash>  <basename>\n" per wheel.
+  if [ "$have_manifest" = "1" ]; then
+    # Run sha256sum -c from the extract dir so the basenames in the manifest
+    # line up with the extracted files. --quiet suppresses per-line OK output
+    # but still emits mismatches, and the exit code is non-zero on any fail.
+    if ! ( cd "$extract_dir" && $sha256_cmd -c "$tmp_manifest" --quiet >/dev/null 2>&1 ); then
+      echo "  Wheelhouse manifest sha256 mismatch — falling back to source install."
+      rm -rf "$tmp_dir"
+      return 1
+    fi
   fi
 
   WHEELHOUSE_DIR="$extract_dir"

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -938,6 +938,135 @@ class TestCommonWheelhouseFunctions:
         assert "mktemp" in body
         assert 'rm -rf "$tmp_dir"' in body
 
+    def test_fetch_wheelhouse_verifies_integrity(self):
+        # JTN-697: After extraction, every wheel must be integrity-checked.
+        # The original "at least one .whl exists" gate let truncated bundles
+        # (zero-byte numpy wheels, corrupt zips) pass, with ImportError only
+        # surfacing on first display refresh.
+        body = self._fetch_fn_body()
+
+        # Guard 1: empty-wheel rejection must exist and appear AFTER the
+        # "at least one .whl" existence check so we actually iterate every
+        # extracted wheel rather than just checking presence.
+        assert (
+            "[ ! -s " in body or '! -s "$whl"' in body
+        ), "fetch_wheelhouse must reject empty (zero-byte) wheels"
+
+        # Guard 2: structural zip check using python -m zipfile — pip refuses
+        # to install malformed zips and we want to catch them before pip sees
+        # them so the fallback is cleaner.
+        assert (
+            "python3 -m zipfile" in body
+        ), "fetch_wheelhouse must validate each wheel is a readable zip"
+
+        # Guard 3 (preferred): per-wheel sha256 manifest verification.
+        # Accept either `sha256sum -c` or the shasum fallback.
+        assert ".manifest.sha256" in body
+        assert "sha256sum -c" in body or "shasum -a 256 -c" in body, (
+            "fetch_wheelhouse must verify wheels against the published "
+            "per-wheel sha256 manifest when available"
+        )
+
+        # The new integrity gate must precede WHEELHOUSE_DIR assignment so
+        # callers never see a populated dir on corrupt input.
+        integrity_pos = body.index("python3 -m zipfile")
+        set_pos = body.index('WHEELHOUSE_DIR="$extract_dir"')
+        assert (
+            integrity_pos < set_pos
+        ), "integrity checks must run before WHEELHOUSE_DIR is exposed"
+
+        # Failure paths must still rm -rf and return 1 so the caller falls
+        # back to source install.
+        # (Covered structurally by test_fetch_is_graceful_on_curl_failure;
+        # here we assert the new fail messages route through the same path.)
+        assert "Wheelhouse integrity check failed" in body
+        assert "manifest sha256 mismatch" in body.lower()
+
+    def test_fetch_wheelhouse_rejects_empty_wheel_integration(self, tmp_path):
+        # JTN-697 integration: craft a wheelhouse tarball containing a
+        # zero-byte .whl, then invoke fetch_wheelhouse with curl stubbed
+        # to serve it from disk. Expect non-zero exit + empty WHEELHOUSE_DIR.
+        import shutil
+        import subprocess
+        import zipfile as _zipfile
+
+        if not shutil.which("bash") or not shutil.which("tar"):
+            pytest.skip("bash/tar not available")
+
+        wheels_src = tmp_path / "wheels_src"
+        wheels_src.mkdir()
+        # Zero-byte wheel → the exact failure mode in the issue.
+        (wheels_src / "numpy-1.0.0-cp313-cp313-linux_armv7l.whl").write_bytes(b"")
+        # Also drop a valid zip so the "at least one .whl" gate passes.
+        good = wheels_src / "pillow-10.0.0-cp313-cp313-linux_armv7l.whl"
+        with _zipfile.ZipFile(good, "w") as zf:
+            zf.writestr("pillow-10.0.0.dist-info/METADATA", "Name: pillow\n")
+
+        tarball = tmp_path / "inkypi-wheels-9.9.9-linux_armv7l.tar.gz"
+        subprocess.run(
+            ["tar", "-czf", str(tarball), "-C", str(wheels_src), "."],
+            check=True,
+        )
+
+        # Stub curl: serve tarball, 404 for sha/manifest (exercises structural
+        # guard, not manifest-mismatch guard).
+        stub_dir = tmp_path / "stub_bin"
+        stub_dir.mkdir()
+        stub_curl = stub_dir / "curl"
+        stub_curl.write_text(f"""#!/usr/bin/env bash
+out=""
+url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output) out="$2"; shift 2 ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$url" in
+  *.tar.gz) cp {tarball} "$out" ;;
+  *) exit 22 ;;
+esac
+""")
+        stub_curl.chmod(0o755)
+
+        stub_uname = stub_dir / "uname"
+        stub_uname.write_text("""#!/usr/bin/env bash
+if [ "$1" = "-m" ]; then echo armv7l; else /usr/bin/uname "$@"; fi
+""")
+        stub_uname.chmod(0o755)
+
+        script_dir = tmp_path / "install"
+        script_dir.mkdir()
+        (tmp_path / "VERSION").write_text("9.9.9\n")
+        shutil.copy(INSTALL_DIR / "_common.sh", script_dir / "_common.sh")
+
+        harness = tmp_path / "run.sh"
+        harness.write_text(f"""#!/usr/bin/env bash
+set +e
+export PATH="{stub_dir}:$PATH"
+SCRIPT_DIR="{script_dir}"
+source "$SCRIPT_DIR/_common.sh"
+fetch_wheelhouse
+rc=$?
+echo "RC=$rc"
+echo "DIR=[$WHEELHOUSE_DIR]"
+""")
+        harness.chmod(0o755)
+
+        result = subprocess.run(
+            ["bash", str(harness)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        combined = result.stdout + result.stderr
+        assert "RC=1" in combined, f"expected rc=1, got:\n{combined}"
+        assert (
+            "DIR=[]" in combined
+        ), f"WHEELHOUSE_DIR must be empty on failure, got:\n{combined}"
+        assert "integrity check failed" in combined.lower()
+
 
 class TestInstallWheelhouseFetch:
     """JTN-604: install.sh sources _common.sh for wheelhouse helpers and
@@ -1062,6 +1191,15 @@ class TestWheelhouseBuildWorkflow:
         # verify the download.
         assert "sha256sum" in self.content
         assert ".sha256" in self.content
+
+    def test_workflow_publishes_per_wheel_manifest(self):
+        # JTN-697: In addition to the tarball-level sha256, publish a
+        # per-wheel sha256 manifest so install.sh can detect individual
+        # truncated/corrupt wheels hiding inside an otherwise-valid tarball.
+        assert ".manifest.sha256" in self.content
+        # Manifest must be produced from the built wheels and uploaded as
+        # a release asset alongside the tarball.
+        assert "sha256sum *.whl" in self.content
 
 
 class TestPiImageBuildWorkflow:


### PR DESCRIPTION
## Summary

`fetch_wheelhouse` previously only checked that at least one `.whl` existed after extracting the release tarball. A truncated-but-decompressing tarball can leave a zero-byte `numpy-*.whl` behind; pip "installs" it and the `ImportError` only surfaces on first display refresh, well after `install.sh` reports success.

This PR adds a two-layer integrity gate after extraction and clamps down the fallback-to-source-install behaviour when any wheel looks wrong.

## Changes

### `install/_common.sh` — `fetch_wheelhouse`
- Download optional `<tarball>.manifest.sha256` (per-wheel hashes with basenames).
- Iterate every extracted wheel and enforce:
  1. **Non-empty** (`[ -s "$whl" ]`) — the exact failure mode in the issue.
  2. **Valid zip** (`python3 -m zipfile -l`) — pip refuses malformed archives.
  3. **Manifest match** when a manifest is published — `sha256sum -c` (or `shasum -a 256 -c`) against every wheel.
- Any failure path still `rm -rf`s the temp dir and `return 1`s, so the existing source-install fallback fires transparently.

### `.github/workflows/build-wheelhouse.yml`
- Emit `<tarball>.manifest.sha256` (one `sha256sum` line per wheel, basenames only) alongside the tarball-level sha256.
- Attach the manifest to the release / workflow_dispatch artifact so `install.sh` on the device can fetch it.

### `tests/unit/test_install_scripts.py`
- `test_fetch_wheelhouse_verifies_integrity` — structural assertions on `_common.sh` (empty guard, zipfile check, manifest verification, ordering against `WHEELHOUSE_DIR` assignment, failure messages).
- `test_fetch_wheelhouse_rejects_empty_wheel_integration` — end-to-end: builds a tarball containing a 0-byte wheel, stubs `curl`/`uname`, sources `_common.sh`, asserts `fetch_wheelhouse` exits 1 with `WHEELHOUSE_DIR` empty.
- `test_workflow_publishes_per_wheel_manifest` — guards the new manifest output in `build-wheelhouse.yml`.

## Compatibility

- Manifest is **optional**: older releases without a `.manifest.sha256` still install, protected by structural guards only.
- No change to the on-device install contract — corruption still falls back to source install, which was the pre-existing behaviour for missing/empty tarballs.

## Test plan
- [x] Full suite: 4172 passed, 5 skipped
- [x] `scripts/lint.sh` (ruff, black, shellcheck) passes
- [x] `bash -n install/_common.sh` passes
- [x] Integration test verifies 0-byte wheel in tarball triggers fallback

Fixes JTN-697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)