### PR TITLE
feat(observability): in-app status badge wired to /api/diagnostics (JTN-709)

### DIFF
--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -25,6 +25,8 @@ import json
 import logging
 import os
 import threading
+import time
+from collections import deque
 from typing import Any
 
 from flask import Blueprint, Response
@@ -76,6 +78,73 @@ def reset_captured_reports() -> None:
     """Clear the process-wide list of captured client-log reports."""
     with _captured_lock:
         _captured_reports.clear()
+
+
+# ---------------------------------------------------------------------------
+# Recent-error ring buffer (JTN-709).
+#
+# The /api/diagnostics endpoint exposes a "recent_client_log_errors" summary so
+# the in-app status badge can flip to warning/error when the browser reports
+# problems. We keep a small bounded deque of ``(timestamp, level)`` pairs —
+# enough to answer "how many errors in the last 5 minutes?" without growing
+# unboundedly on a broken page. In-memory only; disk persistence would leak
+# across restarts for no added UX value.
+# ---------------------------------------------------------------------------
+_RECENT_BUFFER_MAX = 100
+_recent_errors: deque[tuple[float, str]] = deque(maxlen=_RECENT_BUFFER_MAX)
+_recent_lock = threading.Lock()
+
+
+def _record_recent(level: str) -> None:
+    """Append ``(now, level)`` to the recent-errors ring buffer."""
+    with _recent_lock:
+        _recent_errors.append((time.time(), level))
+
+
+def get_recent_error_summary(
+    now: float | None = None, *, window_seconds: int = 300
+) -> dict[str, Any]:
+    """Return a summary of recent client-log entries for diagnostics.
+
+    Shape::
+
+        {
+          "count_5m": int,           # entries with level == "error" in window
+          "warn_count_5m": int,      # entries with level == "warn" in window
+          "last_error_ts": float|None,  # epoch seconds of most recent "error"
+          "window_seconds": int
+        }
+
+    The window defaults to 300s (5 minutes). ``last_error_ts`` is the epoch
+    timestamp of the most recent *error* (not warn) entry in the buffer, or
+    None if the buffer contains no error entries at all.
+    """
+    cutoff = (time.time() if now is None else now) - float(window_seconds)
+    err_count = 0
+    warn_count = 0
+    last_error_ts: float | None = None
+    with _recent_lock:
+        for ts, level in _recent_errors:
+            if level == "error" and (last_error_ts is None or ts > last_error_ts):
+                last_error_ts = ts
+            if ts < cutoff:
+                continue
+            if level == "error":
+                err_count += 1
+            elif level == "warn":
+                warn_count += 1
+    return {
+        "count_5m": err_count,
+        "warn_count_5m": warn_count,
+        "last_error_ts": last_error_ts,
+        "window_seconds": int(window_seconds),
+    }
+
+
+def reset_recent_errors() -> None:
+    """Clear the recent-errors ring buffer (test helper)."""
+    with _recent_lock:
+        _recent_errors.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +220,12 @@ def _build_report(entry: dict[str, Any]) -> dict[str, object]:
 def _emit(report: dict[str, object]) -> None:
     """Emit a single validated report to the logger and (optionally) capture."""
     logger.warning("client log [%s]: %s", report["level"], json.dumps(report))
+    # Track every validated entry in the recent-errors ring buffer so the
+    # diagnostics endpoint (JTN-709) can surface "something is broken" to the
+    # in-app status badge.
+    level = report.get("level")
+    if isinstance(level, str):
+        _record_recent(level)
     if _capture_enabled():
         with _captured_lock:
             _captured_reports.append(dict(report))

--- a/src/blueprints/diagnostics.py
+++ b/src/blueprints/diagnostics.py
@@ -336,6 +336,33 @@ def _log_tail(max_lines: int = _LOG_TAIL_LINES) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Recent client-log errors (JTN-709)
+# ---------------------------------------------------------------------------
+
+
+def _recent_client_log_summary() -> dict[str, Any]:
+    """Return the client-log ring buffer summary for the status badge.
+
+    Surfaces ``count_5m`` / ``warn_count_5m`` / ``last_error_ts`` so the UI
+    can decide whether to flip the badge to warning/error. Returns a safe
+    all-zero shape if the module can't be imported (e.g. during early boot
+    or in test configurations that stub the blueprint).
+    """
+    try:
+        from blueprints.client_log import get_recent_error_summary
+
+        return get_recent_error_summary()
+    except Exception:
+        logger.exception("diagnostics: failed to read recent client-log errors")
+        return {
+            "count_5m": 0,
+            "warn_count_5m": 0,
+            "last_error_ts": None,
+            "window_seconds": 300,
+        }
+
+
+# ---------------------------------------------------------------------------
 # Route
 # ---------------------------------------------------------------------------
 
@@ -358,7 +385,13 @@ def api_diagnostics():
         "refresh_task": {"running": true, "last_run_ts": "...", "last_error": null},
         "plugin_health": {"clock": "ok", "weather": "fail"},
         "log_tail_100": ["..."],
-        "last_update_failure": null
+        "last_update_failure": null,
+        "recent_client_log_errors": {
+          "count_5m": 0,
+          "warn_count_5m": 0,
+          "last_error_ts": null,
+          "window_seconds": 300
+        }
       }
     """
     allowed, reason = _access_allowed()
@@ -376,5 +409,6 @@ def api_diagnostics():
         "plugin_health": _plugin_health_summary(),
         "log_tail_100": _log_tail(_LOG_TAIL_LINES),
         "last_update_failure": _read_last_update_failure(),
+        "recent_client_log_errors": _recent_client_log_summary(),
     }
     return jsonify(payload), 200

--- a/src/static/scripts/status_badge.js
+++ b/src/static/scripts/status_badge.js
@@ -1,0 +1,324 @@
+// In-app status badge (JTN-709).
+//
+// Polls /api/diagnostics (JTN-707) every 30s and surfaces a small floating
+// badge in the page corner when something is wrong. Click opens a popover
+// with the active issues and quick links (logs, pretty diagnostics, settings
+// updates page).
+//
+// Badge state derivation:
+//   ok      : refresh_task.last_error == null
+//             AND every plugin_health value == "ok"
+//             AND last_update_failure == null
+//             AND recent_client_log_errors.count_5m == 0
+//             AND recent_client_log_errors.warn_count_5m == 0
+//   warning : any plugin_health == "unknown"
+//             OR recent_client_log_errors.warn_count_5m > 0
+//   error   : refresh_task.last_error != null
+//             OR any plugin_health == "fail"
+//             OR last_update_failure != null
+//             OR recent_client_log_errors.count_5m > 0
+//
+// Error beats warning. The badge is hidden when state is "ok" so a healthy
+// system shows no UI noise. If /api/diagnostics returns 401/403 the badge
+// stays hidden permanently for this page load (the user isn't on the local
+// network).
+(function () {
+  "use strict";
+
+  // Opt-out: tests set this meta tag to avoid console noise and prevent the
+  // fetch loop from racing with the test harness.
+  const optOut = document.querySelector('meta[name="status-badge-disabled"]');
+  if (optOut?.getAttribute("content") === "1") {
+    return;
+  }
+
+  const ENDPOINT = "/api/diagnostics";
+  const POLL_MS = 30_000;
+
+  let badgeEl = null;
+  let popoverEl = null;
+  let pollTimer = null;
+  let disabled = false;
+  let currentState = "ok";
+
+  function ensureBadge() {
+    if (badgeEl) return badgeEl;
+    badgeEl = document.getElementById("statusBadge");
+    if (!badgeEl) {
+      badgeEl = document.createElement("div");
+      badgeEl.id = "statusBadge";
+      badgeEl.className = "status-badge hidden";
+      badgeEl.setAttribute("role", "status");
+      badgeEl.setAttribute("aria-live", "polite");
+      badgeEl.setAttribute("tabindex", "0");
+      badgeEl.setAttribute("aria-label", "System status");
+      badgeEl.hidden = true;
+      const dot = document.createElement("span");
+      dot.className = "status-badge-dot";
+      dot.setAttribute("aria-hidden", "true");
+      badgeEl.appendChild(dot);
+      const label = document.createElement("span");
+      label.className = "status-badge-label";
+      label.textContent = "OK";
+      badgeEl.appendChild(label);
+      document.body.appendChild(badgeEl);
+      badgeEl.addEventListener("click", togglePopover);
+      badgeEl.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter" || ev.key === " ") {
+          ev.preventDefault();
+          togglePopover();
+        } else if (ev.key === "Escape") {
+          hidePopover();
+        }
+      });
+    }
+    return badgeEl;
+  }
+
+  function setState(state, issues, raw) {
+    currentState = state;
+    const el = ensureBadge();
+    el.classList.remove("status-ok", "status-warning", "status-error");
+    el.classList.add(`status-${state}`);
+    const label = el.querySelector(".status-badge-label");
+    if (state === "ok") {
+      if (label) label.textContent = "OK";
+      el.classList.add("hidden");
+      el.hidden = true;
+      el.setAttribute("aria-label", "System status: OK");
+      hidePopover();
+    } else {
+      if (label)
+        label.textContent = state === "error" ? "Issue" : "Check status";
+      el.classList.remove("hidden");
+      el.hidden = false;
+      el.setAttribute(
+        "aria-label",
+        `System status: ${state === "error" ? "error" : "warning"} — ${issues.length} issue${issues.length === 1 ? "" : "s"}`
+      );
+    }
+    el.dataset.state = state;
+    el.dataset.issueCount = String(issues.length);
+    el.__issues = issues;
+    el.__rawDiagnostics = raw;
+    if (popoverEl && !popoverEl.hidden) {
+      renderPopover();
+    }
+  }
+
+  function deriveState(data) {
+    const issues = [];
+    const rt = data?.refresh_task || {};
+    if (rt.last_error) {
+      issues.push({
+        severity: "error",
+        label: "Refresh task error",
+        detail: String(rt.last_error).slice(0, 200),
+      });
+    }
+    const ph = data?.plugin_health || {};
+    const failed = [];
+    const unknown = [];
+    for (const [pid, status] of Object.entries(ph)) {
+      if (status === "fail") failed.push(pid);
+      else if (status === "unknown") unknown.push(pid);
+    }
+    if (failed.length) {
+      issues.push({
+        severity: "error",
+        label: "Plugin failure",
+        detail: failed.join(", "),
+      });
+    }
+    if (data?.last_update_failure) {
+      issues.push({
+        severity: "error",
+        label: "Update failed",
+        detail: "Last update did not complete",
+        link: "/settings#updates",
+      });
+    }
+    const rc = data?.recent_client_log_errors || {};
+    if ((rc.count_5m || 0) > 0) {
+      issues.push({
+        severity: "error",
+        label: "Browser errors",
+        detail: `${rc.count_5m} error${rc.count_5m === 1 ? "" : "s"} in the last 5 minutes`,
+      });
+    } else if ((rc.warn_count_5m || 0) > 0) {
+      issues.push({
+        severity: "warning",
+        label: "Browser warnings",
+        detail: `${rc.warn_count_5m} warning${rc.warn_count_5m === 1 ? "" : "s"} in the last 5 minutes`,
+      });
+    }
+    if (unknown.length && failed.length === 0) {
+      issues.push({
+        severity: "warning",
+        label: "Plugin health unknown",
+        detail: unknown.slice(0, 5).join(", "),
+      });
+    }
+
+    let state = "ok";
+    if (issues.some((i) => i.severity === "error")) {
+      state = "error";
+    } else if (issues.some((i) => i.severity === "warning")) {
+      state = "warning";
+    }
+    return { state, issues };
+  }
+
+  function renderPopover() {
+    if (!popoverEl) return;
+    const issues = badgeEl?.__issues || [];
+    popoverEl.innerHTML = "";
+
+    const heading = document.createElement("div");
+    heading.className = "status-popover-heading";
+    heading.textContent =
+      currentState === "error" ? "Something needs attention" : "Check status";
+    popoverEl.appendChild(heading);
+
+    const list = document.createElement("ul");
+    list.className = "status-popover-list";
+    for (const issue of issues) {
+      const li = document.createElement("li");
+      li.className = `status-popover-item severity-${issue.severity}`;
+      const strong = document.createElement("strong");
+      strong.textContent = issue.label;
+      li.appendChild(strong);
+      if (issue.detail) {
+        const detail = document.createElement("span");
+        detail.className = "status-popover-detail";
+        detail.textContent = ": " + issue.detail;
+        li.appendChild(detail);
+      }
+      if (issue.link) {
+        const a = document.createElement("a");
+        a.href = issue.link;
+        a.className = "status-popover-link";
+        a.textContent = "Open";
+        li.appendChild(document.createTextNode(" "));
+        li.appendChild(a);
+      }
+      list.appendChild(li);
+    }
+    popoverEl.appendChild(list);
+
+    const actions = document.createElement("div");
+    actions.className = "status-popover-actions";
+    const logsLink = document.createElement("a");
+    logsLink.href = "/download-logs";
+    logsLink.className = "status-popover-action";
+    logsLink.textContent = "Download logs";
+    actions.appendChild(logsLink);
+    const diagLink = document.createElement("a");
+    diagLink.href = ENDPOINT;
+    diagLink.className = "status-popover-action";
+    diagLink.target = "_blank";
+    diagLink.rel = "noopener";
+    diagLink.textContent = "Raw diagnostics";
+    actions.appendChild(diagLink);
+    popoverEl.appendChild(actions);
+  }
+
+  function ensurePopover() {
+    if (popoverEl) return popoverEl;
+    popoverEl = document.createElement("div");
+    popoverEl.id = "statusBadgePopover";
+    popoverEl.className = "status-popover";
+    popoverEl.setAttribute("role", "dialog");
+    popoverEl.setAttribute("aria-label", "Active issues");
+    popoverEl.hidden = true;
+    document.body.appendChild(popoverEl);
+    document.addEventListener("click", (ev) => {
+      if (popoverEl.hidden) return;
+      if (ev.target === badgeEl || badgeEl?.contains(ev.target)) return;
+      if (popoverEl.contains(ev.target)) return;
+      hidePopover();
+    });
+    return popoverEl;
+  }
+
+  function togglePopover() {
+    const el = ensurePopover();
+    if (el.hidden) {
+      renderPopover();
+      el.hidden = false;
+      el.classList.add("visible");
+    } else {
+      hidePopover();
+    }
+  }
+
+  function hidePopover() {
+    if (!popoverEl) return;
+    popoverEl.hidden = true;
+    popoverEl.classList.remove("visible");
+  }
+
+  async function poll() {
+    if (disabled) return;
+    try {
+      const resp = await fetch(ENDPOINT, {
+        credentials: "same-origin",
+        headers: { Accept: "application/json" },
+      });
+      if (resp.status === 401 || resp.status === 403) {
+        // Gracefully hide — the viewer isn't on the local network.
+        disabled = true;
+        if (badgeEl) {
+          badgeEl.classList.add("hidden");
+          badgeEl.hidden = true;
+        }
+        stopPolling();
+        return;
+      }
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const { state, issues } = deriveState(data);
+      setState(state, issues, data);
+    } catch (_err) {
+      // Network blip — swallow; the next tick will retry.
+    }
+  }
+
+  function startPolling() {
+    stopPolling();
+    pollTimer = window.setInterval(poll, POLL_MS);
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      window.clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === "visible" && !disabled) {
+      poll();
+    }
+  }
+
+  function init() {
+    ensureBadge();
+    poll();
+    startPolling();
+    document.addEventListener("visibilitychange", handleVisibility);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // Expose a minimal test hook so integration tests can force a refresh
+  // without waiting on the 30s poll timer.
+  window.__statusBadge = {
+    refresh: poll,
+    getState: () => currentState,
+  };
+})();

--- a/src/static/styles/_imports.css
+++ b/src/static/styles/_imports.css
@@ -13,5 +13,6 @@
 @import "partials/_api-keys.css";
 @import "partials/_history.css";
 @import "partials/_feedback.css";
+@import "partials/_status_badge.css";
 @import "partials/_responsive.css";
 @import "partials/_print.css";

--- a/src/static/styles/partials/_status_badge.css
+++ b/src/static/styles/partials/_status_badge.css
@@ -1,0 +1,124 @@
+/* In-app status badge (JTN-709) ------------------------------------------- */
+
+.status-badge {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 9000;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--status-badge-fg, rgb(255 255 255));
+    background: var(--status-badge-bg, #d97706);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+    cursor: pointer;
+    user-select: none;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    transition: transform 120ms ease, opacity 120ms ease;
+}
+
+.status-badge:hover,
+.status-badge:focus-visible {
+    transform: translateY(-1px);
+    outline: 2px solid var(--focus-ring, #60a5fa);
+    outline-offset: 2px;
+}
+
+.status-badge.hidden,
+.status-badge[hidden] {
+    display: none !important;
+}
+
+.status-badge-dot {
+    display: inline-block;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.95;
+}
+
+.status-badge.status-ok {
+    --status-badge-bg: #059669;
+}
+
+.status-badge.status-warning {
+    --status-badge-bg: #d97706;
+}
+
+.status-badge.status-error {
+    --status-badge-bg: #dc2626;
+    animation: status-badge-pulse 2s ease-in-out infinite;
+}
+
+@keyframes status-badge-pulse {
+    0%, 100% { box-shadow: 0 4px 14px rgba(220, 38, 38, 0.25); }
+    50% { box-shadow: 0 4px 20px rgba(220, 38, 38, 0.55); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .status-badge.status-error { animation: none; }
+}
+
+/* Popover ------------------------------------------------------------------ */
+
+.status-popover {
+    position: fixed;
+    bottom: 3.75rem;
+    right: 1rem;
+    z-index: 9001;
+    min-width: 16rem;
+    max-width: 22rem;
+    padding: 0.75rem 1rem;
+    background: var(--surface-bg, #f9fafb);
+    color: var(--surface-fg, #111827);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 0.5rem;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.18);
+    font-size: 0.9rem;
+}
+
+.status-popover[hidden] { display: none; }
+
+.status-popover-heading {
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+}
+
+.status-popover-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.5rem 0;
+}
+
+.status-popover-item {
+    padding: 0.25rem 0;
+    border-top: 1px solid var(--border-color, #e5e7eb);
+}
+
+.status-popover-item:first-child { border-top: 0; }
+
+.status-popover-item.severity-error strong { color: #dc2626; }
+.status-popover-item.severity-warning strong { color: #d97706; }
+
+.status-popover-detail {
+    color: var(--muted-fg, #4b5563);
+}
+
+.status-popover-link,
+.status-popover-action {
+    color: var(--link-color, #2563eb);
+    text-decoration: underline;
+}
+
+.status-popover-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--border-color, #e5e7eb);
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -19,6 +19,7 @@
     <script src="{{ url_for('static', filename='scripts/client_errors.js') }}"></script>
     <script src="{{ url_for('static', filename='scripts/client_error_reporter.js') }}" defer></script>
     <script src="{{ url_for('static', filename='scripts/client_log_reporter.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='scripts/status_badge.js') }}" defer></script>
     <script src="{{ url_for('static', filename='scripts/form_validator.js') }}" defer></script>
     <script src="{{ url_for('static', filename='scripts/response_modal.js') }}" defer></script>
     <script src="{{ url_for('static', filename='scripts/form_state.js') }}" defer></script>

--- a/tests/integration/test_status_badge.py
+++ b/tests/integration/test_status_badge.py
@@ -1,0 +1,104 @@
+# pyright: reportMissingImports=false
+"""Tests for the in-app status badge surface (JTN-709).
+
+The badge is a tiny fixed-position element injected by `status_badge.js` on
+every page. Playwright-level tests would add value but are deferred — these
+server-rendered checks verify the script is wired in and that the diagnostics
+contract the badge depends on is intact.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def test_every_page_loads_status_badge_script(client):
+    """Every top-level page in the shared base template loads status_badge.js."""
+    paths = ["/", "/playlist", "/history", "/settings", "/plugin/clock"]
+    for path in paths:
+        resp = client.get(path)
+        assert resp.status_code == 200, f"{path}: expected 200"
+        html = resp.data.decode()
+        assert "scripts/status_badge.js" in html, (
+            f"{path}: status_badge.js is not loaded — the base template must "
+            "include it so the badge surfaces on every page"
+        )
+
+
+def test_diagnostics_exposes_badge_contract(client, flask_app):
+    """The diagnostics endpoint exposes the keys the badge consumes."""
+    import blueprints.client_log as cl_mod
+
+    if "client_log" not in flask_app.blueprints:
+        flask_app.register_blueprint(cl_mod.client_log_bp)
+    cl_mod.reset_recent_errors()
+
+    resp = client.get("/api/diagnostics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Keys derived by deriveState() in status_badge.js
+    assert "refresh_task" in data
+    assert "plugin_health" in data
+    assert "last_update_failure" in data
+    assert "recent_client_log_errors" in data
+    assert set(data["recent_client_log_errors"].keys()) >= {
+        "count_5m",
+        "warn_count_5m",
+    }
+
+
+def test_client_log_error_flips_recent_counter(client, flask_app):
+    """Posting a client-log error shows up in the diagnostics payload the badge polls."""
+    import blueprints.client_log as cl_mod
+
+    if "client_log" not in flask_app.blueprints:
+        flask_app.register_blueprint(cl_mod.client_log_bp)
+    cl_mod.reset_recent_errors()
+
+    # Baseline: zero errors.
+    data = client.get("/api/diagnostics").get_json()
+    assert data["recent_client_log_errors"]["count_5m"] == 0
+
+    # Post a client-log error — badge should flip to "error" on the next poll.
+    resp = client.post(
+        "/api/client-log",
+        data=json.dumps({"level": "error", "message": "boom"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+    data = client.get("/api/diagnostics").get_json()
+    assert data["recent_client_log_errors"]["count_5m"] == 1
+    assert data["recent_client_log_errors"]["last_error_ts"] is not None
+
+    # Clear the autouse client-log tripwire — we intentionally posted an
+    # error as part of this test and don't want the teardown assertion to
+    # fire. The tripwire is designed to catch stray console.warn/error from
+    # browser JS, not deliberate server-side fixtures.
+    cl_mod.reset_captured_reports()
+
+
+def test_no_polling_in_test_mode_via_opt_out_meta(client):
+    """The badge script respects the status-badge-disabled meta opt-out.
+
+    Pages don't currently set this meta, but the script is expected to no-op
+    when the meta is present — this protects future test pages that want to
+    suppress the 30s poll.
+    """
+    import re
+    from pathlib import Path
+
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "status_badge.js"
+    )
+    text = js_path.read_text()
+    # Opt-out check happens before any fetch/polling is scheduled.
+    m_optout = re.search(r'status-badge-disabled', text)
+    m_fetch = text.find("fetch(")
+    assert m_optout is not None, "opt-out meta not referenced in status_badge.js"
+    assert m_fetch > 0
+    assert m_optout.start() < m_fetch, "opt-out must be checked before fetch runs"

--- a/tests/integration/test_status_badge.py
+++ b/tests/integration/test_status_badge.py
@@ -97,7 +97,7 @@ def test_no_polling_in_test_mode_via_opt_out_meta(client):
     )
     text = js_path.read_text()
     # Opt-out check happens before any fetch/polling is scheduled.
-    m_optout = re.search(r'status-badge-disabled', text)
+    m_optout = re.search(r"status-badge-disabled", text)
     m_fetch = text.find("fetch(")
     assert m_optout is not None, "opt-out meta not referenced in status_badge.js"
     assert m_fetch > 0

--- a/tests/unit/test_diagnostics_recent_errors.py
+++ b/tests/unit/test_diagnostics_recent_errors.py
@@ -124,7 +124,7 @@ def test_five_minute_cutoff_excludes_old_entries():
 def test_ring_buffer_is_bounded():
     """The ring buffer discards oldest entries when it fills up."""
     cl_mod.reset_recent_errors()
-    for i in range(cl_mod._RECENT_BUFFER_MAX + 25):
+    for _ in range(cl_mod._RECENT_BUFFER_MAX + 25):
         cl_mod._record_recent("error")
     assert len(cl_mod._recent_errors) == cl_mod._RECENT_BUFFER_MAX
 

--- a/tests/unit/test_diagnostics_recent_errors.py
+++ b/tests/unit/test_diagnostics_recent_errors.py
@@ -1,0 +1,142 @@
+# pyright: reportMissingImports=false
+"""Tests for the /api/diagnostics recent_client_log_errors summary (JTN-709).
+
+The diagnostics endpoint surfaces a small window of recent /api/client-log
+entries so the in-app status badge can flip to warning/error without needing
+a second round-trip to another endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import blueprints.client_log as cl_mod
+import blueprints.diagnostics as diag
+
+
+@pytest.fixture()
+def client(flask_app):
+    # The conftest flask_app fixture does not register the client_log blueprint
+    # by default — register it here so the diagnostics integration tests can
+    # exercise the real POST -> ring-buffer -> GET pipeline.
+    if "client_log" not in flask_app.blueprints:
+        flask_app.register_blueprint(cl_mod.client_log_bp)
+    return flask_app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _reset_paths_and_buffer(tmp_path, monkeypatch):
+    """Isolate diagnostics paths and the client-log ring buffer per test."""
+    monkeypatch.setattr(diag, "_PREV_VERSION_PATH", tmp_path / "prev_version")
+    monkeypatch.setattr(
+        diag, "_LAST_UPDATE_FAILURE_PATH", tmp_path / ".last-update-failure"
+    )
+    monkeypatch.setenv("INKYPI_ENV", "dev")
+    cl_mod.reset_recent_errors()
+    yield
+    cl_mod.reset_recent_errors()
+
+
+def _post_log(client, level: str, message: str = "hi"):
+    return client.post(
+        "/api/client-log",
+        data=json.dumps({"level": level, "message": message}),
+        content_type="application/json",
+    )
+
+
+def test_diagnostics_includes_recent_client_log_errors_key(client):
+    """The endpoint returns the recent_client_log_errors summary key."""
+    resp = client.get("/api/diagnostics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "recent_client_log_errors" in data
+    summary = data["recent_client_log_errors"]
+    assert isinstance(summary, dict)
+    assert set(summary.keys()) >= {
+        "count_5m",
+        "warn_count_5m",
+        "last_error_ts",
+        "window_seconds",
+    }
+    assert summary["count_5m"] == 0
+    assert summary["warn_count_5m"] == 0
+    assert summary["last_error_ts"] is None
+    assert summary["window_seconds"] == 300
+
+
+def test_counter_increments_on_client_log_error_post(client):
+    """POST /api/client-log with level=error bumps count_5m by 1."""
+    assert _post_log(client, "error", "boom").status_code == 204
+    data = client.get("/api/diagnostics").get_json()
+    summary = data["recent_client_log_errors"]
+    assert summary["count_5m"] == 1
+    assert summary["warn_count_5m"] == 0
+    assert isinstance(summary["last_error_ts"], (int, float))
+    assert summary["last_error_ts"] > 0
+
+
+def test_warn_counter_tracked_separately(client):
+    """A warn-level entry updates warn_count_5m but not count_5m."""
+    assert _post_log(client, "warn", "careful").status_code == 204
+    summary = client.get("/api/diagnostics").get_json()["recent_client_log_errors"]
+    assert summary["count_5m"] == 0
+    assert summary["warn_count_5m"] == 1
+    # warn-only activity leaves last_error_ts at None
+    assert summary["last_error_ts"] is None
+
+
+def test_batch_post_increments_per_entry(client):
+    """A batch POST increments the counter once per validated entry."""
+    payload = [
+        {"level": "error", "message": "a"},
+        {"level": "error", "message": "b"},
+        {"level": "warn", "message": "c"},
+    ]
+    resp = client.post(
+        "/api/client-log",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    summary = client.get("/api/diagnostics").get_json()["recent_client_log_errors"]
+    assert summary["count_5m"] == 2
+    assert summary["warn_count_5m"] == 1
+
+
+def test_five_minute_cutoff_excludes_old_entries():
+    """Entries older than the window are excluded from count_5m."""
+    cl_mod.reset_recent_errors()
+    # Seed one fresh error and one entry well past the 5-minute cutoff.
+    now = 1_800_000_000.0
+    cl_mod._recent_errors.append((now - 10.0, "error"))  # within window
+    cl_mod._recent_errors.append((now - 3600.0, "error"))  # an hour ago
+
+    summary = cl_mod.get_recent_error_summary(now=now, window_seconds=300)
+    assert summary["count_5m"] == 1
+    # last_error_ts reflects the most recent error regardless of cutoff so
+    # the UI can still say "we saw one an hour ago".
+    assert summary["last_error_ts"] == now - 10.0
+
+
+def test_ring_buffer_is_bounded():
+    """The ring buffer discards oldest entries when it fills up."""
+    cl_mod.reset_recent_errors()
+    for i in range(cl_mod._RECENT_BUFFER_MAX + 25):
+        cl_mod._record_recent("error")
+    assert len(cl_mod._recent_errors) == cl_mod._RECENT_BUFFER_MAX
+
+
+def test_invalid_entries_do_not_count(client):
+    """Validation failures leave the counter untouched."""
+    resp = client.post(
+        "/api/client-log",
+        data=json.dumps({"level": "info", "message": "nope"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    summary = client.get("/api/diagnostics").get_json()["recent_client_log_errors"]
+    assert summary["count_5m"] == 0
+    assert summary["warn_count_5m"] == 0


### PR DESCRIPTION
## Summary
- Adds a tiny fixed-position status badge wired to `/api/diagnostics` (JTN-707) that polls every 30s and flips to warning/error when something is broken. Hidden by default when healthy — no UI noise.
- Click opens a popover listing active issues with links to `/download-logs`, raw diagnostics JSON, and the settings updates page (when `last_update_failure` is set).
- Extends `/api/diagnostics` with `recent_client_log_errors: {count_5m, warn_count_5m, last_error_ts, window_seconds}`, backed by a bounded 100-entry in-memory ring buffer populated from `/api/client-log` POSTs. In-memory only; no disk persistence.

Consumes the contract established in #483 (JTN-707 — diagnostics endpoint) without breaking any existing field.

Linear: https://linear.app/jtn0123/issue/JTN-709/observability-in-app-something-broke-status-badge

## Badge state derivation
- `ok` — `refresh_task.last_error` null, all `plugin_health` == `"ok"`, `last_update_failure` null, no recent client-log warn/error.
- `warning` — any plugin status `"unknown"` OR recent client-log warnings.
- `error` — `refresh_task.last_error` set, any plugin `"fail"`, `last_update_failure` present, or recent client-log errors.

Graceful degradation: 401/403 from `/api/diagnostics` hides the badge and stops polling (viewer isn't on the local network). Tests can opt out via `<meta name="status-badge-disabled" content="1">`.

## Changes
- `src/static/scripts/status_badge.js` (new) — client polling/popover logic
- `src/static/styles/partials/_status_badge.css` (new) — minimal styles, dark-mode safe
- `src/static/styles/_imports.css`, `src/templates/base.html` — wire the new assets
- `src/blueprints/client_log.py` — ring buffer + `get_recent_error_summary()` helper
- `src/blueprints/diagnostics.py` — surface `recent_client_log_errors` in the payload
- `tests/unit/test_diagnostics_recent_errors.py` (new) — counter, 5m cutoff, bounded buffer, validation boundary
- `tests/integration/test_status_badge.py` (new) — script loaded on every page; POST → counter round-trip

## Test plan
- [x] `pytest tests/` — 4251 passed, 4 skipped
- [x] `scripts/lint.sh` — ruff + black + shellcheck clean; mypy strict subset clean
- [x] Dark-mode CSS guard passes (`tests/static/test_dark_mode_css.py`)
- [ ] Manual visual check in dev mode — badge renders hidden when healthy, red + popover on forced failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)