### PR TITLE
feat(a11y): add role="dialog" to What's New modal (JTN-589)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -338,6 +338,47 @@
       setDeviceActionModalOpen("shutdownConfirmModal", false);
     }
 
+    // JTN-589: What's New modal — shows release notes for the current version.
+    let _lastWhatsNewTrigger = null;
+
+    function openWhatsNew(event) {
+      const modal = document.getElementById("whatsNewModal");
+      if (!modal) return;
+      _lastWhatsNewTrigger = event?.currentTarget || null;
+      modal.hidden = false;
+      modal.style.display = "flex";
+      modal.classList.add("is-open");
+      const ui = globalThis.InkyPiUI;
+      if (ui?.syncModalOpenState) {
+        ui.syncModalOpenState();
+      } else {
+        document.body.classList.add("modal-open");
+      }
+      const focusable = modal.querySelector(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable) setTimeout(() => focusable.focus(), 0);
+    }
+
+    function closeWhatsNew() {
+      const modal = document.getElementById("whatsNewModal");
+      if (!modal) return;
+      modal.hidden = true;
+      modal.style.display = "none";
+      modal.classList.remove("is-open");
+      const ui = globalThis.InkyPiUI;
+      if (ui?.syncModalOpenState) {
+        ui.syncModalOpenState();
+      } else {
+        const anyOpen = document.querySelector(".modal.is-open");
+        document.body.classList.toggle("modal-open", !!anyOpen);
+      }
+      if (_lastWhatsNewTrigger) {
+        try { _lastWhatsNewTrigger.focus(); } catch (_e) { /* ignore */ }
+        _lastWhatsNewTrigger = null;
+      }
+    }
+
     function isDeviceActionModalOpen(modalId) {
       const modal = document.getElementById(modalId);
       return !!(modal && !modal.hidden);
@@ -600,6 +641,8 @@
       const checkBtn = document.getElementById("checkUpdatesBtn");
       const notesContainer = document.getElementById("releaseNotesContainer");
       const notesBody = document.getElementById("releaseNotesBody");
+      const whatsNewBtn = document.getElementById("whatsNewBtn");
+      const whatsNewBody = document.getElementById("whatsNewBody");
 
       // Show spinner + disable button while checking (JTN-352)
       if (checkBtn) {
@@ -630,6 +673,13 @@
           notesContainer.hidden = false;
         } else if (notesContainer) {
           notesContainer.hidden = true;
+        }
+        // JTN-589: Show "What's New" button when release notes are available
+        if (data.release_notes && whatsNewBtn && whatsNewBody) {
+          whatsNewBody.textContent = data.release_notes;
+          whatsNewBtn.hidden = false;
+        } else if (whatsNewBtn) {
+          whatsNewBtn.hidden = true;
         }
       } catch (e) {
         console.warn("Version check failed:", e);
@@ -1287,6 +1337,9 @@
       document.getElementById("refreshIsolationBtn")?.addEventListener("click", refreshIsolation);
       document.getElementById("checkUpdatesBtn")?.addEventListener("click", checkForUpdates);
       document.getElementById("startUpdateBtn")?.addEventListener("click", startUpdate);
+      // JTN-589: What's New modal
+      document.getElementById("whatsNewBtn")?.addEventListener("click", openWhatsNew);
+      document.getElementById("closeWhatsNewModalBtn")?.addEventListener("click", closeWhatsNew);
       // JTN-621: Reboot/Shutdown are gated behind a confirmation modal so
       // an accidental touch doesn't make the device unreachable.
       document.getElementById("rebootBtn")?.addEventListener("click", openRebootConfirm);
@@ -1304,7 +1357,11 @@
       // via keyboard was to tab to the Cancel button.
       document.addEventListener("keydown", (event) => {
         if (event.key !== "Escape") return;
-        if (isDeviceActionModalOpen("rebootConfirmModal")) {
+        const whatsNewModal = document.getElementById("whatsNewModal");
+        if (whatsNewModal && !whatsNewModal.hidden) {
+          event.preventDefault();
+          closeWhatsNew();
+        } else if (isDeviceActionModalOpen("rebootConfirmModal")) {
           event.preventDefault();
           closeRebootConfirm();
         } else if (isDeviceActionModalOpen("shutdownConfirmModal")) {
@@ -1313,9 +1370,11 @@
         }
       });
       globalThis.addEventListener("click", (event) => {
+        const whatsNewModal = document.getElementById("whatsNewModal");
         const rebootModal = document.getElementById("rebootConfirmModal");
         const shutdownModal = document.getElementById("shutdownConfirmModal");
-        if (event.target === rebootModal) closeRebootConfirm();
+        if (event.target === whatsNewModal) closeWhatsNew();
+        else if (event.target === rebootModal) closeRebootConfirm();
         else if (event.target === shutdownModal) closeShutdownConfirm();
       });
       document.getElementById("useDeviceLocation")?.addEventListener("change", (event) => {

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -190,6 +190,7 @@
                     <div class="update-actions">
                         <button type="button" id="checkUpdatesBtn" class="action-button compact"><span class="btn-spinner" aria-hidden="true"></span> Check for Updates</button>
                         <button type="button" id="startUpdateBtn" class="action-button compact" disabled>Update Now</button>
+                        <button type="button" id="whatsNewBtn" class="action-button compact" hidden>What's New</button>
                     </div>
                 </div>
 
@@ -375,6 +376,16 @@
     </div>
 
     <button type="button" class="action-button settings-logs-toggle" id="settingsLogsToggle">Show Logs</button>
+
+    <!-- What's New modal (JTN-589) -->
+    <div id="whatsNewModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="whatsNewModalTitle" hidden>
+        <div class="modal-content">
+            <button type="button" id="closeWhatsNewModalBtn" class="close-button" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
+            <h2 id="whatsNewModalTitle">What's New</h2>
+            <div class="separator"></div>
+            <div id="whatsNewBody" class="update-release-notes-body"></div>
+        </div>
+    </div>
 
     <!-- Reboot confirmation modal (JTN-621) -->
     <div id="rebootConfirmModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="rebootConfirmTitle" hidden>

--- a/tests/static/test_whats_new_dialog_role.py
+++ b/tests/static/test_whats_new_dialog_role.py
@@ -1,0 +1,116 @@
+"""Regression guard: What's New modal must carry role="dialog" (JTN-589).
+
+document.querySelector('[role=dialog]') must find the modal while it is open.
+The critical attributes are validated against the static HTML rather than a
+live browser so the guard runs in every CI environment, including headless.
+"""
+
+from pathlib import Path
+
+_SETTINGS_TPL = Path("src/templates/settings.html")
+_SETTINGS_JS = Path("src/static/scripts/settings_page.js")
+
+
+def _settings_html() -> str:
+    return _SETTINGS_TPL.read_text(encoding="utf-8")
+
+
+def _settings_js() -> str:
+    return _SETTINGS_JS.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Template assertions — static HTML attributes
+# ---------------------------------------------------------------------------
+
+
+def test_whats_new_modal_has_role_dialog():
+    """The What's New modal container must have role="dialog"."""
+    content = _settings_html()
+    assert 'id="whatsNewModal"' in content, "whatsNewModal element missing"
+    # Verify role=dialog appears on the same element
+    idx = content.index('id="whatsNewModal"')
+    # Grab a reasonable window around the element opening tag
+    tag_region = content[max(0, idx - 20) : idx + 200]
+    assert (
+        'role="dialog"' in tag_region
+    ), 'whatsNewModal must have role="dialog" on its container element'
+
+
+def test_whats_new_modal_has_aria_modal():
+    """The What's New modal must have aria-modal="true"."""
+    content = _settings_html()
+    idx = content.index('id="whatsNewModal"')
+    tag_region = content[max(0, idx - 20) : idx + 200]
+    assert (
+        'aria-modal="true"' in tag_region
+    ), 'whatsNewModal must have aria-modal="true"'
+
+
+def test_whats_new_modal_has_aria_labelledby():
+    """The What's New modal must have aria-labelledby pointing to its heading."""
+    content = _settings_html()
+    idx = content.index('id="whatsNewModal"')
+    tag_region = content[max(0, idx - 20) : idx + 200]
+    assert (
+        'aria-labelledby="whatsNewModalTitle"' in tag_region
+    ), 'whatsNewModal must have aria-labelledby="whatsNewModalTitle"'
+
+
+def test_whats_new_modal_heading_id_matches_labelledby():
+    """The heading referenced by aria-labelledby must exist with the same id."""
+    content = _settings_html()
+    assert (
+        'id="whatsNewModalTitle"' in content
+    ), "Heading with id='whatsNewModalTitle' is required so aria-labelledby resolves"
+
+
+def test_whats_new_button_exists_in_update_panel():
+    """The update panel must contain a trigger button for the What's New modal."""
+    content = _settings_html()
+    assert (
+        'id="whatsNewBtn"' in content
+    ), "whatsNewBtn trigger button must be present in the update panel"
+
+
+def test_whats_new_body_container_exists():
+    """The modal must contain a content container for release notes."""
+    content = _settings_html()
+    assert (
+        'id="whatsNewBody"' in content
+    ), "whatsNewBody element must exist inside the modal"
+
+
+# ---------------------------------------------------------------------------
+# JS assertions — open/close wiring
+# ---------------------------------------------------------------------------
+
+
+def test_settings_js_opens_whats_new_modal():
+    """settings_page.js must define openWhatsNew and wire whatsNewBtn."""
+    content = _settings_js()
+    assert (
+        "openWhatsNew" in content
+    ), "openWhatsNew function must exist in settings_page.js"
+    assert "whatsNewBtn" in content, "whatsNewBtn must be wired in bindButtons()"
+
+
+def test_settings_js_closes_whats_new_on_escape():
+    """settings_page.js must close the What's New modal on Escape."""
+    content = _settings_js()
+    assert (
+        "closeWhatsNew" in content
+    ), "closeWhatsNew function must exist in settings_page.js"
+    assert "whatsNewModal" in content, "Escape handler must reference whatsNewModal"
+
+
+def test_settings_js_whats_new_modal_hidden_attribute():
+    """openWhatsNew must set modal.hidden = false; closeWhatsNew must hide it."""
+    content = _settings_js()
+    assert "whatsNewModal" in content
+    # Both hidden=false (open) and hidden=true (close) must be managed
+    assert (
+        "modal.hidden = false" in content
+        or "modal.hidden=false" in content
+        or "hidden = false" in content
+    ), "openWhatsNew must clear the hidden attribute"


### PR DESCRIPTION
## Summary

- The What's New changelog modal lacked `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`, making `document.querySelector('[role=dialog]')` return `null` even when the dialog was visibly open
- Added the modal to `settings.html` with all required ARIA attributes, wired to a "What's New" trigger button that appears in the update panel once release notes are fetched
- Added `openWhatsNew` / `closeWhatsNew` JS functions in `settings_page.js` with focus management, Escape key dismissal, and backdrop-click to close — consistent with every other modal in the app (reboot/shutdown/schedule modals)
- Added 9 static regression tests in `tests/static/test_whats_new_dialog_role.py` asserting the modal container has `role="dialog"`, `aria-modal="true"`, `aria-labelledby="whatsNewModalTitle"`, and that the trigger/close wiring exists in the JS

## Changes

- `src/templates/settings.html` — new `#whatsNewModal` with ARIA attributes + `#whatsNewBtn` trigger in the update panel
- `src/static/scripts/settings_page.js` — `openWhatsNew`, `closeWhatsNew`, Escape + backdrop handlers, `whatsNewBtn`/`closeWhatsNewModalBtn` wiring, `whatsNewBody` content population in `checkForUpdates()`
- `tests/static/test_whats_new_dialog_role.py` — 9 new regression tests (all pass)

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] No upstream sync involved

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (4295 pass, 3 pre-existing failures unrelated to this PR)
- [x] No breaking API route/path changes
- [x] No new endpoints introduced

## Testing

- Ran `SKIP_BROWSER=1 pytest tests/ -k "whats_new or dialog or modal or accessibility"` — 87 passed
- Ran full suite — same 3 pre-existing failures (missing `main.css` in worktree + CSS route 404), no regressions

Closes JTN-589