### PR TITLE
Polish GitHub release notes — emoji sections, trim assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,35 @@ jobs:
           semantic-release version
           semantic-release publish
 
+      - name: Strip build-only files from GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # semantic-release needs VERSION and uv.lock listed as `assets` so
+          # they get committed alongside the version bump, but the same config
+          # also uploads them as GitHub release downloads. Users don't install
+          # those files directly — they live in the repo — so drop them from
+          # the release listing to keep it uncluttered.
+          TAG=$(
+            git tag --points-at HEAD \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$' \
+            | sort -V \
+            | tail -n1 \
+            || true
+          )
+          if [ -z "${TAG}" ]; then
+            echo "No new release tag on this run, skipping asset cleanup"
+            exit 0
+          fi
+          for asset in VERSION uv.lock; do
+            if gh release view "${TAG}" --repo "${{ github.repository }}" --json assets \
+                 --jq '.assets[].name' | grep -Fxq "${asset}"; then
+              gh release delete-asset "${TAG}" "${asset}" \
+                --repo "${{ github.repository }}" --yes
+              echo "Removed ${asset} from release ${TAG}"
+            fi
+          done
+
       - name: Generate SBOM
         run: |
           pip install -r install/requirements.txt

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -1,0 +1,41 @@
+{#
+  Custom GitHub release notes template for python-semantic-release.
+
+  Produces short, scannable, emoji-sectioned release notes in the style of
+  https://github.com/Blur009/Blur-AutoClicker/releases — one line per change,
+  no commit hashes, no PR links, no squash-commit body leakage, no
+  Co-Authored-By noise.
+
+  Context variables (provided by python-semantic-release 9.x):
+    release         - Release TypedDict with version / tagged_date / elements
+    release.elements - dict[str, list[ParsedCommit]] keyed by commit category
+                       (e.g. "features", "bug fixes", "refactoring") — see
+                       angular.LONG_TYPE_NAMES
+
+  The CHANGELOG.md keeps its detailed auto-generated format; this file only
+  customises the GitHub release body.
+#}
+{%- macro render_line(commit) -%}
+{%- set raw = commit.descriptions[0] | trim -%}
+{%- set first_word = raw.split(" ", 1)[0] | capitalize -%}
+{%- set rest = raw.split(" ", 1)[1] if " " in raw else "" -%}
+{%- set summary = (first_word ~ " " ~ rest) | trim -%}
+{%- if commit.scope -%}**{{ commit.scope }}**: {{ summary }}{%- else -%}{{ summary }}{%- endif -%}
+{%- endmacro -%}
+{%- set new_commits     = release.elements.get("features", []) -%}
+{%- set fix_commits     = release.elements.get("bug fixes", []) -%}
+{%- set changed_commits = release.elements.get("refactoring", [])
+                        + release.elements.get("performance improvements", []) -%}
+# {{ release.version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+{% if new_commits %}
+## ❇️ New
+{% for commit in new_commits %}- {{ render_line(commit) }}
+{% endfor %}{% endif -%}
+{% if changed_commits %}
+## 🔹 Changed
+{% for commit in changed_commits %}- {{ render_line(commit) }}
+{% endfor %}{% endif -%}
+{% if fix_commits %}
+## 🔺 Fix
+{% for commit in fix_commits %}- {{ render_line(commit) }}
+{% endfor %}{% endif -%}


### PR DESCRIPTION
## Summary

Makes our automated GitHub releases look more like a hand-curated release page (e.g. [Blur-AutoClicker](https://github.com/Blur009/Blur-AutoClicker/releases)) without moving away from the push-to-main-and-forget flow.

- **Custom release-notes template** — `templates/.release_notes.md.j2` drives the GitHub release body. `python-semantic-release` 9.x auto-discovers it. Output uses emoji section headers (`❇️ New` / `🔹 Changed` / `🔺 Fix`), shows only the first line of each commit description, and drops `Co-Authored-By:` lines, commit hashes, PR link suffixes, and the squash-commit body leak we currently see on v0.60.6. `chore:` / `docs:` / `style:` / `test:` / `build:` / `ci:` commits are omitted from the release body (they still appear in `CHANGELOG.md`, which is unchanged).
- **Trim release assets** — after `semantic-release publish`, the workflow now runs `gh release delete-asset` for `VERSION` and `uv.lock`. They're still needed in the release _commit_ (semantic-release `assets` config syncs them with the version bump), but they don't belong as release _downloads_ since they live in the repo.

**Before** (actual v0.60.6 body):
> ## v0.60.6 (2026-04-16)
>
> ### Bug Fixes
>
> - Dogfood pass 3 — validation, accessibility, UX (JTN-349) ([#509](...), [`0d784bd`](...))
>
> * fix: dogfood pass 3 — validation, accessibility, and UX consistency (JTN-349)
>
> Theme 1 (Form validation): Improve client-side form_validator.js …
> [full squash body continues for ~30 lines]
>
> Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
>
> ---
> **Detailed Changes**: [v0.60.5...v0.60.6](...)

**After** (rendered locally against v0.60.2–v0.60.4 history):
```
# v0.60.2 (2026-04-16)

## 🔺 Fix
- Use low-memory image loading in preview plugins (#507)
- Prevent duplicate click handlers on repeater remove buttons
- **lint**: Apply Black formatting to dogfood pass 4 test file
- Remove extraneous f-string prefix flagged by ruff
- Address JTN-376 dogfood pass 4 — validation, accessibility, and UX
```

## Test plan

- [x] Rendered the new template against the last three real releases using the installed `python-semantic-release` + local git history — confirmed emoji sections, no hashes, no squash body, no coauthor leak.
- [ ] Asset-cleanup step only runs on `main` — will be observed on the next merge that produces a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)