### PR TITLE
feat(security): HTML-escape string leaves in json_error details (JTN-657)

### DIFF
--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -62,7 +62,30 @@ if TYPE_CHECKING:  # pragma: no cover — type hints only
     import requests
     from urllib3.util.retry import Retry
 
+from utils.form_utils import sanitize_response_value
+
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_details(details: dict[str, Any]) -> dict[str, Any]:
+    """Recursively HTML-escape all string leaf values in *details*.
+
+    Non-string scalars (int, bool, float, None) pass through unchanged.
+    Nested dicts are traversed recursively.  Lists are sanitized element-wise.
+    This is defense-in-depth: any user-derived string reaching the JSON error
+    envelope will have angle brackets and ampersands escaped before serialisation.
+    """
+
+    def _sanitize(value: Any) -> Any:
+        if isinstance(value, str):
+            return sanitize_response_value(value)
+        if isinstance(value, dict):
+            return {k: _sanitize(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_sanitize(item) for item in value]
+        return value
+
+    return {k: _sanitize(v) for k, v in details.items()}
 
 
 class APIError(Exception):
@@ -136,7 +159,7 @@ def json_error(
     if code is not None:
         payload["code"] = code
     if details is not None:
-        payload["details"] = details
+        payload["details"] = _sanitize_details(details)
     rid = _get_or_set_request_id()
     if rid is not None:
         payload["request_id"] = rid

--- a/tests/unit/test_json_error_details_escape.py
+++ b/tests/unit/test_json_error_details_escape.py
@@ -1,0 +1,91 @@
+"""Unit tests for HTML-escaping of user-derived strings in json_error details.
+
+Defense-in-depth: even if the frontend uses textContent today, any future
+innerHTML slip would otherwise expose stored XSS.  (JTN-657)
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from src.utils.http_utils import json_error
+
+
+@pytest.fixture
+def app():
+    return Flask(__name__)
+
+
+class TestJsonErrorDetailsEscape:
+    """Verify that string values in the details dict are HTML-escaped."""
+
+    def test_script_tag_escaped_in_details_string(self, app):
+        """A bare <script> payload in a details value must have < and > escaped."""
+        payload = "<script>alert(1)</script>"
+        with app.app_context():
+            response, status = json_error(
+                "Validation failed",
+                status=422,
+                details={"field": payload},
+            )
+        data = response.get_json()
+        assert status == 422
+        field_value = data["details"]["field"]
+        assert "<" not in field_value
+        assert ">" not in field_value
+        assert "&lt;" in field_value
+        assert "&gt;" in field_value
+
+    def test_nested_details_string_escaped(self, app):
+        """String leaves inside nested dicts are escaped."""
+        with app.app_context():
+            response, _ = json_error(
+                "err",
+                details={"outer": {"inner": "<b>bold</b>"}},
+            )
+        data = response.get_json()
+        assert "<b>" not in data["details"]["outer"]["inner"]
+        assert "&lt;b&gt;" in data["details"]["outer"]["inner"]
+
+    def test_list_details_strings_escaped(self, app):
+        """Strings inside a list value are escaped."""
+        with app.app_context():
+            response, _ = json_error(
+                "err",
+                details={"errors": ["<bad>", "ok"]},
+            )
+        data = response.get_json()
+        assert "<bad>" not in data["details"]["errors"][0]
+        assert "&lt;bad&gt;" in data["details"]["errors"][0]
+        assert data["details"]["errors"][1] == "ok"
+
+    def test_non_string_values_unchanged(self, app):
+        """Non-string scalars (int, bool, None) pass through without modification."""
+        with app.app_context():
+            response, _ = json_error(
+                "err",
+                details={"count": 3, "flag": True, "missing": None},
+            )
+        data = response.get_json()
+        assert data["details"]["count"] == 3
+        assert data["details"]["flag"] is True
+        assert data["details"]["missing"] is None
+
+    def test_ampersand_escaped(self, app):
+        """Ampersands are HTML-escaped as well."""
+        with app.app_context():
+            response, _ = json_error(
+                "err",
+                details={"msg": "a & b"},
+            )
+        data = response.get_json()
+        assert "&" not in data["details"]["msg"].replace("&amp;", "")
+        assert "&amp;" in data["details"]["msg"]
+
+    def test_none_details_omitted(self, app):
+        """When details is None the key is absent from the response."""
+        with app.app_context():
+            response, _ = json_error("err", details=None)
+        data = response.get_json()
+        assert "details" not in data


### PR DESCRIPTION
## Summary

- Defense-in-depth: user-derived strings entering the `details` dict of the JSON error envelope are now recursively sanitized via `sanitize_response_value` before serialisation
- HTML-escapes angle brackets and ampersands (`<`, `>`, `&`) in all string leaves; non-string scalars (int, bool, None) pass through unchanged
- Closes the gap where a future `innerHTML` slip in the frontend could become stored XSS
- Reuses existing `sanitize_response_value` from `src/utils/form_utils.py` — no new dependencies

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] N/A — original work, not a sync from upstream

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (4292 passed, 3 pre-existing CSS failures unrelated to this PR)
- [x] No breaking API route/path changes — response envelope shape is unchanged
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI — N/A (no new flags/endpoints)

## Testing

- Added `tests/unit/test_json_error_details_escape.py` with 6 unit tests:
  - `<script>alert(1)</script>` in a details value has `<`/`>` escaped to `&lt;`/`&gt;`
  - Nested dict string leaves are escaped
  - Strings inside list values are escaped
  - Non-string scalars (int, bool, None) pass through unchanged
  - Ampersands are HTML-escaped
  - `None` details omits the `details` key entirely

## Changes

- `src/utils/http_utils.py` — add `_sanitize_details()` helper + wire it into `json_error()`
- `tests/unit/test_json_error_details_escape.py` — new test file (6 tests)

Linear: JTN-657