### PR TITLE
chore: tighten static quality gates for typing + datetime linting (JTN-676, JTN-714)

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -30,6 +30,7 @@ ongoing feature work.
 | `src/refresh_task/worker.py` | Refresh guards PR |
 | `src/utils/sri.py` | Quality guards follow-up PR |
 | `src/utils/time_utils.py` | Quality guards PR |
+| `src/utils/http_cache.py` | JTN-676 |
 | `src/model.py` | JTN-663 |
 
 `src/utils/http_cache.py` was deliberately deferred from the initial strict

--- a/mypy.ini
+++ b/mypy.ini
@@ -81,6 +81,9 @@ strict = True
 [mypy-utils.time_utils]
 strict = True
 
+[mypy-utils.http_cache]
+strict = True
+
 [mypy-refresh_task.actions]
 strict = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,10 @@ known-first-party = ["src"]
 [tool.ruff.lint.per-file-ignores]
 # Tests intentionally construct naive datetimes for fixture-style assertions and
 # deterministic clock stubs. Mirroring production's tz-aware datetime everywhere
-# would bloat the suite without exercising new behavior. Enforce DTZ in src/
-# and scripts/ only.
-"tests/**" = ["DTZ001", "DTZ002", "DTZ003", "DTZ005", "DTZ006", "DTZ007", "DTZ011"]
+# would bloat the suite without exercising new behavior. We still enforce
+# timezone-awareness for clock-based calls (now/fromtimestamp/date.today) in
+# tests because those drift with host locale and can hide real bugs.
+"tests/**" = ["DTZ001", "DTZ002", "DTZ003", "DTZ007"]
 
 [tool.mutmut]
 paths_to_mutate = "src/app_setup/,src/blueprints/,src/utils/,src/refresh_task/"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -115,6 +115,7 @@ mypy --strict \
     src/refresh_task/worker.py \
     src/utils/sri.py \
     src/utils/time_utils.py \
+    src/utils/http_cache.py \
     src/model.py
 MYPY_STRICT_EXIT=$?
 if [ $MYPY_STRICT_EXIT -ne 0 ]; then

--- a/src/utils/http_cache.py
+++ b/src/utils/http_cache.py
@@ -48,7 +48,7 @@ class CacheEntry:
         resp = requests.models.Response()
         resp.status_code = self.cached_data["status_code"]
         resp.headers.update(self.cached_data["headers"])
-        resp._content = self.cached_data["content"]  # type: ignore[attr-defined]
+        resp._content = self.cached_data["content"]
         return resp
 
 
@@ -383,12 +383,14 @@ def get_cache() -> HTTPCache:
     """
     global _global_cache
 
-    if _global_cache is not None:
-        return _global_cache
+    cache = _global_cache
+    if cache is not None:
+        return cache
 
     with _cache_lock:
-        if _global_cache is not None:
-            return _global_cache
+        cache = _global_cache
+        if cache is not None:
+            return cache
 
         # Read configuration from environment
         enabled = os.getenv("INKYPI_HTTP_CACHE_ENABLED", "true").lower() in (

--- a/tests/plugins/test_calendar.py
+++ b/tests/plugins/test_calendar.py
@@ -366,8 +366,8 @@ def test_fetch_ics_events_empty_calendar():
                 ["http://example.com"],
                 ["#000"],
                 UTC,
-                datetime.now(),
-                datetime.now() + timedelta(days=1),
+                datetime.now(UTC),
+                datetime.now(UTC) + timedelta(days=1),
             )
             assert events == []
 

--- a/tests/plugins/test_wpotd.py
+++ b/tests/plugins/test_wpotd.py
@@ -475,7 +475,7 @@ def test_make_request_api_error():
 
 def test_fetch_potd_api_error():
     """Test _fetch_potd with API error."""
-    from datetime import date
+    from datetime import UTC, datetime
 
     from plugins.wpotd.wpotd import Wpotd
 
@@ -486,12 +486,12 @@ def test_fetch_potd_api_error():
         mock_make_request.side_effect = RuntimeError("Wikipedia API request failed")
 
         with pytest.raises(RuntimeError, match="Wikipedia API request failed"):
-            p._fetch_potd(date.today())
+            p._fetch_potd(datetime.now(UTC).date())
 
 
 def test_fetch_potd_missing_images():
     """Test _fetch_potd with missing images in response."""
-    from datetime import date
+    from datetime import UTC, datetime
 
     from plugins.wpotd.wpotd import Wpotd
 
@@ -505,4 +505,4 @@ def test_fetch_potd_missing_images():
         }
 
         with pytest.raises(RuntimeError, match="Failed to retrieve POTD filename"):
-            p._fetch_potd(date.today())
+            p._fetch_potd(datetime.now(UTC).date())

--- a/tests/unit/test_refresh_invariants_property_based.py
+++ b/tests/unit/test_refresh_invariants_property_based.py
@@ -1,5 +1,5 @@
 # pyright: reportMissingImports=false
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from hypothesis import HealthCheck, given, settings, strategies as st
 
@@ -13,7 +13,7 @@ from model import Playlist, PlaylistManager, RefreshInfo
 )
 @settings(max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_should_refresh_matches_elapsed_time(latest_epoch, elapsed_s, interval_s):
-    latest = datetime.fromtimestamp(latest_epoch)
+    latest = datetime.fromtimestamp(latest_epoch, tz=UTC)
     current = latest + timedelta(seconds=elapsed_s)
     assert PlaylistManager.should_refresh(latest, interval_s, current) is (
         elapsed_s >= interval_s

--- a/tests/unit/test_settings_health.py
+++ b/tests/unit/test_settings_health.py
@@ -1,7 +1,7 @@
 # pyright: reportMissingImports=false
 """Tests for settings health and progress SSE endpoints (_health.py)."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 
@@ -10,7 +10,7 @@ class TestHealthPlugins:
         """Entries with last_seen older than the window are filtered out."""
         monkeypatch.setenv("INKYPI_HEALTH_WINDOW_MIN", "1440")
 
-        stale_time = (datetime.now() - timedelta(days=2)).isoformat()
+        stale_time = (datetime.now(UTC) - timedelta(days=2)).isoformat()
         snapshot = {"old_plugin": {"last_seen": stale_time, "status": "ok"}}
 
         rt = MagicMock()
@@ -28,7 +28,7 @@ class TestHealthPlugins:
     def test_keeps_recent_entries(self, client, monkeypatch):
         """Entries with recent last_seen are preserved."""
         monkeypatch.setenv("INKYPI_HEALTH_WINDOW_MIN", "1440")
-        recent_time = datetime.now().isoformat()
+        recent_time = datetime.now(UTC).isoformat()
         snapshot = {"fresh_plugin": {"last_seen": recent_time, "status": "ok"}}
 
         rt = MagicMock()
@@ -73,7 +73,7 @@ class TestHealthPlugins:
         """Non-numeric INKYPI_HEALTH_WINDOW_MIN falls back to 1440."""
         monkeypatch.setenv("INKYPI_HEALTH_WINDOW_MIN", "abc")
 
-        recent_time = datetime.now().isoformat()
+        recent_time = datetime.now(UTC).isoformat()
         snapshot = {"plugin": {"last_seen": recent_time}}
 
         rt = MagicMock()


### PR DESCRIPTION
## Summary

- promote `src/utils/http_cache.py` into the CI-blocking `mypy --strict` subset
- fix strict typing issues in `http_cache` so the new blocking gate is stable
- tighten test-side DTZ policy by enforcing timezone-aware `now()/fromtimestamp()/date.today()` usage
- update affected tests to use explicit UTC-based calls and keep deterministic behavior

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

## Testing

- `bash scripts/lint.sh`
- `.venv/bin/ruff check tests --select DTZ005,DTZ006,DTZ011`
- `.venv/bin/pytest tests/plugins/test_calendar.py tests/plugins/test_wpotd.py tests/unit/test_settings_health.py tests/unit/test_refresh_invariants_property_based.py -q`
