### PR TITLE
feat(update): surface update failures in web UI (JTN-710)

### DIFF
--- a/src/blueprints/settings/_update_status.py
+++ b/src/blueprints/settings/_update_status.py
@@ -1,0 +1,109 @@
+"""Helpers for surfacing update-failure metadata written by ``install/update.sh``.
+
+JTN-704 installed an EXIT trap in ``install/update.sh`` that writes a JSON
+record to ``/var/lib/inkypi/.last-update-failure`` whenever the update exits
+with a non-zero status.  JTN-710 wires that file through the Flask update
+status endpoint so the Settings -> Updates page can surface *why* the last
+update failed instead of making the user SSH in and read the journal.
+
+The contract written by the shell trap is:
+
+    {
+      "timestamp": "2026-04-14T23:00:00Z",
+      "exit_code": 97,
+      "last_command": "apt_install",
+      "recent_journal_lines": "...multi-line journal tail..."
+    }
+
+This helper reads that file defensively:
+
+* Missing file -> ``None``.
+* Malformed JSON or unreadable file -> ``{"parse_error": True}`` so the UI
+  can still show a "last update failed but we can't read the record" hint
+  without crashing the status endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Default on-disk location written by ``install/update.sh`` (JTN-704).
+_DEFAULT_LOCKFILE_DIR = "/var/lib/inkypi"
+_FAILURE_FILENAME = ".last-update-failure"
+
+# Cap how much of the failure record we ever return to a browser so a runaway
+# journal capture can't blow up the response body (the shell trap captures the
+# last 20 journal lines, but belt-and-suspenders is cheap).
+_MAX_FAILURE_BYTES = 64 * 1024
+
+
+def _failure_file_path() -> Path:
+    """Resolve the failure-file path, honoring ``INKYPI_LOCKFILE_DIR``.
+
+    The shell script already honors ``INKYPI_LOCKFILE_DIR`` (see
+    ``install/update.sh``) so tests can redirect writes to a tempdir; mirror
+    that contract in Python so unit tests can point us at a fixture without
+    monkey-patching the module.
+    """
+
+    base = os.environ.get("INKYPI_LOCKFILE_DIR") or _DEFAULT_LOCKFILE_DIR
+    return Path(base) / _FAILURE_FILENAME
+
+
+def read_last_update_failure() -> dict[str, Any] | None:
+    """Return the parsed ``.last-update-failure`` record, or ``None``.
+
+    Return values:
+
+    * ``None`` -> no failure file on disk (happy path, or file already
+      cleared by a subsequent successful update).
+    * ``dict`` -> parsed JSON record.  Keys are whatever the shell trap
+      wrote; we do not validate individual fields here because the UI is
+      happy to render partial records.
+    * ``{"parse_error": True}`` -> the file exists but could not be read
+      or parsed as JSON.  The UI still gets a truthy value so it can show
+      a generic "last update failed" banner, and the ``parse_error`` key
+      tells callers not to trust the other fields.
+    """
+
+    path = _failure_file_path()
+    try:
+        if not path.is_file():
+            return None
+    except OSError:
+        # e.g. permission denied on the parent dir; treat as "no file" so we
+        # do not spam the UI with an error banner when the real issue is that
+        # we cannot read /var/lib/inkypi at all.
+        logger.debug("Could not stat %s", path, exc_info=True)
+        return None
+
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        logger.warning("Failed to read %s", path, exc_info=True)
+        return {"parse_error": True}
+
+    if len(raw) > _MAX_FAILURE_BYTES:
+        # Truncate to the cap so the response stays small; we still try to
+        # parse in case the prefix is valid JSON (it normally will not be,
+        # but return parse_error either way so the UI does not show a
+        # half-truncated journal).
+        raw = raw[:_MAX_FAILURE_BYTES]
+
+    try:
+        data = json.loads(raw.decode("utf-8", errors="replace"))
+    except (ValueError, UnicodeDecodeError):
+        logger.warning("Malformed JSON in %s", path)
+        return {"parse_error": True}
+
+    if not isinstance(data, dict):
+        logger.warning("Unexpected JSON shape in %s: %r", path, type(data).__name__)
+        return {"parse_error": True}
+
+    return data

--- a/src/blueprints/settings/_update_status.py
+++ b/src/blueprints/settings/_update_status.py
@@ -98,7 +98,9 @@ def read_last_update_failure() -> dict[str, Any] | None:
 
     try:
         data = json.loads(raw.decode("utf-8", errors="replace"))
-    except (ValueError, UnicodeDecodeError):
+    except ValueError:
+        # json.JSONDecodeError is a ValueError subclass; errors="replace"
+        # above means the decode step cannot raise.
         logger.warning("Malformed JSON in %s", path)
         return {"parse_error": True}
 

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -6,6 +6,7 @@ from flask import current_app, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 import blueprints.settings as _mod
+from blueprints.settings._update_status import read_last_update_failure
 from utils.http_utils import json_error, json_internal_error, json_success
 
 
@@ -32,12 +33,29 @@ def start_update():
         else:
             body = {}
 
-        raw = body.get("target_version")
-        if raw and isinstance(raw, str):
+        # JTN-710: if ``target_version`` is present in the body, validate
+        # it explicitly instead of silently falling through to the
+        # "latest semver tag" code path when it's null/empty.  Without this
+        # guard, a client sending ``{"target_version": null}`` or
+        # ``{"target_version": ""}`` caused do_update.sh to fail with
+        # "No semver tags found" only visible in the system journal.
+        if "target_version" in body:
+            raw = body.get("target_version")
+            if raw is None or not isinstance(raw, str) or not raw.strip():
+                return json_error(
+                    "target_version must be a non-empty string",
+                    status=400,
+                    code="validation_error",
+                    details={"field": "target_version"},
+                )
             target_tag = raw.strip()
-
-        if target_tag and not _mod._TAG_RE.fullmatch(target_tag):
-            return json_error("Invalid target version format", status=400)
+            if not _mod._TAG_RE.fullmatch(target_tag):
+                return json_error(
+                    "Invalid target version format",
+                    status=400,
+                    code="validation_error",
+                    details={"field": "target_version"},
+                )
 
         script_path = _mod._get_update_script_path()
         # NOTE: the systemd unit name is now generated *inside*
@@ -140,11 +158,17 @@ def update_status():
             unit = _mod._UPDATE_STATE.get("unit")
             started_at = _mod._UPDATE_STATE.get("started_at")
 
+        # JTN-710: surface the last update failure (written by the EXIT trap
+        # in install/update.sh) so the UI can show *why* an update failed
+        # without the user SSHing in to read the system journal.
+        last_failure = read_last_update_failure()
+
         return jsonify(
             {
                 "running": running,
                 "unit": unit,
                 "started_at": started_at,
+                "last_failure": last_failure,
             }
         )
     except Exception as e:

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -59,6 +59,67 @@
     return /\bWARNING\b/i.test(line);
   }
 
+  // JTN-710: banner rendering helpers.  Kept at module scope (outside the
+  // createSettingsPage closure) so Sonar S7721/S3776 stay green and the
+  // helpers can be individually tested/tree-shaken.
+  function setTextIfPresent(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  }
+
+  function renderUpdateFailureUnreadable(banner) {
+    setTextIfPresent("updateFailureTimestamp", "");
+    setTextIfPresent("updateFailureExitCode", "");
+    setTextIfPresent(
+      "updateFailureStep",
+      "Last update failure record was unreadable."
+    );
+    const details = document.getElementById("updateFailureDetails");
+    if (details) details.hidden = true;
+    banner.hidden = false;
+  }
+
+  function renderUpdateFailureFields(lastFailure) {
+    const tsText = lastFailure.timestamp
+      ? `Failed at ${lastFailure.timestamp}`
+      : "";
+    const codeText =
+      typeof lastFailure.exit_code === "number"
+        ? `exit ${lastFailure.exit_code}`
+        : "";
+    const stepText = lastFailure.last_command
+      ? `step: ${lastFailure.last_command}`
+      : "";
+    setTextIfPresent("updateFailureTimestamp", tsText);
+    setTextIfPresent("updateFailureExitCode", codeText);
+    setTextIfPresent("updateFailureStep", stepText);
+
+    const journalText = lastFailure.recent_journal_lines || "";
+    setTextIfPresent("updateFailureJournal", journalText);
+    const details = document.getElementById("updateFailureDetails");
+    if (details) details.hidden = !journalText;
+  }
+
+  // Render the update-failure banner from a /settings/update_status payload.
+  // ``lastFailure`` mirrors the JSON written to /var/lib/inkypi/.last-update-failure
+  // by install/update.sh's EXIT trap (JTN-704): timestamp, exit_code,
+  // last_command, recent_journal_lines.  A malformed file surfaces as
+  // ``{parse_error: true}`` so we can still show a generic banner.
+  function renderUpdateFailureBanner(lastFailure) {
+    const banner = document.getElementById("updateFailureBanner");
+    if (!banner) return;
+    if (!lastFailure) {
+      banner.hidden = true;
+      return;
+    }
+    if (lastFailure.parse_error) {
+      renderUpdateFailureUnreadable(banner);
+      return;
+    }
+    renderUpdateFailureFields(lastFailure);
+    banner.hidden = false;
+  }
+
   function prefKey(key) {
     return `logs_${key}`;
   }
@@ -581,54 +642,6 @@
           if (sp) sp.style.display = "none";
         }
       }
-    }
-
-    // JTN-710: render the update-failure banner from a status payload
-    // returned by /settings/update_status.  The shape of ``last_failure`` is
-    // whatever install/update.sh's EXIT trap (JTN-704) wrote to
-    // ``/var/lib/inkypi/.last-update-failure``: timestamp, exit_code,
-    // last_command, recent_journal_lines.  A malformed file surfaces as
-    // ``{parse_error: true}`` so we can still show a generic banner.
-    function renderUpdateFailureBanner(lastFailure) {
-      const banner = document.getElementById("updateFailureBanner");
-      if (!banner) return;
-      if (!lastFailure) {
-        banner.hidden = true;
-        return;
-      }
-      const ts = document.getElementById("updateFailureTimestamp");
-      const code = document.getElementById("updateFailureExitCode");
-      const step = document.getElementById("updateFailureStep");
-      const details = document.getElementById("updateFailureDetails");
-      const journal = document.getElementById("updateFailureJournal");
-      if (lastFailure.parse_error) {
-        if (ts) ts.textContent = "";
-        if (code) code.textContent = "";
-        if (step) step.textContent = "Last update failure record was unreadable.";
-        if (details) details.hidden = true;
-        banner.hidden = false;
-        return;
-      }
-      if (ts) {
-        ts.textContent = lastFailure.timestamp
-          ? `Failed at ${lastFailure.timestamp}`
-          : "";
-      }
-      if (code) {
-        code.textContent =
-          typeof lastFailure.exit_code === "number"
-            ? `exit ${lastFailure.exit_code}`
-            : "";
-      }
-      if (step) {
-        step.textContent = lastFailure.last_command
-          ? `step: ${lastFailure.last_command}`
-          : "";
-      }
-      const journalText = lastFailure.recent_journal_lines || "";
-      if (journal) journal.textContent = journalText;
-      if (details) details.hidden = !journalText;
-      banner.hidden = false;
     }
 
     async function refreshUpdateStatus() {

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -583,6 +583,66 @@
       }
     }
 
+    // JTN-710: render the update-failure banner from a status payload
+    // returned by /settings/update_status.  The shape of ``last_failure`` is
+    // whatever install/update.sh's EXIT trap (JTN-704) wrote to
+    // ``/var/lib/inkypi/.last-update-failure``: timestamp, exit_code,
+    // last_command, recent_journal_lines.  A malformed file surfaces as
+    // ``{parse_error: true}`` so we can still show a generic banner.
+    function renderUpdateFailureBanner(lastFailure) {
+      const banner = document.getElementById("updateFailureBanner");
+      if (!banner) return;
+      if (!lastFailure) {
+        banner.hidden = true;
+        return;
+      }
+      const ts = document.getElementById("updateFailureTimestamp");
+      const code = document.getElementById("updateFailureExitCode");
+      const step = document.getElementById("updateFailureStep");
+      const details = document.getElementById("updateFailureDetails");
+      const journal = document.getElementById("updateFailureJournal");
+      if (lastFailure.parse_error) {
+        if (ts) ts.textContent = "";
+        if (code) code.textContent = "";
+        if (step) step.textContent = "Last update failure record was unreadable.";
+        if (details) details.hidden = true;
+        banner.hidden = false;
+        return;
+      }
+      if (ts) {
+        ts.textContent = lastFailure.timestamp
+          ? `Failed at ${lastFailure.timestamp}`
+          : "";
+      }
+      if (code) {
+        code.textContent =
+          typeof lastFailure.exit_code === "number"
+            ? `exit ${lastFailure.exit_code}`
+            : "";
+      }
+      if (step) {
+        step.textContent = lastFailure.last_command
+          ? `step: ${lastFailure.last_command}`
+          : "";
+      }
+      const journalText = lastFailure.recent_journal_lines || "";
+      if (journal) journal.textContent = journalText;
+      if (details) details.hidden = !journalText;
+      banner.hidden = false;
+    }
+
+    async function refreshUpdateStatus() {
+      try {
+        const resp = await fetch(config.updateStatusUrl, { cache: "no-store" });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        renderUpdateFailureBanner(data?.last_failure ?? null);
+      } catch (e) {
+        // Silent: the banner is best-effort; do not block the UI.
+        console.warn("Update status refresh failed:", e);
+      }
+    }
+
     async function startUpdate() {
       const btns = document.querySelectorAll(".header-actions .header-button");
       try {
@@ -602,6 +662,8 @@
             await fetchAndRenderLogs();
             const sresp = await fetch(config.updateStatusUrl);
             const sdata = await sresp.json();
+            // JTN-710: surface any newly-written failure record as soon as it lands.
+            renderUpdateFailureBanner(sdata?.last_failure ?? null);
             if (!sdata?.running) {
               clearInterval(state.updateTimer);
               state.updateTimer = null;
@@ -1266,6 +1328,8 @@
       refreshIsolation();
       initProgressSSE();
       setTimeout(checkForUpdates, 5000);
+      // JTN-710: show a banner if the previous update failed.
+      refreshUpdateStatus();
       if (mobileQuery && typeof mobileQuery.addEventListener === "function") {
         mobileQuery.addEventListener("change", () => setActiveTab(state.activeTab));
       }

--- a/src/static/styles/partials/_feedback.css
+++ b/src/static/styles/partials/_feedback.css
@@ -1203,6 +1203,45 @@ body.modal-open {
     flex-shrink: 0;
 }
 
+/* JTN-710: banner shown when install/update.sh wrote .last-update-failure. */
+.update-failure-banner {
+    margin: var(--spacing-sm) 0 var(--spacing-md);
+    padding: 12px 14px;
+    border: 1px solid var(--color-danger, #b94a48);
+    border-left-width: 4px;
+    border-radius: var(--border-radius-sm);
+    background: var(--surface);
+    color: var(--text-primary);
+}
+
+.update-failure-title {
+    font-weight: 600;
+    color: var(--color-danger, #b94a48);
+    margin-bottom: 4px;
+}
+
+.update-failure-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.update-failure-journal {
+    margin-top: 6px;
+    padding: 8px;
+    background: var(--surface-alt, var(--surface));
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
 .update-release-notes {
     margin-bottom: var(--spacing-md);
 }

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -155,6 +155,21 @@
                         <h3>Software Update</h3>
                         <span class="status-chip" id="updateBadge">Checking...</span>
                     </div>
+                    {# JTN-710: banner populated from /settings/update_status
+                       when install/update.sh's EXIT trap (JTN-704) wrote a
+                       .last-update-failure record on the previous run. #}
+                    <div class="update-failure-banner" id="updateFailureBanner" role="alert" hidden>
+                        <div class="update-failure-title">Last update failed</div>
+                        <div class="update-failure-meta">
+                            <span id="updateFailureTimestamp"></span>
+                            <span id="updateFailureExitCode"></span>
+                            <span id="updateFailureStep"></span>
+                        </div>
+                        <details id="updateFailureDetails" hidden>
+                            <summary>Recent journal output</summary>
+                            <pre id="updateFailureJournal" class="update-failure-journal"></pre>
+                        </details>
+                    </div>
                     <div class="update-version-row">
                         <div class="update-version-card">
                             <span class="update-version-label">Installed</span>

--- a/tests/unit/test_updates_surface_errors.py
+++ b/tests/unit/test_updates_surface_errors.py
@@ -1,0 +1,229 @@
+# pyright: reportMissingImports=false
+"""Tests for JTN-710: surface update failures in the web UI.
+
+Covers two sides of the fix:
+
+1. ``/settings/update_status`` now includes ``last_failure`` read from
+   ``/var/lib/inkypi/.last-update-failure`` (the file written by the EXIT
+   trap in ``install/update.sh``, JTN-704).
+2. ``POST /settings/update`` now rejects null/empty ``target_version`` with
+   a ``validation_error`` envelope instead of silently falling through to
+   the "latest semver tag" code path.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+
+class TestUpdateStatusLastFailure:
+    """GET /settings/update_status surfaces .last-update-failure contents."""
+
+    def test_update_status_includes_last_failure_when_file_present(
+        self, client, monkeypatch, tmp_path
+    ):
+        import blueprints.settings as mod
+
+        mod._set_update_state(False, None)
+        failure_payload = {
+            "timestamp": "2026-04-14T23:00:00Z",
+            "exit_code": 97,
+            "last_command": "apt_install",
+            "recent_journal_lines": "apt-get: failed\nE: could not resolve",
+        }
+        (tmp_path / ".last-update-failure").write_text(
+            json.dumps(failure_payload), encoding="utf-8"
+        )
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+
+        resp = client.get("/settings/update_status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["last_failure"] == failure_payload
+
+    def test_update_status_last_failure_null_when_missing(
+        self, client, monkeypatch, tmp_path
+    ):
+        import blueprints.settings as mod
+
+        mod._set_update_state(False, None)
+        # tmp_path exists but contains no .last-update-failure file
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+
+        resp = client.get("/settings/update_status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "last_failure" in data
+        assert data["last_failure"] is None
+
+    def test_update_status_handles_malformed_failure_json(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Malformed JSON must not crash the endpoint."""
+        import blueprints.settings as mod
+
+        mod._set_update_state(False, None)
+        (tmp_path / ".last-update-failure").write_text(
+            "{ this is not json",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+
+        resp = client.get("/settings/update_status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Helper returns {"parse_error": True} for unreadable/malformed records
+        assert data["last_failure"] == {"parse_error": True}
+
+    def test_update_status_handles_non_object_failure_json(
+        self, client, monkeypatch, tmp_path
+    ):
+        """A JSON array/scalar at the top level is still treated as parse_error."""
+        import blueprints.settings as mod
+
+        mod._set_update_state(False, None)
+        (tmp_path / ".last-update-failure").write_text("[1, 2, 3]", encoding="utf-8")
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+
+        resp = client.get("/settings/update_status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["last_failure"] == {"parse_error": True}
+
+
+class TestStartUpdateRejectsEmptyTargetVersion:
+    """POST /settings/update validates ``target_version`` explicitly."""
+
+    def _install_mocks(self, monkeypatch):
+        import blueprints.settings as mod
+
+        monkeypatch.setattr(mod, "_systemd_available", lambda: False)
+        monkeypatch.setattr(mod, "_get_update_script_path", lambda: None)
+        fallback_mock = MagicMock()
+        monkeypatch.setattr(mod, "_start_update_fallback_thread", fallback_mock)
+        mod._set_update_state(False, None)
+        return mod, fallback_mock
+
+    def test_update_endpoint_rejects_null_target_version_with_validation_error(
+        self, client, monkeypatch
+    ):
+        mod, fallback_mock = self._install_mocks(monkeypatch)
+        try:
+            resp = client.post("/settings/update", json={"target_version": None})
+            assert resp.status_code == 400
+            data = resp.get_json()
+            assert data["success"] is False
+            assert data["code"] == "validation_error"
+            assert data["details"] == {"field": "target_version"}
+            fallback_mock.assert_not_called()
+        finally:
+            mod._set_update_state(False, None)
+
+    def test_update_endpoint_rejects_empty_target_version_with_validation_error(
+        self, client, monkeypatch
+    ):
+        mod, fallback_mock = self._install_mocks(monkeypatch)
+        try:
+            resp = client.post("/settings/update", json={"target_version": ""})
+            assert resp.status_code == 400
+            data = resp.get_json()
+            assert data["success"] is False
+            assert data["code"] == "validation_error"
+            assert data["details"] == {"field": "target_version"}
+            fallback_mock.assert_not_called()
+        finally:
+            mod._set_update_state(False, None)
+
+    def test_update_endpoint_rejects_whitespace_only_target_version(
+        self, client, monkeypatch
+    ):
+        mod, fallback_mock = self._install_mocks(monkeypatch)
+        try:
+            resp = client.post("/settings/update", json={"target_version": "   "})
+            assert resp.status_code == 400
+            data = resp.get_json()
+            assert data["code"] == "validation_error"
+            assert data["details"] == {"field": "target_version"}
+            fallback_mock.assert_not_called()
+        finally:
+            mod._set_update_state(False, None)
+
+    def test_update_endpoint_rejects_non_string_target_version(
+        self, client, monkeypatch
+    ):
+        mod, fallback_mock = self._install_mocks(monkeypatch)
+        try:
+            resp = client.post("/settings/update", json={"target_version": 123})
+            assert resp.status_code == 400
+            data = resp.get_json()
+            assert data["code"] == "validation_error"
+            assert data["details"] == {"field": "target_version"}
+            fallback_mock.assert_not_called()
+        finally:
+            mod._set_update_state(False, None)
+
+    def test_update_endpoint_invalid_tag_format_returns_validation_envelope(
+        self, client, monkeypatch
+    ):
+        """Existing invalid-format rejection now also uses the envelope."""
+        mod, fallback_mock = self._install_mocks(monkeypatch)
+        try:
+            resp = client.post(
+                "/settings/update", json={"target_version": "not-a-version"}
+            )
+            assert resp.status_code == 400
+            data = resp.get_json()
+            assert data["code"] == "validation_error"
+            assert data["details"] == {"field": "target_version"}
+            fallback_mock.assert_not_called()
+        finally:
+            mod._set_update_state(False, None)
+
+    def test_update_endpoint_missing_target_version_still_allowed(
+        self, client, monkeypatch
+    ):
+        """Omitting ``target_version`` entirely remains valid (latest-tag path)."""
+        mod, fallback_mock = self._install_mocks(monkeypatch)
+        try:
+            resp = client.post("/settings/update", json={})
+            assert resp.status_code == 200
+            fallback_mock.assert_called_once_with(None, target_tag=None)
+        finally:
+            mod._set_update_state(False, None)
+
+
+class TestReadLastUpdateFailureHelper:
+    """Direct unit tests for the read_last_update_failure helper."""
+
+    def test_returns_none_when_file_missing(self, monkeypatch, tmp_path):
+        from blueprints.settings._update_status import read_last_update_failure
+
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+        assert read_last_update_failure() is None
+
+    def test_returns_parsed_record_when_present(self, monkeypatch, tmp_path):
+        from blueprints.settings._update_status import read_last_update_failure
+
+        record = {
+            "timestamp": "2026-04-14T00:00:00Z",
+            "exit_code": 1,
+            "last_command": "stop_service",
+            "recent_journal_lines": "line1\nline2",
+        }
+        (tmp_path / ".last-update-failure").write_text(
+            json.dumps(record), encoding="utf-8"
+        )
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+        assert read_last_update_failure() == record
+
+    def test_caps_oversized_file(self, monkeypatch, tmp_path):
+        """A 1 MiB failure file must not blow up the response."""
+        from blueprints.settings._update_status import read_last_update_failure
+
+        (tmp_path / ".last-update-failure").write_text(
+            "x" * (1024 * 1024), encoding="utf-8"
+        )
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+        # Oversized + unparseable content yields the parse_error sentinel.
+        assert read_last_update_failure() == {"parse_error": True}


### PR DESCRIPTION
## Summary

Wire the `.last-update-failure` JSON record written by `install/update.sh`'s EXIT trap (JTN-704, #484) through the `/settings/update_status` endpoint so the Settings -> Updates page surfaces *why* the previous update failed without the user needing to SSH in and read the system journal.

Also tightens `POST /settings/update` validation so a `target_version` of `null`, `""`, or a whitespace/non-string value is rejected up-front with the standard `validation_error` envelope instead of silently falling through to the "latest semver tag" path in `do_update.sh` (which, on a fresh fork with no semver tags, emitted `No semver tags found` to stderr only).

Linear: [JTN-710](https://linear.app/jtn0123/issue/JTN-710/update-surface-errors-in-web-ui-not-just-journal)
Depends on: JTN-704's `.last-update-failure` JSON contract (merged in #484).

## Changes

- `src/blueprints/settings/_update_status.py` (new) — helper that reads `/var/lib/inkypi/.last-update-failure` defensively. Missing file -> `None`; malformed/oversized (>64 KiB) -> `{parse_error: true}` so the UI can still show a generic banner.
- `src/blueprints/settings/_updates.py` — `/settings/update_status` now returns `last_failure`; `POST /settings/update` rejects null/empty/non-string `target_version` with a `validation_error` envelope (`details.field: "target_version"`). Omitting the key entirely remains valid (still hits the latest-tag code path).
- `src/templates/settings.html` — new inline banner (`#updateFailureBanner`) at the top of the Updates panel.
- `src/static/scripts/settings_page.js` — `renderUpdateFailureBanner()` + `refreshUpdateStatus()`; wired into `init()` and the post-update poll so a newly-failed update appears as soon as the trap writes the file.
- `src/static/styles/partials/_feedback.css` — styles for the banner + journal `<pre>`.

## Test plan

- [x] New unit file `tests/unit/test_updates_surface_errors.py` (13 tests) covers:
  - `last_failure` populated when file present; `null` when missing; `{parse_error: true}` on malformed JSON, non-object JSON, or oversized files.
  - `POST /settings/update` rejects `null`, `""`, whitespace-only, non-string, and malformed-tag `target_version` values with the `validation_error` envelope.
  - Omitting `target_version` entirely still succeeds (latest-tag path).
  - Direct helper tests for `read_last_update_failure()` (missing/present/oversized).
- [x] Existing `tests/unit/test_settings_updates.py` + `test_settings_update.py` still pass (51 tests).
- [x] Full suite: `4195 passed, 4 skipped`.
- [x] `scripts/lint.sh` clean (ruff + black + shellcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)