### PR TITLE
fix(update): trap-cleanup lockfile + record failure cause (JTN-704)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -13,16 +13,30 @@ INSTALL_PATH="/usr/local/$APPNAME"
 BINPATH="/usr/local/bin"
 VENV_PATH="$INSTALL_PATH/venv_$APPNAME"
 
-# JTN-666: Defense-in-depth for JTN-600 parity. While update.sh is running,
-# create /var/lib/inkypi/.install-in-progress. inkypi.service's ExecStartPre
-# refuses to start if this file exists, so even if someone manually runs
-# `systemctl start inkypi.service` or systemd tries to auto-restart, the
-# service cannot thrash the Pi mid-update. The lockfile is removed once all
-# update steps succeed (see end of script). On failure exit the file is
-# deliberately left in place so the user MUST rerun update.sh (or manually
-# remove it) before the service can start.
+# JTN-666 / JTN-704: Defense-in-depth for JTN-600 parity. While update.sh is
+# running, create /var/lib/inkypi/.install-in-progress. inkypi.service's
+# ExecStartPre refuses to start if this file exists, so even if someone
+# manually runs `systemctl start inkypi.service` or systemd tries to
+# auto-restart, the service cannot thrash the Pi mid-update.
+#
+# JTN-704: The lockfile is cleared unconditionally by the EXIT trap (whether
+# the update succeeds, errors, is killed, or Ctrl-C'd) so a failed update no
+# longer leaves the service permanently disabled. On failure exit, structured
+# failure metadata is written to .last-update-failure for later inspection
+# (UI surfacing, diagnostics, rollback).
+# JTN-704: LOCKFILE_DIR is overridable via env so the failure-recovery
+# integration test can redirect state writes to a tempdir without touching the
+# real /var/lib/inkypi. Production callers (install.sh, do_update.sh, the
+# systemd-run invocation in settings) do NOT set this var, so behavior is
+# unchanged in production.
 LOCKFILE_DIR="/var/lib/inkypi"
+# JTN-704: allow the integration test to redirect state writes without
+# touching the real /var/lib/inkypi. Production callers do not set this.
+if [ -n "${INKYPI_LOCKFILE_DIR:-}" ]; then
+  LOCKFILE_DIR="$INKYPI_LOCKFILE_DIR"
+fi
 LOCKFILE="$LOCKFILE_DIR/.install-in-progress"
+FAILURE_FILE="$LOCKFILE_DIR/.last-update-failure"
 
 SERVICE_FILE="$APPNAME.service"
 SERVICE_FILE_SOURCE="$SCRIPT_DIR/$SERVICE_FILE"
@@ -84,45 +98,148 @@ update_cli() {
   sudo chmod +x "$INSTALL_PATH/cli/"*
 }
 
-# Ensure script is run with sudo
-if [ "$EUID" -ne 0 ]; then
+# Ensure script is run with sudo. JTN-704: when the test-only env hook is
+# set we skip the root check so the trap can be exercised from pytest without
+# running the test suite as root; behavior is unchanged in production where
+# INKYPI_UPDATE_TEST_FAIL_AT is never set.
+if [ -z "${INKYPI_UPDATE_TEST_FAIL_AT:-}" ] \
+   && [ -z "${INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP:-}" ] \
+   && [ "$EUID" -ne 0 ]; then
   echo_error "ERROR: This script requires root privileges. Please run it with sudo."
   exit 1
 fi
 
-# JTN-666: Create the install-in-progress lockfile. inkypi.service's
+# JTN-666 / JTN-704: Create the install-in-progress lockfile. inkypi.service's
 # ExecStartPre refuses to start while this file exists (defense-in-depth for
-# JTN-600's systemctl disable). The lockfile is removed just before
-# update_app_service() calls `systemctl start` (see below); on intentional
-# failure exit it is left in place so the user must rerun update.sh (or
-# manually rm it) before the service can start.
+# JTN-600's systemctl disable).
 mkdir -p "$LOCKFILE_DIR"
 touch "$LOCKFILE"
 
-# JTN-685: Defense-in-depth EXIT trap for abnormal exits (SIGTERM, SIGHUP,
-# unhandled errors).  Intentional failure paths (exit 1 after an error message)
-# set _lockfile_keep=1 before exiting so the lockfile is intentionally
-# preserved — forcing a manual rerun.  Signals and unexpected exits leave
-# _lockfile_keep unset, so the trap clears the lockfile and allows the service
-# to start after the interruption.
-_lockfile_keep=0
-trap '[[ "${_lockfile_keep:-0}" -eq 1 ]] || rm -f "$LOCKFILE"' EXIT
+# JTN-704: Track the most recent command-line description so the EXIT trap can
+# record *which step* failed in the structured failure record. Each top-level
+# phase sets _current_step before the work begins.
+_current_step="startup"
+
+# JTN-704: Unconditional cleanup trap.
+#
+# On EVERY exit (success, explicit exit N, errexit, SIGINT, SIGTERM, SIGHUP),
+# remove the lockfile so the service is never left permanently blocked by a
+# stale /var/lib/inkypi/.install-in-progress. When the exit code is non-zero
+# we also write a structured failure record to .last-update-failure so the UI
+# / diagnostics can surface *why* the update failed (pip failure, CSS build,
+# OOM, etc.) instead of relying on the system journal. On a successful exit
+# we clear the stale .last-update-failure so downstream consumers see a clean
+# signal.
+#
+# The trap fires via EXIT for `exit N` and errexit paths. We additionally
+# install it on INT/TERM/HUP so Ctrl-C and systemd-stop during the update
+# still clear the lockfile cleanly.
+_inkypi_update_exit_trap() {
+  local rc=$?
+  # Remove lockfile first — this is the load-bearing invariant (JTN-704).
+  rm -f "$LOCKFILE" 2>/dev/null || true
+  if [ "$rc" -ne 0 ]; then
+    # Non-zero exit: persist failure metadata for UI / diagnostics.
+    local ts
+    ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+    local journal_tail=""
+    if command -v journalctl >/dev/null 2>&1; then
+      # Capture last 20 lines of inkypi-update journal if available; never fail
+      # the trap because of this best-effort read.
+      journal_tail=$(journalctl -u inkypi-update -n 20 --no-pager 2>/dev/null \
+        | tail -n 20 || true)
+    fi
+    # Escape for embedding in a JSON string (backslash, dquote, control chars).
+    # Use python3 when available for correctness; fall back to a conservative
+    # sed transform when python3 is absent (target: minimal Pi OS environments).
+    local journal_json
+    if command -v python3 >/dev/null 2>&1; then
+      journal_json=$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' \
+        <<<"$journal_tail" 2>/dev/null || echo '""')
+    else
+      # Strip CR, escape backslash + dquote, drop non-printables. Wrap in quotes.
+      journal_json='"'$(printf '%s' "$journal_tail" \
+        | tr -d '\r' \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g' \
+        | tr -d '\000-\010\013\014\016-\037')'"'
+    fi
+    # Escape _current_step the same way (may contain spaces / quotes).
+    local step_json
+    if command -v python3 >/dev/null 2>&1; then
+      step_json=$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))' \
+        <<<"$_current_step" 2>/dev/null || echo '""')
+    else
+      step_json='"'$(printf '%s' "$_current_step" \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')'"'
+    fi
+    mkdir -p "$LOCKFILE_DIR" 2>/dev/null || true
+    # Write atomically via tmpfile + mv so a partial write never leaves the
+    # consumer parsing half a JSON object.
+    local tmp="${FAILURE_FILE}.tmp"
+    {
+      printf '{'
+      printf '"timestamp":"%s",' "$ts"
+      printf '"exit_code":%d,' "$rc"
+      printf '"last_command":%s,' "$step_json"
+      printf '"recent_journal_lines":%s' "$journal_json"
+      printf '}\n'
+    } > "$tmp" 2>/dev/null || true
+    if [ -s "$tmp" ]; then
+      mv -f "$tmp" "$FAILURE_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+    else
+      rm -f "$tmp" 2>/dev/null || true
+    fi
+  else
+    # Success: remove any stale failure record from a previous aborted run.
+    rm -f "$FAILURE_FILE" 2>/dev/null || true
+  fi
+}
+trap _inkypi_update_exit_trap EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+# JTN-704: Test-only failure injection hook. Production behavior is unchanged
+# unless INKYPI_UPDATE_TEST_FAIL_AT is set. The integration test sets this env
+# var to simulate a mid-update failure and assert the trap writes a correct
+# .last-update-failure record and removes the lockfile.
+_inkypi_maybe_inject_failure() {
+  local step="$1"
+  if [ -n "${INKYPI_UPDATE_TEST_FAIL_AT:-}" ] && [ "$step" = "$INKYPI_UPDATE_TEST_FAIL_AT" ]; then
+    _current_step="$step"
+    echo "TEST: injecting failure at step '$step'" >&2
+    exit 97
+  fi
+}
+_inkypi_maybe_inject_failure "startup"
+
+# JTN-704: Test-only success simulation. When set, exit 0 immediately after
+# trap setup so the integration test can verify the success-path trap branch
+# (no .last-update-failure written, lockfile removed). Production callers do
+# not set this variable.
+if [ -n "${INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP:-}" ]; then
+  exit 0
+fi
 
 # JTN-666: Stop and disable the service BEFORE touching files or venv so
 # systemd cannot restart a half-installed service and thrash the Pi.
+_current_step="stop_service"
+_inkypi_maybe_inject_failure "stop_service"
 stop_service
 
+_current_step="apt_install"
+_inkypi_maybe_inject_failure "apt_install"
 apt-get update -y > /dev/null &
 if [ -f "$APT_REQUIREMENTS_FILE" ]; then
   echo "Installing system dependencies... "
   if ! xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null; then
     echo_error "ERROR: apt-get install failed — aborting update."
-    _lockfile_keep=1; exit 1
+    exit 1
   fi
   echo_success "Installed system dependencies."
 else
   echo_error "ERROR: System dependencies file $APT_REQUIREMENTS_FILE not found!"
-  _lockfile_keep=1; exit 1
+  exit 1
 fi
 
 # Setup zramswap on any modern Pi OS that ships zram-tools (Bullseye/Bookworm/Trixie).
@@ -137,10 +254,11 @@ else
 fi
 setup_earlyoom_service
 
+_current_step="venv_check"
 # Check if virtual environment exists
 if [ ! -d "$VENV_PATH" ]; then
   echo_error "ERROR: Virtual environment not found at $VENV_PATH. Run the installation script first."
-  _lockfile_keep=1; exit 1
+  exit 1
 fi
 
 # JTN-668: /tmp on Pi OS Trixie is a 213 MB tmpfs — too small for numpy's
@@ -157,6 +275,8 @@ export TMPDIR="$PIP_BUILD_TMPDIR"
 # shellcheck source=/dev/null
 source "$VENV_PATH/bin/activate"
 
+_current_step="pip_upgrade"
+_inkypi_maybe_inject_failure "pip_upgrade"
 # Upgrade pip
 echo "Upgrading pip..."
 # JTN-665: capture failure so a broken pip/setuptools upgrade does not silently
@@ -164,7 +284,7 @@ echo "Upgrading pip..."
 # JTN-669: --retries 5 --timeout 60 --no-cache-dir for JTN-534/JTN-602 parity.
 if ! "$VENV_PATH/bin/python" -m pip install --retries 5 --timeout 60 --no-cache-dir --upgrade pip setuptools wheel > /dev/null; then
   echo_error "ERROR: pip/setuptools upgrade failed — aborting update."
-  _lockfile_keep=1; exit 1
+  exit 1
 fi
 echo_success "Pip upgraded successfully."
 
@@ -208,6 +328,8 @@ fi
 # JTN-670: --require-hashes enforces supply-chain integrity on every update
 # (JTN-516 parity). Without this, existing Pis that update pull unverified
 # wheels even though fresh installs are hash-verified.
+_current_step="pip_requirements"
+_inkypi_maybe_inject_failure "pip_requirements"
 if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
   echo "Updating Python dependencies..."
   # JTN-665: explicit exit-code check so a compile error stops the update
@@ -225,7 +347,7 @@ if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
         -r "$PIP_REQUIREMENTS_FILE"; then
       cleanup_wheelhouse
       echo_error "ERROR: uv pip install failed — aborting update (service remains stopped)."
-      _lockfile_keep=1; exit 1
+      exit 1
     fi
   else
     # pip fallback: --require-hashes + --no-cache-dir preserve JTN-516/JTN-602 guarantees.
@@ -235,7 +357,7 @@ if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
         -r "$PIP_REQUIREMENTS_FILE"; then
       cleanup_wheelhouse
       echo_error "ERROR: pip install failed — aborting update (service remains stopped)."
-      _lockfile_keep=1; exit 1
+      exit 1
     fi
   fi
   cleanup_wheelhouse
@@ -243,7 +365,7 @@ if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
 else
   cleanup_wheelhouse
   echo_error "ERROR: Requirements file $PIP_REQUIREMENTS_FILE not found!"
-  _lockfile_keep=1; exit 1
+  exit 1
 fi
 
 # Clean up the pip build temp dir — it can be several hundred MB.
@@ -254,27 +376,35 @@ echo "Updating executable in ${BINPATH}/$APPNAME"
 cp "$SCRIPT_DIR/inkypi" "$BINPATH/"
 sudo chmod +x "$BINPATH/$APPNAME"
 
+_current_step="update_vendors"
+_inkypi_maybe_inject_failure "update_vendors"
 echo "Update JS and CSS files"
 if ! bash "$SCRIPT_DIR/update_vendors.sh" > /dev/null; then
   echo_error "ERROR: Vendor JS/CSS download failed. Check network connectivity and re-run."
-  _lockfile_keep=1; exit 1
+  exit 1
 fi
 
 # JTN-674: use shared build_css_bundle from _common.sh
-# build_css_bundle calls exit 1 internally on failure — mark as intentional so
-# the lockfile is preserved and the user is forced to rerun.
-_lockfile_keep=1
+# build_css_bundle calls exit 1 internally on failure; under JTN-704 the EXIT
+# trap unconditionally clears the lockfile and records the failure step.
+_current_step="build_css"
+_inkypi_maybe_inject_failure "build_css"
 build_css_bundle
-_lockfile_keep=0
 
+_current_step="update_cli"
 update_cli
 
 # JTN-685: Remove the lockfile BEFORE starting the service. The ordering bug
 # was: update_app_service() called `systemctl start` while the lockfile was
 # still present, causing ExecStartPre to reject the start attempt.  All
 # dep-install work above is complete; it is now safe to release the lock.
+# JTN-704: the EXIT trap also removes this on any exit path, but we remove it
+# explicitly here too so update_app_service can start the service even though
+# the trap has not fired yet.
 rm -f "$LOCKFILE"
 
+_current_step="update_app_service"
+_inkypi_maybe_inject_failure "update_app_service"
 update_app_service
 
 echo "Version: $(cat "$INSTALL_PATH/VERSION" 2>/dev/null || echo 'unknown')"

--- a/tests/integration/test_update_failure_recovery.py
+++ b/tests/integration/test_update_failure_recovery.py
@@ -1,0 +1,256 @@
+# pyright: reportMissingImports=false
+"""Regression tests for JTN-704 — trap-cleanup lockfile + record failure cause.
+
+`install/update.sh` used to leave `/var/lib/inkypi/.install-in-progress` in
+place whenever anything failed (OOM, pip failure, CSS failure, etc.). The
+systemd unit's ExecStartPre refuses to start while the lockfile exists, so
+the service stayed disabled and the user had to `rm` the lockfile by hand.
+Worse, the *reason* for the failure was only in the system journal — the UI
+had no way to surface it.
+
+JTN-704 inverts this: the EXIT trap *unconditionally* removes the lockfile on
+every exit, and on non-zero exit it writes
+`/var/lib/inkypi/.last-update-failure` with JSON metadata describing what
+failed. This test is the regression gate.
+
+Strategy
+--------
+We drive `install/update.sh` under a test-only env-var hook
+(`INKYPI_UPDATE_TEST_FAIL_AT=<step>`) that `exit 97`s at a named phase after
+the trap is installed. The lockfile directory is redirected via
+`INKYPI_LOCKFILE_DIR` so no real `/var/lib/inkypi` state is touched. We then
+assert the trap honoured JTN-704's contract:
+
+* Lockfile is gone after the failure.
+* `.last-update-failure` exists and parses as JSON with the required keys.
+* `exit_code` matches the injected exit (97).
+* `last_command` matches the injected step label.
+
+A parallel success-path test uses `INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP=1` to
+exit 0 right after the trap is registered and asserts the trap's success
+branch fires: lockfile removed AND stale `.last-update-failure` cleared.
+
+These env-var hooks are guarded by `[ -n "${VAR:-}" ]` checks at the top of
+update.sh, so setting neither leaves production behavior unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "install" / "update.sh"
+
+
+@pytest.fixture
+def lockfile_dir(tmp_path: Path) -> Path:
+    """Isolated replacement for /var/lib/inkypi."""
+    d = tmp_path / "state"
+    d.mkdir()
+    return d
+
+
+def _run_update(
+    lockfile_dir: Path,
+    env_overrides: dict[str, str],
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke install/update.sh with the given env overrides.
+
+    We inherit the current env (PATH etc.) so bash/python3/systemctl are
+    resolvable if present, then layer the overrides on top.
+    """
+    if not shutil.which("bash"):
+        pytest.skip("bash is not available on this host")
+    env = dict(os.environ)
+    env.update(
+        {
+            "INKYPI_LOCKFILE_DIR": str(lockfile_dir),
+            **env_overrides,
+        }
+    )
+    return subprocess.run(
+        ["bash", str(UPDATE_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+class TestFailurePath:
+    """Exit != 0 must remove lockfile and write a parseable failure record."""
+
+    def test_injected_startup_failure_removes_lockfile(
+        self, lockfile_dir: Path
+    ) -> None:
+        proc = _run_update(
+            lockfile_dir,
+            {"INKYPI_UPDATE_TEST_FAIL_AT": "startup"},
+        )
+        # The injection hook exits 97 explicitly.
+        assert proc.returncode == 97, (
+            f"expected exit 97 from injection hook, got {proc.returncode}. "
+            f"stderr: {proc.stderr!r}"
+        )
+        lockfile = lockfile_dir / ".install-in-progress"
+        assert not lockfile.exists(), (
+            f"EXIT trap must remove the lockfile on failure (JTN-704); "
+            f"found {lockfile} still present"
+        )
+
+    def test_injected_failure_writes_last_update_failure_json(
+        self, lockfile_dir: Path
+    ) -> None:
+        proc = _run_update(
+            lockfile_dir,
+            {"INKYPI_UPDATE_TEST_FAIL_AT": "startup"},
+        )
+        assert proc.returncode != 0
+        failure_file = lockfile_dir / ".last-update-failure"
+        assert failure_file.exists(), (
+            f"EXIT trap must write .last-update-failure on non-zero exit "
+            f"(JTN-704). stderr: {proc.stderr!r}"
+        )
+        raw = failure_file.read_text()
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:  # pragma: no cover — diagnostic
+            pytest.fail(f"failure record is not valid JSON: {exc}. contents: {raw!r}")
+        # Required top-level keys for downstream parsers (UI, diagnostics).
+        for key in ("timestamp", "exit_code", "last_command", "recent_journal_lines"):
+            assert key in parsed, (
+                f"failure JSON missing required key {key!r}; got keys "
+                f"{sorted(parsed.keys())}"
+            )
+        assert parsed["exit_code"] == 97, (
+            f"exit_code in failure record must match the injected exit (97); "
+            f"got {parsed['exit_code']!r}"
+        )
+        assert parsed["last_command"] == "startup", (
+            f"last_command must match injected step label 'startup'; "
+            f"got {parsed['last_command']!r}"
+        )
+        assert (
+            isinstance(parsed["timestamp"], str) and parsed["timestamp"]
+        ), "timestamp must be a non-empty string"
+
+    def test_failure_at_later_step_records_that_step(self, lockfile_dir: Path) -> None:
+        # Injecting at a later step name exercises a different code path — the
+        # hook is consulted multiple times as _current_step is updated. This
+        # guards against regressions that only set _current_step once.
+        #
+        # "apt_install" is reachable on any host because the injection fires
+        # before the apt command actually runs. We pair it with a brief stub
+        # on PATH so the preceding `stop_service` (which tries `systemctl`)
+        # does not crash on non-systemd hosts like macOS.
+        proc = _run_update(
+            lockfile_dir,
+            {
+                "INKYPI_UPDATE_TEST_FAIL_AT": "apt_install",
+                # Prepend a tmp bin with a harmless systemctl stub so
+                # stop_service() doesn't abort the script before we reach
+                # the injection point.
+                "PATH": _systemctl_stub_path()
+                + os.pathsep
+                + os.environ.get("PATH", ""),
+            },
+        )
+        assert (
+            proc.returncode == 97
+        ), f"expected exit 97; got {proc.returncode}. stderr: {proc.stderr!r}"
+        failure_file = lockfile_dir / ".last-update-failure"
+        assert failure_file.exists()
+        parsed = json.loads(failure_file.read_text())
+        assert parsed["last_command"] == "apt_install"
+        assert parsed["exit_code"] == 97
+        assert not (lockfile_dir / ".install-in-progress").exists()
+
+
+class TestSuccessPath:
+    """Exit 0 must clear lockfile and stale failure record."""
+
+    def test_success_exit_removes_lockfile(self, lockfile_dir: Path) -> None:
+        proc = _run_update(
+            lockfile_dir,
+            {"INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP": "1"},
+        )
+        assert proc.returncode == 0, (
+            f"success simulation must exit 0; got {proc.returncode}. "
+            f"stderr: {proc.stderr!r}"
+        )
+        assert not (
+            lockfile_dir / ".install-in-progress"
+        ).exists(), "EXIT trap must remove the lockfile on success (JTN-704)"
+
+    def test_success_exit_clears_stale_failure_record(self, lockfile_dir: Path) -> None:
+        stale = lockfile_dir / ".last-update-failure"
+        stale.write_text('{"timestamp":"old","exit_code":1}')
+        proc = _run_update(
+            lockfile_dir,
+            {"INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP": "1"},
+        )
+        assert proc.returncode == 0
+        assert not stale.exists(), (
+            "Success-path trap must clear any stale .last-update-failure so "
+            "downstream consumers see a clean signal (JTN-704)"
+        )
+
+    def test_success_exit_does_not_create_failure_record(
+        self, lockfile_dir: Path
+    ) -> None:
+        proc = _run_update(
+            lockfile_dir,
+            {"INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP": "1"},
+        )
+        assert proc.returncode == 0
+        assert not (
+            lockfile_dir / ".last-update-failure"
+        ).exists(), "Success path must never create .last-update-failure (JTN-704)"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SYSTEMCTL_STUB_DIR: Path | None = None
+
+
+def _systemctl_stub_path() -> str:
+    """Return a directory containing a no-op ``systemctl`` shim on PATH.
+
+    On macOS / CI hosts without systemd, _common.sh's ``stop_service`` would
+    error out before the test injection point is reached. A harmless stub
+    that returns success keeps the script flowing to the injection hook
+    without altering the trap's behavior.
+    """
+    global _SYSTEMCTL_STUB_DIR
+    if _SYSTEMCTL_STUB_DIR is not None and (_SYSTEMCTL_STUB_DIR / "systemctl").exists():
+        return str(_SYSTEMCTL_STUB_DIR)
+    # pytest's tmp_path fixture is per-test; we want a stable location shared
+    # across the module. Use the interpreter-global site-tmpdir.
+    import tempfile
+
+    d = Path(tempfile.mkdtemp(prefix="inkypi-jtn704-stub-"))
+    stub = d / "systemctl"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "# JTN-704 test stub: pretend systemctl succeeded.\n"
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+    _SYSTEMCTL_STUB_DIR = d
+    return str(d)
+
+
+if __name__ == "__main__":  # pragma: no cover — manual debugging
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1388,21 +1388,68 @@ class TestUpdateScript:
         ), "Lockfile removal must come BEFORE update_app_service call (JTN-685)"
 
     def test_update_has_exit_trap_for_lockfile(self):
-        # JTN-685: Defense-in-depth EXIT trap so SIGTERM / unhandled exits clean
-        # up the lockfile and don't permanently block the service.  Intentional
-        # failure paths set _lockfile_keep=1 before exit so the lockfile is
-        # preserved (forcing a manual rerun) while unhandled exits clear it.
+        # JTN-704: EXIT trap unconditionally removes the lockfile on every exit
+        # (success, explicit exit N, errexit, SIGINT, SIGTERM, SIGHUP) so a
+        # failed update never leaves the service permanently blocked by a
+        # stale /var/lib/inkypi/.install-in-progress. On non-zero exit the
+        # trap also writes /var/lib/inkypi/.last-update-failure with
+        # structured metadata (timestamp, exit_code, last_command,
+        # recent_journal_lines) for UI surfacing and diagnostics.
         assert "trap " in self.content, "update.sh must set a trap for EXIT"
-        assert "_lockfile_keep" in self.content, (
-            "update.sh must use _lockfile_keep sentinel to distinguish "
-            "intentional failure exits (keep lockfile) from abnormal exits (clear it)"
+        # The new policy must not keep the lockfile on failure — the stale
+        # _lockfile_keep sentinel from the old JTN-685 implementation must be
+        # gone (or we will regress back to the JTN-704 problem).
+        assert "_lockfile_keep" not in self.content, (
+            "update.sh must NOT use _lockfile_keep sentinel under JTN-704; "
+            "the trap unconditionally clears the lockfile on every exit."
         )
-        # The trap must be set after the lockfile is created
+        # Must register an EXIT trap that references the lockfile cleanup.
+        assert "trap _inkypi_update_exit_trap EXIT" in self.content, (
+            "update.sh must register an EXIT trap that cleans the lockfile "
+            "and records failure metadata (JTN-704)"
+        )
+        # Trap body must remove the lockfile unconditionally on EXIT.
+        assert (
+            'rm -f "$LOCKFILE"' in self.content
+        ), "update.sh EXIT trap must rm the lockfile on every exit (JTN-704)"
+        # Trap body must write .last-update-failure on non-zero exit.
+        assert "FAILURE_FILE=" in self.content, (
+            "update.sh must define FAILURE_FILE for the failure-recording "
+            "trap (JTN-704)"
+        )
+        assert ".last-update-failure" in self.content, (
+            "update.sh must reference /var/lib/inkypi/.last-update-failure "
+            "so the EXIT trap can persist the reason for a failed update "
+            "(JTN-704)"
+        )
+        # Required JSON keys in the failure record for downstream parsers.
+        for key in ("timestamp", "exit_code", "last_command", "recent_journal_lines"):
+            assert (
+                f'"{key}"' in self.content
+            ), f"update.sh failure JSON must include {key!r} key (JTN-704)"
+        # Trap must also fire on SIGINT / SIGTERM / SIGHUP.
+        assert (
+            "trap 'exit 130' INT" in self.content
+        ), "update.sh must trap SIGINT so Ctrl-C still cleans the lockfile"
+        assert (
+            "trap 'exit 143' TERM" in self.content
+        ), "update.sh must trap SIGTERM so systemd-stop still cleans the lockfile"
+        # The trap must be set after the lockfile is created.
         lockfile_pos = self.content.index('touch "$LOCKFILE"')
-        trap_pos = self.content.index("trap ")
+        trap_pos = self.content.index("trap _inkypi_update_exit_trap EXIT")
         assert (
             trap_pos > lockfile_pos
-        ), "EXIT trap must be set after the lockfile is created"
+        ), "EXIT trap must be registered after the lockfile is created"
+
+    def test_update_exposes_test_failure_injection_env_var(self):
+        # JTN-704: The integration test needs a guarded env-var hook to
+        # simulate a mid-update failure without touching production paths.
+        # The hook is a no-op unless INKYPI_UPDATE_TEST_FAIL_AT is set.
+        assert "INKYPI_UPDATE_TEST_FAIL_AT" in self.content, (
+            "update.sh must expose an env-var-guarded test failure "
+            "injection hook (INKYPI_UPDATE_TEST_FAIL_AT) so the regression "
+            "test can simulate failure at a named step (JTN-704)"
+        )
 
     def test_update_upgrades_pip_deps(self):
         assert "pip install" in self.content


### PR DESCRIPTION
## Summary

Fixes [JTN-704](https://linear.app/jtn0123/issue/JTN-704). The update.sh lockfile (`/var/lib/inkypi/.install-in-progress`) was only cleaned up on the success path, so any failure (OOM, pip, CSS build, SIGTERM) orphaned it — `inkypi.service`'s `ExecStartPre` then refused to start until the user manually `rm`'d the file. The failure reason was only in the journal, so the UI had no way to surface it.

This PR inverts the policy:

- **EXIT trap unconditionally removes the lockfile** on every exit (success, `exit N`, errexit, SIGINT, SIGTERM, SIGHUP). Removes the need for any manual recovery after a failed update.
- **On non-zero exit the trap writes** `/var/lib/inkypi/.last-update-failure` with JSON: `{timestamp, exit_code, last_command, recent_journal_lines}`. Written atomically via tmpfile + mv. This is the prerequisite for JTN-K3 (rollback reader) and JTN-K4 (surface errors in UI).
- **On success exit the trap clears** any stale `.last-update-failure` so downstream consumers see a clean signal.
- Removes the old `_lockfile_keep=1` sentinel — all `exit 1` paths now funnel through the uniform trap.
- Introduces a `_current_step` variable updated before each top-level phase so the failure record pinpoints which step failed.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Update succeeds | Lockfile removed | Lockfile removed, stale `.last-update-failure` cleared |
| `exit 1` after `echo_error` | Lockfile stays (required manual `rm`) | Lockfile removed, `.last-update-failure` written |
| SIGTERM / Ctrl-C mid-update | Lockfile removed (JTN-685) | Lockfile removed, `.last-update-failure` written |
| CSS build fails | Lockfile stays | Lockfile removed, `.last-update-failure` written |

Production callers (`install.sh`, `do_update.sh`, the systemd-run invocation in `src/blueprints/settings/__init__.py`) are unchanged.

## Test hooks (env-var guarded — production-invisible)

All three vars are gated by explicit `[ -n "${VAR:-}" ]` checks; default is empty, so prod behavior is unchanged:

- `INKYPI_UPDATE_TEST_FAIL_AT=<step>` — injects `exit 97` at the named step after the trap is installed. Used by the integration test to simulate pip / CSS / OOM failures without needing the full update machinery.
- `INKYPI_UPDATE_TEST_EXIT_AFTER_TRAP=1` — `exit 0` immediately after trap setup, exercising the success-path trap branch.
- `INKYPI_LOCKFILE_DIR=<path>` — redirect state writes to a tempdir so tests don't touch `/var/lib/inkypi`.

## Tests added

- `tests/integration/test_update_failure_recovery.py` — 6 new tests:
  - failure path: lockfile removed, `.last-update-failure` is valid JSON with the required keys, `exit_code`/`last_command` match the injection
  - failure at a later step: proves `_current_step` is maintained through the run
  - success path: lockfile removed, no `.last-update-failure`, stale record cleared
- `tests/unit/test_install_scripts.py::test_update_has_exit_trap_for_lockfile` — rewritten for the new unconditional-cleanup policy; asserts no `_lockfile_keep`, `trap _inkypi_update_exit_trap EXIT`, required JSON keys, and SIGINT/SIGTERM trap registration.
- `tests/unit/test_install_scripts.py::test_update_exposes_test_failure_injection_env_var` — new structural check.

## Test plan

- [x] `bash scripts/lint.sh` → all blocking checks pass (ruff, black, mypy strict, shellcheck)
- [x] `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/unit/test_install_scripts.py tests/integration/test_update_failure_recovery.py -v` → 207 passed
- [x] Full suite: `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/` → 4173 passed, 5 skipped, 0 failed (after `scripts/build_css.py`)
- [x] Manual bash dry-run: lockfile + failure JSON behavior verified with all three env hooks on macOS

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>