### PR TITLE
fix: JTN-376 dogfood pass 4 — validation, accessibility, UX

### DIFF
--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -5,7 +5,11 @@ from io import BytesIO
 from openai import OpenAI
 from PIL import Image
 
-from plugins.base_plugin.base_plugin import BasePlugin
+from plugins.base_plugin.base_plugin import (
+    BasePlugin,
+    validate_provider,
+    validate_required_text,
+)
 from plugins.base_plugin.settings_schema import (
     callout,
     field,
@@ -25,13 +29,10 @@ DEFAULT_IMAGE_QUALITY = "medium"
 class AIImage(BasePlugin):
     def validate_settings(self, settings: dict) -> str | None:
         """Reject empty prompts at save time so bad input does not persist."""
-        prompt = (settings.get("textPrompt") or "").strip()
-        if not prompt:
-            return "Prompt is required."
-
-        provider = settings.get("provider", "openai")
-        if provider not in ("openai", "google"):
-            return f"Unsupported provider: {provider!r}"
+        if err := validate_required_text(settings, "textPrompt", "Prompt"):
+            return err
+        if err := validate_provider(settings):
+            return err
 
         model = settings.get("imageModel", DEFAULT_IMAGE_MODEL)
         if model not in IMAGE_MODELS:

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -23,6 +23,22 @@ DEFAULT_IMAGE_QUALITY = "medium"
 
 
 class AIImage(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject empty prompts at save time so bad input does not persist."""
+        prompt = (settings.get("textPrompt") or "").strip()
+        if not prompt:
+            return "Prompt is required."
+
+        provider = settings.get("provider", "openai")
+        if provider not in ("openai", "google"):
+            return f"Unsupported provider: {provider!r}"
+
+        model = settings.get("imageModel", DEFAULT_IMAGE_MODEL)
+        if model not in IMAGE_MODELS:
+            return f"Invalid image model: {model!r}"
+
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -3,7 +3,11 @@ from datetime import UTC, datetime
 
 from openai import OpenAI
 
-from plugins.base_plugin.base_plugin import BasePlugin
+from plugins.base_plugin.base_plugin import (
+    BasePlugin,
+    validate_provider,
+    validate_required_text,
+)
 from plugins.base_plugin.settings_schema import (
     callout,
     field,
@@ -19,18 +23,12 @@ logger = logging.getLogger(__name__)
 class AIText(BasePlugin):
     def validate_settings(self, settings: dict) -> str | None:
         """Reject empty prompts and missing model at save time."""
-        prompt = (settings.get("textPrompt") or "").strip()
-        if not prompt:
-            return "Prompt is required."
-
-        model = (settings.get("textModel") or "").strip()
-        if not model:
-            return "Text Model is required."
-
-        provider = settings.get("provider", "openai")
-        if provider not in ("openai", "google"):
-            return f"Unsupported provider: {provider!r}"
-
+        if err := validate_required_text(settings, "textPrompt", "Prompt"):
+            return err
+        if err := validate_required_text(settings, "textModel", "Text Model"):
+            return err
+        if err := validate_provider(settings):
+            return err
         return None
 
     def build_settings_schema(self):

--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -17,6 +17,22 @@ logger = logging.getLogger(__name__)
 
 
 class AIText(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject empty prompts and missing model at save time."""
+        prompt = (settings.get("textPrompt") or "").strip()
+        if not prompt:
+            return "Prompt is required."
+
+        model = (settings.get("textModel") or "").strip()
+        if not model:
+            return "Text Model is required."
+
+        provider = settings.get("provider", "openai")
+        if provider not in ("openai", "google"):
+            return f"Unsupported provider: {provider!r}"
+
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -34,6 +34,26 @@ FRAME_STYLES = [
     {"name": "Rectangle", "icon": "frames/rectangle.png"},
 ]
 
+# Shared set of AI provider identifiers accepted across plugins that
+# support both OpenAI and Google backends.
+VALID_AI_PROVIDERS = frozenset({"openai", "google"})
+
+
+def validate_required_text(settings: dict, key: str, label: str) -> str | None:
+    """Return an error string if *settings[key]* is missing or blank."""
+    value = (settings.get(key) or "").strip()
+    if not value:
+        return f"{label} is required."
+    return None
+
+
+def validate_provider(settings: dict) -> str | None:
+    """Return an error string if the provider value is not in VALID_AI_PROVIDERS."""
+    provider = settings.get("provider", "openai")
+    if provider not in VALID_AI_PROVIDERS:
+        return f"Unsupported provider: {provider!r}"
+    return None
+
 
 class BasePlugin:
     """Base class for all plugins."""

--- a/src/plugins/countdown/countdown.py
+++ b/src/plugins/countdown/countdown.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import field, row, schema, section
@@ -9,6 +9,18 @@ logger = logging.getLogger(__name__)
 
 
 class Countdown(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject invalid countdown dates at save time."""
+        date_str = (settings.get("date") or "").strip()
+        if not date_str:
+            # No date provided — generate_image will raise at render time.
+            return None
+        try:
+            date.fromisoformat(date_str)
+        except ValueError:
+            return f"Invalid date format: {date_str!r} (expected YYYY-MM-DD)"
+        return None
+
     def build_settings_schema(self):
         tomorrow = (datetime.now(tz=UTC) + timedelta(days=1)).strftime("%Y-%m-%d")
         return schema(

--- a/src/plugins/image_url/image_url.py
+++ b/src/plugins/image_url/image_url.py
@@ -28,7 +28,7 @@ class ImageURL(BasePlugin):
         except ValueError:
             return f"Image URL is not valid: {url!r}"
         if parsed.scheme.lower() not in {"http", "https"}:
-            return f"Image URL must start with http:// or https://"
+            return "Image URL must start with http:// or https://"
         if not parsed.netloc:
             return f"Image URL is not valid: {url!r}"
         return None

--- a/src/plugins/image_url/image_url.py
+++ b/src/plugins/image_url/image_url.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse
 
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import callout, field, schema, section
@@ -16,6 +17,22 @@ def grab_image(image_url, dimensions, timeout_ms=40000):
 
 
 class ImageURL(BasePlugin):
+    def validate_settings(self, settings: dict) -> str | None:
+        """Reject non-URL image URL values at save time."""
+        raw = settings.get("url")
+        url = (raw or "").strip() if isinstance(raw, str) else ""
+        if not url:
+            return "Image URL is required."
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return f"Image URL is not valid: {url!r}"
+        if parsed.scheme.lower() not in {"http", "https"}:
+            return f"Image URL must start with http:// or https://"
+        if not parsed.netloc:
+            return f"Image URL is not valid: {url!r}"
+        return None
+
     def build_settings_schema(self):
         return schema(
             section(

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -263,7 +263,7 @@
       keyInput.name = `apikey-name-${suffix}`;
       keyInput.setAttribute("aria-label", "API key name");
       const valInput = document.createElement("input");
-      valInput.type = "text";
+      valInput.type = "password";
       valInput.className = "apikey-value";
       valInput.value = value;
       valInput.placeholder = "Enter value";

--- a/src/static/scripts/refresh_settings_manager.js
+++ b/src/static/scripts/refresh_settings_manager.js
@@ -190,15 +190,22 @@ class RefreshSettingsManager {
         }
 
         if (data.refreshType === 'interval') {
-            if (!data.interval || data.interval < 1) {
-                return { valid: false, error: 'Please enter a valid interval' };
+            const interval = parseInt(data.interval, 10);
+            if (!data.interval || isNaN(interval) || interval < 1) {
+                return { valid: false, error: 'Refresh interval must be at least 1' };
             }
-            if (!data.unit) {
-                return { valid: false, error: 'Please select a time unit' };
+            if (interval > 999) {
+                return { valid: false, error: 'Refresh interval must be between 1 and 999' };
+            }
+            if (!data.unit || !['minute', 'hour', 'day'].includes(data.unit)) {
+                return { valid: false, error: 'Please select a valid time unit (minute, hour, or day)' };
             }
         } else if (data.refreshType === 'scheduled') {
             if (!data.refreshTime) {
                 return { valid: false, error: 'Please select a refresh time' };
+            }
+            if (!/^\d{2}:\d{2}(:\d{2})?$/.test(data.refreshTime)) {
+                return { valid: false, error: 'Refresh time must be in HH:MM format' };
             }
         }
 

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -977,16 +977,28 @@
         const panel = document.getElementById("benchSummary");
         panel.textContent = "";
 
-        const heading1 = document.createElement("strong");
-        heading1.textContent = "Benchmark Summary (24h)";
-        panel.appendChild(heading1);
-        panel.appendChild(buildSummaryTable(summary.summary || {}));
+        const summaryData = summary.summary || {};
+        const hasData = Object.values(summaryData).some(function (stage) {
+          return stage && (stage.p50 !== null && stage.p50 !== undefined);
+        });
 
-        if ((plugins.items || []).length > 0) {
-          const heading2 = document.createElement("strong");
-          heading2.textContent = "Per-plugin Averages";
-          panel.appendChild(heading2);
-          panel.appendChild(buildPluginsTable(plugins.items));
+        if (!hasData && (plugins.items || []).length === 0) {
+          const emptyMsg = document.createElement("div");
+          emptyMsg.className = "bench-empty";
+          emptyMsg.textContent = "No benchmark data recorded in the last 24 hours. Benchmarks are collected automatically on each display refresh.";
+          panel.appendChild(emptyMsg);
+        } else {
+          const heading1 = document.createElement("strong");
+          heading1.textContent = "Benchmark Summary (24h)";
+          panel.appendChild(heading1);
+          panel.appendChild(buildSummaryTable(summaryData));
+
+          if ((plugins.items || []).length > 0) {
+            const heading2 = document.createElement("strong");
+            heading2.textContent = "Per-plugin Averages";
+            panel.appendChild(heading2);
+            panel.appendChild(buildPluginsTable(plugins.items));
+          }
         }
       } catch (e) {
         console.warn("Failed to load benchmark summary:", e);
@@ -1176,7 +1188,10 @@
 
     async function isolatePlugin() {
       const pluginId = document.getElementById("isolatePluginInput")?.value?.trim();
-      if (!pluginId) return;
+      if (!pluginId) {
+        showResponseModal("failure", "Enter a plugin ID to isolate.");
+        return;
+      }
       try {
         const resp = await fetch("/settings/isolation", {
           method: "POST",
@@ -1185,20 +1200,28 @@
         });
         const data = await resp.json();
         if (!resp.ok || !data.success) {
-          showResponseModal("failure", data.error || "Failed to isolate plugin");
+          const errMsg = data.error || "Failed to isolate plugin";
+          // Surface a human-readable message instead of raw JSON
+          showResponseModal("failure", errMsg.includes("registered")
+            ? `Plugin "${pluginId}" is not a registered plugin. Check the ID and try again.`
+            : errMsg);
           return;
         }
+        showResponseModal("success", `Plugin "${pluginId}" has been isolated.`);
         await refreshIsolation();
         await refreshHealth();
       } catch (e) {
         console.warn("Failed to isolate plugin:", e);
-        showResponseModal("failure", "Failed to isolate plugin");
+        showResponseModal("failure", "Failed to isolate plugin. Check your connection and try again.");
       }
     }
 
     async function unIsolatePlugin() {
       const pluginId = document.getElementById("isolatePluginInput")?.value?.trim();
-      if (!pluginId) return;
+      if (!pluginId) {
+        showResponseModal("failure", "Enter a plugin ID to un-isolate.");
+        return;
+      }
       try {
         const resp = await fetch("/settings/isolation", {
           method: "DELETE",
@@ -1207,14 +1230,18 @@
         });
         const data = await resp.json();
         if (!resp.ok || !data.success) {
-          showResponseModal("failure", data.error || "Failed to unisolate plugin");
+          const errMsg = data.error || "Failed to un-isolate plugin";
+          showResponseModal("failure", errMsg.includes("registered")
+            ? `Plugin "${pluginId}" is not a registered plugin. Check the ID and try again.`
+            : errMsg);
           return;
         }
+        showResponseModal("success", `Plugin "${pluginId}" has been un-isolated.`);
         await refreshIsolation();
         await refreshHealth();
       } catch (e) {
-        console.warn("Failed to unisolate plugin:", e);
-        showResponseModal("failure", "Failed to unisolate plugin");
+        console.warn("Failed to un-isolate plugin:", e);
+        showResponseModal("failure", "Failed to un-isolate plugin. Check your connection and try again.");
       }
     }
 

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -1186,63 +1186,49 @@
       }
     }
 
-    async function isolatePlugin() {
+    // Shared POST/DELETE helper for the isolation toggle.  Consolidates the
+    // previously duplicated isolatePlugin / unIsolatePlugin bodies
+    // (SonarCloud javascript:S4144 — Identical blocks on new code).
+    async function _toggleIsolation(method, verb) {
       const pluginId = document.getElementById("isolatePluginInput")?.value?.trim();
       if (!pluginId) {
-        showResponseModal("failure", "Enter a plugin ID to isolate.");
+        showResponseModal("failure", `Enter a plugin ID to ${verb}.`);
         return;
       }
       try {
         const resp = await fetch("/settings/isolation", {
-          method: "POST",
+          method,
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ plugin_id: pluginId }),
         });
         const data = await resp.json();
         if (!resp.ok || !data.success) {
-          const errMsg = data.error || "Failed to isolate plugin";
+          const errMsg = data.error || `Failed to ${verb} plugin`;
           // Surface a human-readable message instead of raw JSON
           showResponseModal("failure", errMsg.includes("registered")
             ? `Plugin "${pluginId}" is not a registered plugin. Check the ID and try again.`
             : errMsg);
           return;
         }
-        showResponseModal("success", `Plugin "${pluginId}" has been isolated.`);
+        const past = verb === "isolate" ? "isolated" : "un-isolated";
+        showResponseModal("success", `Plugin "${pluginId}" has been ${past}.`);
         await refreshIsolation();
         await refreshHealth();
       } catch (e) {
-        console.warn("Failed to isolate plugin:", e);
-        showResponseModal("failure", "Failed to isolate plugin. Check your connection and try again.");
+        console.warn(`Failed to ${verb} plugin:`, e);
+        showResponseModal(
+          "failure",
+          `Failed to ${verb} plugin. Check your connection and try again.`
+        );
       }
     }
 
+    async function isolatePlugin() {
+      return _toggleIsolation("POST", "isolate");
+    }
+
     async function unIsolatePlugin() {
-      const pluginId = document.getElementById("isolatePluginInput")?.value?.trim();
-      if (!pluginId) {
-        showResponseModal("failure", "Enter a plugin ID to un-isolate.");
-        return;
-      }
-      try {
-        const resp = await fetch("/settings/isolation", {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ plugin_id: pluginId }),
-        });
-        const data = await resp.json();
-        if (!resp.ok || !data.success) {
-          const errMsg = data.error || "Failed to un-isolate plugin";
-          showResponseModal("failure", errMsg.includes("registered")
-            ? `Plugin "${pluginId}" is not a registered plugin. Check the ID and try again.`
-            : errMsg);
-          return;
-        }
-        showResponseModal("success", `Plugin "${pluginId}" has been un-isolated.`);
-        await refreshIsolation();
-        await refreshHealth();
-      } catch (e) {
-        console.warn("Failed to un-isolate plugin:", e);
-        showResponseModal("failure", "Failed to un-isolate plugin. Check your connection and try again.");
-      }
+      return _toggleIsolation("DELETE", "un-isolate");
     }
 
     async function safeReset() {

--- a/tests/integration/test_api_json_errors.py
+++ b/tests/integration/test_api_json_errors.py
@@ -40,7 +40,7 @@ def test_save_plugin_settings_error_json(client, flask_app, monkeypatch):
 
     resp = client.post(
         "/save_plugin_settings",
-        data={"plugin_id": "ai_text", "textPrompt": "Hello"},
+        data={"plugin_id": "ai_text", "textPrompt": "Hello", "textModel": "gpt-5-nano"},
     )
     assert resp.status_code == 500
     assert "error" in resp.get_json()

--- a/tests/integration/test_jtn_376_dogfood_pass_4.py
+++ b/tests/integration/test_jtn_376_dogfood_pass_4.py
@@ -25,7 +25,11 @@ def test_ai_image_save_rejects_empty_prompt(client):
 def test_ai_image_save_rejects_invalid_provider(client):
     resp = client.post(
         "/save_plugin_settings",
-        data={"plugin_id": "ai_image", "textPrompt": "A cat", "provider": "badprovider"},
+        data={
+            "plugin_id": "ai_image",
+            "textPrompt": "A cat",
+            "provider": "badprovider",
+        },
     )
     assert resp.status_code == 400
     data = resp.get_json()
@@ -191,13 +195,15 @@ def test_add_plugin_rejects_interval_above_999(client, device_config_dev):
         "/add_plugin",
         data={
             "plugin_id": "clock",
-            "refresh_settings": json.dumps({
-                "refreshType": "interval",
-                "interval": "5000",
-                "unit": "minute",
-                "playlist": "Default",
-                "instance_name": "HighInterval",
-            }),
+            "refresh_settings": json.dumps(
+                {
+                    "refreshType": "interval",
+                    "interval": "5000",
+                    "unit": "minute",
+                    "playlist": "Default",
+                    "instance_name": "HighInterval",
+                }
+            ),
         },
     )
     assert resp.status_code == 422
@@ -215,13 +221,15 @@ def test_add_plugin_rejects_interval_zero(client, device_config_dev):
         "/add_plugin",
         data={
             "plugin_id": "clock",
-            "refresh_settings": json.dumps({
-                "refreshType": "interval",
-                "interval": "0",
-                "unit": "minute",
-                "playlist": "Default",
-                "instance_name": "ZeroInterval",
-            }),
+            "refresh_settings": json.dumps(
+                {
+                    "refreshType": "interval",
+                    "interval": "0",
+                    "unit": "minute",
+                    "playlist": "Default",
+                    "instance_name": "ZeroInterval",
+                }
+            ),
         },
     )
     assert resp.status_code == 422

--- a/tests/integration/test_jtn_376_dogfood_pass_4.py
+++ b/tests/integration/test_jtn_376_dogfood_pass_4.py
@@ -6,178 +6,142 @@ the API keys page accessibility improvements.
 """
 
 import json
+from pathlib import Path
+
+import pytest
 
 # ---------------------------------------------------------------------------
-# Theme 3 — Plugin validation: AI Image
+# Shared helpers
 # ---------------------------------------------------------------------------
 
-
-def test_ai_image_save_rejects_empty_prompt(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "ai_image", "textPrompt": ""},
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "Prompt" in data.get("error", "")
+# Root path to the JS scripts directory (resolved once).
+_JS_DIR = Path(__file__).resolve().parents[2] / "src" / "static" / "scripts"
 
 
-def test_ai_image_save_rejects_invalid_provider(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={
-            "plugin_id": "ai_image",
-            "textPrompt": "A cat",
-            "provider": "badprovider",
-        },
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "provider" in data.get("error", "").lower()
-
-
-def test_ai_image_save_rejects_invalid_model(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={
-            "plugin_id": "ai_image",
-            "textPrompt": "A cat",
-            "imageModel": "not-a-model",
-        },
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "model" in data.get("error", "").lower()
-
-
-def test_ai_image_save_accepts_valid_settings(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={
-            "plugin_id": "ai_image",
-            "textPrompt": "A beautiful sunset",
-            "provider": "openai",
-            "imageModel": "gpt-image-1.5",
-        },
-    )
-    assert resp.status_code == 200
+def _save_plugin(client, data, *, expect_status=400):
+    """POST to /save_plugin_settings and return (response, json_body)."""
+    resp = client.post("/save_plugin_settings", data=data)
+    assert resp.status_code == expect_status
+    return resp, resp.get_json() or {}
 
 
 # ---------------------------------------------------------------------------
-# Theme 3 — Plugin validation: AI Text
+# Theme 3 — Plugin validation (parametrized rejection cases)
 # ---------------------------------------------------------------------------
 
-
-def test_ai_text_save_rejects_empty_prompt(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "ai_text", "textPrompt": "", "textModel": "gpt-5-nano"},
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "Prompt" in data.get("error", "")
-
-
-def test_ai_text_save_rejects_missing_model(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "ai_text", "textPrompt": "Hello", "textModel": ""},
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "Model" in data.get("error", "")
-
-
-def test_ai_text_save_rejects_invalid_provider(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={
+_REJECT_CASES = [
+    # (test id, form data, substring expected in error)
+    (
+        "ai_image_empty_prompt",
+        {"plugin_id": "ai_image", "textPrompt": ""},
+        "Prompt",
+    ),
+    (
+        "ai_image_invalid_provider",
+        {"plugin_id": "ai_image", "textPrompt": "A cat", "provider": "badprovider"},
+        "provider",
+    ),
+    (
+        "ai_image_invalid_model",
+        {"plugin_id": "ai_image", "textPrompt": "A cat", "imageModel": "not-a-model"},
+        "model",
+    ),
+    (
+        "ai_text_empty_prompt",
+        {"plugin_id": "ai_text", "textPrompt": "", "textModel": "gpt-5-nano"},
+        "Prompt",
+    ),
+    (
+        "ai_text_missing_model",
+        {"plugin_id": "ai_text", "textPrompt": "Hello", "textModel": ""},
+        "Model",
+    ),
+    (
+        "ai_text_invalid_provider",
+        {
             "plugin_id": "ai_text",
             "textPrompt": "Hello",
             "textModel": "gpt-5-nano",
             "provider": "badprovider",
         },
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "provider" in data.get("error", "").lower()
+        "provider",
+    ),
+    (
+        "countdown_invalid_date",
+        {"plugin_id": "countdown", "title": "Trip", "date": "not-a-date"},
+        "date",
+    ),
+    (
+        "image_url_empty",
+        {"plugin_id": "image_url", "url": ""},
+        "required",
+    ),
+    (
+        "image_url_non_http",
+        {"plugin_id": "image_url", "url": "ftp://example.com/image.png"},
+        "http",
+    ),
+    (
+        "image_url_nonsense",
+        {"plugin_id": "image_url", "url": "not-a-url"},
+        "http",
+    ),
+]
 
 
-def test_ai_text_save_accepts_valid_settings(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={
+@pytest.mark.parametrize(
+    "form_data, error_substr",
+    [(d, s) for _, d, s in _REJECT_CASES],
+    ids=[tid for tid, _, _ in _REJECT_CASES],
+)
+def test_save_plugin_rejects_invalid(client, form_data, error_substr):
+    """Plugin validation rejects bad input with a 400 and a descriptive error."""
+    _, body = _save_plugin(client, form_data, expect_status=400)
+    assert error_substr.lower() in body.get("error", "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Theme 3 — Plugin validation (acceptance cases)
+# ---------------------------------------------------------------------------
+
+_ACCEPT_CASES = [
+    (
+        "ai_image_valid",
+        {
+            "plugin_id": "ai_image",
+            "textPrompt": "A beautiful sunset",
+            "provider": "openai",
+            "imageModel": "gpt-image-1.5",
+        },
+    ),
+    (
+        "ai_text_valid",
+        {
             "plugin_id": "ai_text",
             "textPrompt": "Summarize today's news",
             "textModel": "gpt-5-nano",
             "provider": "openai",
         },
-    )
-    assert resp.status_code == 200
+    ),
+    (
+        "countdown_valid",
+        {"plugin_id": "countdown", "title": "Trip", "date": "2030-01-01"},
+    ),
+    (
+        "image_url_valid",
+        {"plugin_id": "image_url", "url": "https://example.com/image.jpg"},
+    ),
+]
 
 
-# ---------------------------------------------------------------------------
-# Theme 3 — Plugin validation: Countdown
-# ---------------------------------------------------------------------------
-
-
-def test_countdown_save_rejects_invalid_date_format(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "countdown", "title": "Trip", "date": "not-a-date"},
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "date" in data.get("error", "").lower() or "Date" in data.get("error", "")
-
-
-def test_countdown_save_accepts_valid_date(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "countdown", "title": "Trip", "date": "2030-01-01"},
-    )
-    assert resp.status_code == 200
-
-
-# ---------------------------------------------------------------------------
-# Theme 3 — Plugin validation: Image URL
-# ---------------------------------------------------------------------------
-
-
-def test_image_url_save_rejects_empty_url(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "image_url", "url": ""},
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "URL" in data.get("error", "") or "required" in data.get("error", "").lower()
-
-
-def test_image_url_save_rejects_non_http_url(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "image_url", "url": "ftp://example.com/image.png"},
-    )
-    assert resp.status_code == 400
-    data = resp.get_json()
-    assert "http" in data.get("error", "").lower()
-
-
-def test_image_url_save_rejects_nonsense_url(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "image_url", "url": "not-a-url"},
-    )
-    assert resp.status_code == 400
-
-
-def test_image_url_save_accepts_valid_url(client):
-    resp = client.post(
-        "/save_plugin_settings",
-        data={"plugin_id": "image_url", "url": "https://example.com/image.jpg"},
-    )
-    assert resp.status_code == 200
+@pytest.mark.parametrize(
+    "form_data",
+    [d for _, d in _ACCEPT_CASES],
+    ids=[tid for tid, _ in _ACCEPT_CASES],
+)
+def test_save_plugin_accepts_valid(client, form_data):
+    """Valid plugin settings are accepted with a 200."""
+    _save_plugin(client, form_data, expect_status=200)
 
 
 # ---------------------------------------------------------------------------
@@ -185,12 +149,23 @@ def test_image_url_save_accepts_valid_url(client):
 # ---------------------------------------------------------------------------
 
 
-def test_add_plugin_rejects_interval_above_999(client, device_config_dev):
+def _setup_default_playlist(device_config_dev):
+    """Ensure a Default playlist exists for interval-rejection tests."""
     pm = device_config_dev.get_playlist_manager()
     if not pm.get_playlist("Default"):
         pm.add_playlist("Default", "00:00", "24:00")
     device_config_dev.write_config()
 
+
+@pytest.mark.parametrize(
+    "interval, instance_name",
+    [("5000", "HighInterval"), ("0", "ZeroInterval")],
+    ids=["above_999", "zero"],
+)
+def test_add_plugin_rejects_bad_interval(
+    client, device_config_dev, interval, instance_name
+):
+    _setup_default_playlist(device_config_dev)
     resp = client.post(
         "/add_plugin",
         data={
@@ -198,10 +173,10 @@ def test_add_plugin_rejects_interval_above_999(client, device_config_dev):
             "refresh_settings": json.dumps(
                 {
                     "refreshType": "interval",
-                    "interval": "5000",
+                    "interval": interval,
                     "unit": "minute",
                     "playlist": "Default",
-                    "instance_name": "HighInterval",
+                    "instance_name": instance_name,
                 }
             ),
         },
@@ -211,30 +186,6 @@ def test_add_plugin_rejects_interval_above_999(client, device_config_dev):
     assert "between 1 and 999" in (body.get("error") or body.get("message") or "")
 
 
-def test_add_plugin_rejects_interval_zero(client, device_config_dev):
-    pm = device_config_dev.get_playlist_manager()
-    if not pm.get_playlist("Default"):
-        pm.add_playlist("Default", "00:00", "24:00")
-    device_config_dev.write_config()
-
-    resp = client.post(
-        "/add_plugin",
-        data={
-            "plugin_id": "clock",
-            "refresh_settings": json.dumps(
-                {
-                    "refreshType": "interval",
-                    "interval": "0",
-                    "unit": "minute",
-                    "playlist": "Default",
-                    "instance_name": "ZeroInterval",
-                }
-            ),
-        },
-    )
-    assert resp.status_code == 422
-
-
 # ---------------------------------------------------------------------------
 # Theme 4 — API Keys page: value input type=password in JS addRow
 # ---------------------------------------------------------------------------
@@ -242,17 +193,7 @@ def test_add_plugin_rejects_interval_zero(client, device_config_dev):
 
 def test_api_keys_page_js_addrow_uses_password_type():
     """JS-built API key rows must use type=password for value inputs."""
-    from pathlib import Path
-
-    js_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "static"
-        / "scripts"
-        / "api_keys_page.js"
-    )
-    js = js_path.read_text(encoding="utf-8")
-    # The valInput must use type="password", not type="text"
+    js = (_JS_DIR / "api_keys_page.js").read_text(encoding="utf-8")
     assert 'valInput.type = "password"' in js
     assert 'valInput.type = "text"' not in js
 
@@ -264,17 +205,7 @@ def test_api_keys_page_js_addrow_uses_password_type():
 
 def test_refresh_settings_manager_js_validates_interval_range():
     """The JS RefreshSettingsManager must check interval upper bound (999)."""
-    from pathlib import Path
-
-    js_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "static"
-        / "scripts"
-        / "refresh_settings_manager.js"
-    )
-    js = js_path.read_text(encoding="utf-8")
-    # Must check for interval > 999
+    js = (_JS_DIR / "refresh_settings_manager.js").read_text(encoding="utf-8")
     assert "999" in js
     assert "between 1 and 999" in js
 
@@ -286,31 +217,13 @@ def test_refresh_settings_manager_js_validates_interval_range():
 
 def test_settings_page_js_benchmark_empty_state_message():
     """When no benchmark data exists, show a human message instead of null JSON."""
-    from pathlib import Path
-
-    js_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "static"
-        / "scripts"
-        / "settings_page.js"
-    )
-    js = js_path.read_text(encoding="utf-8")
+    js = (_JS_DIR / "settings_page.js").read_text(encoding="utf-8")
     assert "No benchmark data recorded" in js
 
 
 def test_settings_page_js_isolation_human_messages():
     """Isolation actions should show human-readable messages."""
-    from pathlib import Path
-
-    js_path = (
-        Path(__file__).resolve().parents[2]
-        / "src"
-        / "static"
-        / "scripts"
-        / "settings_page.js"
-    )
-    js = js_path.read_text(encoding="utf-8")
+    js = (_JS_DIR / "settings_page.js").read_text(encoding="utf-8")
     assert "has been isolated" in js
     assert "has been un-isolated" in js
     assert "not a registered plugin" in js

--- a/tests/integration/test_jtn_376_dogfood_pass_4.py
+++ b/tests/integration/test_jtn_376_dogfood_pass_4.py
@@ -1,0 +1,308 @@
+"""JTN-376: Dogfood pass 4 — validation and UX fixes.
+
+Tests cover the server-side plugin validation added to ai_image, ai_text,
+countdown, and image_url, the client-side refresh-settings range check, and
+the API keys page accessibility improvements.
+"""
+
+import json
+
+# ---------------------------------------------------------------------------
+# Theme 3 — Plugin validation: AI Image
+# ---------------------------------------------------------------------------
+
+
+def test_ai_image_save_rejects_empty_prompt(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "ai_image", "textPrompt": ""},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Prompt" in data.get("error", "")
+
+
+def test_ai_image_save_rejects_invalid_provider(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "ai_image", "textPrompt": "A cat", "provider": "badprovider"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "provider" in data.get("error", "").lower()
+
+
+def test_ai_image_save_rejects_invalid_model(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_image",
+            "textPrompt": "A cat",
+            "imageModel": "not-a-model",
+        },
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "model" in data.get("error", "").lower()
+
+
+def test_ai_image_save_accepts_valid_settings(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_image",
+            "textPrompt": "A beautiful sunset",
+            "provider": "openai",
+            "imageModel": "gpt-image-1.5",
+        },
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Theme 3 — Plugin validation: AI Text
+# ---------------------------------------------------------------------------
+
+
+def test_ai_text_save_rejects_empty_prompt(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "ai_text", "textPrompt": "", "textModel": "gpt-5-nano"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Prompt" in data.get("error", "")
+
+
+def test_ai_text_save_rejects_missing_model(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "ai_text", "textPrompt": "Hello", "textModel": ""},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "Model" in data.get("error", "")
+
+
+def test_ai_text_save_rejects_invalid_provider(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_text",
+            "textPrompt": "Hello",
+            "textModel": "gpt-5-nano",
+            "provider": "badprovider",
+        },
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "provider" in data.get("error", "").lower()
+
+
+def test_ai_text_save_accepts_valid_settings(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={
+            "plugin_id": "ai_text",
+            "textPrompt": "Summarize today's news",
+            "textModel": "gpt-5-nano",
+            "provider": "openai",
+        },
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Theme 3 — Plugin validation: Countdown
+# ---------------------------------------------------------------------------
+
+
+def test_countdown_save_rejects_invalid_date_format(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "countdown", "title": "Trip", "date": "not-a-date"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "date" in data.get("error", "").lower() or "Date" in data.get("error", "")
+
+
+def test_countdown_save_accepts_valid_date(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "countdown", "title": "Trip", "date": "2030-01-01"},
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Theme 3 — Plugin validation: Image URL
+# ---------------------------------------------------------------------------
+
+
+def test_image_url_save_rejects_empty_url(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_url", "url": ""},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "URL" in data.get("error", "") or "required" in data.get("error", "").lower()
+
+
+def test_image_url_save_rejects_non_http_url(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_url", "url": "ftp://example.com/image.png"},
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "http" in data.get("error", "").lower()
+
+
+def test_image_url_save_rejects_nonsense_url(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_url", "url": "not-a-url"},
+    )
+    assert resp.status_code == 400
+
+
+def test_image_url_save_accepts_valid_url(client):
+    resp = client.post(
+        "/save_plugin_settings",
+        data={"plugin_id": "image_url", "url": "https://example.com/image.jpg"},
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Theme 2 — Refresh Settings interval range validation (server-side)
+# ---------------------------------------------------------------------------
+
+
+def test_add_plugin_rejects_interval_above_999(client, device_config_dev):
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default", "00:00", "24:00")
+    device_config_dev.write_config()
+
+    resp = client.post(
+        "/add_plugin",
+        data={
+            "plugin_id": "clock",
+            "refresh_settings": json.dumps({
+                "refreshType": "interval",
+                "interval": "5000",
+                "unit": "minute",
+                "playlist": "Default",
+                "instance_name": "HighInterval",
+            }),
+        },
+    )
+    assert resp.status_code == 422
+    body = resp.get_json() or {}
+    assert "between 1 and 999" in (body.get("error") or body.get("message") or "")
+
+
+def test_add_plugin_rejects_interval_zero(client, device_config_dev):
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default", "00:00", "24:00")
+    device_config_dev.write_config()
+
+    resp = client.post(
+        "/add_plugin",
+        data={
+            "plugin_id": "clock",
+            "refresh_settings": json.dumps({
+                "refreshType": "interval",
+                "interval": "0",
+                "unit": "minute",
+                "playlist": "Default",
+                "instance_name": "ZeroInterval",
+            }),
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Theme 4 — API Keys page: value input type=password in JS addRow
+# ---------------------------------------------------------------------------
+
+
+def test_api_keys_page_js_addrow_uses_password_type():
+    """JS-built API key rows must use type=password for value inputs."""
+    from pathlib import Path
+
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "api_keys_page.js"
+    )
+    js = js_path.read_text(encoding="utf-8")
+    # The valInput must use type="password", not type="text"
+    assert 'valInput.type = "password"' in js
+    assert 'valInput.type = "text"' not in js
+
+
+# ---------------------------------------------------------------------------
+# Theme 5 — RefreshSettingsManager interval validation (JS)
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_settings_manager_js_validates_interval_range():
+    """The JS RefreshSettingsManager must check interval upper bound (999)."""
+    from pathlib import Path
+
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "refresh_settings_manager.js"
+    )
+    js = js_path.read_text(encoding="utf-8")
+    # Must check for interval > 999
+    assert "999" in js
+    assert "between 1 and 999" in js
+
+
+# ---------------------------------------------------------------------------
+# Theme 5 — Diagnostics: human-readable benchmark + isolation messages
+# ---------------------------------------------------------------------------
+
+
+def test_settings_page_js_benchmark_empty_state_message():
+    """When no benchmark data exists, show a human message instead of null JSON."""
+    from pathlib import Path
+
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "settings_page.js"
+    )
+    js = js_path.read_text(encoding="utf-8")
+    assert "No benchmark data recorded" in js
+
+
+def test_settings_page_js_isolation_human_messages():
+    """Isolation actions should show human-readable messages."""
+    from pathlib import Path
+
+    js_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "static"
+        / "scripts"
+        / "settings_page.js"
+    )
+    js = js_path.read_text(encoding="utf-8")
+    assert "has been isolated" in js
+    assert "has been un-isolated" in js
+    assert "not a registered plugin" in js

--- a/tests/integration/test_jtn_376_dogfood_pass_4.py
+++ b/tests/integration/test_jtn_376_dogfood_pass_4.py
@@ -224,6 +224,9 @@ def test_settings_page_js_benchmark_empty_state_message():
 def test_settings_page_js_isolation_human_messages():
     """Isolation actions should show human-readable messages."""
     js = (_JS_DIR / "settings_page.js").read_text(encoding="utf-8")
-    assert "has been isolated" in js
-    assert "has been un-isolated" in js
+    # Isolation status messages are built from a shared helper that splices
+    # an "isolated" / "un-isolated" participle into "has been ${past}.".
+    assert "has been ${past}" in js
+    assert '"isolated"' in js
+    assert '"un-isolate"' in js
     assert "not a registered plugin" in js

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -419,7 +419,7 @@ def test_save_plugin_settings_exception_handling(client, flask_app, monkeypatch)
 
     resp = client.post(
         "/save_plugin_settings",
-        data={"plugin_id": "ai_text", "textPrompt": "Hello"},
+        data={"plugin_id": "ai_text", "textPrompt": "Hello", "textModel": "gpt-5-nano"},
     )
     assert resp.status_code == 500
     assert "An internal error occurred" in resp.get_json().get("error", "")


### PR DESCRIPTION
## Summary

- **Plugin validation (Theme 3):** Add server-side `validate_settings()` to `ai_image`, `ai_text`, `countdown`, and `image_url` plugins so bad input (empty prompts, invalid dates, non-HTTP URLs, unsupported providers/models) is rejected at save time with a specific error instead of persisting silently and failing at render time.
- **Refresh Settings silent data loss (Theme 2):** Tighten client-side interval validation in `RefreshSettingsManager` to reject values outside the 1-999 range with a clear error before submission, preventing the modal from showing a success toast while the value silently reverts on reload. Server-side validation was already in place from JTN-381.
- **API Keys accessibility (Theme 4):** Switch JS-built API key value inputs from `type="text"` to `type="password"` so secrets are masked consistently across managed and generic modes. Managed-mode inputs already used `type="password"` with proper `<label for>` attributes.
- **Diagnostics UX (Theme 5):** Show a human-readable empty state in benchmarks instead of a table of null/dash values; surface specific success/failure messages for plugin isolation actions instead of raw JSON.
- **Themes 1 and 6** were already addressed in the codebase (form_validator.js has label-aware validation messages; both AI Image and AI Text already use `<textarea>`).
- Existing tests updated where new validation caused previously-passing payloads to fail (missing `textModel` in `ai_text` test fixtures).

## Changes

**Plugins (validation):**
- `src/plugins/ai_image/ai_image.py` — validate prompt, provider, and model
- `src/plugins/ai_text/ai_text.py` — validate prompt, model, and provider
- `src/plugins/countdown/countdown.py` — validate date format
- `src/plugins/image_url/image_url.py` — validate URL scheme and host

**Frontend (JS):**
- `src/static/scripts/refresh_settings_manager.js` — interval range check (1-999), unit whitelist, time format check
- `src/static/scripts/api_keys_page.js` — `type="password"` for JS-built value inputs
- `src/static/scripts/settings_page.js` — human-readable benchmark empty state, isolation action messages

**Tests:**
- `tests/integration/test_jtn_376_dogfood_pass_4.py` — 20 new tests covering all themes
- `tests/integration/test_api_json_errors.py` — add `textModel` to fixture
- `tests/integration/test_plugin_routes.py` — add `textModel` to fixture

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] N/A — no upstream sync involved

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (3473 passed, 5 pre-existing test-order failures)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Frontend changes: JS-only, no template structural changes

## Testing

- 20 new integration tests in `test_jtn_376_dogfood_pass_4.py`
- Covers: plugin validation (ai_image, ai_text, countdown, image_url), refresh interval range, API key password type, JS benchmark/isolation messaging
- Full suite: 3473 passed, 3 skipped, 5 pre-existing test-order failures (all pass individually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)