### PR TITLE
fix(install): harden device update stability

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,7 +62,27 @@ sudo journalctl --vacuum-size=50M
 
 > **Note:** The in-memory log buffer used in dev mode (`--dev`) holds at most 1,000 entries and is never written to disk, so it has no impact on journal size.
 
-The InkyPi install script (`install/install.sh`) automatically applies a 50M journal cap during a fresh install if no `SystemMaxUse` limit is already configured.
+The InkyPi install and update scripts automatically enable persistent journald storage and apply `50M` caps for both `SystemMaxUse` and `RuntimeMaxUse` when no explicit journald settings already exist.
+
+## Intermittent Wi-Fi reachability / SSH drops
+
+If the Pi appears online but drops SSH or misses pings intermittently, check whether Wi-Fi power saving is enabled on `wlan0`:
+
+```bash
+nmcli -g 802-11-wireless.powersave connection show "$(nmcli -g GENERAL.CONNECTION device show wlan0 | head -n 1)"
+```
+
+`2` means disabled, which is the recommended setting for an always-on Pi. InkyPi now hardens NetworkManager-based installs and updates by writing a NetworkManager config drop-in and disabling Wi-Fi powersave on the active `wlan0` profile when possible.
+
+To inspect the current link and roaming state:
+
+```bash
+nmcli -f GENERAL.STATE,GENERAL.CONNECTION,IP4.ADDRESS dev show wlan0
+cat /proc/net/wireless
+journalctl -b | grep -Ei 'wlan0|brcmfmac|CTRL-EVENT|deauth|disassoc'
+```
+
+If you still see drops after power-save hardening, compare signal strength across nearby APs with the same SSID and consider pinning the Pi to the strongest BSSID.
 
 ## Restart the InkyPi Service
 

--- a/install/_common.sh
+++ b/install/_common.sh
@@ -12,6 +12,7 @@
 #     echo_override / show_loader)
 #   - get_os_version
 #   - setup_zramswap_service / setup_earlyoom_service
+#   - configure_persistent_journal / disable_wifi_powersave
 #   - stop_service
 #   - build_css_bundle
 # =============================================================================
@@ -115,6 +116,79 @@ setup_earlyoom_service() {
   echo "Enabling and starting earlyoom service."
   sudo apt-get install -y earlyoom > /dev/null
   sudo systemctl enable --now earlyoom
+}
+
+configure_persistent_journal() {
+  local conf="/etc/systemd/journald.conf"
+  local changed=0
+
+  if [ ! -f "$conf" ]; then
+    echo "journald config not found at $conf — skipping persistent journal setup."
+    return 0
+  fi
+
+  # Ensure logs survive reboots so post-incident diagnosis is still possible.
+  sudo mkdir -p /var/log/journal
+
+  if ! grep -Eq '^[[:space:]]*Storage=' "$conf"; then
+    echo "Configuring persistent journal storage."
+    echo "Storage=persistent" | sudo tee -a "$conf" > /dev/null
+    changed=1
+  fi
+  if ! grep -Eq '^[[:space:]]*SystemMaxUse=' "$conf"; then
+    echo "Configuring journal size limit (50M)."
+    echo "SystemMaxUse=50M" | sudo tee -a "$conf" > /dev/null
+    changed=1
+  fi
+  if ! grep -Eq '^[[:space:]]*RuntimeMaxUse=' "$conf"; then
+    echo "Configuring runtime journal size limit (50M)."
+    echo "RuntimeMaxUse=50M" | sudo tee -a "$conf" > /dev/null
+    changed=1
+  fi
+
+  if [ "$changed" -eq 1 ]; then
+    sudo systemctl restart systemd-journald
+    echo_success "Persistent journal storage configured."
+  else
+    echo_success "Persistent journal storage already configured."
+  fi
+}
+
+disable_wifi_powersave() {
+  local nm_conf_dir="/etc/NetworkManager/conf.d"
+  local nm_conf_file="$nm_conf_dir/100-inkypi-wifi-powersave.conf"
+  local active_wifi_connection=""
+
+  if [ ! -d /sys/class/net/wlan0 ]; then
+    echo "wlan0 not present — skipping Wi-Fi powersave hardening."
+    return 0
+  fi
+
+  if command -v iw >/dev/null 2>&1; then
+    sudo iw dev wlan0 set power_save off >/dev/null 2>&1 || true
+  fi
+
+  if ! command -v nmcli >/dev/null 2>&1; then
+    echo "nmcli not available — applied best-effort runtime Wi-Fi powersave disable only."
+    return 0
+  fi
+
+  sudo mkdir -p "$nm_conf_dir"
+  if [ ! -f "$nm_conf_file" ] || ! grep -Eq '^[[:space:]]*wifi\.powersave[[:space:]]*=[[:space:]]*2[[:space:]]*$' "$nm_conf_file"; then
+    cat <<'EOF' | sudo tee "$nm_conf_file" > /dev/null
+[connection]
+wifi.powersave = 2
+EOF
+    echo "Configured NetworkManager default Wi-Fi powersave to disabled."
+  fi
+
+  active_wifi_connection=$(nmcli -g GENERAL.CONNECTION device show wlan0 2>/dev/null | head -n 1)
+  if [ -n "$active_wifi_connection" ] && [ "$active_wifi_connection" != "--" ]; then
+    sudo nmcli connection modify "$active_wifi_connection" 802-11-wireless.powersave 2 >/dev/null 2>&1 || true
+    echo_success "Disabled Wi-Fi powersave for active NetworkManager profile."
+  else
+    echo "No active NetworkManager Wi-Fi profile on wlan0 — leaving default hardening in place."
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/install/install.sh
+++ b/install/install.sh
@@ -269,16 +269,6 @@ maybe_disable_dphys_swapfile() {
   echo "✓ Reclaimed dphys-swapfile space."
 }
 
-configure_journal_size() {
-  local conf="/etc/systemd/journald.conf"
-  if [ -f "$conf" ] && ! grep -q "^SystemMaxUse=" "$conf"; then
-    echo "Configuring journal size limit (50M)"
-    echo "SystemMaxUse=50M" | sudo tee -a "$conf" > /dev/null
-    sudo systemctl restart systemd-journald
-    echo_success "Journal size limit configured."
-  fi
-}
-
 create_venv(){
   echo "Creating python virtual environment. "
   python3 -m venv "$VENV_PATH"
@@ -625,7 +615,8 @@ else
 fi
 maybe_disable_dphys_swapfile      # JTN-593: reclaim /var/swap when zram is active
 setup_earlyoom_service
-configure_journal_size
+configure_persistent_journal
+disable_wifi_powersave
 install_src
 install_cli
 create_venv

--- a/install/update.sh
+++ b/install/update.sh
@@ -52,7 +52,8 @@ APT_REQUIREMENTS_FILE="$SCRIPT_DIR/debian-requirements.txt"
 PIP_REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 
 # JTN-669/674: Source shared helpers (formatting, stop_service, zramswap,
-# earlyoom, get_os_version, build_css_bundle, fetch_wheelhouse, cleanup_wheelhouse)
+# earlyoom, persistent journald, Wi-Fi hardening, get_os_version,
+# build_css_bundle, fetch_wheelhouse, cleanup_wheelhouse)
 # so install.sh and update.sh share a single source of truth.
 # shellcheck source=install/_common.sh
 source "$SCRIPT_DIR/_common.sh"
@@ -315,6 +316,8 @@ else
   echo "OS version is $os_version - skipping zramswap setup (zram-tools not available on this release)."
 fi
 setup_earlyoom_service
+configure_persistent_journal
+disable_wifi_powersave
 
 _current_step="venv_check"
 # Check if virtual environment exists
@@ -469,5 +472,5 @@ _current_step="update_app_service"
 _inkypi_maybe_inject_failure "update_app_service"
 update_app_service
 
-echo "Version: $(cat "$INSTALL_PATH/VERSION" 2>/dev/null || echo 'unknown')"
+echo "Version: $(cat "$SCRIPT_DIR/../VERSION" 2>/dev/null || echo 'unknown')"
 echo_success "Update completed."

--- a/tests/integration/journeys/test_update_flow_happy_path.py
+++ b/tests/integration/journeys/test_update_flow_happy_path.py
@@ -204,7 +204,7 @@ def test_update_flow_happy_path(
     ), f"#latestVersion should show stubbed tag; got {latest_text!r}"
     badge_text = page.locator("#updateBadge").inner_text().strip()
     assert (
-        "Update available" in badge_text
+        "update available" in badge_text.lower()
     ), f"#updateBadge should reflect update availability; got {badge_text!r}"
 
     # "Update Now" must now be enabled (it ships disabled).

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -407,6 +407,38 @@ class TestInstallScript:
             "and before setup_earlyoom_service in install.sh"
         )
 
+    def test_install_configures_persistent_journal_via_shared_helper(self):
+        assert "configure_persistent_journal() {" in self.combined
+        assert "Storage=persistent" in self.combined
+        assert "SystemMaxUse=50M" in self.combined
+        assert "RuntimeMaxUse=50M" in self.combined
+        assert "/var/log/journal" in self.combined
+        assert "systemctl restart systemd-journald" in self.combined
+
+        earlyoom_pos = self.content.index("setup_earlyoom_service")
+        journal_pos = self.content.index("configure_persistent_journal", earlyoom_pos)
+        install_src_pos = self.content.index("install_src", journal_pos)
+        assert earlyoom_pos < journal_pos < install_src_pos, (
+            "install.sh must configure persistent journald after earlyoom setup "
+            "and before copying the repo into place"
+        )
+
+    def test_install_disables_wifi_powersave_via_shared_helper(self):
+        assert "disable_wifi_powersave() {" in self.combined
+        assert "iw dev wlan0 set power_save off" in self.combined
+        assert "100-inkypi-wifi-powersave.conf" in self.combined
+        assert "wifi.powersave = 2" in self.combined
+        assert "nmcli -g GENERAL.CONNECTION device show wlan0" in self.combined
+        assert "802-11-wireless.powersave 2" in self.combined
+
+        journal_pos = self.content.index("configure_persistent_journal")
+        wifi_pos = self.content.index("disable_wifi_powersave", journal_pos)
+        install_src_pos = self.content.index("install_src", wifi_pos)
+        assert journal_pos < wifi_pos < install_src_pos, (
+            "install.sh must harden Wi-Fi powersave after journald setup and "
+            "before the source/venv work begins"
+        )
+
     def test_disable_dphys_only_runs_when_zram_active(self):
         # JTN-593: The function must check /proc/swaps for /dev/zram BEFORE
         # removing anything — it must be a no-op on systems without zram.
@@ -1783,6 +1815,33 @@ class TestUpdateScript:
         assert "_common.sh" in self.content
         assert 'source "$SCRIPT_DIR/_common.sh"' in self.content
 
+    def test_update_configures_persistent_journal_via_shared_helper(self):
+        assert "configure_persistent_journal() {" in self.combined
+        assert "Storage=persistent" in self.combined
+        assert "RuntimeMaxUse=50M" in self.combined
+
+        earlyoom_pos = self.content.index("setup_earlyoom_service")
+        journal_pos = self.content.index("configure_persistent_journal", earlyoom_pos)
+        venv_pos = self.content.index('_current_step="venv_check"')
+        assert earlyoom_pos < journal_pos < venv_pos, (
+            "update.sh must configure persistent journald after earlyoom setup "
+            "and before venv / pip work starts"
+        )
+
+    def test_update_disables_wifi_powersave_via_shared_helper(self):
+        assert "disable_wifi_powersave() {" in self.combined
+        assert "iw dev wlan0 set power_save off" in self.combined
+        assert "100-inkypi-wifi-powersave.conf" in self.combined
+        assert "802-11-wireless.powersave 2" in self.combined
+
+        journal_pos = self.content.index("configure_persistent_journal")
+        wifi_pos = self.content.index("disable_wifi_powersave", journal_pos)
+        venv_pos = self.content.index('_current_step="venv_check"')
+        assert journal_pos < wifi_pos < venv_pos, (
+            "update.sh must harden Wi-Fi powersave after journald setup and "
+            "before dependency updates begin"
+        )
+
     def test_update_calls_fetch_wheelhouse(self):
         # JTN-669: fetch_wheelhouse must be called before the pip upgrade
         # so the pre-built bundle is available when pip resolves packages.
@@ -1791,6 +1850,10 @@ class TestUpdateScript:
     def test_update_calls_cleanup_wheelhouse(self):
         # The temp wheelhouse dir must always be cleaned up after install.
         assert "cleanup_wheelhouse" in self.content
+
+    def test_update_reports_version_from_checked_out_repo(self):
+        assert "$SCRIPT_DIR/../VERSION" in self.content
+        assert "$INSTALL_PATH/VERSION" not in self.content
 
     def test_update_pip_uses_find_links_when_available(self):
         # When the wheelhouse is available, pip must be pointed at it via


### PR DESCRIPTION
## Summary

- disable Wi-Fi powersave during install/update so always-on Pi devices are less likely to flap off the network
- enable persistent journald storage with 50M caps so post-reboot outage evidence survives long enough to diagnose
- fix `install/update.sh` version reporting so successful updates show the checked-out app version instead of `unknown`
- document the new hardening and expand script coverage tests, plus make the update badge assertion resilient to uppercased UI text

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a `fatihak/InkyPi` sync PR

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI
- [x] No `src/static/**` or `src/templates/**` frontend source changes in this PR

## Testing

- `scripts/lint.sh`
- `INKYPI_ENV=dev INKYPI_NO_REFRESH=1 PYTHONPATH=src pytest -q tests/unit/test_install_scripts.py tests/integration/test_update_failure_recovery.py tests/integration/journeys/test_update_flow_happy_path.py`
