### PR TITLE
feat(dev): watch-mode CSS + asset rebuild script (JTN-713)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -121,6 +121,25 @@ exit                                 # Exit devbox shell and deactivates Python 
 </tr>
 </table>
 
+## Dev quick reference
+
+Running commands for the tight edit-refresh loop:
+
+```bash
+# Start the Flask dev server (full program, auto-reloads Python + templates)
+./scripts/dev.sh
+# or:  .venv/bin/python src/inkypi.py --dev --web-only     # port 8080
+
+# Auto-rebuild bundled CSS/JS on file changes (JTN-713)
+./scripts/dev_watch.sh
+#   watches src/static/styles/  → runs scripts/build_css.py
+#   watches src/static/scripts/ → runs scripts/build_assets.py
+#   watches src/templates/      → logs only (Flask auto-reloads templates)
+# Requires `watchdog` (pip install watchdog). Ctrl+C exits cleanly.
+# One-shot CSS build (no watcher):
+python3 scripts/build_css.py
+```
+
 ## Development Tips
 
 1. **Check rendered output**: Images are saved to `runtime/mock_display_output/`

--- a/install/requirements-dev.in
+++ b/install/requirements-dev.in
@@ -27,6 +27,12 @@ types-requests==2.32.0.20241016
 black>=26.0,<27
 ruff>=0.6,<1
 
+# Dev watch-mode rebuilds (JTN-713) — provides the `watchmedo` CLI used by
+# scripts/dev_watch.sh to auto-rebuild CSS/JS bundles on file changes.
+# Not pinned in the compiled lockfile on purpose: it is an optional developer
+# convenience, not a CI requirement.
+watchdog>=4.0,<7
+
 # Browser / E2E testing
 playwright>=1.55,<2
 

--- a/scripts/_dev_watch_dispatch.py
+++ b/scripts/_dev_watch_dispatch.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Dispatcher for scripts/dev_watch.sh.
+
+Invoked by ``watchmedo shell-command`` on every matched filesystem event.
+Responsibilities:
+
+* Route the change to the right builder based on which watched dir the path
+  lives under (styles → build_css.py, scripts → build_assets.py, templates →
+  log-only since Flask auto-reloads templates).
+* Debounce rapid successive events — IDE auto-save often fires a burst of
+  create/modify/move events within a few ms. We coalesce anything within a
+  200 ms window per (kind, builder) pair using an on-disk timestamp so that
+  successive ``watchmedo`` invocations (each a fresh subprocess) can see the
+  previous one's activity.
+* Print exactly one line per rebuild:
+    ``[2026-04-14T12:34:56] rebuild css (source: _buttons.css)``
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STYLES_DIR = REPO_ROOT / "src" / "static" / "styles"
+SCRIPTS_DIR = REPO_ROOT / "src" / "static" / "scripts"
+TEMPLATES_DIR = REPO_ROOT / "src" / "templates"
+
+# 200 ms debounce window — coalesces IDE save bursts without feeling laggy.
+DEBOUNCE_SECONDS = 0.2
+
+# Where we stash per-kind "last build" timestamps. Using the system tempdir
+# keeps the repo clean and avoids confusing git status.
+_STATE_DIR = Path(tempfile.gettempdir()) / "inkypi-dev-watch"
+
+
+def _kind_for(path: Path) -> str | None:
+    """Return 'css', 'js', 'template', or None if the path isn't watched."""
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+
+    for candidate, label in (
+        (STYLES_DIR, "css"),
+        (SCRIPTS_DIR, "js"),
+        (TEMPLATES_DIR, "template"),
+    ):
+        try:
+            resolved.relative_to(candidate.resolve())
+            return label
+        except ValueError:
+            continue
+    return None
+
+
+def _debounce(kind: str) -> bool:
+    """Return True if we should proceed; False if another event just ran.
+
+    State is tracked per-kind in a temp file so the debounce survives across
+    the short-lived subprocesses that ``watchmedo shell-command`` spawns.
+    """
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = _STATE_DIR / f"{kind}.last"
+    now = time.monotonic()
+    try:
+        last = float(stamp.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        last = 0.0
+    if now - last < DEBOUNCE_SECONDS:
+        return False
+    stamp.write_text(str(now))
+    return True
+
+
+def _log(action: str, source: Path) -> None:
+    # Local wall-clock time, stripped to seconds. Developers read this at
+    # the terminal — an ISO-with-offset string would be harder to scan.
+    ts = datetime.now().astimezone().replace(microsecond=0, tzinfo=None).isoformat()
+    print(f"[{ts}] {action} (source: {source.name})", flush=True)
+
+
+def _run_builder(script: str) -> int:
+    """Run scripts/<script> with the current Python, return exit code."""
+    builder = REPO_ROOT / "scripts" / script
+    result = subprocess.run(
+        [sys.executable, str(builder)],
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+    return result.returncode
+
+
+def main(argv: list[str]) -> int:
+    # watchmedo passes: <event_type> <src_path>
+    if len(argv) < 3:
+        return 0
+    event_type = argv[1]
+    src_path = Path(argv[2])
+
+    # Ignore directory-level events; --ignore-directories in the shell command
+    # should prevent these, but be defensive.
+    if event_type == "moved" and src_path.is_dir():
+        return 0
+
+    kind = _kind_for(src_path)
+    if kind is None:
+        return 0
+
+    if not _debounce(kind):
+        return 0
+
+    if kind == "css":
+        _log("rebuild css", src_path)
+        return _run_builder("build_css.py")
+    if kind == "js":
+        _log("rebuild js", src_path)
+        # build_assets.py covers both JS and CSS; we run it here to refresh
+        # the dist/ bundle hash used by base.html.
+        return _run_builder("build_assets.py")
+    if kind == "template":
+        # Flask's reloader picks up template changes; no build step needed.
+        _log("template changed (Flask will auto-reload)", src_path)
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except KeyboardInterrupt:  # pragma: no cover - interactive only
+        sys.exit(0)
+    except OSError as exc:  # pragma: no cover - defensive
+        print(f"dev_watch dispatch error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/dev_watch.sh
+++ b/scripts/dev_watch.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# dev_watch.sh — watch src/static/* and src/templates/ and auto-rebuild.
+#
+# Behavior
+#   - src/static/styles/    → runs `python3 scripts/build_css.py`
+#   - src/static/scripts/   → runs `python3 scripts/build_assets.py` (JS bundle)
+#   - src/templates/        → logs the change (Flask auto-reloads templates)
+#
+# One line per rebuild:
+#   [2026-04-14T12:34:56] rebuild css (source: _buttons.css)
+#
+# Ctrl+C exits cleanly. Rapid successive file events are debounced (200ms
+# window) so IDE auto-save bursts don't trigger N rebuilds.
+#
+# Requires the `watchdog` Python package (ships with `watchmedo`). If it's
+# missing, the script prints an install hint and exits non-zero.
+#
+# Works on macOS and Linux. Primary dev platform: macOS.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+cd "${REPO_ROOT}"
+
+# Prefer the repo venv's python if present; fall back to python3 on PATH.
+PYTHON="python3"
+if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+  PYTHON="${REPO_ROOT}/.venv/bin/python"
+elif [ -x "${REPO_ROOT}/venv/bin/python" ]; then
+  PYTHON="${REPO_ROOT}/venv/bin/python"
+fi
+
+# Detect watchdog + watchmedo. We shell out to the python above so we pick up
+# whatever environment the developer is actually using.
+if ! "${PYTHON}" -c "import watchdog" >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+error: watchdog is not installed in the active Python environment.
+
+Install it with one of:
+
+  pip install watchdog
+  .venv/bin/pip install watchdog
+
+(watchdog is listed in install/requirements-dev.in but is not part of the
+compiled lockfile; installing the single package is the quickest fix.)
+
+Then re-run ./scripts/dev_watch.sh
+EOF
+  exit 1
+fi
+
+# Path to the bundled CLI that ships with watchdog.
+WATCHMEDO="$(dirname "${PYTHON}")/watchmedo"
+if [ ! -x "${WATCHMEDO}" ]; then
+  # Fall back to running it via `python -m watchdog.watchmedo`. This works on
+  # distros that don't install the CLI shim.
+  WATCHMEDO_RUN=("${PYTHON}" -m watchdog.watchmedo)
+else
+  WATCHMEDO_RUN=("${WATCHMEDO}")
+fi
+
+STYLES_DIR="${REPO_ROOT}/src/static/styles"
+SCRIPTS_DIR="${REPO_ROOT}/src/static/scripts"
+TEMPLATES_DIR="${REPO_ROOT}/src/templates"
+
+for d in "${STYLES_DIR}" "${SCRIPTS_DIR}" "${TEMPLATES_DIR}"; do
+  if [ ! -d "${d}" ]; then
+    echo "error: watched directory not found: ${d}" >&2
+    exit 1
+  fi
+done
+
+# Dispatcher script — called by watchmedo with the event type and path. This
+# is what debounces + routes + logs.
+DISPATCHER="${SCRIPT_DIR}/_dev_watch_dispatch.py"
+if [ ! -f "${DISPATCHER}" ]; then
+  echo "error: missing dispatcher helper: ${DISPATCHER}" >&2
+  exit 1
+fi
+
+echo "dev_watch: watching styles/, scripts/, templates/ (Ctrl+C to exit)"
+
+# Trap Ctrl+C so the message is clean rather than a traceback.
+trap 'echo ""; echo "dev_watch: stopped."; exit 0' INT TERM
+
+# --recursive so nested partials/macros are covered. --ignore-patterns avoids
+# rebuild loops from the generated main.css / dist bundles.
+exec "${WATCHMEDO_RUN[@]}" shell-command \
+  --patterns="*.css;*.js;*.html" \
+  --ignore-patterns="*/main.css;*/dist/*;*/__pycache__/*" \
+  --ignore-directories \
+  --recursive \
+  --command="${PYTHON} ${DISPATCHER} \${watch_event_type} \${watch_src_path}" \
+  "${STYLES_DIR}" "${SCRIPTS_DIR}" "${TEMPLATES_DIR}"

--- a/tests/unit/test_dev_watch_script.py
+++ b/tests/unit/test_dev_watch_script.py
@@ -1,0 +1,201 @@
+# pyright: reportMissingImports=false
+"""Structural validation of scripts/dev_watch.sh and its dispatcher helper.
+
+The filesystem watcher itself is not exercised here (it's flaky in CI and
+depends on inotify/FSEvents). Instead we validate that:
+
+* The shell script has a shebang, is executable, and invokes watchmedo with
+  the expected watched directories and patterns.
+* The Python dispatcher routes by directory, debounces rapid events within a
+  200 ms window, and emits the documented log line format.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+WATCH_SH = SCRIPTS_DIR / "dev_watch.sh"
+DISPATCH_PY = SCRIPTS_DIR / "_dev_watch_dispatch.py"
+
+
+# ---------------------------------------------------------------------------
+# Shell script structure
+# ---------------------------------------------------------------------------
+
+
+class TestDevWatchShellScript:
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        assert WATCH_SH.is_file(), f"missing {WATCH_SH}"
+        self.content = WATCH_SH.read_text()
+
+    def test_has_bash_shebang(self):
+        first_line = self.content.splitlines()[0]
+        assert first_line.startswith("#!"), "script must start with a shebang"
+        assert "bash" in first_line
+
+    def test_is_executable(self):
+        mode = WATCH_SH.stat().st_mode
+        assert mode & 0o111, "dev_watch.sh must be chmod +x"
+
+    def test_uses_strict_mode(self):
+        assert "set -euo pipefail" in self.content
+
+    def test_invokes_watchmedo(self):
+        # Either the CLI shim or the python -m fallback counts.
+        assert "watchmedo" in self.content or "watchdog.watchmedo" in self.content
+
+    def test_watches_expected_directories(self):
+        for needle in (
+            "src/static/styles",
+            "src/static/scripts",
+            "src/templates",
+        ):
+            assert needle in self.content, f"script must watch {needle}"
+
+    def test_recursive_watch(self):
+        assert "--recursive" in self.content
+
+    def test_patterns_cover_css_js_html(self):
+        match = re.search(r'--patterns=["\']([^"\']+)["\']', self.content)
+        assert match, "expected --patterns=... in watchmedo invocation"
+        patterns = match.group(1)
+        for ext in ("*.css", "*.js", "*.html"):
+            assert ext in patterns
+
+    def test_ignores_generated_outputs(self):
+        # Prevent rebuild loops from main.css and dist/ bundle writes.
+        assert "--ignore-patterns" in self.content
+        assert "main.css" in self.content
+        assert "dist" in self.content
+
+    def test_checks_watchdog_installed(self):
+        assert "import watchdog" in self.content
+        # Must print an install hint when missing.
+        assert "pip install watchdog" in self.content
+
+    def test_handles_ctrl_c_cleanly(self):
+        # A trap on INT/TERM ensures the last line is our message, not a
+        # Python KeyboardInterrupt traceback.
+        assert "trap" in self.content
+        assert "INT" in self.content
+
+    def test_uses_venv_python_when_present(self):
+        assert ".venv/bin/python" in self.content
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher helper
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherStructure:
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        assert DISPATCH_PY.is_file(), f"missing {DISPATCH_PY}"
+        self.content = DISPATCH_PY.read_text()
+
+    def test_has_python_shebang(self):
+        first_line = self.content.splitlines()[0]
+        assert first_line.startswith("#!"), "must start with shebang"
+        assert "python" in first_line
+
+    def test_is_executable(self):
+        mode = DISPATCH_PY.stat().st_mode
+        assert mode & 0o111, "_dev_watch_dispatch.py must be chmod +x"
+
+    def test_defines_200ms_debounce(self):
+        assert "DEBOUNCE_SECONDS = 0.2" in self.content
+
+    def test_routes_all_three_kinds(self):
+        for kind in ("css", "js", "template"):
+            assert f'"{kind}"' in self.content or f"'{kind}'" in self.content
+
+    def test_log_format_matches_spec(self):
+        # Required format: "[<iso-timestamp>] <action> (source: <name>)"
+        assert "rebuild css" in self.content
+        assert "rebuild js" in self.content
+        assert "(source:" in self.content
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher behavior — import and exercise pure-python pieces in isolation.
+# No filesystem watcher is started; we just call helpers directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dispatch_module(monkeypatch, tmp_path):
+    """Import the dispatcher with a temp state dir so debounce is hermetic."""
+    # Load the module by path (it lives outside any package).
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("dev_watch_dispatch", DISPATCH_PY)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    # Redirect the on-disk debounce state into tmp.
+    monkeypatch.setattr(mod, "_STATE_DIR", tmp_path / "state")
+    return mod
+
+
+class TestDispatcherBehavior:
+    def test_kind_for_routes_by_directory(self, dispatch_module):
+        mod = dispatch_module
+        styles_file = REPO_ROOT / "src" / "static" / "styles" / "main.css"
+        scripts_file = REPO_ROOT / "src" / "static" / "scripts" / "csrf.js"
+        tmpl_file = REPO_ROOT / "src" / "templates" / "base.html"
+        outside = REPO_ROOT / "README.md"
+
+        assert mod._kind_for(styles_file) == "css"
+        assert mod._kind_for(scripts_file) == "js"
+        assert mod._kind_for(tmpl_file) == "template"
+        assert mod._kind_for(outside) is None
+
+    def test_debounce_blocks_rapid_second_call(self, dispatch_module):
+        mod = dispatch_module
+        assert mod._debounce("css") is True
+        # Immediately after: within 200ms window, should block.
+        assert mod._debounce("css") is False
+
+    def test_debounce_clears_after_window(self, dispatch_module, monkeypatch):
+        mod = dispatch_module
+        # Pretend time jumped forward past the debounce window.
+        real_monotonic = time.monotonic
+        base = real_monotonic()
+        seq = iter([base, base + 1.0])
+        monkeypatch.setattr(mod.time, "monotonic", lambda: next(seq))
+        assert mod._debounce("js") is True
+        assert mod._debounce("js") is True
+
+    def test_log_format(self, dispatch_module, capsys):
+        mod = dispatch_module
+        mod._log("rebuild css", Path("_buttons.css"))
+        out = capsys.readouterr().out.strip()
+        assert re.match(
+            r"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\] rebuild css "
+            r"\(source: _buttons\.css\)$",
+            out,
+        ), f"unexpected log line: {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# Requirements entry
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogDependencyDeclared:
+    def test_watchdog_in_requirements_dev_in(self):
+        req_in = (REPO_ROOT / "install" / "requirements-dev.in").read_text()
+        # Tolerate any version constraint — we just want it present.
+        assert re.search(r"^watchdog[>=<~!\s]", req_in, re.MULTILINE), (
+            "watchdog should be declared in install/requirements-dev.in "
+            "so contributors know it's an expected dev dependency"
+        )


### PR DESCRIPTION
## Summary

- Add `scripts/dev_watch.sh` + `scripts/_dev_watch_dispatch.py`: a watchmedo-driven wrapper that auto-runs `build_css.py` / `build_assets.py` when `src/static/styles/**` or `src/static/scripts/**` change, and logs (no rebuild) when `src/templates/**` changes since Flask already auto-reloads templates.
- Debounces rapid IDE-save bursts with a 200 ms window (per-kind state in tempdir so it survives the short-lived `watchmedo shell-command` subprocesses).
- Prints exactly one line per rebuild in the documented format: `[2026-04-14T12:34:56] rebuild css (source: _buttons.css)`.
- Clean Ctrl+C handling (trap INT/TERM; no KeyboardInterrupt traceback).
- Declares `watchdog` in `install/requirements-dev.in` as an optional dev convenience and documents the new workflow in `docs/development.md` under a "Dev quick reference" block alongside `./scripts/dev.sh`.
- Tests: `tests/unit/test_dev_watch_script.py` — 21 structural tests covering the shell script (shebang, chmod +x, strict mode, watchmedo invocation, watched paths, patterns, ignore rules, Ctrl+C trap) and the dispatcher's pure-python behaviour (kind routing, 200 ms debounce, log format). No live filesystem watcher is started — that's filesystem-flaky in CI.

Closes JTN-713.

## Test plan

- [x] `ruff check` clean on new files
- [x] `black --check` clean on new files
- [x] `shellcheck` clean on `dev_watch.sh`
- [x] `bash -n scripts/dev_watch.sh` passes
- [x] `pytest tests/unit/test_dev_watch_script.py` → 21 passed
- [x] `scripts/lint.sh` → all blocking checks pass
- [ ] Manual smoke on macOS: `./scripts/dev_watch.sh`, edit a CSS partial, observe a single rebuild log line within 1 s; Ctrl+C exits cleanly