### PR TITLE
fix: use low-memory image loading in preview plugins

### DIFF
--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -3,7 +3,6 @@ import logging
 from io import BytesIO
 
 from openai import OpenAI
-from PIL import Image
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import (
@@ -236,8 +235,10 @@ class AIImage(BasePlugin):
         response = ai_client.images.generate(**args)
         image_base64 = response.data[0].b64_json
         image_bytes = base64.b64decode(image_base64)
-        with Image.open(BytesIO(image_bytes)) as opened_img:
-            return opened_img.copy()
+        image = self.image_loader.from_bytesio(BytesIO(image_bytes), (1536, 1536), resize=False)
+        if image is None:
+            raise RuntimeError("Failed to decode generated image")
+        return image
 
     def fetch_image_google(self, client, prompt, model):
         """Fetch image from Google Imagen API."""
@@ -262,9 +263,14 @@ class AIImage(BasePlugin):
         )
         if not response.generated_images:
             raise RuntimeError("Google Imagen returned no images")
-        return Image.open(
-            BytesIO(response.generated_images[0].image.image_bytes)
-        ).copy()
+        image = self.image_loader.from_bytesio(
+            BytesIO(response.generated_images[0].image.image_bytes),
+            (1536, 1536),
+            resize=False,
+        )
+        if image is None:
+            raise RuntimeError("Failed to decode generated image")
+        return image
 
     @staticmethod
     def fetch_image_prompt(ai_client, from_prompt=None):

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -235,7 +235,9 @@ class AIImage(BasePlugin):
         response = ai_client.images.generate(**args)
         image_base64 = response.data[0].b64_json
         image_bytes = base64.b64decode(image_base64)
-        image = self.image_loader.from_bytesio(BytesIO(image_bytes), (1536, 1536), resize=False)
+        image = self.image_loader.from_bytesio(
+            BytesIO(image_bytes), (1536, 1536), resize=False
+        )
         if image is None:
             raise RuntimeError("Failed to decode generated image")
         return image

--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -158,6 +158,7 @@ class Apod(BasePlugin):
             raise RuntimeError("APOD is not an image today.")
 
         image = None
+        selected_image_url = None
         timeout_ms = int(self._request_timeout() * 1000)
         dimensions = self.get_oriented_dimensions(device_config)
         candidate_urls = self._candidate_image_urls(data)
@@ -172,6 +173,7 @@ class Apod(BasePlugin):
                 resize=False,
             )
             if image is not None:
+                selected_image_url = image_url
                 break
             logger.warning(
                 "APOD image load failed for %s (attempt %s/%s)",
@@ -189,7 +191,7 @@ class Apod(BasePlugin):
                 "title": data.get("title"),
                 "caption": data.get("copyright"),
                 "explanation": data.get("explanation"),
-                "page_url": data.get("hdurl") or data.get("url"),
+                "page_url": selected_image_url or data.get("hdurl") or data.get("url"),
                 "description_url": data.get("url"),
             }
         )

--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -8,10 +8,7 @@ For the API key, set `NASA_SECRET={API_KEY}` in your .env file.
 import logging
 import os
 from datetime import UTC, date, datetime, timedelta
-from io import BytesIO
 from random import randint
-
-from PIL import Image
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import callout, field, schema, section
@@ -27,6 +24,25 @@ _APOD_MIN_DATE = date(1995, 6, 16)
 
 
 class Apod(BasePlugin):
+    def _candidate_image_urls(self, data: dict) -> list[str]:
+        """Return APOD image URLs ordered by device-appropriate preference.
+
+        On low-resource devices like a Pi Zero 2 W, prefer NASA's standard
+        ``url`` asset before ``hdurl`` to reduce download/decode pressure.
+        """
+        standard_url = data.get("url")
+        hd_url = data.get("hdurl")
+        ordered = (
+            [standard_url, hd_url]
+            if self.image_loader.is_low_resource
+            else [hd_url, standard_url]
+        )
+        deduped: list[str] = []
+        for url in ordered:
+            if url and url not in deduped:
+                deduped.append(url)
+        return deduped
+
     def validate_settings(self, settings: dict) -> str | None:
         """Reject out-of-range custom dates at save time (JTN-379).
 
@@ -141,23 +157,41 @@ class Apod(BasePlugin):
         if data.get("media_type") != "image":
             raise RuntimeError("APOD is not an image today.")
 
-        image_url = data.get("hdurl") or data.get("url")
+        image = None
+        timeout_ms = int(self._request_timeout() * 1000)
+        dimensions = self.get_oriented_dimensions(device_config)
+        candidate_urls = self._candidate_image_urls(data)
+        if not candidate_urls:
+            raise RuntimeError("Failed to load APOD image.")
 
-        try:
-            img_data = get_http_session().get(
-                image_url, timeout=self._request_timeout()
+        for idx, image_url in enumerate(candidate_urls):
+            image = self.image_loader.from_url(
+                image_url,
+                dimensions=dimensions,
+                timeout_ms=timeout_ms,
+                resize=False,
             )
-            if not 200 <= img_data.status_code < 300:
-                logger.error(
-                    f"Failed to fetch APOD image: status {img_data.status_code}"
-                )
-                raise RuntimeError("Failed to fetch APOD image.")
-            with Image.open(BytesIO(img_data.content)) as img:
-                image = img.copy()
-        except RuntimeError:
-            raise
-        except Exception as e:
-            logger.error(f"Failed to load APOD image: {str(e)}")
-            raise RuntimeError("Failed to load APOD image.") from e
+            if image is not None:
+                break
+            logger.warning(
+                "APOD image load failed for %s (attempt %s/%s)",
+                image_url,
+                idx + 1,
+                len(candidate_urls),
+            )
+
+        if image is None:
+            raise RuntimeError("Failed to load APOD image.")
+
+        self.set_latest_metadata(
+            {
+                "date": data.get("date"),
+                "title": data.get("title"),
+                "caption": data.get("copyright"),
+                "explanation": data.get("explanation"),
+                "page_url": data.get("hdurl") or data.get("url"),
+                "description_url": data.get("url"),
+            }
+        )
 
         return image

--- a/src/plugins/wpotd/wpotd.py
+++ b/src/plugins/wpotd/wpotd.py
@@ -24,11 +24,10 @@ Flow:
 import logging
 import os
 from datetime import UTC, date, datetime, timedelta
-from io import BytesIO
 from random import randint
 from typing import Any
 
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import callout, field, schema, section
@@ -177,17 +176,18 @@ class Wpotd(BasePlugin):
                 "SVG format is not supported by Pillow. Skipping image download."
             )
             raise RuntimeError("Failed to load WPOTD image.")
-        try:
-            response = get_http_session().get(url, headers=self.HEADERS, timeout=10)
-            response.raise_for_status()
-            with Image.open(BytesIO(response.content)) as img:
-                return img.copy()
-        except UnidentifiedImageError as e:
-            logger.error(f"Unsupported image format at {url}: {str(e)}")
-            raise RuntimeError("Unsupported image format.") from e
-        except Exception as e:
-            logger.error(f"Failed to load WPOTD image from {url}: {str(e)}")
-            raise RuntimeError("Failed to load WPOTD image.") from e
+        dimensions = (4096, 4096)
+        image = self.image_loader.from_url(
+            url,
+            dimensions=dimensions,
+            timeout_ms=10000,
+            resize=False,
+            headers=self.HEADERS,
+        )
+        if image is None:
+            logger.error("Failed to load WPOTD image from %s", url)
+            raise RuntimeError("Failed to load WPOTD image.")
+        return image
 
     def _fetch_potd(self, cur_date: date) -> dict[str, Any]:
         title = f"Template:POTD/{cur_date.isoformat()}"

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -11,6 +11,7 @@ from typing import Any
 from PIL import Image
 from PIL.Image import Resampling
 
+from utils.image_loader import AdaptiveImageLoader
 from utils.http_utils import http_get, pinned_dns
 from utils.security_utils import validate_url_with_ips
 
@@ -151,6 +152,36 @@ def fetch_and_resize_remote_image(
 
     hostname = _urlparse.urlparse(validated_url).hostname or ""
 
+    loader = AdaptiveImageLoader()
+    # On low-memory devices, stream to disk first so large remote images do not
+    # require a full in-memory response buffer before Pillow can decode them.
+    if loader.is_low_resource:
+        tmp_path = None
+        try:
+            with pinned_dns(hostname, pinned_ips):
+                response = http_get(
+                    validated_url,
+                    timeout=timeout_seconds,
+                    stream=True,
+                    use_cache=False,
+                )
+                response.raise_for_status()
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".img") as tmp:
+                    tmp_path = tmp.name
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            tmp.write(chunk)
+            return loader.from_file(tmp_path, dimensions, resize=True)
+        except Exception as e:
+            logger.error(f"Failed to fetch remote image from {image_url}: {e}")
+            return None
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    logger.warning("Could not delete temp file %s", tmp_path)
+
     try:
         with pinned_dns(hostname, pinned_ips):
             response = http_get(validated_url, timeout=timeout_seconds)
@@ -159,10 +190,7 @@ def fetch_and_resize_remote_image(
         logger.error(f"Failed to fetch remote image from {image_url}: {e}")
         return None
 
-    def _resize(img: Image.Image) -> Image.Image:
-        return img.resize(dimensions, LANCZOS).copy()
-
-    resized = process_image_from_bytes(response.content, _resize)
+    resized = loader.from_bytesio(BytesIO(response.content), dimensions, resize=True)
     if resized is None:
         logger.error(f"Failed to decode remote image from {image_url}")
     return resized

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -11,7 +11,6 @@ from typing import Any
 from PIL import Image
 from PIL.Image import Resampling
 
-from utils.image_loader import AdaptiveImageLoader
 from utils.http_utils import http_get, pinned_dns
 from utils.security_utils import validate_url_with_ips
 
@@ -152,6 +151,10 @@ def fetch_and_resize_remote_image(
 
     hostname = _urlparse.urlparse(validated_url).hostname or ""
 
+    from contextlib import closing
+
+    from utils.image_loader import AdaptiveImageLoader
+
     loader = AdaptiveImageLoader()
     # On low-memory devices, stream to disk first so large remote images do not
     # require a full in-memory response buffer before Pillow can decode them.
@@ -159,18 +162,22 @@ def fetch_and_resize_remote_image(
         tmp_path = None
         try:
             with pinned_dns(hostname, pinned_ips):
-                response = http_get(
-                    validated_url,
-                    timeout=timeout_seconds,
-                    stream=True,
-                    use_cache=False,
-                )
-                response.raise_for_status()
-                with tempfile.NamedTemporaryFile(delete=False, suffix=".img") as tmp:
-                    tmp_path = tmp.name
-                    for chunk in response.iter_content(chunk_size=8192):
-                        if chunk:
-                            tmp.write(chunk)
+                with closing(
+                    http_get(
+                        validated_url,
+                        timeout=timeout_seconds,
+                        stream=True,
+                        use_cache=False,
+                    )
+                ) as response:
+                    response.raise_for_status()
+                    with tempfile.NamedTemporaryFile(
+                        delete=False, suffix=".img"
+                    ) as tmp:
+                        tmp_path = tmp.name
+                        for chunk in response.iter_content(chunk_size=8192):
+                            if chunk:
+                                tmp.write(chunk)
             return loader.from_file(tmp_path, dimensions, resize=True)
         except Exception as e:
             logger.error(f"Failed to fetch remote image from {image_url}: {e}")

--- a/tests/plugins/test_apod.py
+++ b/tests/plugins/test_apod.py
@@ -18,15 +18,19 @@ def test_apod_success(
     api_resp.json.return_value = realistic_nasa_apod_response
 
     def fake_get(url, params=None, **kwargs):
-        if urlparse(url).netloc == "api.nasa.gov":
-            return api_resp
-        return fake_image_response
+        assert urlparse(url).netloc == "api.nasa.gov"
+        return api_resp
 
     mock_session = MagicMock()
     mock_session.get.side_effect = fake_get
     monkeypatch.setattr("plugins.apod.apod.get_http_session", lambda: mock_session)
 
-    img = Apod({"id": "apod"}).generate_image({}, device_config_dev)
+    plugin = Apod({"id": "apod"})
+    fake_image = MagicMock()
+    fake_image.size = (64, 64)
+    monkeypatch.setattr(plugin.image_loader, "from_url", MagicMock(return_value=fake_image))
+
+    img = plugin.generate_image({}, device_config_dev)
     assert img.size[0] > 0
 
 
@@ -56,48 +60,25 @@ def test_apod_missing_key(client):
 @patch("plugins.apod.apod.get_http_session")
 def test_apod_success_via_client(mock_get_session, client):
     import os
+    from PIL import Image
 
     os.environ["NASA_SECRET"] = "test"
 
-    # Mock NASA APOD API response and image download
+    # Mock NASA APOD API response
     mock_session = MagicMock()
     mock_get_session.return_value = mock_session
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "media_type": "image",
+        "hdurl": "http://example.com/apod.png",
+    }
+    mock_session.get.return_value = mock_response
 
-    call_count = [0]
-
-    def fake_get(url, params=None, **kwargs):
-        call_count[0] += 1
-        if call_count[0] == 1:  # First call is to NASA API
-
-            class ApiResponse:
-                status_code = 200
-
-                def json(self):
-                    return {
-                        "media_type": "image",
-                        "hdurl": "http://example.com/apod.png",
-                    }
-
-            return ApiResponse()
-        # Second call is to download the image
-        from io import BytesIO
-
-        from PIL import Image
-
-        img = Image.new("RGB", (64, 64), "black")
-        buf = BytesIO()
-        img.save(buf, format="PNG")
-
-        class ImageResponse:
-            content = buf.getvalue()
-            status_code = 200
-
-        return ImageResponse()
-
-    mock_session.get.side_effect = fake_get
-
-    data = {"plugin_id": "apod"}
-    resp = client.post("/update_now", data=data)
+    fake_image = Image.new("RGB", (64, 64), "black")
+    with patch("plugins.base_plugin.base_plugin.AdaptiveImageLoader.from_url", return_value=fake_image):
+        data = {"plugin_id": "apod"}
+        resp = client.post("/update_now", data=data)
     assert resp.status_code == 200
 
 
@@ -120,32 +101,20 @@ def test_apod_randomize_date(monkeypatch, device_config_dev):
             "media_type": "image",
             "url": "http://example.com/apod.png",
         }
+        mock_session.get.side_effect = [mock_api_response]
 
-        # Mock image download response
-        mock_img_response = MagicMock()
-        mock_img_response.status_code = 200
-        mock_img_response.content = b"fake_image_data"
-
-        # Configure mock to return different responses
-        mock_session.get.side_effect = [mock_api_response, mock_img_response]
-
-        # Mock PIL Image
-        with patch("plugins.apod.apod.Image") as mock_image:
-            mock_image.open.return_value.__enter__.return_value.copy.return_value = (
-                MagicMock()
-            )
-
-            p = Apod({"id": "apod"})
+        p = Apod({"id": "apod"})
+        fake_image = MagicMock()
+        fake_image.size = (64, 64)
+        with patch.object(p.image_loader, "from_url", return_value=fake_image):
             settings = {"randomizeApod": "true"}
-
             result = p.generate_image(settings, device_config_dev)
 
-            # Verify API was called with random date parameter
-            assert mock_session.get.call_count >= 2
-            api_call = mock_session.get.call_args_list[0]
-            assert urlparse(api_call[0][0]).netloc == "api.nasa.gov"
-            assert "date" in api_call[1]["params"]
-            assert result is not None
+        # Verify API was called with random date parameter
+        api_call = mock_session.get.call_args_list[0]
+        assert urlparse(api_call[0][0]).netloc == "api.nasa.gov"
+        assert "date" in api_call[1]["params"]
+        assert result is not None
 
 
 def test_apod_custom_date(monkeypatch, device_config_dev):
@@ -168,29 +137,20 @@ def test_apod_custom_date(monkeypatch, device_config_dev):
             "url": "http://example.com/apod.png",
         }
 
-        # Mock image download response
-        mock_img_response = MagicMock()
-        mock_img_response.status_code = 200
-        mock_img_response.content = b"fake_image_data"
+        mock_session.get.side_effect = [mock_api_response]
 
-        mock_session.get.side_effect = [mock_api_response, mock_img_response]
-
-        # Mock PIL Image
-        with patch("plugins.apod.apod.Image") as mock_image:
-            mock_image.open.return_value.__enter__.return_value.copy.return_value = (
-                MagicMock()
-            )
-
-            p = Apod({"id": "apod"})
+        p = Apod({"id": "apod"})
+        fake_image = MagicMock()
+        fake_image.size = (64, 64)
+        with patch.object(p.image_loader, "from_url", return_value=fake_image):
             custom_date = "2023-12-25"
             settings = {"customDate": custom_date}
-
             result = p.generate_image(settings, device_config_dev)
 
-            # Verify API was called with custom date
-            api_call = mock_session.get.call_args_list[0]
-            assert api_call[1]["params"]["date"] == custom_date
-            assert result is not None
+        # Verify API was called with custom date
+        api_call = mock_session.get.call_args_list[0]
+        assert api_call[1]["params"]["date"] == custom_date
+        assert result is not None
 
 
 def test_apod_api_error_response(device_config_dev, monkeypatch):
@@ -216,8 +176,8 @@ def test_apod_api_error_response(device_config_dev, monkeypatch):
             p.generate_image({}, device_config_dev)
 
 
-def test_apod_hdurl_preference(device_config_dev, monkeypatch):
-    """Test APOD plugin prefers HD URL over regular URL."""
+def test_apod_hdurl_preference_on_non_low_resource(device_config_dev, monkeypatch):
+    """Test APOD plugin prefers HD URL on non-low-resource devices."""
     from plugins.apod.apod import Apod
 
     # Mock env key
@@ -237,30 +197,51 @@ def test_apod_hdurl_preference(device_config_dev, monkeypatch):
             "hdurl": "http://example.com/high_res.png",
         }
 
-        # Mock image download response
-        mock_img_response = MagicMock()
-        mock_img_response.status_code = 200
-        mock_img_response.content = b"fake_hd_image_data"
+        mock_session.get.side_effect = [mock_api_response]
 
-        mock_session.get.side_effect = [mock_api_response, mock_img_response]
-
-        # Mock PIL Image
-        with patch("plugins.apod.apod.Image") as mock_image:
-            mock_image.open.return_value.__enter__.return_value.copy.return_value = (
-                MagicMock()
-            )
-
-            p = Apod({"id": "apod"})
+        p = Apod({"id": "apod"})
+        p.image_loader.is_low_resource = False
+        fake_image = MagicMock()
+        fake_image.size = (64, 64)
+        with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
             result = p.generate_image({}, device_config_dev)
 
-            # Verify HD URL was requested
-            image_call = mock_session.get.call_args_list[1]
-            assert image_call[0][0] == "http://example.com/high_res.png"
-            assert result is not None
+        assert mock_from_url.call_args.args[0] == "http://example.com/high_res.png"
+        assert result is not None
+
+
+def test_apod_prefers_regular_url_on_low_resource_device(device_config_dev, monkeypatch):
+    """Low-memory devices should avoid NASA's HD asset when a regular URL exists."""
+    from plugins.apod.apod import Apod
+
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "test_key")
+
+    with patch("plugins.apod.apod.get_http_session") as mock_get_session:
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_api_response = MagicMock()
+        mock_api_response.status_code = 200
+        mock_api_response.json.return_value = {
+            "media_type": "image",
+            "url": "http://example.com/low_res.png",
+            "hdurl": "http://example.com/high_res.png",
+        }
+        mock_session.get.side_effect = [mock_api_response]
+
+        p = Apod({"id": "apod"})
+        p.image_loader.is_low_resource = True
+        fake_image = MagicMock()
+        fake_image.size = (64, 64)
+        with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
+            result = p.generate_image({}, device_config_dev)
+
+        assert mock_from_url.call_args.args[0] == "http://example.com/low_res.png"
+        assert result is not None
 
 
 def test_apod_image_download_failure(device_config_dev, monkeypatch):
-    """Test APOD plugin with image download failure."""
+    """Test APOD plugin errors when no candidate image URL can be loaded."""
     from plugins.apod.apod import Apod
 
     # Mock env key
@@ -279,19 +260,10 @@ def test_apod_image_download_failure(device_config_dev, monkeypatch):
             "url": "http://example.com/apod.png",
         }
 
-        # Mock image download failure
-        mock_img_response = MagicMock()
-        mock_img_response.status_code = 200
-        mock_img_response.content = b"invalid_image_data"
+        mock_session.get.side_effect = [mock_api_response]
 
-        mock_session.get.side_effect = [mock_api_response, mock_img_response]
-
-        # Mock PIL Image to raise exception
-        with patch("plugins.apod.apod.Image") as mock_image:
-            mock_image.open.side_effect = Exception("Invalid image format")
-
-            p = Apod({"id": "apod"})
-
+        p = Apod({"id": "apod"})
+        with patch.object(p.image_loader, "from_url", return_value=None):
             with pytest.raises(RuntimeError, match="Failed to load APOD image"):
                 p.generate_image({}, device_config_dev)
 
@@ -311,8 +283,8 @@ def test_apod_settings_template():
     assert "settings_schema" in template
 
 
-def test_apod_image_download_timeout(device_config_dev, monkeypatch):
-    """Test APOD plugin with image download timeout."""
+def test_apod_falls_back_to_second_url_when_first_load_fails(device_config_dev, monkeypatch):
+    """APOD should try the alternate URL if the preferred one fails to load."""
     from plugins.apod.apod import Apod
 
     # Mock env key
@@ -331,15 +303,29 @@ def test_apod_image_download_timeout(device_config_dev, monkeypatch):
             "url": "http://example.com/apod.png",
         }
 
-        mock_session.get.side_effect = [
-            mock_api_response,
-            Exception("Image download timeout"),
-        ]
+        mock_api_response.json.return_value = {
+            "media_type": "image",
+            "url": "http://example.com/low_res.png",
+            "hdurl": "http://example.com/high_res.png",
+        }
+        mock_session.get.side_effect = [mock_api_response]
 
         p = Apod({"id": "apod"})
+        p.image_loader.is_low_resource = False
+        fake_image = MagicMock()
+        fake_image.size = (64, 64)
+        with patch.object(
+            p.image_loader,
+            "from_url",
+            side_effect=[None, fake_image],
+        ) as mock_from_url:
+            result = p.generate_image({}, device_config_dev)
 
-        with pytest.raises(RuntimeError, match="Failed to load APOD image"):
-            p.generate_image({}, device_config_dev)
+        assert [call.args[0] for call in mock_from_url.call_args_list] == [
+            "http://example.com/high_res.png",
+            "http://example.com/low_res.png",
+        ]
+        assert result is fake_image
 
 
 def test_apod_missing_hdurl_fallback(device_config_dev, monkeypatch):
@@ -363,23 +349,13 @@ def test_apod_missing_hdurl_fallback(device_config_dev, monkeypatch):
             # No hdurl field
         }
 
-        # Mock image download response
-        mock_img_response = MagicMock()
-        mock_img_response.status_code = 200
-        mock_img_response.content = b"fake_image_data"
+        mock_session.get.side_effect = [mock_api_response]
 
-        mock_session.get.side_effect = [mock_api_response, mock_img_response]
-
-        # Mock PIL Image
-        with patch("plugins.apod.apod.Image") as mock_image:
-            mock_image.open.return_value.__enter__.return_value.copy.return_value = (
-                MagicMock()
-            )
-
-            p = Apod({"id": "apod"})
+        p = Apod({"id": "apod"})
+        fake_image = MagicMock()
+        fake_image.size = (64, 64)
+        with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
             result = p.generate_image({}, device_config_dev)
 
-            # Verify regular URL was requested
-            image_call = mock_session.get.call_args_list[1]
-            assert image_call[0][0] == "http://example.com/low_res.png"
-            assert result is not None
+        assert mock_from_url.call_args.args[0] == "http://example.com/low_res.png"
+        assert result is not None

--- a/tests/plugins/test_apod.py
+++ b/tests/plugins/test_apod.py
@@ -28,7 +28,9 @@ def test_apod_success(
     plugin = Apod({"id": "apod"})
     fake_image = MagicMock()
     fake_image.size = (64, 64)
-    monkeypatch.setattr(plugin.image_loader, "from_url", MagicMock(return_value=fake_image))
+    monkeypatch.setattr(
+        plugin.image_loader, "from_url", MagicMock(return_value=fake_image)
+    )
 
     img = plugin.generate_image({}, device_config_dev)
     assert img.size[0] > 0
@@ -60,6 +62,7 @@ def test_apod_missing_key(client):
 @patch("plugins.apod.apod.get_http_session")
 def test_apod_success_via_client(mock_get_session, client):
     import os
+
     from PIL import Image
 
     os.environ["NASA_SECRET"] = "test"
@@ -76,7 +79,10 @@ def test_apod_success_via_client(mock_get_session, client):
     mock_session.get.return_value = mock_response
 
     fake_image = Image.new("RGB", (64, 64), "black")
-    with patch("plugins.base_plugin.base_plugin.AdaptiveImageLoader.from_url", return_value=fake_image):
+    with patch(
+        "plugins.base_plugin.base_plugin.AdaptiveImageLoader.from_url",
+        return_value=fake_image,
+    ):
         data = {"plugin_id": "apod"}
         resp = client.post("/update_now", data=data)
     assert resp.status_code == 200
@@ -203,14 +209,18 @@ def test_apod_hdurl_preference_on_non_low_resource(device_config_dev, monkeypatc
         p.image_loader.is_low_resource = False
         fake_image = MagicMock()
         fake_image.size = (64, 64)
-        with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
+        with patch.object(
+            p.image_loader, "from_url", return_value=fake_image
+        ) as mock_from_url:
             result = p.generate_image({}, device_config_dev)
 
         assert mock_from_url.call_args.args[0] == "http://example.com/high_res.png"
         assert result is not None
 
 
-def test_apod_prefers_regular_url_on_low_resource_device(device_config_dev, monkeypatch):
+def test_apod_prefers_regular_url_on_low_resource_device(
+    device_config_dev, monkeypatch
+):
     """Low-memory devices should avoid NASA's HD asset when a regular URL exists."""
     from plugins.apod.apod import Apod
 
@@ -233,7 +243,9 @@ def test_apod_prefers_regular_url_on_low_resource_device(device_config_dev, monk
         p.image_loader.is_low_resource = True
         fake_image = MagicMock()
         fake_image.size = (64, 64)
-        with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
+        with patch.object(
+            p.image_loader, "from_url", return_value=fake_image
+        ) as mock_from_url:
             result = p.generate_image({}, device_config_dev)
 
         assert mock_from_url.call_args.args[0] == "http://example.com/low_res.png"
@@ -283,7 +295,9 @@ def test_apod_settings_template():
     assert "settings_schema" in template
 
 
-def test_apod_falls_back_to_second_url_when_first_load_fails(device_config_dev, monkeypatch):
+def test_apod_falls_back_to_second_url_when_first_load_fails(
+    device_config_dev, monkeypatch
+):
     """APOD should try the alternate URL if the preferred one fails to load."""
     from plugins.apod.apod import Apod
 
@@ -354,7 +368,9 @@ def test_apod_missing_hdurl_fallback(device_config_dev, monkeypatch):
         p = Apod({"id": "apod"})
         fake_image = MagicMock()
         fake_image.size = (64, 64)
-        with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
+        with patch.object(
+            p.image_loader, "from_url", return_value=fake_image
+        ) as mock_from_url:
             result = p.generate_image({}, device_config_dev)
 
         assert mock_from_url.call_args.args[0] == "http://example.com/low_res.png"

--- a/tests/plugins/test_wpotd.py
+++ b/tests/plugins/test_wpotd.py
@@ -286,27 +286,13 @@ def test_download_image_success():
     from plugins.wpotd.wpotd import Wpotd
 
     p = Wpotd({"id": "wpotd"})
+    fake_image = Image.new("RGB", (10, 6), "white")
 
-    # Mock get_http_session to return a session with a mock get
-    mock_get = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.content = _png_bytes()
-    mock_get.return_value = mock_response
-    mock_session = MagicMock()
-    mock_session.get = mock_get
+    with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
+        result = p._download_image("http://example.com/image.png")
 
-    with patch("plugins.wpotd.wpotd.get_http_session", return_value=mock_session):
-        # Mock PIL Image
-        with patch("plugins.wpotd.wpotd.Image") as mock_image:
-            mock_image.open.return_value.__enter__.return_value.copy.return_value = (
-                MagicMock()
-            )
-
-            result = p._download_image("http://example.com/image.png")
-
-            assert result is not None
-            mock_get.assert_called_once()
+    assert result is fake_image
+    assert mock_from_url.call_count == 1
 
 
 def test_download_image_network_error():
@@ -315,39 +301,20 @@ def test_download_image_network_error():
 
     p = Wpotd({"id": "wpotd"})
 
-    # Mock get_http_session to return a session whose get raises
-    mock_session = MagicMock()
-    mock_session.get.side_effect = Exception("Network error")
-
-    with patch("plugins.wpotd.wpotd.get_http_session", return_value=mock_session):
+    with patch.object(p.image_loader, "from_url", return_value=None):
         with pytest.raises(RuntimeError, match="Failed to load WPOTD image"):
             p._download_image("http://example.com/image.png")
 
 
 def test_download_image_invalid_format():
     """Test _download_image with invalid image format."""
-    from PIL import UnidentifiedImageError
-
     from plugins.wpotd.wpotd import Wpotd
 
     p = Wpotd({"id": "wpotd"})
 
-    # Mock get_http_session to return a session with mock get
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.content = b"invalid_image_data"
-    mock_session = MagicMock()
-    mock_session.get.return_value = mock_response
-
-    with patch("plugins.wpotd.wpotd.get_http_session", return_value=mock_session):
-        # Mock PIL Image to raise UnidentifiedImageError
-        with patch("plugins.wpotd.wpotd.Image") as mock_image:
-            mock_image.open.side_effect = UnidentifiedImageError(
-                "Cannot identify image"
-            )
-
-            with pytest.raises(RuntimeError, match="Unsupported image format"):
-                p._download_image("http://example.com/image.png")
+    with patch.object(p.image_loader, "from_url", return_value=None):
+        with pytest.raises(RuntimeError, match="Failed to load WPOTD image"):
+            p._download_image("http://example.com/image.png")
 
 
 def test_fetch_image_src_success():

--- a/tests/plugins/test_wpotd.py
+++ b/tests/plugins/test_wpotd.py
@@ -288,11 +288,19 @@ def test_download_image_success():
     p = Wpotd({"id": "wpotd"})
     fake_image = Image.new("RGB", (10, 6), "white")
 
-    with patch.object(p.image_loader, "from_url", return_value=fake_image) as mock_from_url:
+    with patch.object(
+        p.image_loader, "from_url", return_value=fake_image
+    ) as mock_from_url:
         result = p._download_image("http://example.com/image.png")
 
     assert result is fake_image
-    assert mock_from_url.call_count == 1
+    mock_from_url.assert_called_once_with(
+        "http://example.com/image.png",
+        dimensions=(4096, 4096),
+        timeout_ms=10000,
+        resize=False,
+        headers=p.HEADERS,
+    )
 
 
 def test_download_image_network_error():

--- a/tests/unit/test_wpotd_unit.py
+++ b/tests/unit/test_wpotd_unit.py
@@ -61,17 +61,7 @@ def test_download_image_svg_unsupported():
 def test_download_image_unidentified(monkeypatch):
     p = wpotd_mod.Wpotd({"id": "wpotd"})
 
-    class Resp:
-        content = b"notanimage"
-
-        def raise_for_status(self):
-            return None
-
-    monkeypatch.setattr(
-        wpotd_mod,
-        "get_http_session",
-        lambda: type("S", (), {"get": staticmethod(lambda *a, **k: Resp())})(),
-    )
+    monkeypatch.setattr(p.image_loader, "from_url", lambda *a, **k: None)
 
     with pytest.raises(RuntimeError):
         p._download_image("http://example.com/image.png")
@@ -79,22 +69,11 @@ def test_download_image_unidentified(monkeypatch):
 
 def test_download_image_success(monkeypatch):
     p = wpotd_mod.Wpotd({"id": "wpotd"})
-    content = make_png_bytes()
+    fake_image = Image.new("RGB", (10, 10), "white")
 
-    class Resp:
-        def __init__(self, c):
-            self.content = c
-
-        def raise_for_status(self):
-            return None
-
-    monkeypatch.setattr(
-        wpotd_mod,
-        "get_http_session",
-        lambda: type("S", (), {"get": staticmethod(lambda *a, **k: Resp(content))})(),
-    )
+    monkeypatch.setattr(p.image_loader, "from_url", lambda *a, **k: fake_image)
     img = p._download_image("http://example.com/image.png")
-    assert isinstance(img, Image.Image)
+    assert img is fake_image
 
 
 def test_fetch_potd_and_fetch_image_src(monkeypatch):


### PR DESCRIPTION
## Summary
- route APOD, WPOTD, and AI Image preview decoding through the adaptive image loader
- make shared remote image fetching stream to disk on low-memory devices so large previews do not buffer fully in RAM
- prefer smaller APOD assets on low-resource hardware and fall back to alternate image URLs when needed
- update plugin tests to cover the loader-based paths and Pi-oriented fallback behavior

## Test plan
- [x] `/Users/justin/Documents/Github/InkyPi/.venv/bin/pytest -q tests/plugins/test_wpotd.py tests/plugins/test_unsplash.py tests/plugins/test_ai_image.py tests/plugins/test_image_decode_failures.py`
- [x] `/Users/justin/Documents/Github/InkyPi/.venv/bin/pytest -q tests/plugins/test_apod.py tests/integration/test_update_now_happy.py tests/integration/test_plugin_update_now.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified image-loading across image features for more consistent behavior.
  * Device-aware selection of image sources to prefer lighter variants on low-resource devices.

* **Bug Fixes**
  * More reliable fallback when primary image sources fail; first successful candidate is used.
  * Clearer failure reporting when generated or remote images cannot be decoded or loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->