### PR TITLE
fix(weather): JTN-716 click-sweep no-ops on Style picker + nav links

### DIFF
--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -524,7 +524,9 @@
     };
 
     const openModal = () => {
+      modal.hidden = false;
       modal.style.display = "block";
+      modal.classList.add("is-open");
       setTimeout(initLeafletMap, 100);
     };
 
@@ -534,7 +536,9 @@
         latInput.value = position.lat;
         lonInput.value = position.lng;
       }
+      modal.hidden = true;
       modal.style.display = "none";
+      modal.classList.remove("is-open");
     };
 
     openButton.addEventListener("click", openModal);

--- a/src/static/scripts/response_modal.js
+++ b/src/static/scripts/response_modal.js
@@ -143,6 +143,7 @@ function showResponseModal(status, message, useToast = true) {
     }
 
     // Display Modal
+    modal.hidden = false;
     modal.style.display = 'block';
 
     // Auto-close modal (skip for failure so users can read error details)
@@ -155,6 +156,7 @@ function showResponseModal(status, message, useToast = true) {
 function closeResponseModal() {
     const modal = document.getElementById('responseModal');
     if (modal) {
+        modal.hidden = true;
         modal.style.display = 'none';
     }
 }

--- a/src/templates/response_modal.html
+++ b/src/templates/response_modal.html
@@ -1,6 +1,6 @@
 <!-- Reusable Success/Failure Notification Modal -->
 <!-- aria-live="assertive" announces modal text to screen readers immediately (JTN-507) -->
-<div id="responseModal" class="response-modal success-failure-modal" role="alertdialog" aria-modal="true" aria-labelledby="modalMessage" aria-label="Notification" aria-live="assertive">
+<div id="responseModal" class="response-modal success-failure-modal" role="alertdialog" aria-modal="true" aria-labelledby="modalMessage" aria-label="Notification" aria-live="assertive" hidden>
     <div id="modalContent" class="response-modal-content">
         <button type="button" class="close-button" id="responseModalClose" aria-label="Close"><svg class="close-icon" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg"><line x1="200" y1="56" x2="56" y2="200" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="200" y1="200" x2="56" y2="56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/></svg></button>
         <p id="modalMessage"></p>

--- a/src/templates/widgets/weather_map.html
+++ b/src/templates/widgets/weather_map.html
@@ -13,7 +13,7 @@
 </div>
 <button type="button" id="openMap" class="action-button compact">Select Location</button>
 
-<div id="mapModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="mapModalTitle">
+<div id="mapModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="mapModalTitle" hidden>
     <div class="modal-content">
         <button type="button" class="close-button" aria-label="Close">&times;</button>
         <h2 id="mapModalTitle">Select Location</h2>

--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -156,11 +156,7 @@ _PLUGIN_MAX_CLICKS_PER_PAGE = 15
 # issue so they get cleaned up, not left to rot. Discovered during the
 # initial JTN-698 landing — these plugins have real handler bugs the sweep
 # surfaced, tracked separately so the infra lands green.
-_PLUGIN_XFAIL: dict[str, str] = {
-    "weather": (
-        "JTN-716 — Style picker collapsible + nav links no-op on /plugin/weather"
-    ),
-}
+_PLUGIN_XFAIL: dict[str, str] = {}
 
 
 _ENUMERATE_JS = """
@@ -204,12 +200,26 @@ _ENUMERATE_JS = """
     el.setAttribute('data-clicksweep-id', marker);
     const hrefAttr = el.getAttribute('href');
     // "Already at target state" heuristics — clicking one of these is a
-    // legitimate no-op and should not count as a silent failure. Two cases:
+    // legitimate no-op and should not count as a silent failure. Cases:
     // * An anchor whose href is the current pathname (logo/home links).
     // * A selector-style button already flagged selected/active.
+    // * A pure hash anchor (`/foo#section` on `/foo`, or `#section`) —
+    //   Playwright treats hash-only navigations as non-navigations and the
+    //   snapshot's URL comparison only tracks pathname differences, so
+    //   hash-only changes may register as no-op even though the handler
+    //   (native anchor scroll) fired correctly. See JTN-716.
+    const hrefUrl = (() => {
+      try { return hrefAttr ? new URL(hrefAttr, window.location.href) : null; }
+      catch (_) { return null; }
+    })();
     const isSameLink =
       el.tagName === 'A' && hrefAttr && (hrefAttr === currentPath ||
         hrefAttr === currentPath + '/' || hrefAttr === '#');
+    const isSameOriginHashLink =
+      el.tagName === 'A' && !!hrefUrl &&
+      hrefUrl.origin === window.location.origin &&
+      hrefUrl.pathname === currentPath &&
+      !!hrefUrl.hash;
     const isAlreadySelected =
       el.classList.contains('selected') || el.classList.contains('active') ||
       el.getAttribute('aria-pressed') === 'true' ||
@@ -222,7 +232,7 @@ _ENUMERATE_JS = """
         !!(el.dataset && (el.dataset.pluginAction || el.dataset.apiAction ||
                           el.dataset.historyAction || el.dataset.settingsTab)),
       href: hrefAttr || null,
-      tolerateNoChange: isSameLink || isAlreadySelected,
+      tolerateNoChange: isSameLink || isSameOriginHashLink || isAlreadySelected,
     });
   }
   return descriptors;
@@ -356,6 +366,71 @@ def _reset_page_state(page, base_url: str, sweep: SweepPage) -> None:
     _install_observer(page)
 
 
+# After a click opens a modal, close it before the next iteration so the
+# overlay doesn't intercept subsequent clicks on background controls. Without
+# this, clicking "Select Location" on /plugin/weather leaves the map modal
+# open for the rest of the sweep and every later click silently no-ops.
+# Closing is best-effort: first try the modal's own close handler so focus
+# restoration + stacking-context cleanup runs (JS force-close leaves focus
+# trapped inside the hidden modal and subsequent clicks misbehave — see
+# JTN-716), then fall back to attribute flips when no close button exists.
+_CLOSE_OPEN_MODALS_JS = """
+() => {
+  const modals = Array.from(document.querySelectorAll(
+    '.modal.is-open, .modal[style*="display: block"], .modal[style*="display:block"], ' +
+    '.modal[style*="display: flex"], .modal[style*="display:flex"], ' +
+    '[aria-modal="true"]:not([hidden])'
+  ));
+  // Filter to modals whose computed display is actually visible — matching
+  // the selector without the display check picks up modals that carry
+  // `aria-modal` but are already display:none via CSS.
+  const visibleModals = modals.filter((m) => getComputedStyle(m).display !== 'none');
+  let closed = 0;
+  for (const modal of visibleModals) {
+    // Prefer the modal's own close button so the page's close handler runs
+    // (focus restore, backdrop cleanup, body.modal-open toggle). Only fall
+    // back to attribute flips when no close button exists — raw style flips
+    // leave focus trapped inside the now-hidden modal, which causes later
+    // hit-testing to route clicks to the wrong element.
+    const closeBtn = modal.querySelector(
+      '[data-close-modal], .close-button, .modal-close, [aria-label="Close"]'
+    );
+    if (closeBtn && typeof closeBtn.click === 'function') {
+      try {
+        closeBtn.click();
+        if (getComputedStyle(modal).display === 'none' || modal.hidden) {
+          closed += 1;
+          continue;
+        }
+      } catch (_) { /* fall through to style flip */ }
+    }
+    modal.hidden = true;
+    modal.style.display = 'none';
+    modal.classList.remove('is-open');
+    closed += 1;
+  }
+  if (closed > 0) {
+    document.body?.classList.remove('modal-open');
+    // Move focus back to body so subsequent clicks aren't trapped inside a
+    // hidden modal descendant, and blur whatever had focus inside the modal.
+    const active = document.activeElement;
+    if (active && active !== document.body && typeof active.blur === 'function') {
+      try { active.blur(); } catch (_) { /* ignore */ }
+    }
+  }
+  return closed;
+}
+"""
+
+
+def _close_open_modals(page) -> None:
+    """Best-effort close any modal dialogs opened by a click."""
+    try:
+        page.evaluate(_CLOSE_OPEN_MODALS_JS)
+    except Exception:  # noqa: BLE001 — modal-close is advisory
+        pass
+
+
 def _run_click_sweep(
     page,
     live_server: str,
@@ -418,6 +493,11 @@ def _run_click_sweep(
         # us back so the rest of the sweep runs against the intended page.
         if before["url"] != after["url"]:
             _reset_page_state(page, live_server, sweep)
+        elif after.get("openModal") and not before.get("openModal"):
+            # Click opened a modal. Close it before the next iteration so the
+            # overlay doesn't intercept clicks on background controls. See
+            # JTN-716 for why this matters on /plugin/weather.
+            _close_open_modals(page)
 
     assert clicks_performed > 0, (
         f"{sweep.path}: enumerated {len(descriptors)} candidates but clicked "

--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -212,13 +212,16 @@ _ENUMERATE_JS = """
       try { return hrefAttr ? new URL(hrefAttr, window.location.href) : null; }
       catch (_) { return null; }
     })();
+    const normalizePath = (p) =>
+      (p && p.length > 1 && p.endsWith('/')) ? p.slice(0, -1) : p;
+    const normalizedCurrentPath = normalizePath(currentPath);
     const isSameLink =
       el.tagName === 'A' && hrefAttr && (hrefAttr === currentPath ||
         hrefAttr === currentPath + '/' || hrefAttr === '#');
     const isSameOriginHashLink =
       el.tagName === 'A' && !!hrefUrl &&
       hrefUrl.origin === window.location.origin &&
-      hrefUrl.pathname === currentPath &&
+      normalizePath(hrefUrl.pathname) === normalizedCurrentPath &&
       !!hrefUrl.hash;
     const isAlreadySelected =
       el.classList.contains('selected') || el.classList.contains('active') ||
@@ -379,7 +382,7 @@ _CLOSE_OPEN_MODALS_JS = """
   const modals = Array.from(document.querySelectorAll(
     '.modal.is-open, .modal[style*="display: block"], .modal[style*="display:block"], ' +
     '.modal[style*="display: flex"], .modal[style*="display:flex"], ' +
-    '[aria-modal="true"]:not([hidden])'
+    '[aria-modal="true"]:not([hidden]), dialog[open]'
   ));
   // Filter to modals whose computed display is actually visible — matching
   // the selector without the display check picks up modals that carry
@@ -387,6 +390,18 @@ _CLOSE_OPEN_MODALS_JS = """
   const visibleModals = modals.filter((m) => getComputedStyle(m).display !== 'none');
   let closed = 0;
   for (const modal of visibleModals) {
+    if (modal.tagName === 'DIALOG') {
+      if (typeof modal.close === 'function') {
+        try { modal.close(); } catch (_) { /* ignore and continue fallback */ }
+      } else {
+        modal.removeAttribute('open');
+        modal.open = false;
+      }
+      if (!modal.open && !modal.hasAttribute('open')) {
+        closed += 1;
+        continue;
+      }
+    }
     // Prefer the modal's own close button so the page's close handler runs
     // (focus restore, backdrop cleanup, body.modal-open toggle). Only fall
     // back to attribute flips when no close button exists — raw style flips


### PR DESCRIPTION
## Summary

Fixes [JTN-716](https://linear.app/jtn0123/issue/JTN-716). The weather plugin's click-sweep flagged the Style picker collapsible and every nav link as silent no-ops. Root cause was `#mapModal` (weather location picker) and `#responseModal` carrying `aria-modal="true"` without the `hidden` attribute, so clicking "Select Location" opened the map modal on top of the page, and every subsequent click (Style, Home, API Required, HOME/PLUGINS breadcrumb) was intercepted by the overlay.

## Base Branch Confirmation

- [x] This PR is based on `origin/main`
- [x] Rebased off latest `origin/main` before opening

## Changes

- `src/templates/response_modal.html`, `src/templates/widgets/weather_map.html` — add `hidden` attribute so the click-sweep snapshot correctly tracks modal visibility instead of matching them at boot.
- `src/static/scripts/plugin_schema.js`, `src/static/scripts/response_modal.js` — toggle `hidden` alongside `style.display` in open/close helpers so the attribute and computed style stay in sync.
- `tests/integration/test_click_sweep.py`:
  - Close any modal opened by a click before the next iteration. Prefer the modal's own close button so focus restore + `body.modal-open` cleanup runs; plain style-flips leave focus trapped inside the hidden modal and re-route later hit-testing to the wrong element (repro'd on `/playlist`).
  - Tolerate same-origin hash anchors (e.g. `/#plugins-grid` clicked from `/plugin/weather`) so legitimate in-page scroll links aren't flagged when the URL's pathname doesn't change.
  - Remove `weather` from `_PLUGIN_XFAIL` — click-sweep now passes.

## Compatibility/Release Checklist

- [x] `pytest tests/integration/test_click_sweep.py` — 29 passed, 2 pre-existing xfailed, 1 pre-existing flake (`api_keys-mobile`, exists on main)
- [x] No breaking API route/path changes
- [x] No error response contract changes
- [x] Frontend changes (`src/static/**`, `src/templates/**`): ran browser tests locally

## Testing

- Ran `uv run pytest tests/integration/test_click_sweep.py::test_click_sweep_plugin_pages` — all 20 plugins pass (no xfails).
- Ran full `pytest tests/integration/test_click_sweep.py` — only pre-existing `api_keys-mobile` failure, verified against `main`.
- Confirmed pre-existing failures in `test_plugin_workflow_e2e`, `test_e2e_form_workflows`, `test_collapsible_sections_e2e`, `test_more_a11y`, etc. all reproduce on `origin/main` and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Weather Map and Response modals' open/close behavior and visibility handling
  * Prevented modals from being visible/announced by default on page load

* **Tests**
  * Strengthened integration click-sweep to close stray modals after clicks
  * Updated test heuristics for hash-only navigation and removed a weather page expected failure case
<!-- end of auto-generated comment: release notes by coderabbit.ai -->