### PR TITLE
fix(ux): show disk free GB in system health table (JTN-585)

### DIFF
--- a/src/blueprints/settings/_health.py
+++ b/src/blueprints/settings/_health.py
@@ -56,14 +56,20 @@ def health_system():
         try:
             import psutil  # type: ignore
 
+            du = psutil.disk_usage("/")
+            vm = psutil.virtual_memory()
             data["cpu_percent"] = psutil.cpu_percent(interval=None)
-            data["memory_percent"] = psutil.virtual_memory().percent
-            data["disk_percent"] = psutil.disk_usage("/").percent
+            data["memory_percent"] = vm.percent
+            data["disk_percent"] = du.percent
+            data["disk_free_gb"] = round(du.free / (1024**3), 1)
+            data["disk_total_gb"] = round(du.total / (1024**3), 1)
             data["uptime_seconds"] = int(time.time() - psutil.boot_time())
         except Exception:
             data["cpu_percent"] = None
             data["memory_percent"] = None
             data["disk_percent"] = None
+            data["disk_free_gb"] = None
+            data["disk_total_gb"] = None
             data["uptime_seconds"] = None
         return json_success(**data)
     except Exception as e:

--- a/src/schemas/responses.py
+++ b/src/schemas/responses.py
@@ -144,6 +144,8 @@ class HealthSystemResponse(TypedDict, total=False):
     cpu_percent: float | None
     memory_percent: float | None
     disk_percent: float | None
+    disk_free_gb: float | None
+    disk_total_gb: float | None
     uptime_seconds: int | None
 
 

--- a/src/static/openapi.json
+++ b/src/static/openapi.json
@@ -23,7 +23,7 @@
       "get": {
         "tags": ["Health"],
         "summary": "System health metrics",
-        "description": "Returns CPU, memory, and disk usage percentages plus uptime in seconds. Fields are null when psutil is not installed.",
+        "description": "Returns CPU, memory, and disk usage percentages, disk free/total GB, and uptime in seconds. Fields are null when psutil is not installed.",
         "operationId": "healthSystem",
         "responses": {
           "200": {
@@ -38,6 +38,8 @@
                   "cpu_percent": 12.4,
                   "memory_percent": 48.2,
                   "disk_percent": 31.0,
+                  "disk_free_gb": 9.8,
+                  "disk_total_gb": 31.3,
                   "uptime_seconds": 86400
                 }
               }
@@ -517,6 +519,18 @@
             "format": "float",
             "nullable": true,
             "description": "Disk usage percentage for root filesystem"
+          },
+          "disk_free_gb": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "Free disk space in GB for root filesystem"
+          },
+          "disk_total_gb": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "Total disk capacity in GB for root filesystem"
           },
           "uptime_seconds": {
             "type": "integer",

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -883,6 +883,13 @@
       return Number(val).toFixed(1) + "%";
     }
 
+    function formatDiskFree(val) {
+      if (val === null || val === undefined || Number.isNaN(Number(val))) {
+        return "\u2014";
+      }
+      return Number(val).toFixed(1) + " GB free";
+    }
+
     function formatUptime(seconds) {
       if (seconds === null || seconds === undefined || Number.isNaN(Number(seconds))) {
         return "\u2014";
@@ -899,7 +906,7 @@
     const SYSTEM_HEALTH_ROWS = [
       { key: "cpu_percent", label: "CPU", formatter: formatPercent },
       { key: "memory_percent", label: "Memory", formatter: formatPercent },
-      { key: "disk_percent", label: "Disk", formatter: formatPercent },
+      { key: "disk_free_gb", label: "Disk", formatter: formatDiskFree },
       { key: "uptime_seconds", label: "Uptime", formatter: formatUptime },
     ];
 

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -1,0 +1,6681 @@
+/* Base styling - CSS Reset */
+
+/* Jost — geometric sans-serif for the industrial aesthetic */
+@font-face {
+    font-family: Jost;
+    src: url('../fonts/Jost.ttf') format('truetype');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: Jost;
+    src: url('../fonts/Jost-SemiBold.ttf') format('truetype');
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+}
+
+/* Base body styling */
+body {
+    font-family: Jost, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background-color: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    /* Let content flow naturally; pages control their own centering */
+}
+
+/* Refined Industrial — warm paper + hardware console */
+:root {
+    /* Core palette — warm paper stock with ink */
+    --bg: #f5f3ef;
+    --surface: #ffffff;
+    --surface-border: #d8d4cd;
+    --text: #1c1917;
+    --muted: #6b6560;
+    --divider: var(--surface-border);
+    --button-bg: #f0ede8;
+    --input-bg: #ffffff;
+    --accent: #b5522f;
+    --panel-bg: #f0ede8;
+    --panel-border: #ddd8d0;
+    --subtext: #6b6560;
+    --frame-lining: #9a9590;
+    --skeleton-base: rgba(28, 25, 23, 0.05);
+    --skeleton-highlight: rgba(28, 25, 23, 0.09);
+    --error: #c4453a;
+    --success: #3d6b5d;
+    --warning: #b8862e;
+    --primary: #3d6b5d;
+    --primary-hover: #2d5347;
+    --text-primary: var(--text);
+    --text-muted: var(--muted);
+    --text-secondary: var(--subtext);
+    --border-color: var(--surface-border);
+    --bg-primary: var(--surface);
+    --bg-secondary: #eceae5;
+    --card-bg: rgba(255, 255, 255, 0.82);
+    --modal-overlay: rgba(28, 25, 23, 0.45);
+    --modal-bg: var(--surface);
+    --shadow-medium: rgba(28, 25, 23, 0.14);
+    --close-btn-color: var(--muted);
+    --close-btn-hover: var(--text);
+    --success-bg: rgba(61, 107, 93, 0.10);
+    --success-border: rgba(61, 107, 93, 0.30);
+    --error-bg: rgba(196, 69, 58, 0.10);
+    --error-border: rgba(196, 69, 58, 0.30);
+    --error-contrast: #a03530;
+    --primary-bg: rgba(61, 107, 93, 0.10);
+    --primary-border: rgba(61, 107, 93, 0.30);
+    --info-contrast: #2d5347;
+    --warning-bg: rgba(184, 134, 46, 0.12);
+    --warning-border: rgba(184, 134, 46, 0.30);
+    --warning-contrast: #8a6500;
+    --danger: #c4453a;
+    --danger-hover: #a93530;
+    --accent-hover: #984428;
+    --on-accent: #ffffff;
+    --storage-track: #d8d4cd;
+    --storage-fill-start: #5aab7a;
+    --storage-fill-end: #3d6b5d;
+    --info-bg: rgba(196, 93, 62, 0.07);
+    --info-border: rgba(196, 93, 62, 0.20);
+    --icon-accent: var(--accent);
+
+    /* Standardized Typography System */
+    --text-2xs: 0.72rem;  /* ~11.5px - Uppercase section labels */
+    --text-xs: 0.75rem;   /* 12px - Labels, captions, timestamps */
+    --text-sm: 0.875rem;  /* 14px - Secondary text, small buttons */
+    --text-base: 1rem;    /* 16px - Body text, inputs */
+    --text-lg: 1.125rem;  /* 18px - Emphasized text */
+    --text-xl: 1.25rem;   /* 20px - Section headings */
+    --text-2xl: 1.5rem;   /* 24px - Page subheadings */
+    --text-3xl: 2rem;     /* 32px - Page titles */
+
+    /* Font weights */
+    --font-normal: 400;
+    --font-medium: 500;
+    --font-semibold: 600;
+    --font-bold: 700;
+
+    /* Line heights */
+    --leading-tight: 1.25;
+    --leading-normal: 1.5;
+    --leading-relaxed: 1.75;
+
+    /* Letter spacing — industrial label styling */
+    --tracking-tight: -0.01em;
+    --tracking-wide: 0.02em;
+    --tracking-wider: 0.04em;
+
+    /* Standardized Icon Sizing System */
+    --icon-xs: 14px;      /* Small inline icons */
+    --icon-sm: 16px;      /* Timeline, small UI elements, header nav */
+    --icon-md: 20px;      /* Standard UI, action buttons */
+    --icon-lg: 24px;      /* App icons, prominent elements */
+    --icon-xl: 32px;      /* Large plugin icons */
+    --icon-xxl: 48px;     /* Hero/display icons */
+
+    /* Header-specific sizing for subtle navigation */
+    --icon-header: 22px;  /* Header navigation icons - standardized glyph size */
+    --container-header: 44px; /* Header icon containers - standardized touch target */
+    --container-padding: 4px; /* Minimal padding for header containers */
+
+    /* Icon stroke and styling */
+    --icon-stroke: 2px;
+    --icon-stroke-thin: 1.5px;
+    --icon-opacity: 1;
+    --icon-opacity-muted: 0.7;
+
+    /* Standardized spacing system */
+    --spacing-xs: 4px;
+    --spacing-sm: 8px;
+    --spacing-md: 12px;
+    --spacing-lg: 16px;
+    --spacing-xl: 20px;
+    --spacing-xxl: 24px;
+
+    /* Component sizing */
+    --border-radius-sm: 4px;
+    --border-radius-md: 6px;
+    --border-radius-lg: 10px;
+    --border-radius-xl: 14px;
+
+    /* Form sizing */
+    --form-input-height: 36px;
+    --form-button-height: 48px;
+    --form-slider-max-width: 400px;
+    --form-label-min-width: 100px;
+
+    /* Shadow scale — warm tones */
+    --shadow-xs: 0 1px 2px rgba(28, 25, 23, 0.05);
+    --shadow-sm: 0 2px 4px rgba(28, 25, 23, 0.06);
+    --shadow-md: 0 4px 12px rgba(28, 25, 23, 0.08);
+    --shadow-lg: 0 8px 24px rgba(28, 25, 23, 0.10);
+
+    /* Input depth */
+    --input-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+
+    /* Card tokens */
+    --card-border: 1px solid var(--surface-border);
+    --card-radius: var(--border-radius-lg);
+
+    /* Animation */
+    --transition-speed: 0.18s;
+
+    /* Breakpoint reference (CSS custom properties cannot be used in
+       @media queries, so these serve as a single-source-of-truth
+       reference for the values used throughout _responsive.css and
+       per-component @media blocks):
+       --bp-xs:  430px   Narrowest phones
+       --bp-sm:  520px   Small phones
+       --bp-md:  640px   Progress-step threshold
+       --bp-tab: 768px   Tablet / mobile boundary
+       --bp-lg:  900px   Enhanced responsive
+       --bp-xl:  1024px  Tablet landscape
+       --bp-2xl: 1440px  Large screens */
+}
+[data-theme="dark"] {
+    /* Hardware diagnostic console */
+    --bg: #121210;
+    --surface: #1c1b18;
+    --surface-border: #333028;
+    --text: #e8e4de;
+    --muted: #9a9590;
+    --divider: var(--surface-border);
+    --button-bg: #252320;
+    --input-bg: #161513;
+    --accent: #e07a5c;
+    --panel-bg: #211f1c;
+    --panel-border: #333028;
+    --subtext: #9a9590;
+    --frame-lining: #6b6560;
+    --skeleton-base: rgba(232, 228, 222, 0.06);
+    --skeleton-highlight: rgba(232, 228, 222, 0.10);
+    --error: #e8685e;
+    --success: #6db89f;
+    --warning: #d4a03a;
+    --primary: #6db89f;
+    --primary-hover: #8acab2;
+    --text-primary: var(--text);
+    --text-muted: var(--muted);
+    --text-secondary: var(--subtext);
+    --border-color: var(--surface-border);
+    --bg-primary: var(--surface);
+    --bg-secondary: #1a1816;
+    --card-bg: rgba(28, 27, 24, 0.88);
+    --modal-overlay: rgba(12, 11, 10, 0.68);
+    --modal-bg: #211f1c;
+    --shadow-medium: rgba(0, 0, 0, 0.35);
+    --close-btn-color: var(--muted);
+    --close-btn-hover: var(--text);
+    --success-bg: rgba(109, 184, 159, 0.14);
+    --success-border: rgba(109, 184, 159, 0.30);
+    --error-bg: rgba(232, 104, 94, 0.14);
+    --error-border: rgba(232, 104, 94, 0.30);
+    --error-contrast: #ffb1ab;
+    --primary-bg: rgba(109, 184, 159, 0.14);
+    --primary-border: rgba(109, 184, 159, 0.30);
+    --info-contrast: #8acab2;
+    --warning-bg: rgba(212, 160, 58, 0.14);
+    --warning-border: rgba(212, 160, 58, 0.30);
+    --warning-contrast: #f0c060;
+    --danger: #e8685e;
+    --danger-hover: #f08070;
+    --accent-hover: #f09880;
+    --on-accent: #121210;
+    --storage-track: #333028;
+    --storage-fill-start: #6db89f;
+    --storage-fill-end: #4a9a80;
+    --info-bg: rgba(224, 122, 92, 0.10);
+    --info-border: rgba(224, 122, 92, 0.20);
+    --icon-accent: var(--accent);
+
+    /* Dark shadow overrides */
+    --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.20);
+    --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.25);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.30);
+    --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+[hidden] { display: none !important; }
+
+/* Subtle frame container */
+.frame {
+    background-color: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-xl);
+    padding: 20px;
+    width: 95%;
+    max-width: 1100px;
+    margin: 16px auto;
+    min-height: auto;
+    box-shadow: var(--shadow-md);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: var(--spacing-lg);
+}
+
+.frame > * + * {
+    margin-top: var(--spacing-lg);
+}
+
+/* Current image styling with improved hierarchy */
+.image-container {
+    position: relative;
+    width: 300px;
+    margin: 0 auto;
+    padding: var(--spacing-xs);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.image-container img {
+    height: auto;
+    display: block;
+    margin: auto;
+    border-radius: 6px;
+    max-width: 20rem;
+    max-height: 15rem;
+    cursor: zoom-in;
+}
+
+/* Any image marked lightboxable gets the zoom-in cursor */
+.lightboxable { cursor: zoom-in; }
+
+/* Enhanced meta information hierarchy */
+.image-meta {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: var(--border-radius-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    margin: var(--spacing-sm) 0;
+    color: var(--text);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.image-meta strong {
+    color: var(--accent);
+    font-weight: 600;
+}
+
+/* Improved spacing for status sections */
+.image-meta + .image-meta {
+    margin-top: var(--spacing-xs);
+}
+
+/* A/B compare UI styles removed (feature disabled in UI). */
+
+.preview-link {
+    cursor: pointer;
+}
+
+/* When native (full-size) preview is enabled, allow scrolling to see full image */
+.image-container.native {
+    width: auto;
+    max-width: 100%;
+    overflow: auto;
+}
+
+.image-container.native img {
+    max-width: none;
+    max-height: none;
+    cursor: zoom-out;
+}
+
+/* Separator zeroed — spacing now handled by header border-bottom and component margins */
+.separator {
+    width: 100%;
+    height: 0;
+    margin: 0;
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    flex-wrap: wrap;
+    row-gap: 8px;
+}
+
+.title-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.title-stack {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+}
+
+.app-subtitle {
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+    line-height: 1.2;
+}
+
+.header-identity {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.page-intro {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 0 18px;
+}
+
+.page-intro-body {
+    display: grid;
+    gap: 6px;
+    min-width: 0;
+}
+
+.page-subtitle {
+    margin: 0;
+    color: var(--text-secondary);
+    max-width: 68ch;
+    line-height: 1.5;
+}
+
+.page-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.page-shell {
+  width: 100%;
+  animation: pageIn 0.25s ease-out;
+}
+
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+main[data-page-shell="dashboard"] .frame,
+main[data-page-shell="management"] .frame,
+main[data-page-shell="workflow"] .frame {
+  gap: 16px;
+}
+
+.hidden {
+    display: none;
+}
+
+/* Skip-to-main-content link for keyboard navigation */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 16px;
+  z-index: 10000;
+  padding: 8px 16px;
+  background: var(--surface);
+  color: var(--text);
+  border: 2px solid var(--accent);
+  border-radius: 4px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.skip-link:focus {
+  top: 8px;
+}
+
+/* Visually hidden helper for accessibility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap; /* added line */
+  border: 0;
+}
+
+/* Device frame overlay for large preview */
+.device-frame-overlay {
+  position: absolute;
+  inset: 0;
+  background: center / contain no-repeat;
+  pointer-events: none;
+  display: none;
+}
+.image-container.show-frame .device-frame-overlay { display: block; }
+
+/* Status bar (top previews) */
+.status-bar {
+    display: grid;
+    grid-template-columns: auto 1fr; /* auto-size compact card, remaining space for instance */
+    gap: 8px;
+    margin: 6px 0 0 0;
+}
+.status-card {
+    border: 1px solid var(--surface-border);
+    border-radius: 10px;
+    background: var(--surface);
+    padding: 8px;
+}
+.status-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 4px;
+}
+.status-body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    overflow: hidden;
+    padding: 6px 8px;
+}
+
+/* Compact cards have minimal height, instance cards maintain space for larger content */
+.status-card.compact .status-body {
+    min-height: auto;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.status-card.instance .status-body {
+    min-height: 56px;
+}
+.status-body img { max-width: 100%; max-height: 160px; display: block; }
+
+/* Compact current display thumbnail */
+.status-card.compact .image-container {
+    width: 200px;
+    max-width: 100%;
+}
+.status-card.compact .image-container img {
+    max-width: 100%;
+    max-height: 10rem;
+    object-fit: contain;
+    cursor: zoom-in;
+}
+
+.status-card.compact .image-container.native {
+    width: 200px;
+    max-width: 100%;
+    overflow: hidden;
+}
+
+/* Status card image hover feedback */
+.status-card.instance .status-body {
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.status-card.instance .status-body:hover {
+    border-color: var(--accent);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.status-card .status-body img:hover {
+    opacity: 0.92;
+}
+
+/* Full, non-cropped instance preview */
+.status-card.instance .status-body { overflow: visible; }
+.status-card.instance .status-body img { width: 100%; height: auto; max-height: none; object-fit: contain; }
+
+.status-placeholder {
+    color: var(--muted);
+    font-size: 0.9rem;
+    padding: 10px;
+    text-align: center;
+}
+.status-meta {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+    align-items: baseline;
+}
+.status-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.status-row .status-meta { margin-top: 0; }
+.status-divider { width: 1px; height: 18px; background: var(--surface-border); flex: 0 0 1px; opacity: 0.8; }
+.status-meta .label { color: var(--muted); font-size: 0.85rem; }
+.status-meta .value { color: var(--text); font-size: 0.95rem; font-weight: 600; }
+
+.section-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 4px 0 16px 0;
+}
+
+.section-focus {
+    animation: sectionFocusPulse 700ms ease-out;
+}
+
+@keyframes sectionFocusPulse {
+    0% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 35%, transparent); }
+    100% { box-shadow: 0 0 0 10px color-mix(in srgb, var(--accent) 0%, transparent); }
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 3px 10px;
+    border: 1px solid var(--surface-border);
+    background: var(--surface);
+    color: var(--text);
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+}
+
+.status-chip.success {
+    background: var(--success-bg);
+    border-color: var(--success-border);
+    color: var(--success);
+}
+
+.status-chip.warning {
+    background: var(--warning-bg);
+    border-color: var(--warning-border);
+    color: var(--warning-contrast);
+}
+
+.status-chip.info {
+    background: var(--primary-bg);
+    border-color: var(--primary-border);
+    color: var(--info-contrast);
+}
+
+.status-chip.error {
+    background: var(--error-bg);
+    border-color: var(--error-border);
+    color: var(--error-contrast);
+}
+
+.plugin-mode-row {
+    margin: 2px 0 10px 0;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+}
+
+/* Compact meta styling when inside status-body */
+.status-meta.compact {
+    margin-top: 0;
+    margin-bottom: 2px;
+    font-size: 0.8rem;
+    justify-content: center;
+}
+.status-meta.compact .label { font-size: 0.75rem; }
+.status-meta.compact .value { font-size: 0.85rem; }
+
+.status-placeholder-actions {
+  margin-top: 8px;
+}
+
+.instance-preview-skeleton,
+.lightbox-preview-image {
+  width: 100%;
+  display: block;
+}
+
+.lightbox-preview-image {
+  max-width: 92vw;
+  max-height: 85vh;
+  margin: 0 auto;
+  cursor: zoom-out;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.lightbox-preview-image.lightbox-img-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.section-nav .status-chip {
+  cursor: pointer;
+}
+
+.metric-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.metric-pill {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+  display: grid;
+  gap: 4px;
+}
+
+.metric-pill-label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metric-pill-value {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.metric-strip.compact .metric-pill {
+  padding: 12px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-secondary);
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
+  background: var(--card-bg);
+}
+
+.empty-state-icon {
+  margin-bottom: 10px;
+  width: var(--icon-xxl);
+  height: var(--icon-xxl);
+}
+
+.empty-state.compact {
+  padding: 22px 18px;
+  text-align: left;
+}
+
+.empty-state.compact .empty-state-icon {
+  margin-bottom: 8px;
+}
+
+.empty-state-message {
+  color: var(--muted);
+  font-size: 0.9rem;
+  padding: 24px 16px;
+  text-align: center;
+}
+
+.empty-state-primary {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.empty-state-secondary {
+  margin: 4px 0 0;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.info-banner {
+  background: var(--info-bg);
+  border: 1px solid var(--info-border);
+  border-radius: 10px;
+  padding: 12px 15px;
+  margin-top: 20px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.info-banner-icon,
+.empty-state-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--icon-accent);
+}
+
+.info-banner-icon svg,
+.empty-state-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.info-banner-text {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.danger-zone {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: var(--border-radius-md);
+  border: 1px solid color-mix(in srgb, var(--error) 35%, var(--panel-border));
+  background: color-mix(in srgb, var(--error) 6%, var(--panel-bg));
+}
+
+.danger-zone h3 {
+  margin: 0;
+}
+
+.displayed-now {
+    background-color: var(--accent);
+    color: var(--on-accent);
+    padding: 2px 8px;
+    border-radius: 999px; /* pill */
+    font-size: 0.78rem;
+}
+
+/* Snackbar for undo */
+#undoSnackbar {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  z-index: 1100;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
+  display: none;
+  padding: 10px 12px;
+  gap: 10px;
+  align-items: center;
+}
+#undoSnackbar .btn-link { background: none; border: none; color: var(--accent); cursor: pointer; font-weight: 700; }
+
+/* Virtualize large lists with content-visibility */
+.playlist-list, .button-grid, .history-grid {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 5000px; /* allow fast initial layout */
+}
+
+/* Dashboard header spacer - reserves space where home button would be on other pages */
+.header-nav-spacer {
+  display: inline-block;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+/* Staggered card reveal animation */
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.plugins-container .icon-button {
+  animation: fade-in-up 0.3s ease-out both;
+}
+
+.plugins-container .icon-button:nth-child(1) { animation-delay: 0ms; }
+.plugins-container .icon-button:nth-child(2) { animation-delay: 30ms; }
+.plugins-container .icon-button:nth-child(3) { animation-delay: 60ms; }
+.plugins-container .icon-button:nth-child(4) { animation-delay: 90ms; }
+.plugins-container .icon-button:nth-child(5) { animation-delay: 120ms; }
+.plugins-container .icon-button:nth-child(6) { animation-delay: 150ms; }
+.plugins-container .icon-button:nth-child(7) { animation-delay: 180ms; }
+.plugins-container .icon-button:nth-child(8) { animation-delay: 210ms; }
+.plugins-container .icon-button:nth-child(9) { animation-delay: 240ms; }
+.plugins-container .icon-button:nth-child(10) { animation-delay: 270ms; }
+.plugins-container .icon-button:nth-child(11) { animation-delay: 300ms; }
+.plugins-container .icon-button:nth-child(12) { animation-delay: 330ms; }
+
+@media (max-width: 768px) {
+  .header-nav-spacer {
+    display: none;
+  }
+}
+
+/* Enhanced app header layout */
+.app-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0;
+    padding-bottom: var(--spacing-md);
+    border-bottom: 1px solid var(--divider);
+    min-height: 48px; /* Consistent header height */
+}
+
+.app-header .app-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: var(--tracking-tight);
+    color: var(--text);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* App icon standardization */
+.app-header .app-icon {
+    width: var(--icon-lg);
+    height: var(--icon-lg);
+    flex-shrink: 0;
+}
+
+/* Header actions container */
+.app-header .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+}
+
+/* Ghost-style icon buttons for navigation (no fill, border on hover) */
+.header-button.icon {
+    background-color: transparent;
+    color: var(--muted);
+    border: 1px solid transparent;
+    padding: var(--container-padding);
+    width: var(--container-header);
+    height: var(--container-header);
+    border-radius: var(--border-radius-md);
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.header-button.icon:hover {
+    background-color: var(--panel-bg);
+    border-color: var(--surface-border);
+    color: var(--text);
+}
+
+.header-button.icon.current-page {
+    opacity: 0.5;
+    cursor: default;
+    pointer-events: none;
+}
+
+.app-header > .header-button.icon {
+    margin-left: 0;
+}
+
+/* Standardized icon styling with better centering */
+.icon-image {
+    width: var(--icon-xl);
+    height: var(--icon-xl);
+    flex-shrink: 0;
+    color: var(--text);
+}
+
+.icon-xs { width: var(--icon-xs); height: var(--icon-xs); }
+.icon-sm { width: var(--icon-sm); height: var(--icon-sm); }
+.icon-md { width: var(--icon-md); height: var(--icon-md); }
+.icon-lg { width: var(--icon-lg); height: var(--icon-lg); }
+.icon-xl { width: var(--icon-xl); height: var(--icon-xl); }
+.icon-xxl { width: var(--icon-xxl); height: var(--icon-xxl); }
+
+/* SVG icon standardization */
+svg.icon-image,
+svg.app-icon,
+svg.action-icon,
+svg.plugin-icon {
+    stroke-width: var(--icon-stroke);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
+    stroke: currentColor;
+}
+
+/* Thin stroke variant for delicate icons */
+.icon-thin,
+svg.icon-thin {
+    stroke-width: var(--icon-stroke-thin);
+}
+
+/* Consistent action icon sizing */
+.action-icon {
+    width: var(--icon-md);
+    height: var(--icon-md);
+    stroke: currentColor;
+    fill: none;
+    stroke-width: var(--icon-stroke);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+}
+
+/* Back button with enhanced feedback */
+.back-button {
+    background-color: var(--button-bg);
+    color: var(--text);
+    border: 1px solid var(--surface-border);
+    border-radius: 5px;
+    padding: 10px 20px;
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
+    margin-bottom: 20px;
+    text-align: left;
+    width: fit-content; /* Button takes up only the width of the text */
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    transition: transform 0.2s cubic-bezier(0.2, 0, 0.38, 0.9),
+                background-color 0.2s ease;
+}
+.back-button:hover {
+    background-color: rgba(255,255,255,0.08);
+    transform: translateX(-2px);
+}
+/* Enhanced focus management */
+.back-button:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 6px;
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+/* Enhanced global focus with better visibility */
+*:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: var(--border-radius-sm);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.icon-button:focus-visible,
+.action-button:focus-visible,
+.header-button:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 3px;
+    z-index: 1;
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 18%, transparent),
+                0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+/* Back button icon sizing */
+.back-button .icon-image {
+    width: var(--icon-sm);
+    height: var(--icon-sm);
+    margin: 0;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: var(--icon-stroke);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+/* Settings button styling */
+.header-icons { display: flex; align-items: center; gap: 16px; }
+.nav-icons { display: inline-flex; align-items: center; gap: 8px; }
+
+.settings-button {
+    font-size: 1rem;
+    color: var(--muted);
+    text-decoration: none;
+    padding: 6px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.settings-button img {
+    margin-bottom: 0px;
+}
+
+/* Compact header and navigation icon sizing */
+.settings-button svg.icon-image,
+.settings-button .icon-image svg,
+.settings-button .app-icon svg,
+.settings-button svg.app-icon {
+    width: var(--icon-header);
+    height: var(--icon-header);
+    display: inline-block;
+    vertical-align: middle;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: var(--icon-stroke-thin);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+/* Compact navigation icons */
+.nav-icons {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.nav-icons .settings-button {
+    padding: var(--container-padding);
+    border-radius: var(--border-radius-md);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--container-header);
+    height: var(--container-header);
+    border: 1px solid transparent;
+    box-sizing: border-box;
+    position: relative;
+    overflow: hidden;
+    background-color: transparent;
+    background-clip: padding-box;
+    transition: background-color var(--transition-speed) ease,
+                border-color var(--transition-speed) ease,
+                color var(--transition-speed) ease;
+}
+
+/* Subtle accent overlay to mirror plugin card hover */
+/* Create overlay only on hover to avoid any inner-edge artifacts */
+.nav-icons .settings-button::before { content: none; }
+.nav-icons .settings-button:hover::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--accent);
+    opacity: 0.04;
+    transition: opacity 0.2s ease;
+    background-clip: padding-box;
+}
+
+.nav-icons .settings-button:hover {
+    background-color: var(--panel-bg);
+    border-color: var(--surface-border);
+    transform: none;
+}
+
+/* On dark themes, ensure hover overlay stays subtle and no edge shows */
+[data-theme="dark"] .nav-icons .settings-button:hover::before,
+[data-theme="dark"] .header-button.icon:hover::before {
+    opacity: 0.05;
+}
+
+.header-button.icon svg {
+    display: block;
+    shape-rendering: geometricPrecision;
+}
+
+.header-button.icon .icon-image {
+    width: var(--icon-header);
+    height: var(--icon-header);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+}
+
+.header-button.icon .icon-image svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.header-button.icon .theme-icon {
+    width: var(--icon-header);
+    height: var(--icon-header);
+}
+
+/* Ensure nav icons are perfectly centered and not pushed by defaults */
+.nav-icons .settings-button .icon-image {
+    width: var(--icon-header);
+    height: var(--icon-header);
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    background-color: transparent;
+    background-clip: padding-box;
+}
+
+/* Generic: inner SVGs fill their icon-image wrapper */
+.icon-image svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.app-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.nav-icons .settings-button .icon-image svg {
+    shape-rendering: geometricPrecision;
+    background: transparent;
+    pointer-events: none; /* avoid capturing hover inside */
+}
+
+.settings-button:hover {
+    background-color: var(--panel-bg);
+    color: var(--text);
+    transform: none; /* Remove excessive animations */
+}
+
+.header-button {
+    background-color: var(--primary);
+    color: var(--on-accent);
+    border: none;
+    padding: 10px 16px;
+    border-radius: var(--border-radius-md);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    cursor: pointer;
+    transition: all var(--transition-speed) cubic-bezier(0.2, 0, 0.38, 0.9);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 44px;
+    line-height: 1;
+}
+
+.header-button:hover {
+    background-color: var(--primary-hover);
+}
+
+.header-button.is-secondary {
+    background-color: var(--bg-secondary);
+    color: var(--text);
+    border: 1px solid var(--border-color);
+}
+.header-button.is-secondary:hover {
+    background-color: var(--panel-bg);
+}
+.header-button.is-dark {
+    background-color: var(--text);
+    color: var(--bg);
+}
+.header-button.is-dark:hover {
+    opacity: 0.85;
+}
+
+.header-button.is-danger,
+.header-button.delete-button-danger {
+    background-color: var(--error);
+}
+
+.header-button.is-danger:hover,
+.header-button.delete-button-danger:hover {
+    background-color: var(--danger-hover);
+}
+
+.header-button.is-warning {
+    background-color: var(--warning);
+}
+
+/* Breadcrumb navigation */
+.breadcrumb {
+    margin-bottom: var(--spacing-md);
+}
+
+.breadcrumb ol {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+.breadcrumb li {
+    display: inline-flex;
+    align-items: center;
+}
+
+.breadcrumb li + li::before {
+    content: "\203A";
+    margin: 0 var(--spacing-sm);
+    color: var(--muted);
+    font-weight: var(--font-normal);
+    font-size: var(--text-sm);
+}
+
+.breadcrumb a {
+    color: var(--primary);
+    text-decoration: none;
+    transition: color var(--transition-speed) ease;
+}
+
+.breadcrumb a:hover {
+    color: var(--primary-hover);
+    text-decoration: underline;
+}
+
+.breadcrumb [aria-current="page"] span {
+    color: var(--text);
+    font-weight: var(--font-medium);
+}
+
+/* Optimized button grid with better performance and consistency */
+.button-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 140px));
+    gap: 20px;
+    overflow-y: auto;
+    padding: 20px;
+    content-visibility: auto;
+    contain-intrinsic-size: 1px 400px;
+    justify-content: center;
+    /* Ensure consistent sizing across all grid items */
+    align-items: stretch;
+}
+
+/* Improved button styling with better touch targets and consistent sizing */
+.icon-button {
+    border: var(--card-border);
+    border-radius: var(--card-radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 90px;
+    height: 90px;
+    aspect-ratio: 1;
+    padding: 12px;
+    cursor: pointer;
+    transition: transform var(--transition-speed) cubic-bezier(0.2, 0, 0.38, 0.9),
+                box-shadow var(--transition-speed) cubic-bezier(0.2, 0, 0.38, 0.9),
+                border-color var(--transition-speed) ease;
+    box-shadow: var(--shadow-xs);
+    background-color: var(--surface);
+    position: relative;
+    overflow: hidden;
+    text-decoration: none;
+}
+
+.icon-button:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--accent);
+}
+
+.icon-button:active {
+    transform: translateY(0);
+    transition-duration: 0.1s;
+    box-shadow: var(--shadow-xs);
+}
+
+.icon-button::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--accent);
+    opacity: 0;
+    transition: opacity var(--transition-speed) ease;
+}
+
+.icon-button:hover::before {
+    opacity: 0.04;
+}
+
+/* Ensure icon buttons inherit high-contrast color */
+.icon-button svg,
+.icon-button .icon-image {
+    color: var(--text);
+}
+
+/* Buttons container */
+.buttons-container {
+    display: flex;
+    gap: 10px;
+    margin-top: auto;
+}
+
+/* Enhanced action buttons */
+.action-button {
+    flex: 1;
+    background-color: var(--primary);
+    color: var(--on-accent);
+    border: none;
+    border-radius: var(--border-radius-md);
+    padding: 16px;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    cursor: pointer;
+    text-align: center;
+    width: 100%;
+    min-height: 48px;
+    position: relative;
+    overflow: hidden;
+    transition: transform var(--transition-speed) cubic-bezier(0.2, 0, 0.38, 0.9),
+                box-shadow var(--transition-speed) cubic-bezier(0.2, 0, 0.38, 0.9),
+                background-color var(--transition-speed) ease;
+    box-shadow: var(--shadow-sm);
+}
+
+.action-button.warn {
+    background-color: var(--error);
+}
+
+.action-button.warn:hover {
+    background-color: var(--danger-hover);
+}
+
+.action-button:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.action-button:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-xs);
+    transition-duration: 0.1s;
+}
+
+.action-button.compact {
+    font-size: 0.9rem;
+    padding: 10px;
+    width: auto;
+}
+
+/* Loading state for action buttons */
+.action-button.loading {
+    pointer-events: none;
+    opacity: 0.7;
+    cursor: wait;
+}
+
+.action-button.loading::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 18px;
+    height: 18px;
+    margin-left: -9px;
+    margin-top: -9px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: var(--on-accent);
+    border-radius: 50%;
+    animation: button-spin 0.8s linear infinite;
+    z-index: 1;
+}
+
+.action-button.loading span,
+.action-button.loading .button-text {
+    visibility: hidden;
+}
+
+@keyframes button-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Secondary/outline variants for action buttons to keep consistency app-wide */
+.action-button.is-secondary {
+    background-color: var(--primary);
+}
+.action-button.is-secondary:hover {
+    background-color: var(--primary-hover);
+}
+.action-button.is-outline {
+    background: transparent;
+    color: var(--text);
+    border: 1px solid var(--surface-border);
+}
+.action-button.is-outline:hover {
+    background-color: rgba(255,255,255,0.04);
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0; /* Remove spacing between buttons */
+}
+
+.button-group button {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--surface-border);
+  background-color: var(--bg-secondary);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 0; /* Reset default radius */
+  margin-left: -1px; /* Collapse left borders */
+  position: relative;
+  z-index: 1;
+}
+
+.button-group button:first-child {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  margin-left: 0; /* Reset for first button */
+}
+
+.button-group button:last-child {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.button-group button.active {
+  background-color: var(--accent);
+  color: var(--on-accent);
+  border-color: var(--accent);
+  z-index: 2; /* Ensure active button is above others */
+}
+
+/* Edit & Delete Buttons */
+.edit-button, .delete-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Disabled state for buttons */
+.action-button:disabled,
+.header-button:disabled,
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+/* Global focus-visible outline for interactive elements */
+button:focus-visible,
+a:focus-visible,
+.action-button:focus-visible,
+.header-button:focus-visible,
+.view-toggle:focus-visible,
+.sort-toggle:focus-visible,
+.icon-button:focus-visible,
+.toggle-container:focus-visible,
+.playlist-toggle-button:focus-visible,
+.workflow-mode-tab:focus-visible,
+.btn:focus-visible,
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* ── Button responsive: small screens ── */
+@media (max-width: 520px) {
+    .buttons-container {
+        flex-direction: column;
+    }
+
+    .buttons-container .action-button,
+    .buttons-container .header-button {
+        width: 100%;
+    }
+}
+
+/* ── Button responsive: tablet ── */
+@media (max-width: 768px) {
+    .buttons-container {
+        flex-direction: column;
+        gap: 12px;
+    }
+}
+
+/* ── Button responsive: mobile ── */
+@media (max-width: 900px) {
+    /* Improve button spacing on mobile */
+    .button-grid {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 20px;
+        padding: 20px 12px;
+    }
+
+    .buttons-container {
+        flex-direction: column;
+        gap: 12px;
+    }
+}
+
+/* ── Touch device button improvements ── */
+@media (hover: none) and (pointer: coarse) {
+    .icon-button,
+    .action-button,
+    .header-button {
+        min-height: 48px;
+        padding: 12px;
+    }
+
+    .icon-button:hover {
+        transform: none;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+
+    .action-button:hover {
+        transform: none;
+        background-color: var(--accent);
+    }
+
+    /* Better tap feedback */
+    .icon-button:active,
+    .action-button:active,
+    .header-button:active {
+        transform: scale(0.95);
+        transition-duration: 0.1s;
+    }
+
+    .button-group button {
+        min-height: 48px;
+    }
+}
+
+/* Ensure form and settings container expand */
+.settings-form {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    margin: 0px 0px 10px 0px;
+    flex-grow: 1;
+}
+
+.settings-container {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding: 0px 10px;
+}
+
+/* Style the form inputs and labels */
+.form-group {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem 1rem;
+    margin: 6px 0 6px 0; /* even spacing */
+    flex-wrap: wrap;
+    flex: auto;
+}
+
+.form-group .nowrap{
+    flex-wrap: nowrap;
+}
+
+.nowrap{
+    flex-wrap: nowrap;
+}
+
+.form-group label {
+    white-space: nowrap; /* Prevent label wrapping */
+    font-weight: 600;
+    color: var(--text);
+}
+
+.form-group input[type="text"] {
+    flex-grow: 1;
+    padding: 0.5rem;
+    font-size: 1rem;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    box-sizing: border-box;
+    min-width: 50px;
+    background-color: var(--input-bg);
+    color: var(--text);
+    box-shadow: var(--input-shadow);
+}
+
+/* Standardize form input heights for accessibility */
+.form-group input[type="text"],
+.form-group input[type="number"],
+.form-group input[type="email"],
+.form-group input[type="password"],
+.form-group input[type="url"],
+.form-group input[type="time"],
+.form-group select.form-input {
+    min-height: var(--form-input-height);
+    height: auto;
+}
+
+.form-group input[type="number"] {
+    min-width: 50px;
+}
+
+.form-group input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+/* Form styling for inline layout */
+.form-inline {
+    display: flex;
+    align-items: center;
+    gap: 10px; /* Space between the label and input */
+    width: 100%;
+}
+
+/* Label styling */
+.form-label {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text);
+    white-space: nowrap; /* Prevent the label from wrapping */
+}
+
+/* Input field styling */
+.form-input {
+    flex: auto;
+    padding: 0.4rem;
+    font-size: 1rem;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    box-sizing: border-box;
+    background-color: var(--input-bg);
+    color: var(--text);
+    min-height: var(--form-input-height);
+    display: flex;
+    align-items: center;
+    box-shadow: var(--input-shadow);
+}
+
+/* Unified styling for dropdowns to match the rest of the UI */
+select.form-input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: var(--input-bg);
+    color: var(--text);
+    border: 1px solid var(--surface-border);
+    padding-right: 2rem; /* room for chevron */
+    height: 36px;
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 12px 12px;
+    /* Chevron icon (uses a neutral stroke for both themes) */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%239aa3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+}
+
+/* Hide legacy arrow in old browsers */
+select.form-input::-ms-expand { display: none; }
+
+/* Options list should follow theme colors */
+select.form-input option {
+    background-color: var(--surface);
+    color: var(--text);
+}
+
+/* Dark theme: nudge chevron contrast slightly */
+[data-theme="dark"] select.form-input {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%23b3b9c4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+/* Enhanced form validation states */
+.form-field {
+    position: relative;
+    margin-bottom: 1rem;
+}
+
+.form-field.has-error .form-input {
+    border-color: var(--error);
+    box-shadow: 0 0 0 2px rgba(229, 62, 62, 0.2);
+}
+
+.form-field.has-error .form-label {
+    color: var(--error);
+}
+
+.form-error {
+    color: var(--error);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.form-error::before {
+    content: "\26A0";
+    font-size: 1rem;
+}
+
+.form-field.has-success .form-input {
+    border-color: var(--success);
+    box-shadow: 0 0 0 2px rgba(56, 161, 105, 0.2);
+}
+
+.form-success {
+    color: var(--success);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.form-success::before {
+    content: "\2713";
+    font-size: 1rem;
+}
+
+/* Style the custom file upload button */
+.file-upload-label {
+    display: inline-block;
+    background-color: var(--panel-bg);
+    color: var(--text); /* Text color matching the input */
+    padding: 10px 20px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1rem;
+    text-align: center;
+    border: 1px solid var(--divider);
+}
+
+.file-upload-label:hover {
+    background-color: var(--panel-border);
+}
+
+.file-upload-label:active {
+    background-color: var(--divider);
+}
+
+/* Hide the default file input */
+.file-upload-input {
+    display: none;
+}
+
+/* File name display styling */
+.file-name {
+    font-size: 1rem;
+    color: var(--text);
+    word-wrap: break-word;
+}
+
+.image-grid {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+    flex-wrap: wrap;
+}
+
+.image-option {
+    text-align: center;
+    border: 2px solid transparent;
+    padding: 5px;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: border-color var(--transition-speed) ease;
+    background: transparent;
+    font: inherit;
+    display: inline-block;
+}
+
+.image-option img {
+    width: auto;
+    height: auto; /* Ensures aspect ratio is maintained */
+    max-width: 100px; /* Optional: Limits the max width of images */
+}
+
+.image-option.selected {
+    border-color: var(--primary);
+}
+
+.color-picker {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--divider);
+    border-radius: 6px;
+    background-color: var(--surface);
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.color-picker::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+.color-picker::-webkit-color-swatch {
+    border-radius: 6px;
+}
+
+.color-picker-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.color-preview {
+    display: inline-block;
+    width: 48px;
+    height: 32px;
+    border-radius: 6px;
+    border: 1px solid var(--surface-border);
+    vertical-align: middle;
+    background: var(--preview-color);
+    transition: background 0.15s ease;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
+.color-combined-preview {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 28px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    font-size: 0.85rem;
+    font-weight: 600;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.remove-btn {
+    background-color: transparent;
+    border: none;
+    color: var(--error);
+    font-weight: 600; /* Matching the font-weight of other buttons */
+    cursor: pointer;
+    margin-left: 10px;
+    font-size: 1rem; /* Consistent font size */
+    transition: color var(--transition-speed) ease;
+}
+
+.remove-btn:hover {
+    color: var(--danger-hover);
+}
+
+.remove-btn:focus {
+    outline: none;
+    box-shadow: 0 0 3px rgba(26, 188, 156, 0.5); /* Adding a focus effect similar to inputs */
+}
+
+/* Time input styling */
+.time-input {
+    flex: 1;
+    padding: 0.4rem;
+    font-size: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    box-sizing: border-box;
+    text-align: center;
+}
+
+.time-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 3px rgba(26, 188, 156, 0.5);
+}
+
+.form-help {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin-top: 8px;
+}
+
+.form-group:last-child{margin-bottom: 0;}
+
+.form-field + .form-field{margin-top: 16px;}
+.form-section + .form-section{margin-top: 20px;}
+.sections-grid.two-col{grid-template-columns: 1fr 1fr;}
+
+/* Disabled state for form controls */
+input:disabled, select:disabled, textarea:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    background-color: var(--bg-secondary, var(--surface));
+}
+
+.slider-value {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--text);
+    min-width: 2.5em;
+    text-align: center;
+    padding: 2px 8px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── Form responsive: tablet ── */
+@media (max-width: 768px) {
+    .form-group {
+        gap: 8px 12px;
+    }
+
+    /* Stack form elements on very small screens */
+    .form-group.nowrap {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    /* Improve form inputs on mobile */
+    .form-input {
+        font-size: 16px; /* Prevent zoom on iOS */
+        min-height: 44px;
+    }
+}
+
+/* ── Form responsive: mobile ── */
+@media (max-width: 900px) {
+    /* Improved mobile form layouts */
+    .form-group.nowrap {
+        flex-direction: column;
+        gap: 8px;
+        align-items: stretch;
+    }
+
+    .form-group.nowrap > * {
+        width: 100%;
+        flex: none;
+    }
+
+    /* Better spacing for form sections */
+    .form-section {
+        padding: 16px;
+        margin-bottom: 16px;
+    }
+
+    .sections-grid.two-col{grid-template-columns:1fr;}
+}
+
+/* ── Touch device form improvements ── */
+@media (hover: none) and (pointer: coarse) {
+    /* Improve touch targets for form elements */
+    .form-input,
+    .toggle-container {
+        min-height: 48px;
+    }
+
+    .toggle-container {
+        min-width: 48px;
+        min-height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+}
+
+/* Enhanced plugins section hierarchy */
+.plugins-title {
+    font-size: var(--text-2xs);
+    font-weight: 600;
+    color: var(--muted);
+    margin: 0;
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+    transition: color var(--transition-speed) ease;
+}
+
+/* Toggle Container */
+.toggle-container {
+    display: inline-block;
+    position: relative;
+    width: 50px;
+    height: 24px;
+}
+
+/* Legacy hidden checkbox implementation removed to avoid hiding controls */
+/* The project now styles the visible checkbox directly via .toggle-checkbox */
+
+/* Toggle Background */
+.toggle-label {
+    position: absolute;
+    cursor: pointer;
+    background-color: var(--divider);
+    border-radius: 15px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transition: 0.3s;
+}
+
+/* Toggle Knob */
+.toggle-label::before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    background-color: var(--surface);
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    transition: 0.25s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+/* When Checked */
+.toggle-checkbox:checked + .toggle-label {
+    background-color: var(--primary);
+}
+
+.toggle-checkbox:checked + .toggle-label::before {
+    transform: translateX(26px);
+}
+
+/* Collapsible sections */
+.collapsible {
+    width: 100%;
+}
+
+.collapsible-header {
+    background-color: var(--bg-secondary);
+    color: var(--text);
+    border: none;
+    cursor: pointer;
+    padding: 10px;
+    width: 100%;
+    text-align: left;
+    font-size: 1rem;
+    margin: 10px 0px 5px 0px;
+}
+
+.collapsible-icon {
+    float: right;
+    opacity: 50%;
+    transition: transform 0.2s ease;
+}
+
+.collapsible-header[aria-expanded="true"] .collapsible-icon {
+    transform: rotate(180deg);
+}
+
+.collapsible-content {
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    padding: 0px 0px;
+    transition: max-height 0.3s ease, opacity 0.2s ease;
+}
+
+.collapsible-content.is-open {
+    max-height: 2000px;
+    opacity: 1;
+}
+
+/* Components have been split into per-component partials:
+   - _button.css  (buttons, button groups, disabled states, focus-visible)
+   - _form.css    (form inputs, labels, validation, file uploads, color pickers)
+   - _toggle.css  (toggles, collapsibles, plugins-title)
+   See _imports.css for the full manifest. */
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.dashboard-stage,
+.dashboard-overview,
+.storage-card,
+.settings-panel,
+.logs-panel {
+  min-width: 0;
+}
+
+.dashboard-stage,
+.dashboard-status-card,
+.storage-card {
+  padding: 16px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius-lg);
+  background: var(--panel-bg);
+}
+
+.dashboard-stage {
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-stage-header,
+.storage-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.dashboard-stage-header h2,
+.storage-card-title {
+  margin: 0;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--muted);
+}
+
+.dashboard-stage-copy,
+.storage-card-copy {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.dashboard-overview {
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-status-card {
+  display: grid;
+  gap: 10px;
+}
+
+.dashboard-status-card h3 {
+  margin: 0;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--muted);
+}
+
+.dashboard-status-meta {
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.dashboard-status-meta strong {
+  color: var(--text);
+}
+
+.dashboard-status-card .action-button,
+.dashboard-status-card .header-button {
+  justify-self: start;
+}
+
+.dashboard-stage .image-container {
+  width: 100%;
+  max-width: min(100%, 50rem);
+  margin: 0 auto;
+  padding: 4px;
+  aspect-ratio: 5 / 3;
+  min-height: unset;
+  display: block;
+  overflow: hidden;
+  border-radius: var(--border-radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), var(--shadow-sm);
+  transition: border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.dashboard-stage .image-container:hover {
+  border-color: var(--accent);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), var(--shadow-md);
+}
+
+.dashboard-stage .image-container img {
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  max-height: none;
+  object-fit: contain;
+  border-radius: 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.dashboard-stage .image-container .img-skeleton {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border-radius: 10px;
+}
+
+.dashboard-stage .image-container.native {
+  width: auto;
+  max-width: 100%;
+  aspect-ratio: auto;
+  max-height: min(58vh, 32rem);
+  overflow: auto;
+  padding-bottom: 4px;
+}
+
+.dashboard-stage .image-container.native img {
+  width: auto;
+  height: auto;
+  max-width: none;
+}
+
+.dashboard-stage .image-container:not(.native-preview-enabled) {
+  overflow: hidden;
+}
+
+.dashboard-stage .image-container:not(.native-preview-enabled) img {
+  cursor: zoom-in;
+}
+
+.dashboard-meta {
+  margin-top: 8px;
+}
+
+.dashboard-status-row {
+  margin-top: 8px;
+}
+
+.storage-card {
+  display: grid;
+  gap: 12px;
+}
+
+.storage-meter {
+    background: var(--storage-track);
+    border-radius: 8px;
+    height: 14px;
+    overflow: hidden;
+}
+
+.storage-meter-fill {
+    background: linear-gradient(90deg, var(--storage-fill-start), var(--storage-fill-end));
+    height: 100%;
+    width: var(--meter-width, 0%);
+}
+
+.dashboard-overview-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px 20px;
+  border: 1px dashed var(--surface-border);
+  border-radius: var(--border-radius-lg);
+  color: var(--text-secondary);
+  text-align: center;
+  min-height: 120px;
+}
+
+.dashboard-overview-empty .empty-state-icon {
+  width: var(--icon-xl, 32px);
+  height: var(--icon-xl, 32px);
+  opacity: 0.5;
+}
+
+.dashboard-overview-empty p {
+  margin: 0;
+  font-size: 0.9rem;
+  max-width: 24ch;
+}
+
+.icon-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border-radius: var(--border-radius-md);
+}
+
+/* Plugin List */
+.plugin-list {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Plugin Item */
+.plugin-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 10px 25px 10px 40px;
+    border-top: 1px solid var(--surface-border);
+    gap: 10px;
+}
+
+.plugin-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-grow: 1;
+}
+
+.plugin-actions { display:flex; justify-content:flex-end; gap:6px; align-items:center; }
+.plugin-actions .edit-button,
+.plugin-actions .delete-button { gap: 6px; }
+.plugin-actions .action-button-label { display: inline; font-size: 0.82rem; font-weight: 700; }
+.plugin-actions .btn { display:inline-flex; align-items:center; gap:6px; padding: 6px 10px; border:1px solid var(--surface-border); border-radius:6px; background: var(--surface); color: var(--text); }
+.plugin-actions .btn:hover { background: var(--hover-overlay, rgba(255,255,255,0.04)); }
+.plugin-actions .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.plugin-actions .btn-primary { background: var(--primary); color: var(--on-accent); border-color: var(--primary); }
+.plugin-actions .btn-primary:hover { background: var(--primary-hover); }
+.plugin-actions .btn-danger { background: var(--danger); color: var(--on-accent); border-color: var(--danger); }
+.plugin-actions .btn-danger:hover { background: var(--danger-hover); }
+.btn-label { font-size: 0.85em; }
+.btn-spinner { width: 14px; height: 14px; border: 2px solid rgba(255,255,255,0.5); border-top-color: var(--on-accent); border-radius: 50%; display:none; animation: spin .9s linear infinite; }
+
+/* Enhanced plugin icon styling */
+.plugin-icon {
+    width: var(--icon-lg);
+    height: var(--icon-lg);
+    display: inline-block;
+    flex-shrink: 0;
+    color: var(--text);
+}
+
+/* Ensure inline SVG icons inside plugin icon container render uniformly */
+.plugin-info .plugin-icon {
+    flex: 0 0 var(--icon-lg);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.plugin-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: var(--icon-stroke);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.plugin-instance {
+    color: var(--text);
+}
+
+/* Highlight the currently displayed instance */
+.plugin-item.is-current {
+  border-left: 4px solid var(--accent);
+}
+
+.timing-row { display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
+.latest-refresh { background-color: var(--panel-bg); color: var(--text); padding: 2px 6px; border-radius: 4px; font-size: 0.78em; border:1px solid var(--panel-border); }
+.latest-refresh.nextin:empty { display:none; }
+
+/* Plugin Grid/List View Styles */
+.plugins-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 15px;
+}
+
+.plugins-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.view-toggle,
+.sort-toggle {
+    background: var(--button-bg);
+    border: 1px solid var(--surface-border);
+    border-radius: 4px;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--text);
+    transition: all var(--transition-speed);
+}
+
+.view-toggle:hover,
+.sort-toggle:hover {
+    background: var(--button-bg);
+}
+
+.sort-toggle.active {
+    background: var(--success);
+    color: var(--on-accent);
+    border-color: var(--success);
+}
+
+/* Grid View (default) */
+.plugins-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 10px;
+    justify-items: stretch;
+}
+
+.plugins-container .plugin-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    text-decoration: none;
+    color: var(--text);
+    padding: 12px 8px 10px;
+    border-radius: 8px;
+    border: 1px solid var(--surface-border);
+    box-sizing: border-box;
+    width: 100%;
+    justify-self: stretch;
+    transition: background 0.2s, border-color 0.2s, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.plugins-container .plugin-item:hover {
+    background: var(--button-bg);
+    border-color: var(--muted);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.plugins-container .plugin-item:active {
+    transform: translateY(0);
+    box-shadow: none;
+    transition-duration: 0.05s;
+}
+
+.plugins-container .plugin-item .icon-image {
+    width: 48px;
+    height: 48px;
+    min-width: 48px;
+    min-height: 48px;
+    border-radius: 10px;
+    object-fit: cover;
+}
+
+.plugin-name {
+    margin-top: 8px;
+    font-size: 0.78rem;
+    line-height: 1.3;
+    text-align: center;
+    color: var(--muted);
+    width: 100%;
+    padding: 0 2px;
+    box-sizing: border-box;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    min-height: 2.4em;
+}
+
+/* List View */
+.plugins-container.list-view {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.plugins-container.list-view .plugin-item {
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 10px 14px;
+    gap: 12px;
+}
+
+.plugins-container.list-view .plugin-item .icon-image {
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    min-height: 32px;
+}
+
+.plugins-container.list-view .plugin-name {
+    margin-top: 0;
+    font-size: 14px;
+    text-align: left;
+    width: auto;
+    padding: 0;
+    white-space: nowrap;
+}
+
+/* Sorting Mode */
+.plugins-container.sorting .plugin-item {
+    cursor: grab;
+    border-style: dashed;
+}
+
+.plugins-container.sorting .plugin-item:hover {
+    border-color: var(--success);
+    background: var(--success-bg);
+}
+
+.plugins-container.sorting .plugin-item.dragging {
+    opacity: 0.5;
+    cursor: grabbing;
+}
+
+.plugins-container.sorting .plugin-item.drag-over {
+    border-color: var(--primary);
+    border-style: solid;
+    background: var(--primary-bg);
+}
+
+.sort-hint {
+    display: none;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 10px;
+}
+
+.sort-hint.visible {
+    display: block;
+}
+
+/* Workflow layout for plugin page */
+.workflow-frame {
+  gap: var(--spacing-md);
+}
+
+.workflow-mode-bar {
+  display: none;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  align-self: flex-start;
+  position: relative;
+  margin-bottom: 12px;
+}
+
+.workflow-mode-tab {
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 10px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.workflow-mode-tab.active {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.workflow-mode-bar::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--panel-border);
+}
+
+.workflow-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.85fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.workflow-main-panel,
+.workflow-side-panel,
+.settings-console-main {
+  min-width: 0;
+}
+
+.workflow-side-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.workflow-section-header {
+  display: grid;
+  gap: 4px;
+}
+
+.workflow-section-header h2 {
+  font-size: 1.05rem;
+}
+
+.workflow-section-header p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.workflow-meta {
+  margin-top: 8px;
+}
+
+.workflow-meta-row + .workflow-meta-row {
+  margin-top: 6px;
+}
+
+.workflow-action-panel {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius-md);
+}
+
+.workflow-device-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.workflow-action-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.workflow-help {
+  margin-top: 0;
+}
+
+/* Playlist plugin thumbnails */
+.plugin-thumb {
+    width: 120px;
+    height: 90px;
+    border: 1px solid var(--surface-border);
+    border-radius: 4px;
+    overflow: hidden;
+    padding: 8px; /* Inner padding to avoid visual clipping on e-ink */
+    background: var(--surface);
+    position: relative;
+    cursor: zoom-in;
+    margin-left: auto;
+    flex: 0 0 120px;
+}
+.plugin-thumb img { width: 100%; height: 100%; object-fit: contain; display:block; background: var(--panel-bg); }
+
+/* Frame-lining preview overlay on thumbnails by selected frame style */
+.plugin-thumb[data-frame-style]::after {
+  content: "";
+  position: absolute;
+  inset: 6px; /* inner padding lining */
+  pointer-events: none;
+}
+.plugin-thumb[data-frame-style="Rectangle"]::after {
+  border: 1.5px solid var(--frame-lining);
+  border-radius: 2px;
+}
+.plugin-thumb[data-frame-style="Top and Bottom"]::after {
+  border-top: 1.5px solid var(--frame-lining);
+  border-bottom: 1.5px solid var(--frame-lining);
+}
+.plugin-thumb[data-frame-style="Corner"]::after {
+  content: "";
+  background:
+    linear-gradient(to right, var(--frame-lining) 0 100%) left top/12px 1.5px no-repeat,
+    linear-gradient(to bottom, var(--frame-lining) 0 100%) left top/1.5px 12px no-repeat,
+    linear-gradient(to right, var(--frame-lining) 0 100%) right bottom/12px 1.2px no-repeat,
+    linear-gradient(to bottom, var(--frame-lining) 0 100%) right bottom/1.2px 12px no-repeat;
+}
+
+/* Device frame overlay for playlist thumbnails */
+.device-frame-on .plugin-thumb::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: var(--device-frame-url);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  opacity: 0.9;
+}
+
+/* Plugin thumbnail containers */
+.plugin-thumbnail-container {
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: var(--border-radius-sm);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.plugin-thumbnail-container:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.plugin-thumbnail {
+  display: block;
+}
+
+/* Playlist List */
+.playlist-list {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    overflow-y: auto;
+}
+
+.playlist-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    padding: 20px 25px 10px 25px;
+    gap: 14px;
+}
+
+/* Playlist Item */
+.playlist-item {
+    display: flex;
+    padding: 0px 0px 5px 0px;
+    transition: all var(--transition-speed) ease;
+    border: 2px solid var(--surface-border);
+    border-radius: 10px;
+    flex-direction: column;
+    width: 100%
+}
+
+/* Active Playlist Item */
+.playlist-item.active {
+    border-color: var(--accent);
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.playlist-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.playlist-heading {
+    display: grid;
+    gap: 8px;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.playlist-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.playlist-secondary-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.action-button-label {
+    display: none;
+}
+
+.playlist-summary-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.playlist-summary-copy {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.playlist-card-body {
+    display: grid;
+    gap: 12px;
+}
+
+.playlist-toggle-button {
+    border: 1px solid var(--panel-border);
+    background: var(--panel-bg);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 9px 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.playlist-toggle-button:hover {
+    border-color: var(--accent);
+}
+
+.playlist-toggle-button::after {
+    content: '\25BC';
+    font-size: 0.7em;
+    margin-left: 6px;
+    display: inline-block;
+    transition: transform 0.2s ease;
+}
+
+.playlist-toggle-button[aria-expanded="true"]::after {
+    transform: rotate(180deg);
+}
+
+.playlist-frame {
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.playlist-thumbnail-modal {
+    background-color: var(--modal-overlay);
+}
+
+.playlist-thumbnail-content {
+    background-color: var(--modal-bg);
+    box-shadow: 0 4px 20px var(--shadow-medium);
+}
+
+.playlist-thumbnail-info {
+    background-color: var(--bg-primary);
+    color: var(--text-secondary);
+}
+
+/* Drag handle */
+.drag-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+    color: var(--text-secondary);
+    opacity: 0.5;
+    transition: opacity 0.15s ease, background 0.15s ease;
+    flex-shrink: 0;
+    padding: 8px 4px;
+    min-width: 32px;
+    min-height: 44px;
+    border-radius: 6px;
+}
+
+.drag-handle:hover {
+    opacity: 1;
+    background: var(--panel-bg);
+}
+
+.drag-handle:active {
+    cursor: grabbing;
+}
+
+.drag-handle-icon {
+    width: var(--icon-lg, 24px);
+    height: var(--icon-lg, 24px);
+}
+
+.plugin-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+/* Compact grid for groups of options */
+.options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 6px 12px;
+}
+
+.settings-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius-md);
+  padding: 14px;
+}
+
+.settings-card-title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text);
+  margin-bottom: 10px;
+}
+
+.settings-schema {
+  display: grid;
+  gap: 14px;
+}
+
+.schema-section {
+  display: grid;
+  gap: 12px;
+}
+
+.schema-section-body {
+  display: grid;
+  gap: 12px;
+}
+
+.schema-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.schema-field {
+  min-width: 0;
+}
+
+.settings-callout {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--info-border);
+  background: var(--info-bg);
+  color: var(--text);
+}
+
+.settings-callout.warning {
+  background: var(--warning-bg);
+  border-color: var(--warning-border);
+}
+
+.settings-callout .icon-image {
+  width: var(--icon-md);
+  height: var(--icon-md);
+  color: var(--icon-accent);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.settings-callout.warning .icon-image {
+  color: var(--warning);
+}
+
+.settings-callout p,
+.settings-callout small,
+.settings-callout span {
+  margin: 0;
+  color: inherit;
+}
+
+.field-note {
+  display: block;
+  width: 100%;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
+.inline-readonly-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.toggle-list {
+  display: grid;
+  gap: 10px;
+}
+
+.toggle-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--panel-border);
+  background: var(--surface);
+}
+
+.toggle-item.inline-controls {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.toggle-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.toggle-item-label {
+  font-weight: var(--font-medium);
+  color: var(--text);
+}
+
+.toggle-item-hint {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.radio-segment {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.radio-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--surface-border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.radio-option input {
+  margin: 0;
+}
+
+.dynamic-list {
+  display: grid;
+  gap: 12px;
+}
+
+.dynamic-list-item {
+  border: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+  border-radius: var(--border-radius-md);
+  padding: 12px;
+}
+
+.compact-repeater {
+  display: grid;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.dynamic-list-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.dynamic-list-toolbar .form-input {
+  flex: 1;
+}
+
+.compact-repeater-toolbar {
+  align-items: stretch;
+  margin-bottom: 0;
+}
+
+.compact-repeater-toolbar .remove-btn {
+  flex: 0 0 44px;
+  min-height: 44px;
+}
+
+.dynamic-list-color-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.dynamic-list-textarea {
+  min-height: 112px;
+}
+
+.settings-map {
+  width: 100%;
+  height: 240px;
+  margin: 10px 0;
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+}
+
+/* Settings grid layout */
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.settings-panel {
+  gap: 16px;
+}
+
+.logs-panel {
+  display: none;
+  overflow: hidden;
+}
+
+.logs-panel.is-open {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 32px);
+}
+
+.logs-toolbar,
+.logs-header {
+  width: 100%;
+}
+
+.logs-header {
+  display: grid;
+  gap: 14px;
+}
+
+.logs-filters,
+.logs-actions,
+.history-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.logs-filters #logsFilter {
+  flex: 1 1 180px;
+}
+
+.logs-updated-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.logs-viewer {
+  flex: 1;
+  min-height: 320px;
+  max-height: calc(100vh - 240px);
+  overflow: auto;
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--surface-border);
+  background: var(--bg-secondary);
+  padding: 14px;
+  color: var(--text);
+  font-family: ui-monospace, 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.logs-icon {
+    color: var(--text);
+}
+
+.logs-icon .icon-fill {
+    fill: var(--surface);
+}
+
+.logs-icon .icon-accent {
+    stroke: var(--icon-accent);
+}
+
+/* Settings console layout */
+.settings-console-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 20px;
+}
+
+.settings-side-nav {
+  display: grid;
+  gap: 2px;
+  align-self: start;
+  position: sticky;
+  top: 16px;
+  border-right: 1px solid var(--divider);
+  padding-right: var(--spacing-lg);
+}
+
+.settings-side-link {
+  border: none;
+  border-left: 2px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  border-radius: 0;
+  padding: 10px 14px;
+  text-align: left;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  cursor: pointer;
+  transition: color var(--transition-speed) ease,
+              background-color var(--transition-speed) ease,
+              border-color var(--transition-speed) ease;
+}
+
+.settings-side-link:hover {
+  color: var(--text);
+  background: var(--panel-bg);
+}
+
+.settings-side-link.active {
+  border-left-color: var(--accent);
+  color: var(--text);
+  background: var(--panel-bg);
+}
+
+.settings-console-panel {
+  display: none;
+  gap: 16px;
+}
+
+.settings-console-panel.active {
+  display: grid;
+}
+
+.diagnostics-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.inline-action-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.diagnostics-panel {
+  min-height: 120px;
+}
+
+.diagnostics-panel-sm {
+  min-height: 80px;
+}
+
+.bench-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 6px 0 12px;
+  font-size: var(--text-sm);
+}
+
+.bench-table th,
+.bench-table td {
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-color, #ddd);
+}
+
+.bench-table th {
+  font-weight: 600;
+  opacity: 0.75;
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+/* Mobile settings nav toggle */
+.settings-mobile-toggle {
+  display: none;
+  width: 100%;
+  text-align: center;
+  font-weight: 600;
+}
+
+@keyframes shake-item {
+    0%, 100% { transform: translateX(0); }
+    25%, 75% { transform: translateX(-3px); }
+    50% { transform: translateX(3px); }
+}
+
+.dynamic-list-item.shake {
+    animation: shake-item 0.35s ease-in-out;
+}
+
+/* Mobile logs toggle (JTN-339)
+   Uses env(safe-area-inset-bottom) so the floating "Show Logs" action
+   stays above the iOS home indicator and the dynamic mobile address bar
+   on narrow viewports. The companion padding-bottom on
+   .page-shell-management ensures the last in-flow element isn't hidden
+   underneath this fixed button. */
+.settings-logs-toggle {
+  display: block;
+  position: fixed;
+  right: max(16px, env(safe-area-inset-right, 0px) + 8px);
+  bottom: max(16px, env(safe-area-inset-bottom, 0px) + 16px);
+  z-index: 10;
+  border-radius: 999px;
+  padding: 12px 18px;
+  font-weight: 700;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+}
+
+/* Reserve space at the bottom of the settings page so the fixed
+   "Show Logs" toggle never overlaps the last action in the panel
+   (e.g. Save / Reset buttons) on narrow mobile viewports. */
+.page-shell-management {
+  padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+}
+
+.api-key-label {
+    background-color: var(--warning);
+    color: var(--on-accent);
+    font-style: normal;
+    font-weight: 500;
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    line-height: 1.2;
+    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    text-decoration: none;
+    white-space: nowrap;
+    min-height: 32px;
+}
+
+.api-key-label:hover {
+    background-color: var(--warning);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    color: var(--on-accent);
+}
+
+/* API key icon */
+.api-key-label::before {
+    content: "\26A0";
+    font-size: 14px;
+    opacity: 0.9;
+}
+
+/* API key configured state */
+.api-key-label.configured {
+    background-color: var(--success);
+    pointer-events: none; /* Not clickable when configured */
+}
+
+.api-key-label.configured:hover {
+    background-color: var(--success);
+    transform: none;
+    box-shadow: none;
+}
+
+.api-key-label.configured::before {
+    content: "\2713";
+    font-size: 14px;
+    opacity: 0.9;
+}
+
+/* Inline API Key Indicator */
+.api-key-indicator {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    min-height: var(--container-header);
+    box-sizing: border-box;
+    cursor: default;
+}
+
+.api-key-indicator.configured {
+    background: var(--success-bg);
+    color: var(--success);
+    border: 1px solid var(--success-border);
+}
+
+.api-key-indicator.missing {
+    background: var(--warning-bg);
+    color: var(--warning);
+    border: 1px solid var(--warning-border);
+    cursor: pointer;
+}
+
+.api-key-indicator.missing:hover {
+    background: var(--warning-bg);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.api-key-icon {
+    width: var(--icon-header);
+    height: var(--icon-header);
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    line-height: 1;
+    font-weight: bold;
+}
+
+.api-key-text {
+    white-space: nowrap;
+    opacity: 1;
+    transition: opacity 0.3s ease, max-width 0.3s ease;
+    overflow: hidden;
+}
+
+/* Collapsed state */
+.api-key-indicator.collapsed .api-key-text {
+    opacity: 0;
+    max-width: 0;
+    overflow: hidden;
+}
+
+.api-key-indicator.collapsed {
+    padding: 8px;
+    min-width: var(--container-header);
+    justify-content: center;
+}
+
+/* Auto-collapse animation */
+.api-key-indicator.auto-collapse {
+    animation: collapseContainer 3s ease-in-out forwards;
+    overflow: hidden; /* Prevent text overflow during animation */
+}
+
+@keyframes collapseContainer {
+    0%, 66.67% {
+        padding: 8px 12px;
+        gap: 6px;
+    }
+    100% {
+        padding: 8px;
+        gap: 0;
+    }
+}
+
+.api-key-indicator.auto-collapse .api-key-text {
+    animation: fadeOutText 3s ease-in-out forwards;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+@keyframes fadeOutText {
+    0%, 66.67% {
+        opacity: 1;
+        max-width: 100px; /* Set a reasonable max-width instead of auto */
+        margin-right: 0;
+    }
+    100% {
+        opacity: 0;
+        max-width: 0;
+        margin-right: 0;
+    }
+}
+
+/* Hover to expand collapsed state */
+.api-key-indicator.collapsed:hover {
+    padding: 8px 12px;
+    gap: 6px;
+}
+
+.api-key-indicator.collapsed:hover .api-key-text {
+    opacity: 1;
+    max-width: 100px;
+}
+
+/* API Keys page layout */
+.api-keys-frame {
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.api-keys-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.api-keys-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.api-key-card {
+  padding: 16px;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: var(--panel-bg);
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.api-key-card-head {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+}
+
+.api-key-card .form-label {
+  font-size: 1rem;
+}
+
+.api-key-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.api-key-status strong {
+  color: var(--text);
+}
+
+.api-key-usage {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.api-key-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.api-key-actions .header-button {
+  min-width: 0;
+}
+
+.apikey-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.apikey-key,
+.apikey-value {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-family: monospace;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.apikey-value.masked {
+  color: var(--text-secondary);
+  letter-spacing: 2px;
+  background: var(--bg-secondary);
+}
+
+.btn-delete,
+.btn-add,
+.btn-preset {
+  transition: transform 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.btn-delete:hover,
+.btn-add:hover,
+.btn-preset:hover,
+.plugin-card:hover,
+.history-card:hover {
+  transform: translateY(-1px);
+}
+
+.btn-delete {
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: var(--error);
+  color: var(--on-accent);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.add-buttons-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.btn-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border: 2px dashed var(--border-color);
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.btn-preset {
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: monospace;
+}
+
+.clear-button {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 4px 8px;
+}
+
+.toggle-password-btn {
+  background: transparent;
+  border: 1px solid var(--surface-border);
+  border-radius: var(--border-radius-sm);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 6px 10px;
+  min-height: var(--form-input-height);
+  transition: color var(--transition-speed) ease, border-color var(--transition-speed) ease;
+}
+
+.toggle-password-btn:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.delete-button-danger {
+  color: var(--error);
+  border-color: var(--error);
+}
+
+.history-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.history-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: var(--card-border);
+  border-radius: var(--card-radius);
+  background: var(--panel-bg);
+  box-shadow: var(--shadow-xs);
+  transition: transform var(--transition-speed) ease, border-color var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.history-card-body {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.history-thumb {
+  position: relative;
+  display: block;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  aspect-ratio: 4 / 3;
+  cursor: zoom-in;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.history-thumb:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+
+.history-thumb img,
+.history-thumb .img-skeleton {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.history-meta {
+  display: grid;
+  gap: 6px;
+}
+
+.history-name {
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.35;
+}
+
+.history-sub {
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.history-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.history-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  border-radius: 10px;
+  border: 1px solid var(--surface-border);
+  background: var(--surface);
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.18s ease;
+}
+
+.history-actions .btn:hover {
+  background: var(--bg-secondary);
+  border-color: var(--muted);
+}
+
+.history-actions .btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+
+.history-actions .btn-primary:hover {
+  background: var(--primary-hover);
+}
+
+.history-actions .btn-danger {
+  background: var(--error);
+  border-color: var(--error);
+  color: var(--on-accent);
+}
+
+.history-actions .btn-danger:hover {
+  background: var(--danger-hover);
+}
+
+.history-danger-zone {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 8px;
+  padding: 20px;
+  border-width: 2px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--error) 20%, transparent);
+}
+
+.history-danger-zone .danger-zone-body {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.history-danger-zone p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.history-danger-zone h3 {
+  color: var(--error);
+}
+
+.danger-zone-divider {
+  margin: 28px 0 16px;
+  border: 0;
+  border-top: 1px solid var(--panel-border);
+  opacity: 0.75;
+}
+
+.danger-zone-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-bottom: 2px;
+}
+
+.history-source-unknown {
+  color: var(--text-muted, var(--text-secondary));
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .history-danger-zone {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .history-danger-zone .header-button.is-danger {
+    width: 100%;
+  }
+}
+
+.thumbnail-preview-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.thumbnail-preview-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  border-radius: 12px;
+  overflow: hidden;
+  padding: 16px;
+}
+
+.thumbnail-preview-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.thumbnail-preview-info {
+  padding: 12px 0 0;
+  font-size: 0.9rem;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px 0;
+}
+
+.pagination-info {
+  font-size: 0.9rem;
+  opacity: 0.7;
+}
+
+.pagination-disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+  color: var(--text-muted, currentColor);
+}
+
+/* Enhanced skeleton loader system */
+.skeleton,
+.img-skeleton,
+.form-skeleton,
+.button-skeleton,
+.text-skeleton {
+    background: linear-gradient(
+        90deg,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 25%,
+        var(--skeleton-highlight, rgba(0,0,0,0.10)) 37%,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+    will-change: background-position;
+    border-radius: var(--border-radius-sm);
+}
+
+/* Specific skeleton types */
+.img-skeleton {
+    width: 100%;
+    height: 100%;
+    transition: opacity 0.3s ease;
+}
+
+.img-skeleton.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.form-skeleton {
+    height: var(--form-input-height);
+    margin-bottom: var(--spacing-md);
+}
+
+.button-skeleton {
+    height: var(--form-button-height);
+    border-radius: var(--border-radius-md);
+}
+
+.text-skeleton {
+    height: 1.2em;
+    margin-bottom: 0.5em;
+}
+
+.text-skeleton.short {
+    width: 60%;
+}
+
+.text-skeleton.medium {
+    width: 80%;
+}
+
+.text-skeleton.long {
+    width: 100%;
+}
+.text-skeleton.large {
+    width: 100%;
+    height: 2em;
+}
+
+/* Plugin-specific skeleton patterns */
+.plugin-skeleton {
+    width: 100%;
+    min-height: 200px;
+    padding: 16px;
+    border-radius: var(--border-radius-md);
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+}
+
+/* Weather plugin skeleton */
+.plugin-skeleton-weather .skeleton-weather-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.plugin-skeleton-weather .skeleton-weather-main {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.plugin-skeleton-weather .skeleton-weather-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: linear-gradient(
+        90deg,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 25%,
+        var(--skeleton-highlight, rgba(0,0,0,0.10)) 37%,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.plugin-skeleton-weather .skeleton-weather-icon.small {
+    width: 32px;
+    height: 32px;
+}
+
+.plugin-skeleton-weather .skeleton-weather-temp {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.plugin-skeleton-weather .skeleton-weather-forecast {
+    display: flex;
+    gap: 16px;
+    justify-content: space-around;
+}
+
+.plugin-skeleton-weather .skeleton-forecast-day {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+}
+
+/* Calendar plugin skeleton */
+.plugin-skeleton-calendar .skeleton-calendar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.plugin-skeleton-calendar .skeleton-calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+}
+
+.plugin-skeleton-calendar .skeleton-calendar-day {
+    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--border-radius-sm);
+}
+
+.plugin-skeleton-calendar .skeleton-calendar-day.weekend {
+    opacity: 0.6;
+}
+
+/* Image plugin skeleton */
+.plugin-skeleton-image .skeleton-image-main {
+    margin-bottom: 12px;
+}
+
+.plugin-skeleton-image .img-skeleton.large {
+    height: 120px;
+    border-radius: var(--border-radius-md);
+}
+
+.plugin-skeleton-image .skeleton-image-caption {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+/* Text plugin skeleton */
+.plugin-skeleton-text .skeleton-text-header {
+    margin-bottom: 16px;
+}
+
+.plugin-skeleton-text .skeleton-text-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+/* Generic plugin skeleton */
+.plugin-skeleton .skeleton-generic-header {
+    margin-bottom: 16px;
+}
+
+.plugin-skeleton .skeleton-generic-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* Progress skeleton */
+.progress-skeleton {
+    width: 100%;
+    padding: 16px;
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-md);
+}
+
+.progress-skeleton .skeleton-progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.progress-skeleton .skeleton-progress-bar {
+    width: 100%;
+    height: 8px;
+    background-color: var(--muted);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 16px;
+}
+
+.progress-skeleton .progress-skeleton-fill {
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        var(--primary) 0%,
+        var(--primary-hover) 100%
+    );
+    transition: width 0.3s ease;
+    border-radius: 4px;
+}
+
+.progress-skeleton .skeleton-progress-steps {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
+
+.progress-skeleton .skeleton-progress-step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    opacity: 0.5;
+    transition: opacity 0.3s ease;
+}
+
+.progress-skeleton .skeleton-progress-step.active {
+    opacity: 1;
+}
+
+.progress-skeleton .skeleton-progress-step.completed {
+    opacity: 0.8;
+}
+
+.progress-skeleton .skeleton-step-indicator {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--muted);
+    transition: background-color 0.3s ease;
+}
+
+.progress-skeleton .skeleton-progress-step.active .skeleton-step-indicator {
+    background: var(--primary);
+    background: linear-gradient(
+        90deg,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 25%,
+        var(--skeleton-highlight, rgba(0,0,0,0.10)) 37%,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.progress-skeleton .skeleton-progress-step.completed .skeleton-step-indicator {
+    background: var(--success);
+}
+
+.progress-skeleton .skeleton-step-text {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
+/* Generating label for skeleton loading */
+.skeleton-generating-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.skeleton-generating-text {
+    font-weight: 600;
+}
+
+.skeleton-elapsed {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.7;
+}
+
+/* Enhanced Progress Display */
+.enhanced-progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 12px;
+}
+
+.progress-title-section {
+    flex: 1;
+}
+
+.progress-title {
+    font-weight: 600;
+    color: var(--text);
+    font-size: 1rem;
+    line-height: 1.4;
+    display: block;
+}
+
+.progress-subtitle {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    line-height: 1.3;
+    margin-top: 2px;
+    display: block;
+}
+
+.progress-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.progress-elapsed {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.enhanced-progress-bar-section {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.progress-bar-container {
+    flex: 1;
+    height: 8px;
+    background-color: var(--muted);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.enhanced-progress-fill {
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        var(--primary) 0%,
+        var(--primary-hover) 100%
+    );
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.progress-percentage {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    font-variant-numeric: tabular-nums;
+    min-width: 3em;
+    text-align: right;
+}
+
+/* Enhanced Step Indicators */
+.enhanced-progress-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.enhanced-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 8px;
+    border-radius: var(--border-radius-sm);
+    transition: all 0.3s ease;
+}
+
+.enhanced-step.active {
+    background-color: var(--primary-bg);
+    border-left: 3px solid var(--primary);
+    padding-left: 9px;
+}
+
+.enhanced-step.completed {
+    opacity: 0.8;
+}
+
+.enhanced-step.failed {
+    background-color: var(--error-bg);
+    border-left: 3px solid var(--error);
+    padding-left: 9px;
+}
+
+.step-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: var(--muted);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    flex-shrink: 0;
+}
+
+.enhanced-step.active .step-indicator {
+    background-color: var(--primary);
+    color: var(--on-accent);
+}
+
+.enhanced-step.completed .step-indicator {
+    background-color: var(--success);
+    color: var(--on-accent);
+}
+
+.enhanced-step.completed .step-indicator::after {
+    content: '\2713';
+    font-size: 0.875rem;
+}
+
+.enhanced-step.completed .step-number {
+    display: none;
+}
+
+.enhanced-step.failed .step-indicator {
+    background-color: var(--error);
+    color: var(--on-accent);
+}
+
+.enhanced-step.failed .step-indicator::after {
+    content: '\2715';
+    font-size: 0.875rem;
+}
+
+.enhanced-step.failed .step-number {
+    display: none;
+}
+
+.step-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.step-name {
+    font-weight: 500;
+    color: var(--text);
+    line-height: 1.4;
+}
+
+.enhanced-step.completed .step-name {
+    color: var(--text-muted);
+}
+
+.step-timing {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Enhanced Progress Details */
+.enhanced-progress-details {
+    border-top: 1px solid var(--surface-border);
+    padding-top: 16px;
+    margin-top: 16px;
+}
+
+.progress-details-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.progress-details-header span {
+    font-weight: 600;
+    color: var(--text);
+    font-size: 0.875rem;
+}
+
+.details-toggle {
+    background: none;
+    border: none;
+    color: var(--primary);
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 4px 8px;
+    border-radius: var(--border-radius-sm);
+    transition: background-color 0.2s ease;
+}
+
+.details-toggle:hover {
+    background-color: var(--primary-bg);
+}
+
+.enhanced-progress-log {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    padding: 8px;
+    background-color: var(--surface);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    list-style: none;
+}
+
+.log-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--surface-border);
+}
+
+.log-entry:last-child {
+    border-bottom: none;
+}
+
+.log-time {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+    min-width: 5em;
+}
+
+.log-content {
+    flex: 1;
+    color: var(--text);
+}
+
+.log-entry.log-step .log-content {
+    font-weight: 500;
+}
+
+.log-entry.log-success .log-content {
+    color: var(--success);
+    font-weight: 500;
+}
+
+.log-entry.log-error .log-content {
+    color: var(--error);
+    font-weight: 500;
+}
+
+/* API Validation Indicators */
+.api-validation-indicator {
+    margin-top: 4px;
+    font-size: 0.875rem;
+}
+
+.validation-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: var(--border-radius-sm);
+    transition: all 0.2s ease;
+}
+
+.validation-status.status-idle {
+    color: var(--text-muted);
+    background-color: transparent;
+}
+
+.validation-status.status-validating {
+    color: var(--primary);
+    background-color: var(--primary-bg);
+}
+
+.validation-status.status-validating .status-icon {
+    animation: spin 1s linear infinite;
+}
+
+.validation-status.status-success {
+    color: var(--success);
+    background-color: var(--success-bg);
+}
+
+.validation-status.status-error {
+    color: var(--error);
+    background-color: var(--error-bg);
+}
+
+.status-icon {
+    font-size: 0.875rem;
+    line-height: 1;
+    font-weight: bold;
+    display: inline-block;
+}
+
+.status-text {
+    flex: 1;
+    line-height: 1.3;
+}
+
+.validation-details {
+    margin-top: 8px;
+    padding: 8px;
+    background-color: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    font-size: 0.75rem;
+}
+
+.detail-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2px 0;
+}
+
+.detail-item:not(:last-child) {
+    border-bottom: 1px solid var(--surface-border);
+    padding-bottom: 4px;
+    margin-bottom: 4px;
+}
+
+.detail-label {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.detail-value {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+}
+
+/* Animation for validating spinner */
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* Enhanced form field validation states */
+.form-field.has-validation {
+    position: relative;
+}
+
+.form-field.validation-success .form-input {
+    border-color: var(--success);
+}
+
+.form-field.validation-error .form-input {
+    border-color: var(--error);
+}
+
+.form-field.validation-validating .form-input {
+    border-color: var(--primary);
+}
+
+/* Status color variables for consistency */
+/* Defined in the canonical theme token blocks below. */
+
+/* Operation Status Indicators */
+.operation-status-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    width: 320px;
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-md);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+    font-size: 0.875rem;
+    max-height: 80vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.status-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--surface-border);
+    background: var(--bg);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.status-summary {
+    display: flex;
+    gap: 12px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.status-count {
+    font-variant-numeric: tabular-nums;
+}
+
+.status-rate {
+    font-variant-numeric: tabular-nums;
+}
+
+.current-operations-list,
+.recent-operations-list {
+    padding: 8px;
+    max-height: 40vh;
+    overflow-y: auto;
+}
+
+.operation-item {
+    padding: 8px 12px;
+    border-radius: var(--border-radius-sm);
+    margin-bottom: 6px;
+    border-left: 3px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.operation-item:last-child {
+    margin-bottom: 0;
+}
+
+.operation-item.status-in_progress {
+    background-color: var(--primary-bg);
+    border-left-color: var(--primary);
+}
+
+.operation-item.status-completed {
+    background-color: var(--success-bg);
+    border-left-color: var(--success);
+}
+
+.operation-item.status-failed {
+    background-color: var(--error-bg);
+    border-left-color: var(--error);
+}
+
+.operation-item.status-cancelled {
+    background-color: var(--muted);
+    border-left-color: var(--text-muted);
+    opacity: 0.7;
+}
+
+.operation-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.operation-icon {
+    font-size: 0.875rem;
+    font-weight: bold;
+    width: 16px;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.operation-item.status-in_progress .operation-icon {
+    animation: spin 1s linear infinite;
+}
+
+.operation-description {
+    flex: 1;
+    font-weight: 500;
+    color: var(--text);
+    line-height: 1.3;
+}
+
+.operation-time {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+
+.operation-progress {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+
+.operation-progress .progress-bar {
+    flex: 1;
+    height: 4px;
+    background-color: var(--progress-track, rgba(255, 255, 255, 0.3));
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.operation-progress .progress-fill {
+    height: 100%;
+    background-color: var(--primary);
+    border-radius: 2px;
+    transition: width 0.3s ease;
+}
+
+.operation-progress .progress-text {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    min-width: 3em;
+    text-align: right;
+}
+
+.operation-step {
+    margin-top: 4px;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    line-height: 1.3;
+}
+
+.operation-error {
+    margin-top: 4px;
+    font-size: 0.75rem;
+    color: var(--error);
+    line-height: 1.3;
+}
+
+.no-operations {
+    text-align: center;
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 16px;
+}
+
+.toggle-recent {
+    background: none;
+    border: none;
+    border-top: 1px solid var(--surface-border);
+    padding: 8px 16px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.75rem;
+    transition: background-color 0.2s ease;
+}
+
+.toggle-recent:hover {
+    background-color: var(--bg);
+    color: var(--text);
+}
+
+.toggle-icon {
+    font-size: 0.625rem;
+    transition: transform 0.2s ease;
+}
+
+/* Hide status container when no operations */
+.operation-status-container:empty,
+.operation-status-container[style*="display: none"] {
+    display: none !important;
+}
+
+/* Integration with existing progress blocks */
+.progress-block .operation-integration {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--surface-border);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.progress-block .operation-integration a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+.progress-block .operation-integration a:hover {
+    text-decoration: underline;
+}
+
+@keyframes shimmer {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+}
+
+.loading-panel {
+    position: relative;
+    color: transparent;
+    border: 1px solid var(--surface-border);
+    background: linear-gradient(
+        90deg,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 25%,
+        var(--skeleton-highlight, rgba(0,0,0,0.10)) 37%,
+        var(--skeleton-base, rgba(0,0,0,0.06)) 63%
+    );
+    background-size: 400% 100%;
+    animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.loading-panel::after {
+    content: "Loading\2026";
+    position: absolute;
+    inset: auto 10px 8px 10px;
+    color: var(--muted);
+    font-size: 0.8rem;
+}
+
+/* Modal Styling */
+.modal {
+    display: none; /* Hidden by default */
+    position: fixed;
+    z-index: 1000; /* On top of other elements */
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto; /* Enable scroll if needed */
+    background-color: var(--modal-overlay, rgba(0, 0, 0, 0.5)); /* Semi-transparent background */
+}
+
+body.modal-open {
+    overflow: hidden;
+}
+
+.modal-content {
+    background-color: var(--surface);
+    margin: 15% auto; /* Center the modal */
+    padding: 20px;
+    border-radius: 10px;
+    width: 90%;
+    max-width: 400px;
+    box-shadow: 0 8px 20px var(--shadow-medium, rgba(0, 0, 0, 0.2));
+    animation: fadeIn 0.22s ease-out;
+}
+
+.modal-sheet {
+    background: var(--modal-bg);
+    border: 1px solid var(--panel-border);
+}
+/* For image preview modal, allow larger canvas */
+.image-modal .modal-content {
+  max-width: 95vw;
+  width: auto;
+  margin: 5vh auto;
+  background: var(--surface);
+  animation: zoomIn 0.2s ease-out;
+  position: relative;
+  padding: 12px 16px 16px;
+}
+
+.image-modal .close-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-muted);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: color 0.15s ease, background-color 0.15s ease;
+  padding: 0;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.image-modal .close-button:hover,
+.image-modal .close-button:focus {
+  color: var(--text);
+  background: var(--bg-secondary, var(--surface));
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.modal-content h2 {
+    font-size: 1.2rem;
+    margin-bottom: 15px;
+    color: var(--text);
+    text-align: center;
+}
+
+.close-button {
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: var(--close-btn-color);
+    float: right;
+    font-size: 1.5rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.close-button:hover,
+.close-button:focus {
+    color: var(--text);
+    text-decoration: none;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+/* Subtle zoom for image lightbox */
+@keyframes zoomIn { from { transform: scale(0.98); opacity: 0.9; } to { transform: scale(1); opacity: 1; } }
+
+/* Lightbox loading state */
+.lightbox-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.lightbox-loading .loading-indicator {
+    display: block;
+    width: 32px;
+    height: 32px;
+}
+
+.lightbox-error {
+    text-align: center;
+    padding: 24px;
+    color: var(--error);
+    font-size: 0.9rem;
+}
+
+/* Enhanced Toast Notification System */
+.toast-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 10000;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    pointer-events: none;
+    max-width: 400px;
+}
+
+.toast {
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-lg);
+    padding: 16px 20px;
+    color: var(--text);
+    font-size: 14px;
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    pointer-events: auto;
+    transform: translateX(100%);
+    opacity: 0;
+    transition: all 0.3s cubic-bezier(0.2, 0, 0.38, 0.9);
+    position: relative;
+    overflow: hidden;
+}
+
+.toast.show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.toast.success {
+    border-left: 4px solid var(--success);
+    background: linear-gradient(90deg, color-mix(in srgb, var(--success) 10%, var(--surface)) 0%, var(--surface) 20%);
+}
+
+.toast.error {
+    border-left: 4px solid var(--error);
+    background: linear-gradient(90deg, color-mix(in srgb, var(--error) 10%, var(--surface)) 0%, var(--surface) 20%);
+}
+
+.toast.warning {
+    border-left: 4px solid var(--warning);
+    background: linear-gradient(90deg, color-mix(in srgb, var(--warning) 10%, var(--surface)) 0%, var(--surface) 20%);
+}
+
+.toast-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
+
+.toast-content {
+    flex: 1;
+    line-height: 1.4;
+}
+
+.toast-close {
+    background: none;
+    border: none;
+    color: var(--muted);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.toast-close:hover {
+    background: var(--hover-overlay, rgba(0, 0, 0, 0.1));
+    color: var(--text);
+}
+
+/* Toast countdown progress bar */
+.toast-progress {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 3px;
+    width: 100%;
+    background: currentcolor;
+    opacity: 0.3;
+    transform-origin: left;
+    animation: toast-countdown linear forwards;
+}
+
+@keyframes toast-countdown {
+    from { transform: scaleX(1); }
+    to { transform: scaleX(0); }
+}
+
+/* Software Update Panel */
+.update-panel {
+    padding: var(--spacing-lg);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-md);
+    margin-bottom: var(--spacing-lg);
+    background: var(--panel-bg);
+}
+
+.update-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--spacing-md);
+}
+
+.update-header h3 {
+    margin: 0;
+    font-size: var(--text-lg);
+    font-weight: var(--font-semibold);
+    color: var(--text);
+}
+
+.update-version-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    flex-wrap: wrap;
+    margin-bottom: var(--spacing-md);
+}
+
+.update-version-card {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 12px 20px;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-md);
+    background: var(--surface);
+    min-width: 100px;
+    flex: 1;
+}
+
+.update-version-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.update-version-number {
+    font-size: 1.25rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+}
+
+.update-arrow {
+    font-size: 1.25rem;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+/* JTN-710: banner shown when install/update.sh wrote .last-update-failure. */
+.update-failure-banner {
+    margin: var(--spacing-sm) 0 var(--spacing-md);
+    padding: 12px 14px;
+    border: 1px solid var(--color-danger, #b94a48);
+    border-left-width: 4px;
+    border-radius: var(--border-radius-sm);
+    background: var(--surface);
+    color: var(--text-primary);
+}
+
+.update-failure-title {
+    font-weight: 600;
+    color: var(--color-danger, #b94a48);
+    margin-bottom: 4px;
+}
+
+.update-failure-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.update-failure-journal {
+    margin-top: 6px;
+    padding: 8px;
+    background: var(--surface-alt, var(--surface));
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
+.update-release-notes {
+    margin-bottom: var(--spacing-md);
+}
+
+.update-release-notes-toggle {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 6px 0;
+}
+
+.update-release-notes-body {
+    margin-top: var(--spacing-sm);
+    padding: 12px;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--border-radius-sm);
+    background: var(--surface);
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+}
+
+.update-actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+}
+
+/* Legacy compatibility */
+.update-version-info {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+}
+
+.update-label {
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+}
+
+.update-value {
+    font-weight: var(--font-semibold);
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+}
+
+/* Form shake animation on blocked submit */
+@keyframes form-shake {
+    0%, 100% { transform: translateX(0); }
+    20% { transform: translateX(-6px); }
+    40% { transform: translateX(6px); }
+    60% { transform: translateX(-4px); }
+    80% { transform: translateX(4px); }
+}
+
+.form-shake {
+    animation: form-shake 0.4s ease-in-out;
+}
+
+/* Legacy modal styles for backward compatibility */
+.success-failure-modal {
+    display: none;
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    max-width: 400px;
+    border-radius: 8px;
+    background-color: var(--accent);
+    padding: 10px 16px 10px 24px;
+    color: var(--on-accent);
+    font-family: inherit;
+    font-size: 16px;
+    text-align: center;
+}
+
+.success-failure-modal .response-modal-content {
+    border-radius: 8px;
+    background: inherit;
+    padding-right: 24px; /* Space between text and close button */
+}
+
+.success-failure-modal .close-button {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    right: 12px;
+    font-size: 20px;
+    cursor: pointer;
+    color: var(--on-accent);
+}
+
+.success-failure-modal.success {
+    background-color: var(--accent);
+}
+
+.success-failure-modal.failure {
+    background-color: var(--error);
+}
+
+/* Request progress block */
+.progress-block {
+    margin: 10px;
+    position: fixed;
+    left: 50%;
+    top: 14px;
+    transform: translateX(-50%);
+    z-index: 1100;
+    min-width: min(720px, 92vw);
+    background: var(--surface);
+    border: 1px solid var(--surface-border);
+    border-radius: 12px;
+    padding: 10px 12px 12px 12px;
+    box-shadow: 0 14px 40px rgba(0,0,0,0.35);
+    animation: slideDown .20s ease-out;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translate(-50%, -12px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+.progress-header {
+    font-size: 0.9rem;
+    color: var(--text);
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.progress-close {
+    background: none;
+    border: 1px solid var(--surface-border);
+    color: var(--muted);
+    border-radius: 999px;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+.progress-close:hover { color: var(--text); background: rgba(0,0,0,0.04); }
+.progress-bar {
+    width: 100%;
+    height: 8px;
+    background-color: var(--panel-border);
+    border-radius: 6px;
+    overflow: hidden;
+}
+.progress-fill {
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+    border-radius: inherit;
+    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+}
+
+.progress-fill::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(255, 255, 255, 0.4),
+        transparent
+    );
+    transform: translateX(-100%);
+    animation: progress-shine 2s ease-in-out infinite;
+}
+
+@keyframes progress-shine {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(100%); }
+}
+
+/* Progress meta row and log */
+.progress-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 0.82rem;
+    color: var(--muted);
+    margin: 4px 2px 6px 2px;
+}
+.progress-meta .meta-item { display: inline-flex; align-items: baseline; gap: 6px; }
+.progress-meta .meta-item .label { color: var(--muted); }
+.progress-meta .meta-item .value { color: var(--text); font-weight: 700; background: var(--panel-bg); border:1px solid var(--panel-border); padding: 2px 8px; border-radius: 999px; }
+
+/* Enhanced progress timeline */
+.progress-log {
+    margin-top: 8px;
+    padding-left: 0;
+    max-height: 140px;
+    overflow: auto;
+    font-size: 0.85rem;
+    color: var(--text);
+    list-style: none;
+}
+
+.progress-log li {
+    display: flex;
+    align-items: flex-start;
+    margin: 0;
+    position: relative;
+    padding: 8px 0 8px 32px;
+    min-height: 32px;
+}
+
+/* Timeline bullet points - properly aligned */
+.progress-log li::before {
+    content: "";
+    position: absolute;
+    left: 12px;
+    top: 12px;
+    width: 8px;
+    height: 8px;
+    background: var(--accent);
+    border-radius: 50%;
+    border: 2px solid var(--surface);
+    box-shadow: 0 0 0 2px var(--accent);
+    z-index: 2;
+}
+
+/* Timeline connector lines */
+.progress-log li::after {
+    content: "";
+    position: absolute;
+    left: 15px;
+    top: 20px;
+    bottom: -8px;
+    width: 2px;
+    background: linear-gradient(to bottom, var(--accent), var(--panel-border));
+    z-index: 1;
+}
+
+.progress-log li:last-child::after {
+    display: none;
+}
+
+/* Timeline content styling */
+.progress-log time {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    font-size: 0.8rem;
+    font-weight: 500;
+    margin-right: 12px;
+    flex-shrink: 0;
+    min-width: 80px;
+}
+
+.progress-log li .log-content {
+    flex: 1;
+    line-height: 1.4;
+}
+
+.progress-fill-seeded {
+  width: 10%;
+}
+
+/* Enhanced Loading Indicators */
+.loading-indicator {
+    display: none;
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--surface-border);
+    border-top: 3px solid var(--accent);
+    border-radius: 50%;
+    animation: spin 1s cubic-bezier(0.68, -0.55, 0.265, 1.55) infinite;
+    margin-left: auto;
+    will-change: transform;
+}
+
+.loading-indicator.small {
+    width: 25px;
+    height: 25px;
+}
+
+.loading-indicator.left-align {
+    margin-right: auto;
+    margin-left: 0;
+}
+
+/* New loading states */
+.loading-dots {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.loading-dots::after {
+    content: '';
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: currentcolor;
+    animation: loading-dots 1.4s ease-in-out infinite both;
+    animation-delay: 0.16s;
+}
+
+.loading-dots::before {
+    content: '';
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: currentcolor;
+    animation: loading-dots 1.4s ease-in-out infinite both;
+}
+
+@keyframes loading-dots {
+    0%, 80%, 100% {
+        transform: scale(0.8);
+        opacity: 0.5;
+    }
+    40% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+/* Compatibility styles for enhanced UI tests */
+.settings-mode-selector,
+.mode-button,
+.mode-button.active,
+.settings-section.basic-only,
+.settings-section.advanced-only,
+.form-section-title,
+.validation-message,
+.validation-message.error,
+.validation-message.success,
+.validation-message.warning,
+.form-input.invalid,
+.form-input.valid,
+.help-icon,
+.setup-wizard,
+.wizard-step,
+.wizard-navigation,
+.wizard-progress,
+.wizard-step-indicator,
+.wizard-step-dot,
+.live-preview-header,
+.live-preview-content,
+.preview-section,
+.preview-current,
+.preview-modified,
+.status-badge,
+.status-badge.success,
+.status-badge.warning,
+.status-badge.error,
+.color-picker:hover,
+.sections-grid,
+[data-theme="dark"] .live-preview-overlay,
+.preview-close,
+.preview-close:hover,
+.enhanced-progress-header,
+.progress-title-section,
+.progress-subtitle,
+.enhanced-progress-bar-section,
+.enhanced-progress-fill,
+.enhanced-progress-steps,
+.enhanced-step,
+.enhanced-step.active,
+.enhanced-step.completed,
+.enhanced-step.failed,
+.enhanced-progress-details,
+.enhanced-progress-log,
+.log-entry,
+.form-input[readonly] {
+    --compat-placeholder: 1;
+}
+.tooltip{visibility: hidden;}
+.tooltip-text{visibility: visible;}
+.live-preview-overlay{backdrop-filter: blur(4px); background: rgba(0,0,0,0.4);}
+.toggle-checkbox::before{content:"";}
+@keyframes slide-in-from-right{from{opacity:0;}to{opacity:1;}}
+@keyframes slide-in-from-bottom{from{opacity:0;}to{opacity:1;}}
+/* @keyframes slideInFromRight */
+/* @keyframes slideInFromBottom */
+/* Enhanced Typography Hierarchy */
+/* Mobile adjustments for live preview */
+.live-preview-overlay{bottom: 20px;}
+.live-preview-content{flex-direction: row;}
+
+/* SVG close icon for modal close buttons */
+.close-icon {
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.close-icon svg {
+    width: 100%;
+    height: 100%;
+}
+
+/* The icon macro wraps SVG in a span.close-icon; target that span */
+.close-button .close-icon,
+.progress-close .close-icon {
+    width: 16px;
+    height: 16px;
+}
+
+.thumbnail-preview-close .close-icon {
+    width: 20px;
+    height: 20px;
+}
+
+/* Help icon (info) */
+.help-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+    cursor: help;
+    vertical-align: middle;
+    flex-shrink: 0;
+}
+
+.help-icon svg {
+    width: 100%;
+    height: 100%;
+}
+
+/* Client-side form validation */
+.form-input[aria-invalid="true"] {
+    border-color: var(--red, #e53e3e);
+}
+
+.validation-message:not(:empty) {
+    color: var(--red, #e53e3e);
+    font-size: 0.85em;
+    margin-top: 0.25rem;
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .img-skeleton {
+        animation: none;
+        background: var(--skeleton-base, rgba(0,0,0,0.06));
+    }
+
+    .loading-panel {
+        animation: none;
+        background: var(--skeleton-base, rgba(0,0,0,0.06));
+    }
+
+    .section-focus {
+        animation: none;
+    }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+    :root {
+        --surface-border: #000;
+        --text: #000;
+        --accent: #0066cc;
+    }
+
+    [data-theme="dark"] {
+        --surface-border: #fff;
+        --text: #fff;
+        --accent: #4d9fff;
+    }
+
+    .icon-button,
+    .action-button,
+    .header-button {
+        border-width: 2px;
+    }
+
+    /* Ensure skeletons remain visible in high contrast */
+    .img-skeleton,
+    .loading-panel {
+        border: 1px solid var(--surface-border);
+    }
+
+    /* Strengthen box shadows for visibility */
+    .frame,
+    .dashboard-stage,
+    .dashboard-status-card {
+        box-shadow: 0 0 0 1px var(--surface-border);
+    }
+
+    /* Disabled states need stronger contrast */
+    .action-button:disabled,
+    .header-button:disabled,
+    button:disabled {
+        opacity: 0.6;
+        border: 2px solid var(--surface-border);
+    }
+}
+
+/* ── Progress steps mobile ── */
+@media (max-width: 640px) {
+    .enhanced-progress-steps {
+        gap: 6px;
+    }
+
+    .enhanced-step {
+        padding: 6px;
+    }
+
+    .enhanced-step.active,
+    .enhanced-step.failed {
+        padding-left: 7px;
+    }
+
+    .step-indicator {
+        width: 20px;
+        height: 20px;
+        font-size: 0.625rem;
+    }
+
+    .progress-controls {
+        gap: 8px;
+    }
+
+    .enhanced-progress-bar-section {
+        gap: 8px;
+    }
+
+    .operation-status-container {
+        position: fixed;
+        top: auto;
+        bottom: 20px;
+        left: 20px;
+        right: 20px;
+        width: auto;
+        max-height: 50vh;
+    }
+
+    .status-header {
+        padding: 10px 12px;
+    }
+
+    .status-summary {
+        gap: 8px;
+    }
+
+    .operation-item {
+        padding: 6px 8px;
+    }
+
+    .operation-header {
+        gap: 6px;
+    }
+
+    .image-container img {
+        max-height: 46vh;
+        object-fit: contain;
+    }
+
+    .dashboard-hero,
+    .settings-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard-stage .image-container img {
+        max-height: none;
+    }
+
+    .dashboard-stage .image-container {
+        max-width: 100%;
+    }
+
+    .dashboard-stage .image-container.native {
+        max-height: min(48vh, 24rem);
+    }
+
+    .dashboard-stage .image-container.native,
+    .dashboard-stage .image-container.native-preview-enabled {
+        overflow: hidden;
+    }
+
+    .dashboard-stage .image-container.native img {
+        width: 100%;
+        max-width: min(100%, 28rem);
+    }
+
+    .status-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .status-divider {
+        display: none;
+    }
+
+    .plugins-container {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+    }
+
+    .plugins-container .plugin-item {
+        padding: 14px 12px;
+    }
+
+    .plugins-container .plugin-item .icon-image {
+        width: 42px;
+        height: 42px;
+        min-width: 42px;
+        min-height: 42px;
+    }
+
+    .plugin-name {
+        font-size: 0.8rem;
+        line-height: 1.35;
+    }
+
+    .logs-viewer {
+        min-height: 260px;
+        max-height: 50vh;
+    }
+
+    .logs-filters,
+    .logs-actions,
+    .history-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dashboard-status-card .action-button,
+    .dashboard-status-card .header-button {
+        justify-self: stretch;
+    }
+}
+
+/* ── Progress block small screens ── */
+@media (max-width: 520px) {
+    .progress-block { left: 8px; right: 8px; transform: none; min-width: auto; }
+    .progress-meta { flex-wrap: wrap; gap: 6px 10px; }
+
+    .playlist-toolbar {
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+}
+
+/* ── API key row mobile ── */
+@media (max-width: 700px) {
+    .apikey-row {
+        grid-template-columns: 1fr;
+    }
+
+    .history-actions {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ── Improved mobile layout ── */
+@media (max-width: 768px) {
+    .frame {
+        width: 95%;
+        padding: 16px;
+        min-height: 95vh;
+    }
+
+    .app-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .api-key-indicator {
+        font-size: 0.75rem;
+        padding: 6px 10px;
+    }
+
+    .api-key-indicator.collapsed {
+        padding: 6px;
+    }
+
+    .api-key-icon {
+        width: var(--icon-sm);
+        height: var(--icon-sm);
+        font-size: 14px;
+    }
+
+    .workflow-layout,
+    .settings-console-layout,
+    .diagnostics-strip {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-side-nav {
+        position: static;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .workflow-mode-bar {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .workflow-action-group,
+    .inline-action-row {
+        flex-direction: column;
+    }
+
+    /* Better modal sizing on small screens */
+    .modal-content {
+        margin: 5% auto;
+        max-height: 90vh;
+        overflow-y: auto;
+    }
+
+    /* Responsive icon sizing for mobile */
+    .app-header .app-icon {
+        width: var(--icon-md);
+        height: var(--icon-md);
+    }
+
+    .header-button.icon {
+        min-width: 44px;
+        min-height: 44px;
+        padding: 10px;
+    }
+
+    .header-button.icon svg {
+        width: var(--icon-lg);
+        height: var(--icon-lg);
+    }
+
+    .section-nav {
+        gap: 6px;
+    }
+
+    .section-nav .status-chip {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .header-identity,
+    .header-actions,
+    .logs-actions,
+    .page-intro,
+    .page-summary {
+        width: 100%;
+    }
+
+    .header-identity {
+        flex-wrap: wrap;
+        justify-content: space-between;
+    }
+
+    .header-actions,
+    .logs-actions {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .page-intro {
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .page-summary {
+        justify-content: flex-start;
+    }
+
+    .playlist-header {
+        padding: 16px 18px 10px;
+    }
+
+    .plugin-item {
+        padding: 12px 18px;
+    }
+
+    .api-key-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .metric-strip {
+        grid-template-columns: 1fr;
+    }
+
+    .history-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ── Enhanced responsive design ── */
+@media (max-width: 900px) {
+    .status-bar {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+    .status-card.compact .image-container {
+        width: 100%;
+        max-width: 300px;
+        margin: 0 auto;
+    }
+
+    /* Better modal sizing */
+    .modal-content {
+        margin: 10% auto;
+        width: 95%;
+        max-width: 500px;
+    }
+
+    /* Stack form controls vertically on mobile */
+    .header-actions {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    /* Improved logs interface on mobile */
+    .logs-filters {
+        flex-direction: column;
+        gap: 12px;
+        align-items: stretch;
+    }
+
+    .logs-actions {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    /* Better title-row layout on mobile */
+    .title-row {
+        flex-direction: column;
+        gap: 8px;
+        align-items: stretch;
+    }
+
+    .custom-title-input {
+        order: 2;
+    }
+}
+
+/* ── Touch device improvements ── */
+@media (hover: none) and (pointer: coarse) {
+    /* Larger touch targets for small interactive elements */
+    .view-toggle,
+    .sort-toggle,
+    .btn-delete,
+    .clear-button,
+    .toggle-password-btn {
+        min-width: 44px;
+        min-height: 44px;
+    }
+
+    /* Toast positioning for mobile */
+    .toast-container {
+        right: 12px;
+        left: 12px;
+        top: 16px;
+        max-width: none;
+    }
+
+    .toast {
+        font-size: 16px; /* Prevent zoom on input focus */
+    }
+}
+
+@media (max-aspect-ratio: 3/4) {
+    .frame {
+        width: 95%;
+    }
+}
+
+/* ── Phone-first mobile hardening ── */
+@media (max-width: 768px) {
+    .frame,
+    .playlist-frame,
+    .api-keys-frame {
+        width: min(100%, 100vw - 16px);
+        margin: 8px auto;
+        padding: 14px;
+        border-radius: 18px;
+    }
+
+    .app-header,
+    .header-content,
+    .header-identity,
+    .header-actions,
+    .page-intro,
+    .page-summary,
+    .history-toolbar,
+    .playlist-header,
+    .playlist-toolbar,
+    .workflow-action-group,
+    .buttons-container,
+    .inline-action-row,
+    .logs-actions,
+    .logs-filters {
+        width: 100%;
+    }
+
+    .header-content,
+    .app-header,
+    .playlist-header,
+    .dashboard-stage-header,
+    .storage-card-head {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .header-actions,
+    .playlist-toolbar,
+    .history-toolbar,
+    .logs-actions {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+    }
+
+    .page-intro {
+        gap: 10px;
+    }
+
+    .page-summary {
+        gap: 6px;
+        overflow-x: auto;
+        padding-bottom: 2px;
+        flex-wrap: nowrap;
+    }
+
+    .page-summary .status-chip {
+        flex: 0 0 auto;
+    }
+
+    .dashboard-hero,
+    .workflow-layout,
+    .settings-grid,
+    .settings-console-layout,
+    .sections-grid.two-col,
+    .api-keys-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard-stage,
+    .dashboard-status-card,
+    .storage-card,
+    .workflow-action-panel,
+    .api-key-card,
+    .playlist-item,
+    .history-card {
+        padding: 14px;
+    }
+
+    .dashboard-stage {
+        gap: 12px;
+    }
+
+    .dashboard-stage .image-container img {
+        max-height: min(42vh, 18rem);
+    }
+
+    .dashboard-overview {
+        gap: 10px;
+    }
+
+    .plugins-container {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+    }
+
+    .plugins-container .plugin-item {
+        padding: 16px 10px 14px;
+        min-height: 120px;
+    }
+
+    .plugin-name {
+        min-height: 2.7em;
+    }
+
+    .settings-grid {
+        gap: 14px;
+    }
+
+    .settings-console-layout {
+        gap: 12px;
+    }
+
+    .settings-mobile-toggle {
+        display: block;
+    }
+
+    .settings-side-nav {
+        position: static;
+        z-index: 5;
+        display: none;
+        flex-direction: column;
+        gap: 6px;
+        padding: 8px;
+        border: 1px solid var(--panel-border);
+        border-radius: var(--border-radius-md);
+        background: color-mix(in srgb, var(--panel-bg) 92%, transparent);
+        backdrop-filter: blur(16px);
+    }
+
+    .settings-side-nav.is-open {
+        display: flex;
+    }
+
+    .settings-side-link {
+        flex: 0 0 auto;
+        min-width: max-content;
+        border-radius: var(--border-radius-md);
+        padding: 10px 14px;
+        text-align: center;
+    }
+
+    .settings-console-main,
+    .settings-console-panel.active {
+        display: grid;
+        gap: 12px;
+    }
+
+    .logs-viewer,
+    .diagnostics-panel,
+    .diagnostics-panel-sm {
+        max-height: min(42vh, 22rem);
+        min-height: 180px;
+    }
+
+    .settings-panel .buttons-container,
+    .api-keys-frame .buttons-container {
+        position: sticky;
+        bottom: 8px;
+        z-index: 6;
+        padding-top: 8px;
+        background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--bg) 94%, transparent) 22%);
+    }
+
+    .workflow-mode-bar {
+        position: sticky;
+        top: 8px;
+        z-index: 6;
+        display: flex;
+        width: 100%;
+    }
+
+    .workflow-mode-tab {
+        justify-content: center;
+    }
+
+    .title-stack {
+        gap: 0;
+    }
+
+    .app-subtitle {
+        font-size: 0.75rem;
+    }
+
+    .plugin-mode-row {
+        margin: 0 0 8px;
+        gap: 6px;
+    }
+
+    .workflow-layout {
+        display: block;
+    }
+
+    .workflow-main-panel,
+    .workflow-side-panel {
+        display: none;
+    }
+
+    .workflow-main-panel.active,
+    .workflow-side-panel.active {
+        display: grid;
+        gap: 14px;
+    }
+
+    .workflow-side-panel {
+        margin-top: 14px;
+    }
+
+    .workflow-action-panel {
+        position: sticky;
+        bottom: 8px;
+        z-index: 7;
+        border-radius: 18px;
+        box-shadow: 0 10px 30px color-mix(in srgb, var(--text) 12%, transparent);
+        background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
+        backdrop-filter: blur(16px);
+    }
+
+    .workflow-device-toggle {
+        font-size: 0.92rem;
+    }
+
+    .workflow-action-group {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+
+    .workflow-help {
+        font-size: 0.88rem;
+        line-height: 1.45;
+    }
+
+    .workflow-section-header p {
+        font-size: 0.88rem;
+    }
+
+    .status-bar {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .status-card.compact .image-container,
+    .status-card.instance .status-body img {
+        max-width: 100%;
+    }
+
+    .playlist-list {
+        gap: 12px;
+    }
+
+    .playlist-item {
+        padding: 0;
+        overflow: hidden;
+    }
+
+    .playlist-header {
+        padding: 14px;
+    }
+
+    .playlist-toolbar {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .playlist-toolbar .run-next-btn {
+        grid-column: 1 / -1;
+    }
+
+    .playlist-secondary-button,
+    .playlist-toggle-button {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 44px;
+    }
+
+    .playlist-secondary-button {
+        border-radius: 999px;
+        border: 1px solid var(--panel-border);
+        background: var(--surface);
+        color: var(--text);
+        padding: 9px 12px;
+    }
+
+    .playlist-secondary-button .action-button-label {
+        display: inline;
+        font-size: 0.82rem;
+        font-weight: 700;
+    }
+
+    .playlist-card-body {
+        padding: 0 14px 14px;
+    }
+
+    .playlist-item.mobile-collapsed .playlist-card-body {
+        display: none;
+    }
+
+    .plugin-item {
+        padding: 12px 0;
+        border-top-width: 1px;
+    }
+
+    .plugin-info {
+        width: 100%;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+
+    .plugin-instance {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+
+    .plugin-thumbnail-container {
+        margin-left: 0;
+        width: 100%;
+        max-width: 180px;
+    }
+
+    .plugin-thumbnail-container .img-skeleton,
+    .plugin-thumbnail {
+        width: 100%;
+        height: auto;
+        min-height: 100px;
+    }
+
+    .plugin-actions {
+        width: 100%;
+        justify-content: stretch;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .plugin-actions .latest-refresh {
+        width: 100%;
+    }
+
+    .edit-button,
+    .delete-button,
+    .plugin-actions .edit-button,
+    .plugin-actions .delete-button {
+        min-width: 44px;
+        min-height: 44px;
+    }
+
+    .history-actions {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+    }
+
+    .history-actions .btn:first-child {
+        grid-column: 1 / -1;
+    }
+
+    .metric-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .history-card {
+        grid-template-columns: 104px minmax(0, 1fr);
+        align-items: start;
+        gap: 12px;
+    }
+
+    .history-thumb {
+        aspect-ratio: 1 / 1.2;
+    }
+
+    .history-name {
+        font-size: 0.94rem;
+    }
+
+    .history-sub {
+        font-size: 0.8rem;
+    }
+
+    .api-key-actions {
+        gap: 8px;
+    }
+
+    .api-key-card {
+        gap: 8px;
+    }
+
+    .api-key-status {
+        font-size: 0.8rem;
+    }
+
+    .api-key-actions .delete-button-danger {
+        align-self: flex-start;
+    }
+
+    .modal-content,
+    .thumbnail-preview-content {
+        width: min(100vw - 12px, 100%);
+        max-width: none;
+        margin: auto auto 0;
+        border-radius: 20px 20px 0 0;
+        max-height: min(88vh, 44rem);
+        overflow-y: auto;
+    }
+
+    .modal {
+        align-items: flex-end;
+    }
+
+    /* ── 36 px minimum touch targets (JTN-223) ── */
+    button,
+    .btn,
+    .action-button,
+    .header-button,
+    .icon-button,
+    .chip,
+    a.btn,
+    select,
+    select.form-input,
+    .button-group button,
+    .collapsible-header {
+        min-height: 36px;
+        min-width: 36px;
+    }
+
+    /* Checkboxes and radios: enlarge the hit area without distorting
+       the visual indicator. Width/height controls the drawn box;
+       the parent label provides the extra tap space. */
+    input[type="checkbox"],
+    input[type="radio"] {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+    }
+
+    /* Labels that wrap a checkbox/radio get a comfortable tap zone */
+    label:has(> input[type="checkbox"]),
+    label:has(> input[type="radio"]) {
+        min-height: 36px;
+        display: inline-flex;
+        align-items: center;
+        padding-top: 8px;
+        padding-bottom: 8px;
+    }
+}
+
+/* ── Narrowest screens ── */
+@media (max-width: 430px) {
+    .frame,
+    .playlist-frame,
+    .api-keys-frame {
+        width: min(100%, 100vw - 8px);
+        margin: 4px auto;
+        padding: 12px;
+    }
+
+    .header-actions,
+    .playlist-toolbar,
+    .history-toolbar,
+    .logs-actions {
+        grid-template-columns: 1fr;
+    }
+
+    .metric-strip {
+        grid-template-columns: 1fr;
+    }
+
+    .history-card {
+        grid-template-columns: 1fr;
+    }
+
+    .history-thumb {
+        aspect-ratio: 4 / 3;
+    }
+
+    .plugins-container {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .plugin-item,
+    .history-card,
+    .api-key-card {
+        border-radius: 14px;
+    }
+
+    .settings-side-nav {
+        top: 4px;
+    }
+
+    .workflow-action-panel {
+        bottom: 4px;
+        padding: 12px;
+    }
+
+    .page-summary {
+        margin-right: -2px;
+    }
+}
+
+/* ── Tablet landscape (iPad landscape, small laptops) ── */
+@media (min-width: 1024px) {
+    .frame {
+        max-width: 1200px;
+        margin-inline: auto;
+    }
+
+    .settings-grid {
+        max-width: 1400px;
+        margin-inline: auto;
+    }
+}
+
+/* ── Large screens (>1440px) ── */
+@media (min-width: 1440px) {
+    .page-shell {
+        max-width: 1600px;
+        margin-inline: auto;
+    }
+}
+
+/* ── Landscape mobile ── */
+@media (max-height: 500px) and (orientation: landscape) {
+    .modal-content,
+    .response-modal-content {
+        max-height: 85vh;
+        overflow-y: auto;
+    }
+
+    .image-modal .modal-content {
+        max-height: 90vh;
+    }
+}
+
+/* ── Short laptop viewports (JTN-572 / JTN-599) ──
+   On common laptop screens shorter than ~860px (1280x800, 1366x768, 1280x768),
+   the Save button at the bottom of /settings and /settings/api-keys sits below
+   the fold, and there is no visible scroll affordance to reveal it. Pin the
+   buttons container to the bottom of the viewport so the primary action is
+   always one click away regardless of scroll position. */
+@media (max-height: 860px) {
+    .settings-panel .buttons-container,
+    .api-keys-frame .buttons-container {
+        position: sticky;
+        bottom: 8px;
+        z-index: 6;
+        padding-top: 8px;
+        background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--bg) 94%, transparent) 22%);
+    }
+}
+
+/* ── Print styles ── */
+@media print {
+  /* Hide non-essential chrome */
+  .header,
+  .back-button,
+  .buttons-container,
+  .action-button,
+  .header-button,
+  .response-modal,
+  .modal,
+  .toast-container,
+  #themeToggle,
+  .sort-toggle,
+  .footer {
+    display: none !important;
+  }
+
+  /* Reset colours for ink */
+  body {
+    background: var(--bg, #fff) !important;
+    color: var(--text, #000) !important;
+  }
+
+  .frame,
+  .page-shell,
+  .settings-section,
+  .plugin-item,
+  .collapsible-content {
+    background: var(--bg, #fff) !important;
+    border-color: var(--surface-border, #ccc) !important;
+    box-shadow: none !important;
+  }
+
+  /* Ensure all collapsible sections are expanded */
+  .collapsible-content {
+    display: block !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  /* Readable links */
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: var(--muted, #555);
+  }
+}
+

--- a/src/static/styles/partials/_settings.css
+++ b/src/static/styles/partials/_settings.css
@@ -378,7 +378,7 @@
   width: 100%;
   border-collapse: collapse;
   margin: 6px 0 12px;
-  font-size: 0.92em;
+  font-size: var(--text-sm);
 }
 
 .bench-table th,
@@ -391,7 +391,7 @@
 .bench-table th {
   font-weight: 600;
   opacity: 0.75;
-  font-size: 0.85em;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }

--- a/tests/static/test_diagnostics_tables.py
+++ b/tests/static/test_diagnostics_tables.py
@@ -60,6 +60,26 @@ class TestDiagnosticsTableBuilders:
         js = _read_js()
         assert "function formatPercent" in js
 
+    def test_format_disk_free_defined(self):
+        js = _read_js()
+        assert "function formatDiskFree" in js
+
+    def test_disk_row_uses_free_gb_key(self):
+        """Disk row must consume disk_free_gb, not disk_percent."""
+        js = _read_js()
+        assert '"disk_free_gb"' in js
+
+    def test_disk_row_label_contains_gb(self):
+        """formatDiskFree must append the 'GB' unit."""
+        js = _read_js()
+        assert "GB free" in js
+
+    def test_disk_row_label_contains_free(self):
+        """formatDiskFree must include the 'free' qualifier."""
+        js = _read_js()
+        assert '"disk_free_gb"' in js
+        assert "GB free" in js
+
     def test_empty_isolation_message(self):
         js = _read_js()
         assert "No plugins isolated" in js

--- a/tests/unit/test_settings_health.py
+++ b/tests/unit/test_settings_health.py
@@ -120,7 +120,17 @@ class TestHealthSystem:
         assert isinstance(data["cpu_percent"], int | float)
         assert isinstance(data["memory_percent"], int | float)
         assert isinstance(data["disk_percent"], int | float)
+        assert isinstance(data["disk_free_gb"], int | float)
+        assert isinstance(data["disk_total_gb"], int | float)
         assert isinstance(data["uptime_seconds"], int)
+
+    def test_disk_free_gb_is_plausible(self, client):
+        """disk_free_gb must be non-negative and less than or equal to disk_total_gb."""
+        resp = client.get("/api/health/system")
+        data = resp.get_json()
+        assert data["disk_free_gb"] >= 0
+        assert data["disk_total_gb"] > 0
+        assert data["disk_free_gb"] <= data["disk_total_gb"]
 
     def test_psutil_unavailable(self, client, monkeypatch):
         """All metrics are None when psutil import fails."""
@@ -141,6 +151,8 @@ class TestHealthSystem:
         assert data["cpu_percent"] is None
         assert data["memory_percent"] is None
         assert data["disk_percent"] is None
+        assert data["disk_free_gb"] is None
+        assert data["disk_total_gb"] is None
         assert data["uptime_seconds"] is None
 
 


### PR DESCRIPTION
## Summary
- The system health diagnostics table showed disk usage as a bare percentage (`9.8%` or ambiguously just `9.8`) with no unit or free/used qualifier, making it confusing alongside the tile that shows used/total in GB
- `/api/health/system` now returns `disk_free_gb` and `disk_total_gb` in addition to `disk_percent`
- The Disk row in `buildSystemHealthTable` now renders `"X.X GB free"` via a new `formatDiskFree` formatter
- Bumped `bench-table` font-size from `0.92em` to `var(--text-sm)` (14 px) and header to `var(--text-2xs)` for readability

## Changes
- `src/blueprints/settings/_health.py` — add `disk_free_gb` / `disk_total_gb` to `/api/health/system`
- `src/schemas/responses.py` — extend `HealthSystemResponse` TypedDict with new fields
- `src/static/openapi.json` — document new fields in SystemHealth schema
- `src/static/scripts/settings_page.js` — add `formatDiskFree`, swap Disk row key to `disk_free_gb`
- `src/static/styles/partials/_settings.css` — bump `bench-table` font sizes
- `src/static/styles/main.css` — rebuilt CSS bundle
- `tests/static/test_diagnostics_tables.py` — assert `formatDiskFree`, `disk_free_gb`, and `"GB free"` are present
- `tests/unit/test_settings_health.py` — assert `disk_free_gb`/`disk_total_gb` in psutil path and null in unavailable path

## Test plan
- [x] All existing tests pass (4294 passed, 4 skipped)
- [x] New tests confirm `formatDiskFree` is defined and `"GB free"` is rendered
- [x] `disk_free_gb <= disk_total_gb` plausibility test added
- [x] Lint passes (ruff + black + mypy strict subset clean)

Closes JTN-585

🤖 Generated with [Claude Code](https://claude.com/claude-code)