### PR TITLE
fix: address dogfood pass 5 issues (JTN-451)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -309,45 +309,103 @@ def _validate_instance_name(raw_name):
     return name, None
 
 
+def _parse_add_plugin_form(form, files):
+    """Parse and validate the add_plugin form data.
+
+    Returns ``(plugin_id, plugin_settings, refresh_settings, error_response)``.
+    On success ``error_response`` is None; on failure the first three are None.
+    """
+    plugin_settings = parse_form(form)
+    raw_refresh = plugin_settings.pop("refresh_settings", None)
+    if not raw_refresh or not isinstance(raw_refresh, str):
+        return (
+            None,
+            None,
+            None,
+            json_error(
+                "refresh_settings is required",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "refresh_settings"},
+            ),
+        )
+    try:
+        refresh_settings = json.loads(raw_refresh)
+    except (json.JSONDecodeError, ValueError):
+        return (
+            None,
+            None,
+            None,
+            json_error(
+                "Invalid JSON in refresh_settings",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "refresh_settings"},
+            ),
+        )
+    if not isinstance(refresh_settings, dict):
+        return (
+            None,
+            None,
+            None,
+            json_error(
+                "refresh_settings must be a JSON object",
+                status=400,
+                code=_CODE_VALIDATION,
+                details={"field": "refresh_settings"},
+            ),
+        )
+    plugin_id = plugin_settings.pop("plugin_id", None)
+    if not plugin_id or not isinstance(plugin_id, str):
+        return (
+            None,
+            None,
+            None,
+            json_error(
+                "plugin_id is required",
+                status=422,
+                code=_CODE_VALIDATION,
+                details={"field": "plugin_id"},
+            ),
+        )
+    plugin_settings.update(handle_request_files(files))
+    return plugin_id, plugin_settings, refresh_settings, None
+
+
+def _validate_plugin_settings_security(device_config, plugin_id, plugin_settings):
+    """JTN-451: Run plugin-specific validation (e.g. URL scheme checks).
+
+    Returns an error response if validation fails, or None on success.
+    Only validates when the settings dict has actual user values.
+    """
+    if not plugin_settings:
+        return None
+    plugin_config = device_config.get_plugin(plugin_id)
+    if not plugin_config:
+        return None
+    try:
+        from plugins.plugin_registry import get_plugin_instance as _get_pi
+
+        plugin_obj = _get_pi(plugin_config)
+        settings_error = plugin_obj.validate_settings(plugin_settings)
+        if settings_error:
+            return json_error(settings_error, status=400)
+    except Exception:
+        logger.debug("Could not validate plugin schema for %s", plugin_id)
+    return None
+
+
 @playlist_bp.route("/add_plugin", methods=["POST"])
 def add_plugin():
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
 
     try:
-        plugin_settings = parse_form(request.form)
-        raw_refresh = plugin_settings.pop("refresh_settings", None)
-        if not raw_refresh or not isinstance(raw_refresh, str):
-            return json_error(
-                "refresh_settings is required",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "refresh_settings"},
-            )
-        try:
-            refresh_settings = json.loads(raw_refresh)
-        except (json.JSONDecodeError, ValueError):
-            return json_error(
-                "Invalid JSON in refresh_settings",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "refresh_settings"},
-            )
-        if not isinstance(refresh_settings, dict):
-            return json_error(
-                "refresh_settings must be a JSON object",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "refresh_settings"},
-            )
-        plugin_id = plugin_settings.pop("plugin_id", None)
-        if not plugin_id or not isinstance(plugin_id, str):
-            return json_error(
-                "plugin_id is required",
-                status=422,
-                code=_CODE_VALIDATION,
-                details={"field": "plugin_id"},
-            )
+        plugin_id, plugin_settings, refresh_settings, parse_err = (
+            _parse_add_plugin_form(request.form, request.files)
+        )
+        if parse_err:
+            return parse_err
 
         playlist = refresh_settings.get("playlist")
         if not playlist:
@@ -376,28 +434,12 @@ def add_plugin():
         if refresh_err:
             return refresh_err
 
-        plugin_settings.update(handle_request_files(request.files))
+        security_err = _validate_plugin_settings_security(
+            device_config, plugin_id, plugin_settings
+        )
+        if security_err:
+            return security_err
 
-        # JTN-451: Run plugin-specific validation (e.g. URL scheme checks)
-        # before persisting settings. Without this, plugins like Screenshot
-        # could have javascript:/file:// URLs saved via the add_plugin path.
-        # Only validate when the settings dict has actual user values (not
-        # just empty from the form parse). This avoids rejecting plugins
-        # that are being added with settings saved from an earlier save.
-        if plugin_settings:
-            plugin_config = device_config.get_plugin(plugin_id)
-            if plugin_config:
-                try:
-                    from plugins.plugin_registry import (
-                        get_plugin_instance as _get_pi,
-                    )
-
-                    plugin_obj = _get_pi(plugin_config)
-                    settings_error = plugin_obj.validate_settings(plugin_settings)
-                    if settings_error:
-                        return json_error(settings_error, status=400)
-                except Exception:
-                    logger.debug("Could not validate plugin schema for %s", plugin_id)
         plugin_dict = {
             "plugin_id": plugin_id,
             "refresh": refresh_config,

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -377,6 +377,31 @@ def add_plugin():
             return refresh_err
 
         plugin_settings.update(handle_request_files(request.files))
+
+        # JTN-451: Run plugin-specific validation (e.g. URL scheme checks)
+        # before persisting settings. Without this, plugins like Screenshot
+        # could have javascript:/file:// URLs saved via the add_plugin path.
+        # Only validate when the settings dict has actual user values (not
+        # just empty from the form parse). This avoids rejecting plugins
+        # that are being added with settings saved from an earlier save.
+        if plugin_settings:
+            plugin_config = device_config.get_plugin(plugin_id)
+            if plugin_config:
+                try:
+                    from plugins.plugin_registry import (
+                        get_plugin_instance as _get_pi,
+                    )
+
+                    plugin_obj = _get_pi(plugin_config)
+                    settings_error = plugin_obj.validate_settings(
+                        plugin_settings
+                    )
+                    if settings_error:
+                        return json_error(settings_error, status=400)
+                except Exception:
+                    logger.debug(
+                        "Could not validate plugin schema for %s", plugin_id
+                    )
         plugin_dict = {
             "plugin_id": plugin_id,
             "refresh": refresh_config,

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -393,15 +393,11 @@ def add_plugin():
                     )
 
                     plugin_obj = _get_pi(plugin_config)
-                    settings_error = plugin_obj.validate_settings(
-                        plugin_settings
-                    )
+                    settings_error = plugin_obj.validate_settings(plugin_settings)
                     if settings_error:
                         return json_error(settings_error, status=400)
                 except Exception:
-                    logger.debug(
-                        "Could not validate plugin schema for %s", plugin_id
-                    )
+                    logger.debug("Could not validate plugin schema for %s", plugin_id)
         plugin_dict = {
             "plugin_id": plugin_id,
             "refresh": refresh_config,

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -309,6 +309,35 @@ def _validate_instance_name(raw_name):
     return name, None
 
 
+def _form_parse_error(message, *, status=400, field="refresh_settings"):
+    """Build a ``(None, None, None, error_response)`` tuple for form parsing."""
+    return (
+        None,
+        None,
+        None,
+        json_error(
+            message, status=status, code=_CODE_VALIDATION, details={"field": field}
+        ),
+    )
+
+
+def _parse_refresh_settings_json(raw_refresh):
+    """Decode *raw_refresh* into a dict.
+
+    Returns ``(refresh_settings, error_tuple)``.  On success the error is
+    ``None``; on failure ``refresh_settings`` is ``None``.
+    """
+    if not raw_refresh or not isinstance(raw_refresh, str):
+        return None, _form_parse_error("refresh_settings is required")
+    try:
+        refresh_settings = json.loads(raw_refresh)
+    except (json.JSONDecodeError, ValueError):
+        return None, _form_parse_error("Invalid JSON in refresh_settings")
+    if not isinstance(refresh_settings, dict):
+        return None, _form_parse_error("refresh_settings must be a JSON object")
+    return refresh_settings, None
+
+
 def _parse_add_plugin_form(form, files):
     """Parse and validate the add_plugin form data.
 
@@ -317,57 +346,12 @@ def _parse_add_plugin_form(form, files):
     """
     plugin_settings = parse_form(form)
     raw_refresh = plugin_settings.pop("refresh_settings", None)
-    if not raw_refresh or not isinstance(raw_refresh, str):
-        return (
-            None,
-            None,
-            None,
-            json_error(
-                "refresh_settings is required",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "refresh_settings"},
-            ),
-        )
-    try:
-        refresh_settings = json.loads(raw_refresh)
-    except (json.JSONDecodeError, ValueError):
-        return (
-            None,
-            None,
-            None,
-            json_error(
-                "Invalid JSON in refresh_settings",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "refresh_settings"},
-            ),
-        )
-    if not isinstance(refresh_settings, dict):
-        return (
-            None,
-            None,
-            None,
-            json_error(
-                "refresh_settings must be a JSON object",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "refresh_settings"},
-            ),
-        )
+    refresh_settings, err = _parse_refresh_settings_json(raw_refresh)
+    if err:
+        return err
     plugin_id = plugin_settings.pop("plugin_id", None)
     if not plugin_id or not isinstance(plugin_id, str):
-        return (
-            None,
-            None,
-            None,
-            json_error(
-                "plugin_id is required",
-                status=422,
-                code=_CODE_VALIDATION,
-                details={"field": "plugin_id"},
-            ),
-        )
+        return _form_parse_error("plugin_id is required", status=422, field="plugin_id")
     plugin_settings.update(handle_request_files(files))
     return plugin_id, plugin_settings, refresh_settings, None
 

--- a/src/blueprints/plugin_history_bp.py
+++ b/src/blueprints/plugin_history_bp.py
@@ -26,7 +26,9 @@ plugin_history_bp = Blueprint("plugin_history", __name__)
 _CONFIG_KEY = "DEVICE_CONFIG"
 # Only allow instance names that are safe filesystem identifiers.
 # Strict allowlist regex makes this an explicit barrier for taint analyzers.
-_VALID_NAME_RE = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9_\-]{0,63}\Z")
+# Aligned with _INSTANCE_NAME_RE in playlist.py to accept user-entered names
+# that include spaces (JTN-451).
+_VALID_NAME_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9 _\-]{0,63}\Z")
 
 
 def _safe_instance_name(name: str) -> str | None:

--- a/src/static/scripts/history_page.js
+++ b/src/static/scripts/history_page.js
@@ -12,10 +12,25 @@
     node.hidden = hidden;
   }
 
-  function setModalOpen(node, open) {
+  // Track the element that triggered the most-recently opened modal so
+  // focus can be restored when the modal closes (WAI-ARIA best practice).
+  let _lastHistoryModalTrigger = null;
+
+  function setModalOpen(node, open, triggerEl) {
     if (!node) return;
+    if (open && triggerEl) _lastHistoryModalTrigger = triggerEl;
     node.hidden = !open;
     node.style.display = open ? "block" : "none";
+    if (open) {
+      // Move focus to the first focusable element inside the modal
+      const focusable = node.querySelector(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable) setTimeout(() => focusable.focus(), 0);
+    } else if (_lastHistoryModalTrigger) {
+      try { _lastHistoryModalTrigger.focus(); } catch (_e) { /* ignore */ }
+      _lastHistoryModalTrigger = null;
+    }
   }
 
   function showStoredMessage() {
@@ -95,11 +110,11 @@
       }
     }
 
-    function openDeleteModal(filename) {
+    function openDeleteModal(filename, triggerEl) {
       state.pendingDelete = filename;
       const text = document.getElementById("deleteHistoryText");
       if (text) text.textContent = `Delete this image '${filename}'?`;
-      setModalOpen(document.getElementById("deleteHistoryModal"), true);
+      setModalOpen(document.getElementById("deleteHistoryModal"), true, triggerEl);
     }
 
     function closeDeleteModal() {
@@ -107,8 +122,8 @@
       setModalOpen(document.getElementById("deleteHistoryModal"), false);
     }
 
-    function openClearModal() {
-      setModalOpen(document.getElementById("clearHistoryModal"), true);
+    function openClearModal(triggerEl) {
+      setModalOpen(document.getElementById("clearHistoryModal"), true, triggerEl);
     }
 
     function closeClearModal() {
@@ -221,7 +236,7 @@
         ?.addEventListener("click", () => globalThis.location.reload());
       document
         .getElementById("historyClearBtn")
-        ?.addEventListener("click", openClearModal);
+        ?.addEventListener("click", (event) => openClearModal(event.currentTarget));
       document
         .getElementById("confirmDeleteHistoryBtn")
         ?.addEventListener("click", confirmDelete);
@@ -249,7 +264,7 @@
           if (action === "display" && filename) {
             redisplay(filename, actionButton);
           } else if (action === "delete" && filename) {
-            openDeleteModal(filename);
+            openDeleteModal(filename, actionButton);
           }
           return;
         }

--- a/src/static/scripts/history_page.js
+++ b/src/static/scripts/history_page.js
@@ -28,7 +28,9 @@
       );
       if (focusable) setTimeout(() => focusable.focus(), 0);
     } else if (_lastHistoryModalTrigger) {
-      _lastHistoryModalTrigger.focus?.();
+      if (typeof _lastHistoryModalTrigger.focus === "function") {
+        _lastHistoryModalTrigger.focus();
+      }
       _lastHistoryModalTrigger = null;
     }
   }

--- a/src/static/scripts/history_page.js
+++ b/src/static/scripts/history_page.js
@@ -28,9 +28,17 @@
       );
       if (focusable) setTimeout(() => focusable.focus(), 0);
     } else if (_lastHistoryModalTrigger) {
-      try { _lastHistoryModalTrigger.focus(); } catch (_e) { /* ignore */ }
+      _lastHistoryModalTrigger.focus?.();
       _lastHistoryModalTrigger = null;
     }
+  }
+
+  function openClearModal(triggerEl) {
+    setModalOpen(document.getElementById("clearHistoryModal"), true, triggerEl);
+  }
+
+  function closeClearModal() {
+    setModalOpen(document.getElementById("clearHistoryModal"), false);
   }
 
   function showStoredMessage() {
@@ -122,13 +130,8 @@
       setModalOpen(document.getElementById("deleteHistoryModal"), false);
     }
 
-    function openClearModal(triggerEl) {
-      setModalOpen(document.getElementById("clearHistoryModal"), true, triggerEl);
-    }
-
-    function closeClearModal() {
-      setModalOpen(document.getElementById("clearHistoryModal"), false);
-    }
+    // openClearModal / closeClearModal are at module scope (below) — they
+    // don't access createHistoryPage closure variables.
 
     async function confirmDelete() {
       if (!state.pendingDelete) return;

--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -560,6 +560,35 @@
         return name;
     }
 
+    function _validateCycleMinutes() {
+        const input = document.getElementById("cycle_minutes");
+        const error = document.getElementById("cycle-minutes-error");
+        if (!input) return true;
+        const raw = (input.value || "").trim();
+        // Empty is valid — means "use device default"
+        if (!raw) {
+            input.setAttribute("aria-invalid", "false");
+            if (error) error.textContent = "";
+            return true;
+        }
+        const val = parseInt(raw, 10);
+        if (isNaN(val) || String(val) !== raw) {
+            input.setAttribute("aria-invalid", "true");
+            if (error) error.textContent = "Must be a whole number";
+            input.focus();
+            return false;
+        }
+        if (val < 1 || val > 1440) {
+            input.setAttribute("aria-invalid", "true");
+            if (error) error.textContent = "Must be between 1 and 1440";
+            input.focus();
+            return false;
+        }
+        input.setAttribute("aria-invalid", "false");
+        if (error) error.textContent = "";
+        return true;
+    }
+
     function _scheduleFormState() {
         const form = document.getElementById('scheduleForm');
         return (globalThis.FormState && form) ? globalThis.FormState.attach(form) : null;
@@ -595,6 +624,7 @@
         if (fs) fs.clearErrors();
         let playlistName = _validatePlaylistName();
         if (!playlistName) return;
+        if (!_validateCycleMinutes()) return;
         let startTime = document.getElementById("start_time").value;
         let endTime = document.getElementById("end_time").value;
         const submit = async () => {
@@ -619,6 +649,7 @@
         let oldName = document.getElementById("editingPlaylistName").value;
         let newName = _validatePlaylistName();
         if (!newName) return;
+        if (!_validateCycleMinutes()) return;
         let startTime = document.getElementById("start_time").value;
         let endTime = document.getElementById("end_time").value;
         let cycleMinutes = document.getElementById('cycle_minutes').value;

--- a/src/static/scripts/response_modal.js
+++ b/src/static/scripts/response_modal.js
@@ -31,11 +31,10 @@ function showToast(status, message, duration = TOAST_DURATION_MS) {
     const container = ensureToastContainer();
     const toastId = `toast-${++toastCounter}`;
 
-    // When showing a new error, dismiss any previous error toasts first
-    // so stale validation messages don't stack up across save attempts.
-    if (status === 'error') {
-        dismissStaleErrors();
-    }
+    // Dismiss stale error toasts when showing any new toast (error or success).
+    // This prevents stale validation messages from lingering after a successful
+    // retry and stops error toasts from stacking across rapid save attempts.
+    dismissStaleErrors();
 
     // Enforce stack limit — remove oldest toasts beyond MAX_VISIBLE_TOASTS
     while (container.children.length >= MAX_VISIBLE_TOASTS) {

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -269,7 +269,7 @@
     {% include 'response_modal.html' %}
 
     <!-- Thumbnail Preview Modal -->
-    <div id="thumbnailPreviewModal" class="thumbnail-preview-modal playlist-thumbnail-modal" role="dialog" aria-modal="true" aria-labelledby="thumbnailPreviewTitle" hidden>
+    <div id="thumbnailPreviewModal" class="thumbnail-preview-modal playlist-thumbnail-modal" role="dialog" aria-modal="true" aria-labelledby="thumbnailPreviewTitle" hidden> <!-- NOSONAR S6819: dialog element migration tracked as follow-up -->
         <div class="thumbnail-preview-content playlist-thumbnail-content">
             <h2 id="thumbnailPreviewTitle" class="sr-only">Image Preview</h2>
             <button class="thumbnail-preview-close" type="button" id="closeThumbnailPreviewBtn" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -269,13 +269,13 @@
     {% include 'response_modal.html' %}
 
     <!-- Thumbnail Preview Modal -->
-    <div id="thumbnailPreviewModal" class="thumbnail-preview-modal playlist-thumbnail-modal" role="dialog" aria-modal="true" aria-labelledby="thumbnailPreviewTitle" hidden> <!-- NOSONAR S6819: dialog element migration tracked as follow-up -->
+    <dialog id="thumbnailPreviewModal" class="thumbnail-preview-modal playlist-thumbnail-modal" aria-labelledby="thumbnailPreviewTitle" hidden>
         <div class="thumbnail-preview-content playlist-thumbnail-content">
             <h2 id="thumbnailPreviewTitle" class="sr-only">Image Preview</h2>
             <button class="thumbnail-preview-close" type="button" id="closeThumbnailPreviewBtn" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
             <img id="thumbnailPreviewImage" src="" alt="Plugin Instance Preview">
             <div class="thumbnail-preview-info playlist-thumbnail-info" id="thumbnailPreviewInfo"></div>
         </div>
-    </div>
+    </dialog>
     </main>
 {% endblock %}

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -269,8 +269,9 @@
     {% include 'response_modal.html' %}
 
     <!-- Thumbnail Preview Modal -->
-    <div id="thumbnailPreviewModal" class="thumbnail-preview-modal playlist-thumbnail-modal" hidden>
+    <div id="thumbnailPreviewModal" class="thumbnail-preview-modal playlist-thumbnail-modal" role="dialog" aria-modal="true" aria-labelledby="thumbnailPreviewTitle" hidden>
         <div class="thumbnail-preview-content playlist-thumbnail-content">
+            <h2 id="thumbnailPreviewTitle" class="sr-only">Image Preview</h2>
             <button class="thumbnail-preview-close" type="button" id="closeThumbnailPreviewBtn" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
             <img id="thumbnailPreviewImage" src="" alt="Plugin Instance Preview">
             <div class="thumbnail-preview-info playlist-thumbnail-info" id="thumbnailPreviewInfo"></div>

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -301,7 +301,7 @@
     {% include 'response_modal.html' %}
 
     <!-- Schedule Configuration Modal -->
-    <div id="scheduleModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="scheduleModalTitle">
+    <div id="scheduleModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="scheduleModalTitle" hidden>
         <div class="modal-content">
             <button class="close-button" type="button" data-close-modal="scheduleModal" aria-label="Close">{{ icon('x', 'close-icon') | safe }}</button>
             <h2 id="scheduleModalTitle">Add to Playlist</h2>

--- a/tests/static/test_history_actions.py
+++ b/tests/static/test_history_actions.py
@@ -152,7 +152,7 @@ def test_history_page_js_delete_action_bound_via_delegation(client):
         'action === "delete"' in js
     ), "delegated click handler must branch on action === 'delete'"
     assert (
-        "openDeleteModal(filename)" in js
+        "openDeleteModal(filename" in js
     ), "delete action must call openDeleteModal with the filename"
 
 

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -645,7 +645,9 @@ class TestAddPluginSettingsValidation:
         )
         assert resp.status_code == 400
         data = resp.get_json()
-        assert "URL" in data.get("error", "") or "scheme" in data.get("error", "").lower()
+        assert (
+            "URL" in data.get("error", "") or "scheme" in data.get("error", "").lower()
+        )
 
     def test_screenshot_file_url_rejected(self, client, device_config_dev):
         _create_playlist(client, "SecTest2", "08:00", "12:00")
@@ -668,7 +670,9 @@ class TestAddPluginSettingsValidation:
         )
         assert resp.status_code == 400
         data = resp.get_json()
-        assert "URL" in data.get("error", "") or "scheme" in data.get("error", "").lower()
+        assert (
+            "URL" in data.get("error", "") or "scheme" in data.get("error", "").lower()
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -616,6 +616,62 @@ class TestAddPlugin:
 
 
 # ---------------------------------------------------------------------------
+# JTN-451: add_plugin must validate settings (URL scheme bypass)
+# ---------------------------------------------------------------------------
+
+
+class TestAddPluginSettingsValidation:
+    """JTN-451: add_plugin must call plugin-specific validate_settings
+    to block unsafe values (e.g. javascript: URLs in the Screenshot plugin)."""
+
+    def test_screenshot_javascript_url_rejected(self, client, device_config_dev):
+        _create_playlist(client, "SecTest", "08:00", "12:00")
+        refresh_settings = json.dumps(
+            {
+                "playlist": "SecTest",
+                "instance_name": "SShot1",
+                "refreshType": "interval",
+                "unit": "minute",
+                "interval": "10",
+            }
+        )
+        resp = client.post(
+            "/add_plugin",
+            data={
+                "plugin_id": "screenshot",
+                "url": "javascript:alert(1)",
+                "refresh_settings": refresh_settings,
+            },
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "URL" in data.get("error", "") or "scheme" in data.get("error", "").lower()
+
+    def test_screenshot_file_url_rejected(self, client, device_config_dev):
+        _create_playlist(client, "SecTest2", "08:00", "12:00")
+        refresh_settings = json.dumps(
+            {
+                "playlist": "SecTest2",
+                "instance_name": "SShot2",
+                "refreshType": "interval",
+                "unit": "minute",
+                "interval": "10",
+            },
+        )
+        resp = client.post(
+            "/add_plugin",
+            data={
+                "plugin_id": "screenshot",
+                "url": "file:///etc/passwd",
+                "refresh_settings": refresh_settings,
+            },
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "URL" in data.get("error", "") or "scheme" in data.get("error", "").lower()
+
+
+# ---------------------------------------------------------------------------
 # /display_next_in_playlist (POST)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fixes 10 issues from dogfood pass 5 (JTN-451) across six themes:

- **Security (HIGH):** Validate plugin settings in the `add_plugin` path so Screenshot plugin rejects `javascript:` and `file://` URLs before they persist to `device.json`
- **Modal accessibility:** Add `role="dialog"`, `aria-modal`, and `aria-labelledby` to the thumbnail preview modal; add `hidden` attribute to scheduleModal; add focus management and trigger restoration to history page modals
- **Data validation:** Add client-side `cycle_minutes` validation in the Edit Playlist modal to prevent silent persistence of invalid input
- **Toast lifecycle:** Dismiss stale error toasts when showing any new toast (not just errors), preventing confusing stacked errors between save attempts
- **Naming consistency:** Align `plugin_history_bp` instance name regex with the playlist instance name regex to accept spaces in user-entered names

## Changes
- `src/blueprints/playlist.py` — call `validate_settings` in add_plugin route
- `src/blueprints/plugin_history_bp.py` — widen `_VALID_NAME_RE` to accept spaces
- `src/static/scripts/history_page.js` — focus management + trigger restoration for modals
- `src/static/scripts/playlist.js` — `_validateCycleMinutes()` client-side validation
- `src/static/scripts/response_modal.js` — clear stale errors on all toasts
- `src/templates/playlist.html` — aria attrs on thumbnailPreviewModal
- `src/templates/plugin.html` — add `hidden` to scheduleModal
- `tests/unit/test_playlist_blueprint.py` — security tests for URL scheme validation
- `tests/static/test_history_actions.py` — update assertion for new function signature

## Test plan
- [x] All existing tests pass (4391 passed, 6 skipped)
- [x] New tests added for screenshot URL scheme rejection in add_plugin path
- [x] Updated test assertion for history modal focus management change

🤖 Generated with [Claude Code](https://claude.com/claude-code)