### PR TITLE
feat(observability): batch + raise cap on /api/client-log (JTN-711)

### DIFF
--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -7,7 +7,16 @@ SecretRedactionFilter (JTN-364) strips any secrets before they reach disk.
 Only active when the page opts in via:
     <meta name="client-log-enabled" content="1">
 
-Rate-limited per remote IP using TokenBucket (capacity=10, refill=1/s).
+Rate-limited per remote IP using TokenBucket. In production the bucket is sized
+at capacity=60, refill=10/s (JTN-711) so a burst of errors from a broken page
+is not silently dropped. Each POST — whether it carries a single entry or a
+batch array — consumes exactly one token.
+
+Payload shapes (both accepted):
+    1. Single object: ``{"level": "warn", "message": "..."}``
+    2. Batch array:   ``[{"level": "warn", ...}, {"level": "error", ...}]``
+       Batch size is capped at ``_BATCH_MAX`` entries; oversized batches are
+       rejected with 400.
 """
 
 from __future__ import annotations
@@ -16,12 +25,12 @@ import json
 import logging
 import os
 import threading
+from typing import Any
 
-from flask import Blueprint, Response
+from flask import Blueprint, Response, request
 
-from utils.client_endpoint import parse_client_report, strip_newlines
 from utils.form_utils import sanitize_log_field
-from utils.http_utils import json_error, reissue_json_error
+from utils.http_utils import json_error
 from utils.rate_limit import TokenBucket
 
 logger = logging.getLogger(__name__)
@@ -69,16 +78,21 @@ def reset_captured_reports() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Rate limiting — 10-token burst, refills at 1 token/s
+# Rate limiting — JTN-711: raised from capacity=10, refill=1/s.
+#
+# 60-token burst, refills at 10 tokens/s. A broken page can now emit ~60
+# errors in a single burst without the browser reporter self-disabling, and
+# each batched POST consumes only one token regardless of entry count.
 # ---------------------------------------------------------------------------
-_rate_limiter: TokenBucket = TokenBucket(capacity=10, refill_rate=1.0)
+_rate_limiter: TokenBucket = TokenBucket(capacity=60, refill_rate=10.0)
 
 # ---------------------------------------------------------------------------
 # Size limits
 # ---------------------------------------------------------------------------
 _MESSAGE_MAX = 2048  # bytes for message field
 _ARGS_MAX = 4096  # bytes for args field
-_BODY_MAX = 16_384  # 16 KB total body
+_BODY_MAX = 256 * 1024  # 256 KB total body — batch of 50 × ~4KB entries + slack
+_BATCH_MAX = 50  # maximum entries per batch POST
 
 # Accepted levels — info/debug rejected to avoid noise
 _ACCEPTED_LEVELS = frozenset({"warn", "error"})
@@ -89,53 +103,127 @@ def _cap(value: object, max_len: int) -> str:
     return str(value)[:max_len]
 
 
-@client_log_bp.route("/api/client-log", methods=["POST"])
-def receive_client_log() -> tuple[Response, int] | Response:
-    """Accept a browser console.warn/error report and emit it as a WARNING log entry.
+def _validate_and_normalize(entry: Any) -> tuple[dict[str, object] | None, str | None]:
+    """Validate a single client-log entry dict.
 
-    Returns 204 on success so the browser-side script has a cheap ack with
-    no body to parse.
+    Returns ``(normalized_entry, None)`` on success or ``(None, error_message)``
+    otherwise. Newline stripping happens downstream in ``_build_report``.
     """
-    data, error = parse_client_report(_rate_limiter, _BODY_MAX)
-    if error is not None:
-        return reissue_json_error(error, "Invalid client log report")
+    if not isinstance(entry, dict):
+        return None, "entry must be a JSON object"
 
-    level = data.get("level", "")
+    level = entry.get("level", "")
     if level not in _ACCEPTED_LEVELS:
-        # Log the rejected value (sanitized) for debugging but do not echo
-        # it back to the client — that would be a reflective-xss sink
-        # (CodeQL py/reflective-xss). Response carries a generic message.
         logger.warning(
             "client log rejected: invalid level %s (accepted: %s)",
             sanitize_log_field(level),
             sorted(_ACCEPTED_LEVELS),
         )
-        return json_error(
-            f"Invalid level: must be one of {sorted(_ACCEPTED_LEVELS)}",
-            status=400,
-        )
+        return None, f"Invalid level: must be one of {sorted(_ACCEPTED_LEVELS)}"
+    return entry, None
 
-    # Strip CR/LF from each field to prevent log injection (Sonar S5145).
-    # SecretRedactionFilter (JTN-364) handles secret stripping downstream.
-    report: dict[str, object] = {"level": level}
-    if "message" in data:
-        report["message"] = strip_newlines(_cap(data["message"], _MESSAGE_MAX))
-    if "args" in data:
-        report["args"] = strip_newlines(_cap(data["args"], _ARGS_MAX))
-    if "url" in data:
-        report["url"] = strip_newlines(_cap(data["url"], _MESSAGE_MAX))
-    if "ts" in data:
-        report["ts"] = strip_newlines(_cap(data["ts"], 64))
 
-    logger.warning("client log [%s]: %s", level, json.dumps(report))
+def _strip_newlines(value: str) -> str:
+    """Replace CR/LF with spaces to prevent log-injection (Sonar S5145)."""
+    return value.replace("\r", " ").replace("\n", " ")
 
-    # Test-only capture hook (JTN-680). No-op in production: the env-var
-    # check is a single dict lookup + short-circuited string compare when
-    # the variable is unset, so overhead is negligible and behaviour is
-    # bit-identical to the pre-hook implementation.
+
+def _build_report(entry: dict[str, Any]) -> dict[str, object]:
+    """Build the logged report dict from a validated entry.
+
+    CR/LF is stripped from every field to prevent log injection
+    (Sonar S5145). SecretRedactionFilter (JTN-364) handles secret stripping
+    downstream in the logging layer.
+    """
+    report: dict[str, object] = {"level": entry["level"]}
+    if "message" in entry:
+        report["message"] = _strip_newlines(_cap(entry["message"], _MESSAGE_MAX))
+    if "args" in entry:
+        report["args"] = _strip_newlines(_cap(entry["args"], _ARGS_MAX))
+    if "url" in entry:
+        report["url"] = _strip_newlines(_cap(entry["url"], _MESSAGE_MAX))
+    if "ts" in entry:
+        report["ts"] = _strip_newlines(_cap(entry["ts"], 64))
+    return report
+
+
+def _emit(report: dict[str, object]) -> None:
+    """Emit a single validated report to the logger and (optionally) capture."""
+    logger.warning("client log [%s]: %s", report["level"], json.dumps(report))
     if _capture_enabled():
         with _captured_lock:
             _captured_reports.append(dict(report))
+
+
+@client_log_bp.route("/api/client-log", methods=["POST"])
+def receive_client_log() -> tuple[Response, int] | Response:
+    """Accept a single entry OR an array of entries and log each as WARNING.
+
+    * Single object payload: legacy shape, still supported (JTN-481).
+    * Array payload: one POST carries up to ``_BATCH_MAX`` entries and
+      consumes exactly one rate-limit token (JTN-711).
+
+    Returns 204 on success. On batch requests where one or more entries fail
+    validation, returns 400 with a JSON body listing per-entry errors so the
+    client can fix the payload; valid entries in the same request are NOT
+    emitted in that case (all-or-nothing semantics keep the contract simple).
+    """
+    # ---- Size + rate-limit + JSON parse (inline, not via parse_client_report
+    # which hardcodes the dict requirement). -------------------------------
+    content_length = request.content_length
+    if content_length is not None and content_length > _BODY_MAX:
+        return json_error("Request body too large", status=413)
+
+    raw_body = request.get_data(as_text=False)
+    if len(raw_body) > _BODY_MAX:
+        return json_error("Request body too large", status=413)
+
+    remote_ip = request.remote_addr or "unknown"
+    if not _rate_limiter.try_acquire(remote_ip):
+        return json_error("Rate limit exceeded", status=429)
+
+    try:
+        data = json.loads(raw_body)
+    except ValueError:
+        return json_error("Request body must be valid JSON", status=400)
+
+    # ---- Normalise single object vs batch array --------------------------
+    if isinstance(data, list):
+        entries = data
+        if len(entries) == 0:
+            return json_error("Batch must contain at least one entry", status=400)
+        if len(entries) > _BATCH_MAX:
+            return json_error(
+                f"Batch too large: max {_BATCH_MAX} entries per POST", status=400
+            )
+    elif isinstance(data, dict):
+        entries = [data]
+    else:
+        return json_error(
+            "Request body must be a JSON object or array of objects", status=400
+        )
+
+    # ---- Validate every entry before emitting (all-or-nothing) -----------
+    validated: list[dict[str, Any]] = []
+    errors: list[dict[str, object]] = []
+    for idx, entry in enumerate(entries):
+        normalized, err = _validate_and_normalize(entry)
+        if err is not None:
+            errors.append({"index": idx, "error": err})
+        else:
+            assert normalized is not None
+            validated.append(normalized)
+
+    if errors:
+        # Return the first error in the generic `error` field (kept stable for
+        # legacy clients that only read it) and the full per-entry list so
+        # batched senders can self-correct.
+        first_msg = str(errors[0]["error"])
+        return json_error(first_msg, status=400, details={"entry_errors": errors})
+
+    # ---- Emit every validated entry --------------------------------------
+    for entry in validated:
+        _emit(_build_report(entry))
 
     return Response(status=204)
 

--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -31,7 +31,7 @@ from flask import Blueprint, Response
 
 from utils.client_endpoint import enforce_size_and_rate
 from utils.form_utils import sanitize_log_field
-from utils.http_utils import json_error
+from utils.http_utils import json_error, reissue_json_error
 from utils.rate_limit import TokenBucket
 
 logger = logging.getLogger(__name__)
@@ -171,9 +171,15 @@ def receive_client_log() -> tuple[Response, int] | Response:
     """
     # ---- Size + rate-limit (shared helper; parse_client_report isn't used
     # here because it hardcodes the dict requirement). ---------------------
+    #
+    # The helper already returns a server-controlled error tuple on failure,
+    # but CodeQL can't prove the message is trusted through the boundary
+    # (it treats everything derived from the request as tainted). We
+    # reissue with a hardcoded message + the helper's status to break the
+    # taint flow explicitly.
     raw_body, err = enforce_size_and_rate(_rate_limiter, _BODY_MAX)
     if err is not None:
-        return err
+        return reissue_json_error(err, "Request rejected")
     assert raw_body is not None
 
     try:
@@ -209,11 +215,19 @@ def receive_client_log() -> tuple[Response, int] | Response:
             validated.append(normalized)
 
     if errors:
-        # Return the first error in the generic `error` field (kept stable for
-        # legacy clients that only read it) and the full per-entry list so
-        # batched senders can self-correct.
-        first_msg = str(errors[0]["error"])
-        return json_error(first_msg, status=400, details={"entry_errors": errors})
+        # Top-level error message is a fixed server-controlled string —
+        # CodeQL flagged an earlier version because it tracks any value
+        # derived from the request body as tainted, even when the code path
+        # only ever picks from a fixed set of error strings. The full
+        # per-entry list is still returned under ``details.entry_errors``
+        # so batched senders can self-correct; each entry error message is
+        # one of a small set of server-controlled literals built in
+        # ``_validate_and_normalize``.
+        return json_error(
+            "One or more batch entries failed validation",
+            status=400,
+            details={"entry_errors": errors},
+        )
 
     # ---- Emit every validated entry --------------------------------------
     for entry in validated:

--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -27,8 +27,9 @@ import os
 import threading
 from typing import Any
 
-from flask import Blueprint, Response, request
+from flask import Blueprint, Response
 
+from utils.client_endpoint import enforce_size_and_rate
 from utils.form_utils import sanitize_log_field
 from utils.http_utils import json_error
 from utils.rate_limit import TokenBucket
@@ -168,19 +169,12 @@ def receive_client_log() -> tuple[Response, int] | Response:
     client can fix the payload; valid entries in the same request are NOT
     emitted in that case (all-or-nothing semantics keep the contract simple).
     """
-    # ---- Size + rate-limit + JSON parse (inline, not via parse_client_report
-    # which hardcodes the dict requirement). -------------------------------
-    content_length = request.content_length
-    if content_length is not None and content_length > _BODY_MAX:
-        return json_error("Request body too large", status=413)
-
-    raw_body = request.get_data(as_text=False)
-    if len(raw_body) > _BODY_MAX:
-        return json_error("Request body too large", status=413)
-
-    remote_ip = request.remote_addr or "unknown"
-    if not _rate_limiter.try_acquire(remote_ip):
-        return json_error("Rate limit exceeded", status=429)
+    # ---- Size + rate-limit (shared helper; parse_client_report isn't used
+    # here because it hardcodes the dict requirement). ---------------------
+    raw_body, err = enforce_size_and_rate(_rate_limiter, _BODY_MAX)
+    if err is not None:
+        return err
+    assert raw_body is not None
 
     try:
         data = json.loads(raw_body)

--- a/src/static/scripts/client_log_reporter.js
+++ b/src/static/scripts/client_log_reporter.js
@@ -1,11 +1,15 @@
 // Forward browser console.warn and console.error calls to /api/client-log.
 // Only activates when the page opts in via:
 //   <meta name="client-log-enabled" content="1">
-// Features:
+// Features (JTN-711):
 //   - 50% sampling (less critical than thrown errors)
 //   - Calls original console methods first — never breaks existing logging
-//   - Uses navigator.sendBeacon when available (works during page unload)
-//   - Self-disables after 5 consecutive send failures
+//   - Coalesces reports within a 500ms window into a single batched POST
+//     so bursts of errors consume only one server-side rate-limit token.
+//   - Splits across multiple POSTs if batch exceeds the server cap (50).
+//   - Falls back to navigator.sendBeacon for the tail flush on page unload.
+//   - Self-disables after 10 consecutive send failures (raised from 5 now
+//     that the server capacity is higher — JTN-711).
 (function () {
   "use strict";
 
@@ -17,7 +21,9 @@
 
   const ENDPOINT = "/api/client-log";
   const SAMPLE_RATE = 0.5; // report 50% of console messages
-  const MAX_FAILURES = 5;
+  const MAX_FAILURES = 10; // JTN-711: raised from 5
+  const BATCH_WINDOW_MS = 500; // coalesce window
+  const BATCH_MAX = 50; // must match server-side _BATCH_MAX
   let failures = 0;
   let disabled = false;
 
@@ -33,6 +39,10 @@
 
   const originalWarn = console.warn.bind(console);
   const originalError = console.error.bind(console);
+
+  // Pending queue + coalesce timer.
+  const pending = [];
+  let flushTimer = null;
 
   function shouldSample() {
     if (TEST_MODE) return true;
@@ -64,19 +74,24 @@
     }
   }
 
-  function send(level, args) {
-    if (disabled) return;
-    if (!shouldSample()) return;
+  function buildEntry(level, args) {
+    return {
+      level: level,
+      message: (args[0] === undefined ? "" : String(args[0])).slice(0, 2048),
+      args: argsToString(args),
+      url: location.pathname.slice(0, 2048),
+      ts: new Date().toISOString(),
+    };
+  }
+
+  function postBatch(entries, useBeacon) {
+    if (entries.length === 0) return;
+    // Server accepts both single-object and array payloads. Always use an
+    // array here — it keeps the code path uniform and the server parses
+    // either shape in one token.
+    const body = JSON.stringify(entries);
     try {
-      const payload = {
-        level: level,
-        message: (args[0] === undefined ? "" : String(args[0])).slice(0, 2048),
-        args: argsToString(args),
-        url: location.pathname.slice(0, 2048),
-        ts: new Date().toISOString(),
-      };
-      const body = JSON.stringify(payload);
-      if (navigator.sendBeacon) {
+      if (useBeacon && navigator.sendBeacon) {
         // sendBeacon works during page unload; CSRF token embedded in body
         // because sendBeacon does not support custom headers.
         const blob = new Blob([body], { type: "application/json" });
@@ -109,15 +124,64 @@
     }
   }
 
+  function flush(useBeacon) {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    if (pending.length === 0) return;
+    // Drain pending in chunks of at most BATCH_MAX per POST. Splitting like
+    // this preserves the 1-token-per-POST contract even if coalescing
+    // accumulated more than the server cap.
+    while (pending.length > 0) {
+      const chunk = pending.splice(0, BATCH_MAX);
+      postBatch(chunk, !!useBeacon);
+    }
+  }
+
+  function scheduleFlush() {
+    if (flushTimer !== null) return;
+    flushTimer = setTimeout(function () {
+      flushTimer = null;
+      flush(false);
+    }, BATCH_WINDOW_MS);
+  }
+
+  function enqueue(level, args) {
+    if (disabled) return;
+    if (!shouldSample()) return;
+    try {
+      pending.push(buildEntry(level, args));
+      // If we've already hit the server cap in a single burst, flush now
+      // and avoid waiting the remaining window.
+      if (pending.length >= BATCH_MAX) {
+        flush(false);
+        return;
+      }
+      scheduleFlush();
+    } catch {
+      onSendFailure();
+    }
+  }
+
+  // Flush any pending reports on page unload using sendBeacon so nothing
+  // is lost when the user navigates away mid-coalesce-window.
+  window.addEventListener("pagehide", function () {
+    flush(true);
+  });
+  window.addEventListener("beforeunload", function () {
+    flush(true);
+  });
+
   console.warn = function () {
     // Call original first — never suppress existing console output.
     originalWarn.apply(console, arguments);
-    send("warn", arguments);
+    enqueue("warn", arguments);
   };
 
   console.error = function () {
     // Call original first — never suppress existing console output.
     originalError.apply(console, arguments);
-    send("error", arguments);
+    enqueue("error", arguments);
   };
 })();

--- a/src/utils/client_endpoint.py
+++ b/src/utils/client_endpoint.py
@@ -17,6 +17,32 @@ from utils.http_utils import json_error
 from utils.rate_limit import TokenBucket
 
 
+def enforce_size_and_rate(
+    rate_limiter: TokenBucket, body_max: int
+) -> tuple[bytes | None, tuple[Response, int] | None]:
+    """Enforce body-size cap + per-IP rate-limit.
+
+    Returns ``(raw_body, None)`` on success or ``(None, error_response)``.
+
+    Callers that need array-aware JSON parsing (e.g. /api/client-log batch
+    payloads, JTN-711) use this helper and parse the body themselves;
+    callers expecting a single object can still use ``parse_client_report``.
+    """
+    content_length = request.content_length
+    if content_length is not None and content_length > body_max:
+        return None, json_error("Request body too large", status=413)
+
+    raw_body = request.get_data(as_text=False)
+    if len(raw_body) > body_max:
+        return None, json_error("Request body too large", status=413)
+
+    remote_ip = request.remote_addr or "unknown"
+    if not rate_limiter.try_acquire(remote_ip):
+        return None, json_error("Rate limit exceeded", status=429)
+
+    return raw_body, None
+
+
 def parse_client_report(
     rate_limiter: TokenBucket, body_max: int
 ) -> tuple[dict[str, Any] | None, Response | tuple[Response, int] | None]:

--- a/tests/integration/test_client_log_xss.py
+++ b/tests/integration/test_client_log_xss.py
@@ -61,7 +61,15 @@ def test_invalid_level_not_reflected(client, payload: str) -> None:
     # The level validation message remains specific, but the tainted payload
     # itself must never be reflected.
     parsed = json.loads(body)
-    assert "Invalid level" in parsed.get("error", "")
+    # JTN-711: top-level error is a fixed server-controlled string to avoid
+    # CodeQL flagging any request-derived reflection. The per-entry error
+    # list still carries the detailed "Invalid level: ..." message for
+    # debugging — and the tainted payload itself never appears anywhere.
+    top_error = parsed.get("error", "")
+    entry_errors = parsed.get("details", {}).get("entry_errors") or []
+    detail_msgs = " ".join(str(e.get("error", "")) for e in entry_errors)
+    combined = f"{top_error} {detail_msgs}".lower()
+    assert "invalid level" in combined or "validation" in combined
 
 
 def test_invalid_level_missing_still_rejected(client) -> None:

--- a/tests/test_client_log_forwarding.py
+++ b/tests/test_client_log_forwarding.py
@@ -138,10 +138,11 @@ class TestGetReturns405:
 
 
 class TestOversizedBody:
-    def test_body_over_16kb_returns_413(self, cl_client):
-        giant_message = "x" * 20_000
+    def test_body_over_limit_returns_413(self, cl_client):
+        """Bodies over the 256 KB cap (JTN-711 raised to fit batches) → 413."""
+        giant_message = "x" * (300 * 1024)
         body = json.dumps({"level": "warn", "message": giant_message}).encode()
-        assert len(body) > 16_384
+        assert len(body) > 256 * 1024
         resp = _post(cl_client, body=body)
         assert resp.status_code == 413
 
@@ -157,7 +158,7 @@ class TestOversizedBody:
 
 class TestRateLimit:
     def test_rate_limit_kicks_in_after_capacity(self):
-        """After exhausting 10-token burst capacity the next request returns 429."""
+        """After exhausting 60-token burst capacity the next request returns 429 (JTN-711)."""
         import blueprints.client_log as cl_mod
 
         importlib.reload(cl_mod)
@@ -168,12 +169,12 @@ class TestRateLimit:
         app.register_blueprint(client_log_bp)
         c = app.test_client()
 
-        # First 10 requests should succeed (capacity = 10)
-        for _ in range(10):
+        # First 60 requests should succeed (capacity = 60, JTN-711)
+        for _ in range(60):
             resp = _post(c, {"level": "warn", "message": "log"})
             assert resp.status_code == 204
 
-        # The 11th request should be rate-limited
+        # The 61st request should be rate-limited
         resp = _post(c, {"level": "warn", "message": "log"})
         assert resp.status_code == 429
 

--- a/tests/unit/test_client_log_batch.py
+++ b/tests/unit/test_client_log_batch.py
@@ -1,0 +1,255 @@
+# pyright: reportMissingImports=false
+"""Tests for /api/client-log batch payload support (JTN-711).
+
+The endpoint now accepts either the legacy single-object payload or a JSON
+array of entries. Each POST — whether single or batch — consumes exactly
+one rate-limit token.
+
+Coverage:
+  * Batch endpoint accepts array payloads
+  * Batch is rejected when oversized (> 50 entries)
+  * One bad entry causes the whole batch to fail with per-entry errors
+  * Rate-limit capacity was raised to 60 (JTN-711)
+  * Each batch POST consumes one token (not N)
+  * Single-entry payload still works (backwards-compat)
+  * Newline stripping / field capping runs on every batch entry
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+
+import pytest
+from flask import Flask  # noqa: E402
+
+
+def _fresh_app(monkeypatch=None, *, capture: bool = False) -> Flask:
+    """Reload ``blueprints.client_log`` and return a fresh Flask app.
+
+    Reloading resets the module-level rate limiter so each test starts with a
+    full bucket.
+    """
+    import blueprints.client_log as cl_mod
+
+    importlib.reload(cl_mod)
+    if monkeypatch is not None:
+        if capture:
+            monkeypatch.setenv("INKYPI_TEST_CAPTURE_CLIENT_LOG", "1")
+        else:
+            monkeypatch.delenv("INKYPI_TEST_CAPTURE_CLIENT_LOG", raising=False)
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(cl_mod.client_log_bp)
+    return app
+
+
+def _post(client, payload):
+    return client.post(
+        "/api/client-log",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+class TestBatchAccepted:
+    def test_batch_endpoint_accepts_array_payload(self, monkeypatch):
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        batch = [
+            {"level": "warn", "message": "w1"},
+            {"level": "error", "message": "e1"},
+            {"level": "warn", "message": "w2"},
+        ]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 204
+
+        reports = cl_mod.get_captured_reports()
+        assert [r["message"] for r in reports] == ["w1", "e1", "w2"]
+        assert [r["level"] for r in reports] == ["warn", "error", "warn"]
+
+    def test_existing_single_entry_payload_still_works(self, monkeypatch):
+        """Backwards-compat: legacy single-object POSTs still return 204."""
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        resp = _post(app.test_client(), {"level": "warn", "message": "solo"})
+        assert resp.status_code == 204
+        reports = cl_mod.get_captured_reports()
+        assert len(reports) == 1
+        assert reports[0]["message"] == "solo"
+
+    def test_batch_at_cap_is_accepted(self, monkeypatch):
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        batch = [{"level": "warn", "message": f"m{i}"} for i in range(50)]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 204
+        assert len(cl_mod.get_captured_reports()) == 50
+
+
+class TestBatchRejected:
+    def test_batch_endpoint_rejects_oversized_batch(self, monkeypatch):
+        """> 50 entries → 400."""
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        batch = [{"level": "warn", "message": f"m{i}"} for i in range(51)]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert body["success"] is False
+        assert "max" in body["error"].lower() or "50" in body["error"]
+        # Nothing should have been captured.
+        assert cl_mod.get_captured_reports() == []
+
+    def test_empty_batch_rejected(self, monkeypatch):
+        app = _fresh_app(monkeypatch)
+        resp = _post(app.test_client(), [])
+        assert resp.status_code == 400
+
+    def test_batch_entries_individually_validated(self, monkeypatch):
+        """One bad entry returns 400 with per-entry errors; good entries are
+        NOT emitted in that case (all-or-nothing)."""
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        batch = [
+            {"level": "warn", "message": "ok1"},
+            {"level": "info", "message": "nope"},  # invalid level
+            {"level": "error", "message": "ok2"},
+        ]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        assert body["details"]["entry_errors"][0]["index"] == 1
+        # All-or-nothing semantics — no entries captured.
+        assert cl_mod.get_captured_reports() == []
+
+    def test_non_object_entry_in_batch_rejected(self, monkeypatch):
+        app = _fresh_app(monkeypatch)
+        batch = [{"level": "warn", "message": "ok"}, "bad-entry", 42]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 400
+        body = json.loads(resp.data)
+        indexes = [e["index"] for e in body["details"]["entry_errors"]]
+        assert indexes == [1, 2]
+
+    def test_non_object_non_array_body_rejected(self, monkeypatch):
+        app = _fresh_app(monkeypatch)
+        resp = _post(app.test_client(), "just-a-string")
+        assert resp.status_code == 400
+
+
+class TestRateLimitCapacity:
+    def test_rate_limit_capacity_raised_to_60(self, monkeypatch):
+        """JTN-711: the bucket now holds 60 tokens (up from 10)."""
+        app = _fresh_app(monkeypatch)
+        c = app.test_client()
+
+        for i in range(60):
+            resp = _post(c, {"level": "warn", "message": f"m{i}"})
+            assert resp.status_code == 204, f"unexpected failure at iteration {i}"
+
+        # 61st → 429
+        resp = _post(c, {"level": "warn", "message": "over"})
+        assert resp.status_code == 429
+
+    def test_each_batch_post_consumes_one_token(self, monkeypatch):
+        """60 POSTs, each carrying 10 entries, should all succeed. That's
+        600 *entries* worth of traffic — proving the bucket is keyed on
+        requests, not entries."""
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        c = app.test_client()
+        per_batch = 10
+        batches = 60
+        for i in range(batches):
+            batch = [
+                {"level": "warn", "message": f"b{i}-e{j}"} for j in range(per_batch)
+            ]
+            resp = _post(c, batch)
+            assert resp.status_code == 204
+
+        # 61st batch → 429 (capacity exhausted)
+        resp = _post(c, [{"level": "warn", "message": "over"}])
+        assert resp.status_code == 429
+
+        # All 600 entries landed in the capture list
+        assert len(cl_mod.get_captured_reports()) == batches * per_batch
+
+
+class TestBatchFieldHandling:
+    def test_secret_redaction_applied_to_every_batch_entry(self, monkeypatch, caplog):
+        """Every entry is logged at WARNING so SecretRedactionFilter (JTN-364)
+        strips secrets. Here we assert each entry reaches the logger — the
+        downstream filter is tested separately in its own suite."""
+        app = _fresh_app(monkeypatch)
+
+        batch = [{"level": "warn", "message": f"entry-{i}"} for i in range(5)]
+        with caplog.at_level(logging.WARNING, logger="blueprints.client_log"):
+            resp = _post(app.test_client(), batch)
+        assert resp.status_code == 204
+
+        warning_msgs = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        for i in range(5):
+            assert any(
+                f"entry-{i}" in m for m in warning_msgs
+            ), f"entry-{i} missing from logs"
+
+    def test_cr_lf_stripped_on_every_batch_entry(self, monkeypatch, caplog):
+        app = _fresh_app(monkeypatch)
+        batch = [
+            {"level": "warn", "message": "line\r\nbad1"},
+            {"level": "error", "message": "also\nbad2"},
+        ]
+        with caplog.at_level(logging.WARNING, logger="blueprints.client_log"):
+            resp = _post(app.test_client(), batch)
+        assert resp.status_code == 204
+        joined = " ".join(
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        )
+        assert "\r" not in joined
+        assert "\n" not in joined
+        assert "bad1" in joined
+        assert "bad2" in joined
+
+    def test_message_field_capped_per_entry(self, monkeypatch):
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        huge = "x" * 5000  # exceeds 2048 message cap
+        batch = [{"level": "warn", "message": huge}]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 204
+        reports = cl_mod.get_captured_reports()
+        assert len(reports[0]["message"]) == 2048
+
+
+class TestBurstAllLands:
+    """Acceptance test from JTN-711: 30 errors in a burst all land in the
+    capture list, because the reporter coalesces them into at most one POST.
+
+    We simulate the coalesced POST directly here — the JS coalescing is
+    tested in the browser integration suite."""
+
+    def test_30_errors_in_a_burst_all_land(self, monkeypatch):
+        app = _fresh_app(monkeypatch, capture=True)
+        import blueprints.client_log as cl_mod
+
+        batch = [{"level": "error", "message": f"burst-{i}"} for i in range(30)]
+        resp = _post(app.test_client(), batch)
+        assert resp.status_code == 204
+
+        messages = [r["message"] for r in cl_mod.get_captured_reports()]
+        assert messages == [f"burst-{i}" for i in range(30)]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes the /api/client-log tripwire blinding itself on error bursts. A broken page emitting 10+ errors in a few seconds used to drop 9+ of them (429) and then auto-disable the reporter after 5 consecutive rejections — losing exactly the data the tripwire was designed to catch (JTN-711).

- **Server cap raised**: token bucket now capacity=60, refill=10/s (was 10 / 1s)
- **Batch payload accepted**: POST either a single object (legacy) or an array of up to 50 entries. Each POST consumes exactly one rate-limit token.
- **Client coalescing**: `client_log_reporter.js` batches reports within a 500ms window into a single POST; splits across multiple POSTs if the cap is exceeded; flushes pending via `sendBeacon` on pagehide/beforeunload.
- **Self-disable threshold**: raised from 5×429 to 10×429 now that server cap is higher.
- **All-or-nothing batch validation**: any invalid entry returns 400 with per-entry errors in `details.entry_errors`; secret redaction (via the logging filter) runs on every validated entry.

## Changes

- `src/blueprints/client_log.py` — raise bucket capacity, accept array payload, per-entry validation, 256 KB body cap.
- `src/static/scripts/client_log_reporter.js` — 500ms coalescing window, multi-POST split for oversized batches, MAX_FAILURES=10, pagehide/beforeunload flush.
- `tests/test_client_log_forwarding.py` — update capacity + body-size tests to new limits.
- `tests/unit/test_client_log_batch.py` — new suite covering batch accept/reject, per-entry validation, token accounting, newline stripping, field capping, and the 30-errors-in-a-burst acceptance case.

## Test plan

- [x] `pytest tests/` — 4196 passed, 4 skipped
- [x] `scripts/lint.sh` — ruff + black + shellcheck green
- [x] JTN-711 acceptance: 30 errors in a single batch all land in the capture list
- [x] `test_each_batch_post_consumes_one_token` — 60 batches × 10 entries = 600 entries processed in one bucket refill window
- [x] Backwards-compat — legacy single-object POSTs still return 204

Linear: JTN-711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch posting support to client logging API
  * Implemented client-side log queuing with optimized batched transmission
  * Enhanced error reporting with per-entry validation details

* **Improvements**
  * Increased API rate limits and maximum payload size capacity
  * Improved page-unload logging handling for better data reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->