### PR TITLE
feat(observability): add /api/diagnostics consolidated endpoint (JTN-707)

### DIFF
--- a/src/app_setup/blueprints_registry.py
+++ b/src/app_setup/blueprints_registry.py
@@ -13,6 +13,7 @@ def register_blueprints(app: Flask) -> None:
     from blueprints.client_error import client_error_bp
     from blueprints.client_log import client_log_bp
     from blueprints.csp_report import csp_report_bp
+    from blueprints.diagnostics import diagnostics_bp
     from blueprints.events import events_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
@@ -42,3 +43,4 @@ def register_blueprints(app: Flask) -> None:
     app.register_blueprint(version_info_bp)
     app.register_blueprint(csp_report_bp)
     app.register_blueprint(events_bp)
+    app.register_blueprint(diagnostics_bp)

--- a/src/blueprints/diagnostics.py
+++ b/src/blueprints/diagnostics.py
@@ -201,6 +201,53 @@ def _read_last_update_failure() -> Any | None:
 # ---------------------------------------------------------------------------
 
 
+def _latest_refresh_ts() -> str | None:
+    """Return device_config.refresh_info.latest_refresh_time, or None on any miss."""
+    dc = current_app.config.get("DEVICE_CONFIG")
+    if dc is None:
+        return None
+    try:
+        refresh_info = dc.get_refresh_info()
+    except Exception:
+        return None
+    latest = getattr(refresh_info, "latest_refresh_time", None)
+    if isinstance(latest, str) and latest:
+        return latest
+    return None
+
+
+def _safe_health_snapshot(rt: Any) -> dict[str, Any]:
+    """Return rt.get_health_snapshot() or an empty dict when it fails / is absent."""
+    if rt is None or not hasattr(rt, "get_health_snapshot"):
+        return {}
+    try:
+        snap = rt.get_health_snapshot()
+    except Exception:
+        return {}
+    return snap if isinstance(snap, dict) else {}
+
+
+def _most_recent_plugin_error(snapshot: dict[str, Any]) -> str | None:
+    """Pick the error with the newest last_failure_at across all plugin entries."""
+    last_error: str | None = None
+    last_failure_at: str | None = None
+    for entry in snapshot.values():
+        if not isinstance(entry, dict):
+            continue
+        err = entry.get("last_error")
+        fat = entry.get("last_failure_at")
+        if not err or not isinstance(err, str):
+            continue
+        is_newer = last_failure_at is None or (
+            isinstance(fat, str) and fat > last_failure_at
+        )
+        if is_newer:
+            last_error = err
+            if isinstance(fat, str):
+                last_failure_at = fat
+    return last_error
+
+
 def _refresh_task_snapshot() -> dict[str, Any]:
     """Return running/last_run_ts/last_error summary of the refresh task singleton."""
     payload: dict[str, Any] = {
@@ -213,49 +260,20 @@ def _refresh_task_snapshot() -> dict[str, Any]:
         if rt is None:
             return payload
         payload["running"] = bool(getattr(rt, "running", False))
-
-        # Best signal for "last_run_ts" we have today is the latest_refresh_time
-        # on device_config.refresh_info, which the worker updates on every push.
-        dc = current_app.config.get("DEVICE_CONFIG")
-        if dc is not None:
-            try:
-                refresh_info = dc.get_refresh_info()
-                latest = getattr(refresh_info, "latest_refresh_time", None)
-                if isinstance(latest, str) and latest:
-                    payload["last_run_ts"] = latest
-            except Exception:
-                pass
-
-        # Pull the most recent plugin error, if any, as a coarse "last_error".
-        try:
-            snapshot = (
-                rt.get_health_snapshot() if hasattr(rt, "get_health_snapshot") else {}
-            )
-        except Exception:
-            snapshot = {}
-        last_error: str | None = None
-        last_failure_at: str | None = None
-        if isinstance(snapshot, dict):
-            for entry in snapshot.values():
-                if not isinstance(entry, dict):
-                    continue
-                err = entry.get("last_error")
-                fat = entry.get("last_failure_at")
-                if (
-                    err
-                    and isinstance(err, str)
-                    and (
-                        last_failure_at is None
-                        or (isinstance(fat, str) and fat > last_failure_at)
-                    )
-                ):
-                    last_error = err
-                    if isinstance(fat, str):
-                        last_failure_at = fat
-        payload["last_error"] = last_error
+        payload["last_run_ts"] = _latest_refresh_ts()
+        payload["last_error"] = _most_recent_plugin_error(_safe_health_snapshot(rt))
     except Exception:
         logger.exception("diagnostics: failed to introspect refresh task")
     return payload
+
+
+def _status_to_label(raw: Any) -> str | None:
+    """Map refresh-task status color codes onto the public ok/fail vocabulary."""
+    if raw == "green":
+        return "ok"
+    if raw == "red":
+        return "fail"
+    return None
 
 
 def _plugin_health_summary() -> dict[str, str]:
@@ -277,23 +295,15 @@ def _plugin_health_summary() -> dict[str, str]:
         logger.exception("diagnostics: failed to list registered plugins")
 
     # Overlay with the refresh-task health snapshot so we report ok/fail where known.
-    try:
-        rt = current_app.config.get("REFRESH_TASK")
-        if rt is not None and hasattr(rt, "get_health_snapshot"):
-            snap = rt.get_health_snapshot() or {}
-            if isinstance(snap, dict):
-                for pid, entry in snap.items():
-                    if not isinstance(entry, dict):
-                        continue
-                    status = entry.get("status")
-                    if status == "green":
-                        summary[pid] = "ok"
-                    elif status == "red":
-                        summary[pid] = "fail"
-                    else:
-                        summary.setdefault(pid, "unknown")
-    except Exception:
-        logger.exception("diagnostics: failed to read plugin health snapshot")
+    snap = _safe_health_snapshot(current_app.config.get("REFRESH_TASK"))
+    for pid, entry in snap.items():
+        if not isinstance(entry, dict):
+            continue
+        label = _status_to_label(entry.get("status"))
+        if label is not None:
+            summary[pid] = label
+        else:
+            summary.setdefault(pid, "unknown")
 
     return summary
 

--- a/src/blueprints/diagnostics.py
+++ b/src/blueprints/diagnostics.py
@@ -1,0 +1,370 @@
+"""Consolidated diagnostics endpoint (JTN-707).
+
+Surfaces uptime, memory, disk, refresh-task status, plugin health, a tail of
+recent log lines, version info, and the last update failure in a single JSON
+response. Designed for:
+
+* Support flows ("what's going on with my Pi right now?") without SSH.
+* Downstream UI consumers — M2 status badge, K3 rollback UI.
+
+Access control
+--------------
+The endpoint rides on the app-wide PIN auth gate (see ``app_setup/auth.py``)
+when it is enabled. When PIN auth is *disabled* (no ``INKYPI_AUTH_PIN``),
+requests are additionally restricted to local/private networks unless
+``INKYPI_ENV=dev`` explicitly opts in. The goal is to avoid leaking system
+internals to the open internet on unauthenticated deployments.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import shutil
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from flask import Blueprint, current_app, jsonify, request
+
+from utils.http_utils import json_error
+
+logger = logging.getLogger(__name__)
+
+diagnostics_bp = Blueprint("diagnostics", __name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_LOG_TAIL_LINES = 100
+_PREV_VERSION_PATH = Path("/var/lib/inkypi/prev_version")
+_LAST_UPDATE_FAILURE_PATH = Path("/var/lib/inkypi/.last-update-failure")
+
+
+# ---------------------------------------------------------------------------
+# Access control
+# ---------------------------------------------------------------------------
+
+
+def _is_private_address(addr: str | None) -> bool:
+    """Return True when *addr* is a loopback or RFC1918/ULA private address.
+
+    Unknown / unparseable values are treated as non-private (fail closed).
+    """
+    if not addr:
+        return False
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return ip.is_loopback or ip.is_private or ip.is_link_local
+
+
+def _access_allowed() -> tuple[bool, str | None]:
+    """Return (allowed, reason-if-denied).
+
+    When PIN auth is enabled app-wide, the before_request hook has already
+    authenticated the caller (or redirected them to /login). In that case we
+    trust the gate and allow the request.
+
+    When PIN auth is disabled, we fall back to restricting access to private
+    network addresses. ``INKYPI_ENV=dev`` disables this guardrail so local
+    development / tests are unimpeded.
+    """
+    if current_app.config.get("AUTH_ENABLED"):
+        return True, None
+
+    env = (os.getenv("INKYPI_ENV") or "").strip().lower()
+    if env == "dev":
+        return True, None
+
+    if _is_private_address(request.remote_addr):
+        return True, None
+
+    return False, "diagnostics endpoint requires authentication or local access"
+
+
+# ---------------------------------------------------------------------------
+# System metrics
+# ---------------------------------------------------------------------------
+
+
+def _uptime_seconds() -> int | None:
+    """Return system uptime in seconds via psutil; fall back to /proc/uptime."""
+    try:
+        import psutil  # type: ignore
+
+        return int(time.time() - psutil.boot_time())
+    except Exception:
+        pass
+    try:
+        text = Path("/proc/uptime").read_text()
+        return int(float(text.split()[0]))
+    except Exception:
+        return None
+
+
+def _memory_info() -> dict[str, Any]:
+    """Return {total_mb, used_mb, pct} from psutil, else from /proc/meminfo."""
+    try:
+        import psutil  # type: ignore
+
+        vm = psutil.virtual_memory()
+        total_mb = int(vm.total / (1024 * 1024))
+        used_mb = int((vm.total - vm.available) / (1024 * 1024))
+        return {"total_mb": total_mb, "used_mb": used_mb, "pct": float(vm.percent)}
+    except Exception:
+        pass
+    try:
+        meminfo: dict[str, int] = {}
+        with Path("/proc/meminfo").open() as fh:
+            for line in fh:
+                key, _, rest = line.partition(":")
+                parts = rest.strip().split()
+                if parts and parts[0].isdigit():
+                    # meminfo values are in kB
+                    meminfo[key.strip()] = int(parts[0])
+        total_kb = meminfo.get("MemTotal", 0)
+        avail_kb = meminfo.get("MemAvailable", meminfo.get("MemFree", 0))
+        total_mb = int(total_kb / 1024)
+        used_mb = int((total_kb - avail_kb) / 1024)
+        pct = round(100.0 * (total_kb - avail_kb) / total_kb, 1) if total_kb else 0.0
+        return {"total_mb": total_mb, "used_mb": used_mb, "pct": pct}
+    except Exception:
+        return {"total_mb": None, "used_mb": None, "pct": None}
+
+
+def _disk_info(path: str = "/") -> dict[str, Any]:
+    """Return {total_mb, used_mb, pct, path} for the filesystem containing *path*."""
+    try:
+        du = shutil.disk_usage(path)
+        total_mb = int(du.total / (1024 * 1024))
+        used_mb = int(du.used / (1024 * 1024))
+        pct = round(100.0 * du.used / du.total, 1) if du.total else 0.0
+        return {"total_mb": total_mb, "used_mb": used_mb, "pct": pct, "path": path}
+    except Exception:
+        return {"total_mb": None, "used_mb": None, "pct": None, "path": path}
+
+
+# ---------------------------------------------------------------------------
+# App / deployment metadata
+# ---------------------------------------------------------------------------
+
+
+def _read_version() -> str:
+    """Return the version string from the VERSION file at repo root."""
+    try:
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        value = (repo_root / "VERSION").read_text().strip()
+        if value and value != "{version}":
+            return value
+    except Exception:
+        pass
+    # Fall back to cached APP_VERSION on the flask app if present
+    try:
+        cfg_version = current_app.config.get("APP_VERSION")
+        if isinstance(cfg_version, str) and cfg_version:
+            return cfg_version
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _read_text_file(path: Path) -> str | None:
+    """Return the stripped contents of *path* if readable, else None."""
+    try:
+        value = path.read_text().strip()
+        return value or None
+    except Exception:
+        return None
+
+
+def _read_last_update_failure() -> Any | None:
+    """Return parsed JSON payload at .last-update-failure, else raw string, else None."""
+    raw = _read_text_file(_LAST_UPDATE_FAILURE_PATH)
+    if not raw:
+        return None
+    # Best-effort JSON parse — fall back to raw text
+    try:
+        import json
+
+        return json.loads(raw)
+    except Exception:
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Refresh task / plugin introspection
+# ---------------------------------------------------------------------------
+
+
+def _refresh_task_snapshot() -> dict[str, Any]:
+    """Return running/last_run_ts/last_error summary of the refresh task singleton."""
+    payload: dict[str, Any] = {
+        "running": False,
+        "last_run_ts": None,
+        "last_error": None,
+    }
+    try:
+        rt = current_app.config.get("REFRESH_TASK")
+        if rt is None:
+            return payload
+        payload["running"] = bool(getattr(rt, "running", False))
+
+        # Best signal for "last_run_ts" we have today is the latest_refresh_time
+        # on device_config.refresh_info, which the worker updates on every push.
+        dc = current_app.config.get("DEVICE_CONFIG")
+        if dc is not None:
+            try:
+                refresh_info = dc.get_refresh_info()
+                latest = getattr(refresh_info, "latest_refresh_time", None)
+                if isinstance(latest, str) and latest:
+                    payload["last_run_ts"] = latest
+            except Exception:
+                pass
+
+        # Pull the most recent plugin error, if any, as a coarse "last_error".
+        try:
+            snapshot = (
+                rt.get_health_snapshot() if hasattr(rt, "get_health_snapshot") else {}
+            )
+        except Exception:
+            snapshot = {}
+        last_error: str | None = None
+        last_failure_at: str | None = None
+        if isinstance(snapshot, dict):
+            for entry in snapshot.values():
+                if not isinstance(entry, dict):
+                    continue
+                err = entry.get("last_error")
+                fat = entry.get("last_failure_at")
+                if (
+                    err
+                    and isinstance(err, str)
+                    and (
+                        last_failure_at is None
+                        or (isinstance(fat, str) and fat > last_failure_at)
+                    )
+                ):
+                    last_error = err
+                    if isinstance(fat, str):
+                        last_failure_at = fat
+        payload["last_error"] = last_error
+    except Exception:
+        logger.exception("diagnostics: failed to introspect refresh task")
+    return payload
+
+
+def _plugin_health_summary() -> dict[str, str]:
+    """Return a {plugin_id: 'ok'|'fail'|'unknown'} map for every registered plugin.
+
+    v1 intentionally returns a flat string per plugin for a stable UI shape.
+    Detailed per-plugin metrics remain available on /api/health/plugins.
+    """
+    summary: dict[str, str] = {}
+
+    # Start with every registered plugin id so the shape is complete even when
+    # the refresh task hasn't yet run.
+    try:
+        from plugins.plugin_registry import get_registered_plugin_ids
+
+        for pid in sorted(get_registered_plugin_ids()):
+            summary[pid] = "unknown"
+    except Exception:
+        logger.exception("diagnostics: failed to list registered plugins")
+
+    # Overlay with the refresh-task health snapshot so we report ok/fail where known.
+    try:
+        rt = current_app.config.get("REFRESH_TASK")
+        if rt is not None and hasattr(rt, "get_health_snapshot"):
+            snap = rt.get_health_snapshot() or {}
+            if isinstance(snap, dict):
+                for pid, entry in snap.items():
+                    if not isinstance(entry, dict):
+                        continue
+                    status = entry.get("status")
+                    if status == "green":
+                        summary[pid] = "ok"
+                    elif status == "red":
+                        summary[pid] = "fail"
+                    else:
+                        summary.setdefault(pid, "unknown")
+    except Exception:
+        logger.exception("diagnostics: failed to read plugin health snapshot")
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Log tail
+# ---------------------------------------------------------------------------
+
+
+def _log_tail(max_lines: int = _LOG_TAIL_LINES) -> list[str]:
+    """Return up to *max_lines* most recent log lines, capped by policy."""
+    cap = max(0, min(int(max_lines), _LOG_TAIL_LINES))
+    if cap == 0:
+        return []
+    try:
+        # Reuse the existing helper from the settings blueprint. It knows how to
+        # pull from journald on Linux and falls back to in-memory buffers in
+        # dev mode. 2h of history is ample for a 100-line tail.
+        from blueprints import settings as settings_mod
+
+        lines = settings_mod._read_log_lines(hours=2)  # type: ignore[attr-defined]
+        if not isinstance(lines, list):
+            return []
+        if len(lines) > cap:
+            lines = lines[-cap:]
+        return [str(ln) for ln in lines]
+    except Exception:
+        logger.exception("diagnostics: failed to read log tail")
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@diagnostics_bp.route("/api/diagnostics", methods=["GET"])
+def api_diagnostics():
+    """Return a consolidated system + application diagnostics payload.
+
+    Response shape (stable — downstream UIs consume this):
+
+    .. code-block:: json
+
+      {
+        "ts": "2026-04-14T12:34:56+00:00",
+        "version": "0.51.8",
+        "prev_version": "0.51.7",
+        "uptime_s": 12345,
+        "memory": {"total_mb": 512, "used_mb": 310, "pct": 60.5},
+        "disk": {"total_mb": 16000, "used_mb": 5200, "pct": 32.5, "path": "/"},
+        "refresh_task": {"running": true, "last_run_ts": "...", "last_error": null},
+        "plugin_health": {"clock": "ok", "weather": "fail"},
+        "log_tail_100": ["..."],
+        "last_update_failure": null
+      }
+    """
+    allowed, reason = _access_allowed()
+    if not allowed:
+        return json_error(reason or "forbidden", status=403)
+
+    payload: dict[str, Any] = {
+        "ts": datetime.now(UTC).isoformat(),
+        "version": _read_version(),
+        "prev_version": _read_text_file(_PREV_VERSION_PATH),
+        "uptime_s": _uptime_seconds(),
+        "memory": _memory_info(),
+        "disk": _disk_info("/"),
+        "refresh_task": _refresh_task_snapshot(),
+        "plugin_health": _plugin_health_summary(),
+        "log_tail_100": _log_tail(_LOG_TAIL_LINES),
+        "last_update_failure": _read_last_update_failure(),
+    }
+    return jsonify(payload), 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,6 +269,7 @@ def flask_app(device_config_dev, monkeypatch):
     from blueprints.api_docs import api_docs_bp
     from blueprints.apikeys import apikeys_bp
     from blueprints.csp_report import csp_report_bp
+    from blueprints.diagnostics import diagnostics_bp
     from blueprints.events import events_bp
     from blueprints.history import history_bp
     from blueprints.main import main_bp
@@ -349,6 +350,7 @@ def flask_app(device_config_dev, monkeypatch):
     app.register_blueprint(version_info_bp)
     app.register_blueprint(csp_report_bp)
     app.register_blueprint(events_bp)
+    app.register_blueprint(diagnostics_bp)
 
     setup_http_metrics(app)
     init_sri(app)

--- a/tests/unit/test_diagnostics_endpoint.py
+++ b/tests/unit/test_diagnostics_endpoint.py
@@ -262,3 +262,279 @@ def test_access_allowed_when_auth_enabled(flask_app, monkeypatch):
     client = flask_app.test_client()
     resp = client.get("/api/diagnostics", environ_overrides={"REMOTE_ADDR": "8.8.8.8"})
     assert resp.status_code == 200
+
+
+def test_access_denied_for_unparseable_remote_addr(flask_app, monkeypatch):
+    """An unparseable REMOTE_ADDR fails closed (403), not open."""
+    monkeypatch.delenv("INKYPI_ENV", raising=False)
+    flask_app.config["AUTH_ENABLED"] = False
+    client = flask_app.test_client()
+    resp = client.get(
+        "/api/diagnostics", environ_overrides={"REMOTE_ADDR": "not-an-ip"}
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# System metric helpers — fallback branches
+# ---------------------------------------------------------------------------
+
+
+def test_uptime_seconds_falls_back_to_proc_uptime(monkeypatch, tmp_path):
+    """When psutil.boot_time raises, _uptime_seconds reads /proc/uptime."""
+    import blueprints.diagnostics as diag
+
+    fake = tmp_path / "uptime"
+    fake.write_text("54321.42 12345.67\n")
+
+    class _BoomPsutil:
+        @staticmethod
+        def boot_time():
+            raise RuntimeError("no psutil on this host")
+
+    monkeypatch.setitem(__import__("sys").modules, "psutil", _BoomPsutil)
+    monkeypatch.setattr(
+        diag, "Path", lambda p="": fake if p == "/proc/uptime" else Path(p)
+    )
+    assert diag._uptime_seconds() == 54321
+
+
+def test_uptime_seconds_returns_none_on_total_failure(monkeypatch):
+    """Both psutil and /proc/uptime failing yields None instead of raising."""
+    import blueprints.diagnostics as diag
+
+    class _BoomPsutil:
+        @staticmethod
+        def boot_time():
+            raise RuntimeError("x")
+
+    monkeypatch.setitem(__import__("sys").modules, "psutil", _BoomPsutil)
+
+    class _NoFile:
+        def __init__(self, *_args, **_kw):
+            pass
+
+        def read_text(self):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(diag, "Path", _NoFile)
+    assert diag._uptime_seconds() is None
+
+
+def test_memory_info_falls_back_to_proc_meminfo(monkeypatch, tmp_path):
+    """When psutil raises, _memory_info parses /proc/meminfo in kB."""
+    import blueprints.diagnostics as diag
+
+    fake = tmp_path / "meminfo"
+    fake.write_text(
+        "MemTotal:         512000 kB\n"
+        "MemFree:          100000 kB\n"
+        "MemAvailable:     200000 kB\n"
+    )
+
+    class _BoomPsutil:
+        @staticmethod
+        def virtual_memory():
+            raise RuntimeError("no psutil")
+
+    monkeypatch.setitem(__import__("sys").modules, "psutil", _BoomPsutil)
+
+    # Patch Path("/proc/meminfo") to our temp file while leaving others alone.
+    real_path = diag.Path
+
+    def _path(p=""):
+        if p == "/proc/meminfo":
+            return fake
+        return real_path(p)
+
+    monkeypatch.setattr(diag, "Path", _path)
+    info = diag._memory_info()
+    # Total = 512000 kB ~ 500 MB, used = 512000 - 200000 = 312000 kB ~ 304 MB
+    assert info["total_mb"] == 500
+    assert info["used_mb"] == 304
+    # pct = 100 * (512000-200000)/512000 ~= 60.9
+    assert info["pct"] == pytest.approx(60.9, abs=0.2)
+
+
+def test_memory_info_returns_nulls_on_total_failure(monkeypatch):
+    """When every source raises, _memory_info returns a null-shaped dict."""
+    import blueprints.diagnostics as diag
+
+    class _BoomPsutil:
+        @staticmethod
+        def virtual_memory():
+            raise RuntimeError("x")
+
+    monkeypatch.setitem(__import__("sys").modules, "psutil", _BoomPsutil)
+
+    class _NoFile:
+        def __init__(self, *_args, **_kw):
+            pass
+
+        def open(self, *_a, **_kw):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(diag, "Path", _NoFile)
+    info = diag._memory_info()
+    assert info == {"total_mb": None, "used_mb": None, "pct": None}
+
+
+def test_disk_info_returns_nulls_on_oserror(monkeypatch):
+    """shutil.disk_usage raising gives a null-shaped disk entry (no 500)."""
+    import blueprints.diagnostics as diag
+
+    def _boom(_path):
+        raise OSError("read-only")
+
+    monkeypatch.setattr(diag.shutil, "disk_usage", _boom)
+    info = diag._disk_info("/nope")
+    assert info["path"] == "/nope"
+    assert info["total_mb"] is None
+    assert info["used_mb"] is None
+    assert info["pct"] is None
+
+
+# ---------------------------------------------------------------------------
+# Version resolution
+# ---------------------------------------------------------------------------
+
+
+def test_read_version_falls_back_to_app_config(flask_app, monkeypatch):
+    """When the VERSION file is unreadable, APP_VERSION from flask config is used."""
+    import blueprints.diagnostics as diag
+
+    flask_app.config["APP_VERSION"] = "9.9.9-test"
+
+    class _NoFile:
+        def __init__(self, *_args, **_kw):
+            pass
+
+        def resolve(self):
+            return self
+
+        @property
+        def parent(self):
+            return self
+
+        def __truediv__(self, _other):
+            return self
+
+        def read_text(self, *_a, **_kw):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(diag, "Path", _NoFile)
+    with flask_app.test_request_context("/api/diagnostics"):
+        assert diag._read_version() == "9.9.9-test"
+
+
+def test_read_version_unknown_when_no_source(flask_app, monkeypatch):
+    """Returns the literal 'unknown' when VERSION and APP_VERSION are both missing."""
+    import blueprints.diagnostics as diag
+
+    flask_app.config.pop("APP_VERSION", None)
+
+    class _NoFile:
+        def __init__(self, *_args, **_kw):
+            pass
+
+        def resolve(self):
+            return self
+
+        @property
+        def parent(self):
+            return self
+
+        def __truediv__(self, _other):
+            return self
+
+        def read_text(self, *_a, **_kw):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(diag, "Path", _NoFile)
+    with flask_app.test_request_context("/api/diagnostics"):
+        assert diag._read_version() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Refresh task + plugin registry edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_task_snapshot_no_refresh_task(flask_app):
+    """Missing REFRESH_TASK yields a benign null-shaped snapshot."""
+    import blueprints.diagnostics as diag
+
+    flask_app.config["REFRESH_TASK"] = None
+    with flask_app.test_request_context("/api/diagnostics"):
+        snap = diag._refresh_task_snapshot()
+    assert snap == {"running": False, "last_run_ts": None, "last_error": None}
+
+
+def test_refresh_task_snapshot_picks_most_recent_failure(client, flask_app):
+    """When multiple plugins have errors, the most recent failure wins."""
+    import blueprints.diagnostics as diag
+
+    rt = flask_app.config["REFRESH_TASK"]
+    with patch.object(
+        rt,
+        "get_health_snapshot",
+        return_value={
+            "a": {
+                "last_error": "older",
+                "last_failure_at": "2026-01-01T00:00:00+00:00",
+            },
+            "b": {
+                "last_error": "newer",
+                "last_failure_at": "2026-04-01T00:00:00+00:00",
+            },
+        },
+    ):
+        with flask_app.test_request_context("/api/diagnostics"):
+            snap = diag._refresh_task_snapshot()
+    assert snap["last_error"] == "newer"
+
+
+def test_refresh_task_snapshot_handles_health_method_raising(client, flask_app):
+    """A health-snapshot method that raises doesn't leak past the endpoint."""
+    import blueprints.diagnostics as diag
+
+    rt = flask_app.config["REFRESH_TASK"]
+    with patch.object(rt, "get_health_snapshot", side_effect=RuntimeError("broken")):
+        with flask_app.test_request_context("/api/diagnostics"):
+            snap = diag._refresh_task_snapshot()
+    assert snap["last_error"] is None
+
+
+def test_plugin_health_registry_failure_still_returns_dict(client, monkeypatch):
+    """A broken plugin registry still yields a dict (possibly empty)."""
+
+    def _boom():
+        raise RuntimeError("registry broken")
+
+    monkeypatch.setattr("plugins.plugin_registry.get_registered_plugin_ids", _boom)
+    resp = client.get("/api/diagnostics")
+    assert resp.status_code == 200
+    ph = resp.get_json()["plugin_health"]
+    assert isinstance(ph, dict)
+
+
+# ---------------------------------------------------------------------------
+# Private-address classifier
+# ---------------------------------------------------------------------------
+
+
+def test_is_private_address_classifier():
+    """_is_private_address covers loopback, RFC1918, link-local, and public IPs."""
+    import blueprints.diagnostics as diag
+
+    assert diag._is_private_address("127.0.0.1") is True
+    assert diag._is_private_address("10.0.0.1") is True
+    assert diag._is_private_address("192.168.5.5") is True
+    assert diag._is_private_address("169.254.1.1") is True
+    assert diag._is_private_address("::1") is True
+    assert diag._is_private_address("fc00::1") is True
+    assert diag._is_private_address("8.8.8.8") is False
+    assert diag._is_private_address("1.2.3.4") is False
+    assert diag._is_private_address("") is False
+    assert diag._is_private_address(None) is False
+    assert diag._is_private_address("not-an-ip") is False

--- a/tests/unit/test_diagnostics_endpoint.py
+++ b/tests/unit/test_diagnostics_endpoint.py
@@ -1,0 +1,264 @@
+# pyright: reportMissingImports=false
+"""Tests for the consolidated /api/diagnostics endpoint (JTN-707)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def client(flask_app):
+    """Flask test client with the diagnostics blueprint registered."""
+    return flask_app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _patch_diagnostics_paths(tmp_path, monkeypatch):
+    """Redirect /var/lib/inkypi paths so tests never touch the real fs.
+
+    The endpoint reads ``/var/lib/inkypi/prev_version`` and
+    ``/var/lib/inkypi/.last-update-failure``. Unit tests must never depend on
+    those paths existing (or not existing) on the host machine.
+    """
+    import blueprints.diagnostics as diag
+
+    prev = tmp_path / "prev_version"
+    fail = tmp_path / ".last-update-failure"
+    monkeypatch.setattr(diag, "_PREV_VERSION_PATH", prev)
+    monkeypatch.setattr(diag, "_LAST_UPDATE_FAILURE_PATH", fail)
+    # Dev env so unauthenticated local calls are allowed during tests.
+    monkeypatch.setenv("INKYPI_ENV", "dev")
+    return {"prev": prev, "fail": fail}
+
+
+# ---------------------------------------------------------------------------
+# Shape / required keys
+# ---------------------------------------------------------------------------
+
+
+def test_returns_200_with_required_keys(client):
+    """GET /api/diagnostics returns 200 with the documented top-level shape."""
+    resp = client.get("/api/diagnostics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data is not None
+
+    required_keys = {
+        "ts",
+        "version",
+        "prev_version",
+        "uptime_s",
+        "memory",
+        "disk",
+        "refresh_task",
+        "plugin_health",
+        "log_tail_100",
+        "last_update_failure",
+    }
+    assert required_keys.issubset(
+        data.keys()
+    ), f"missing keys: {required_keys - set(data.keys())}"
+
+    # uptime_s is an integer (or None in exotic environments)
+    assert data["uptime_s"] is None or isinstance(data["uptime_s"], int)
+
+    # memory shape
+    mem = data["memory"]
+    assert isinstance(mem, dict)
+    assert set(mem.keys()) >= {"total_mb", "used_mb", "pct"}
+
+    # disk shape
+    disk = data["disk"]
+    assert isinstance(disk, dict)
+    assert set(disk.keys()) >= {"total_mb", "used_mb", "pct", "path"}
+
+    # version must be non-empty string
+    assert isinstance(data["version"], str) and data["version"]
+
+    # refresh_task shape
+    rt = data["refresh_task"]
+    assert isinstance(rt, dict)
+    assert {"running", "last_run_ts", "last_error"}.issubset(rt.keys())
+
+    # plugin_health is a flat string-to-string map
+    ph = data["plugin_health"]
+    assert isinstance(ph, dict)
+    for v in ph.values():
+        assert v in {"ok", "fail", "unknown"}
+
+
+def test_version_matches_version_file(client):
+    """The `version` field reflects the repo's VERSION file."""
+    repo_root = Path(__file__).resolve().parents[2]
+    expected = (repo_root / "VERSION").read_text().strip()
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    assert data["version"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Missing optional files
+# ---------------------------------------------------------------------------
+
+
+def test_handles_missing_prev_version(client, _patch_diagnostics_paths):
+    """prev_version is null when /var/lib/inkypi/prev_version is absent."""
+    assert not _patch_diagnostics_paths["prev"].exists()
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    assert data["prev_version"] is None
+
+
+def test_reads_prev_version_when_present(client, _patch_diagnostics_paths):
+    """prev_version is returned verbatim (stripped) when the file exists."""
+    _patch_diagnostics_paths["prev"].write_text("0.51.7\n")
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    assert data["prev_version"] == "0.51.7"
+
+
+def test_handles_missing_last_update_failure(client, _patch_diagnostics_paths):
+    """last_update_failure is null when the sentinel file does not exist."""
+    assert not _patch_diagnostics_paths["fail"].exists()
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    assert data["last_update_failure"] is None
+
+
+def test_last_update_failure_parses_json_payload(client, _patch_diagnostics_paths):
+    """A JSON payload in .last-update-failure is parsed and returned as-is."""
+    _patch_diagnostics_paths["fail"].write_text(
+        '{"ts": "2026-04-14T00:00:00Z", "reason": "apt update failed"}'
+    )
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    assert isinstance(data["last_update_failure"], dict)
+    assert data["last_update_failure"]["reason"] == "apt update failed"
+
+
+def test_last_update_failure_raw_text_fallback(client, _patch_diagnostics_paths):
+    """Non-JSON contents are returned as a plain string so info is never lost."""
+    _patch_diagnostics_paths["fail"].write_text("plain text failure note")
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    assert data["last_update_failure"] == "plain text failure note"
+
+
+# ---------------------------------------------------------------------------
+# Plugin health
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_health_includes_all_registered_plugins(client):
+    """Every registered plugin appears in plugin_health, even if never run."""
+    from plugins.plugin_registry import get_registered_plugin_ids
+
+    registered = set(get_registered_plugin_ids())
+    # The test fixture loads at least one plugin; if not, skip rather than fail
+    # the shape contract.
+    if not registered:
+        pytest.skip("no plugins registered in this test environment")
+
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    ph = data["plugin_health"]
+    assert isinstance(ph, dict)
+    assert registered.issubset(
+        set(ph.keys())
+    ), f"missing plugins: {registered - set(ph.keys())}"
+    # All values are one of the documented statuses
+    for pid, status in ph.items():
+        assert status in {"ok", "fail", "unknown"}, (pid, status)
+
+
+def test_plugin_health_reflects_snapshot_status(client, flask_app):
+    """A green/red entry in the refresh-task snapshot maps to ok/fail."""
+    rt = flask_app.config["REFRESH_TASK"]
+    with patch.object(
+        rt,
+        "get_health_snapshot",
+        return_value={
+            "clock": {"status": "green"},
+            "weather": {"status": "red", "last_error": "timeout"},
+        },
+    ):
+        resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    ph = data["plugin_health"]
+    assert ph.get("clock") == "ok"
+    assert ph.get("weather") == "fail"
+    # last_error should also bubble into refresh_task.last_error
+    assert data["refresh_task"]["last_error"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Log tail
+# ---------------------------------------------------------------------------
+
+
+def test_log_tail_respects_100_line_cap(client, monkeypatch):
+    """log_tail_100 is capped to the most recent 100 entries, even if more exist."""
+    import blueprints.settings as settings_mod
+
+    huge = [f"line-{i}" for i in range(500)]
+    monkeypatch.setattr(settings_mod, "_read_log_lines", lambda hours: huge)
+
+    resp = client.get("/api/diagnostics")
+    data = resp.get_json()
+    tail = data["log_tail_100"]
+    assert isinstance(tail, list)
+    assert len(tail) == 100
+    # Cap keeps the most-recent entries (end of the list).
+    assert tail[0] == "line-400"
+    assert tail[-1] == "line-499"
+
+
+def test_log_tail_handles_reader_error(client, monkeypatch):
+    """A failing log reader degrades to an empty list, not a 500."""
+    import blueprints.settings as settings_mod
+
+    def boom(hours):  # noqa: ARG001 — signature match
+        raise RuntimeError("journalctl unavailable")
+
+    monkeypatch.setattr(settings_mod, "_read_log_lines", boom)
+    resp = client.get("/api/diagnostics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["log_tail_100"] == []
+
+
+# ---------------------------------------------------------------------------
+# Access control
+# ---------------------------------------------------------------------------
+
+
+def test_access_denied_for_remote_ip_without_auth(flask_app, monkeypatch):
+    """Without PIN auth and outside INKYPI_ENV=dev, non-private IPs get 403."""
+    monkeypatch.delenv("INKYPI_ENV", raising=False)
+    flask_app.config["AUTH_ENABLED"] = False
+    client = flask_app.test_client()
+    resp = client.get("/api/diagnostics", environ_overrides={"REMOTE_ADDR": "8.8.8.8"})
+    assert resp.status_code == 403
+
+
+def test_access_allowed_for_private_ip_without_auth(flask_app, monkeypatch):
+    """RFC1918 / loopback callers are allowed even without auth."""
+    monkeypatch.delenv("INKYPI_ENV", raising=False)
+    flask_app.config["AUTH_ENABLED"] = False
+    client = flask_app.test_client()
+    resp = client.get(
+        "/api/diagnostics", environ_overrides={"REMOTE_ADDR": "192.168.1.42"}
+    )
+    assert resp.status_code == 200
+
+
+def test_access_allowed_when_auth_enabled(flask_app, monkeypatch):
+    """If app-level PIN auth is enabled, the endpoint trusts the gate."""
+    monkeypatch.delenv("INKYPI_ENV", raising=False)
+    flask_app.config["AUTH_ENABLED"] = True
+    client = flask_app.test_client()
+    resp = client.get("/api/diagnostics", environ_overrides={"REMOTE_ADDR": "8.8.8.8"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Add `GET /api/diagnostics` (new blueprint `src/blueprints/diagnostics.py`) that consolidates uptime, memory, disk, refresh-task state, plugin health, log tail, version info, and last-update failure into one JSON payload — so a wedged Pi Zero 2 W can be diagnosed without SSH.
- Unblocks M2 (in-app status badge) and K3 (rollback UI) which will consume this shape.
- Reads `/var/lib/inkypi/prev_version` and `/var/lib/inkypi/.last-update-failure` when present; returns `null` otherwise (the latter will be written by JTN-704).
- Access control: rides the app-wide PIN auth gate when enabled; when PIN auth is off, private/loopback callers are allowed (or `INKYPI_ENV=dev`) — avoids leaking system internals on un-auth'd deployments.

## Response shape (stable)

```json
{
  "ts": "2026-04-14T12:34:56+00:00",
  "version": "0.51.8",
  "prev_version": "0.51.7",
  "uptime_s": 12345,
  "memory": {"total_mb": 512, "used_mb": 310, "pct": 60.5},
  "disk": {"total_mb": 16000, "used_mb": 5200, "pct": 32.5, "path": "/"},
  "refresh_task": {"running": true, "last_run_ts": "2026-04-14T12:30:00+00:00", "last_error": null},
  "plugin_health": {"clock": "ok", "weather": "ok"},
  "log_tail_100": ["..."],
  "last_update_failure": null
}
```

`plugin_health` is flattened to `"ok" | "fail" | "unknown"` per plugin for a stable UI contract; detailed per-plugin metrics remain on `/api/health/plugins`.

## Changes

- `src/blueprints/diagnostics.py` — new blueprint with one route
- `src/app_setup/blueprints_registry.py` — register the blueprint
- `tests/conftest.py` — register blueprint in the `flask_app` fixture
- `tests/unit/test_diagnostics_endpoint.py` — 14 new tests

## Test plan

- [x] `scripts/lint.sh` passes (ruff + black)
- [x] `pytest tests/unit/test_diagnostics_endpoint.py -v` — 14 passed
- [x] Full suite: `pytest tests/` — 4180 passed, 3 pre-existing static/CSS failures unrelated to this PR
- Tests cover: required-key shape, missing `prev_version`, missing `.last-update-failure`, JSON + raw-text parsing of failure file, plugin_health completeness, plugin_health ok/fail mapping, 100-line tail cap, log-reader error fallback, private-IP access, remote-IP 403, auth-enabled bypass

Linear: JTN-707

🤖 Generated with [Claude Code](https://claude.com/claude-code)