### PR TITLE
fix(update): timeout-based service startup wait (JTN-706)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -62,24 +62,28 @@ update_app_service() {
     sudo systemctl enable "$SERVICE_FILE"
     echo "Starting $APPNAME service."
     sudo systemctl start "$SERVICE_FILE"
-    # JTN-684: Explicitly verify the service reached active state.
+    # JTN-684 / JTN-706: Explicitly verify the service reached active state.
     # systemctl start exits 0 even when the service subsequently fails
-    # (e.g. ExecStart returns non-zero), so we poll is-active with a short
-    # retry loop to give systemd a moment to settle before declaring failure.
-    local attempts=0
-    local max_attempts=3
-    local active=0
-    while [ "$attempts" -lt "$max_attempts" ]; do
-      if sudo systemctl is-active --quiet "$SERVICE_FILE"; then
-        active=1
-        break
+    # (e.g. ExecStart returns non-zero), so we wait for is-active with a
+    # bounded timeout.
+    #
+    # JTN-706: The previous implementation used a 3-attempt retry loop with
+    # sleep 1, which capped the total wait at 3 seconds. On a Pi Zero 2 W,
+    # inkypi routinely takes 5-8 seconds to become active (flask import +
+    # plugin discovery), so updates reported false failures on healthy
+    # devices. We now poll up to 45 seconds via `timeout`, and distinguish
+    # the two error modes: a genuinely-failed service (systemctl reports
+    # `failed`) versus slow startup that exceeded the wait window.
+    local wait_seconds=45
+    if ! sudo timeout "$wait_seconds" bash -c \
+        "until systemctl is-active --quiet \"$SERVICE_FILE\"; do sleep 1; done"; then
+      if sudo systemctl is-failed --quiet "$SERVICE_FILE"; then
+        echo_error "ERROR: $SERVICE_FILE failed to start (systemd reports failed state)."
+      else
+        echo_error "ERROR: Timed out waiting for $SERVICE_FILE to become active after ${wait_seconds}s."
       fi
-      attempts=$(( attempts + 1 ))
-      [ "$attempts" -lt "$max_attempts" ] && sleep 1
-    done
-    if [ "$active" -eq 0 ]; then
-      echo_error "ERROR: $SERVICE_FILE failed to start (not active after $max_attempts attempt(s))."
       echo "Service status:" >&2
+      sudo systemctl status --no-pager "$SERVICE_FILE" >&2 || true
       sudo systemctl show -p ActiveState,SubState,Result "$SERVICE_FILE" >&2 || true
       echo "Last 20 journal lines:" >&2
       sudo journalctl -u "$APPNAME" -n 20 --no-pager >&2 || true

--- a/install/update.sh
+++ b/install/update.sh
@@ -74,7 +74,15 @@ update_app_service() {
     # devices. We now poll up to 45 seconds via `timeout`, and distinguish
     # the two error modes: a genuinely-failed service (systemctl reports
     # `failed`) versus slow startup that exceeded the wait window.
-    local wait_seconds=45
+    # JTN-706: ceiling is overridable via env so slow dev boards or debugging
+    # sessions can extend the wait without a code change. Production callers
+    # (install.sh, settings UI, do_update.sh) do not set this; default is 45s.
+    # Mirrors the INKYPI_LOCKFILE_DIR test-flexibility pattern.
+    local wait_seconds="${INKYPI_SERVICE_START_TIMEOUT:-45}"
+    # Reject non-numeric / empty overrides to prevent `timeout` from erroring.
+    if ! [[ "$wait_seconds" =~ ^[1-9][0-9]*$ ]]; then
+      wait_seconds=45
+    fi
     if ! sudo timeout "$wait_seconds" bash -c \
         "until systemctl is-active --quiet \"$SERVICE_FILE\"; do sleep 1; done"; then
       if sudo systemctl is-failed --quiet "$SERVICE_FILE"; then

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1899,6 +1899,40 @@ class TestUpdateScript:
             "--no-pager" in fn_body
         ), "journalctl in update_app_service must use --no-pager for non-interactive output (JTN-684)"
 
+    def test_update_service_wait_uses_timeout_bound(self):
+        # JTN-706: the 3-attempt sleep 1 loop (total cap 3s) was replaced with
+        # a bounded wait via `timeout 45` so slow boots on Pi Zero 2 W (which
+        # routinely take 5-8s) no longer trigger false-failure reports.
+        fn_start = self.content.index("update_app_service() {")
+        fn_end = self.content.index("\n}", fn_start) + 2
+        fn_body = self.content[fn_start:fn_end]
+
+        # Old pattern must be gone.
+        assert (
+            "max_attempts=3" not in fn_body
+        ), "update_app_service must no longer use 3-attempt loop (JTN-706)"
+        assert (
+            "max_attempts" not in fn_body
+        ), "update_app_service must not reintroduce max_attempts counting (JTN-706)"
+
+        # New pattern must be present: a `timeout 45` (or similar bounded wait)
+        # wrapping the systemctl is-active poll.
+        assert (
+            "timeout" in fn_body and "is-active" in fn_body
+        ), "update_app_service must wrap is-active poll with a `timeout` bound (JTN-706)"
+        assert (
+            "45" in fn_body
+        ), "update_app_service must use a 45-second timeout ceiling (JTN-706)"
+
+        # Timeout and failed states must be distinguished so users know whether
+        # to investigate the service or just be patient.
+        assert (
+            "is-failed" in fn_body
+        ), "update_app_service must check is-failed to distinguish failure from slow start (JTN-706)"
+        assert (
+            "timed out" in fn_body.lower() or "timeout" in fn_body.lower()
+        ), "update_app_service must log timeout distinctly from failed state (JTN-706)"
+
 
 # ---- uninstall.sh ----
 

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1915,13 +1915,17 @@ class TestUpdateScript:
             "max_attempts" not in fn_body
         ), "update_app_service must not reintroduce max_attempts counting (JTN-706)"
 
-        # New pattern must be present: a `timeout 45` (or similar bounded wait)
-        # wrapping the systemctl is-active poll.
+        # New pattern must be present: a `timeout <N>` bounded wait wrapping
+        # the systemctl is-active poll.
         assert (
             "timeout" in fn_body and "is-active" in fn_body
         ), "update_app_service must wrap is-active poll with a `timeout` bound (JTN-706)"
-        assert (
-            "45" in fn_body
+        # Look for an actual 45-second timeout assignment, not just any "45" in
+        # a comment or URL. Match either `wait_seconds=...45` (with optional
+        # env-override expansion) or a literal `timeout 45` invocation.
+        assert re.search(
+            r"(wait_seconds\s*=\s*(?:\"|\')?\$?\{?[^}]*:?-?\s*45|timeout\s+(?:\"[^\"]*\"|'[^']*'|45))",
+            fn_body,
         ), "update_app_service must use a 45-second timeout ceiling (JTN-706)"
 
         # Timeout and failed states must be distinguished so users know whether


### PR DESCRIPTION
## Summary

- `install/update.sh` `update_app_service()` used a 3-attempt loop with `sleep 1` between attempts, capping the service-startup wait at 3 seconds. On a Pi Zero 2 W the `inkypi` service routinely takes 5-8 seconds to become active (flask import + plugin discovery), so updates reported false failures while the service was fine moments later.
- Replaced the fixed-attempt loop with a `timeout 45` bounded wait and split the error message between a genuinely failed unit (`systemctl is-failed`) and a timeout, so the user knows whether to investigate or just be patient.
- The existing JTN-704 `EXIT` trap still captures the failure reason and clears the lockfile on either exit-1 branch; only the wait loop changed.

## Changes

- `install/update.sh`: replace 3x1s retry loop with `timeout 45 bash -c 'until systemctl is-active ...; do sleep 1; done'`, add `is-failed` branch + `systemctl status --no-pager` dump, keep existing `journalctl -n 20 --no-pager` tail.
- `tests/unit/test_install_scripts.py`: add `test_update_service_wait_uses_timeout_bound` — asserts `max_attempts` is gone, `timeout`+`45`+`is-failed` are present, timeout wording is distinct from failed state.

## Not touched

- Integration `tests/integration/test_update_failure_recovery.py`: the `INKYPI_UPDATE_TEST_*` hooks exit well before `update_app_service`, and exercising the new wait requires a real systemd. The regression is covered by the unit script-grep test instead, per the task guidance.

## Test plan

- [x] `SKIP_BROWSER=1 pytest tests/unit/test_install_scripts.py` — 207 passed
- [x] Full suite: 4180 passed, 4 skipped; 3 pre-existing CSS static failures confirmed present on `main` without this diff
- [x] `scripts/lint.sh` (ruff + black + shellcheck blocking) — clean

Closes JTN-706.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced service update process with extended timeout-bound polling (45 seconds) for improved reliability during service activation, replacing the previous short retry loop.

## Tests
* Added unit test verification for timeout-based service update behavior and error handling differentiation, ensuring proper diagnostic output for timeout versus service failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->