### PR TITLE
fix(playlist): delegate card actions and harden toggle state (JTN-692, JTN-660)

### DIFF
--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -135,24 +135,17 @@
         if (!item || !body || !toggle) return;
         const playlistName = item.getAttribute('data-playlist-name');
 
-        if (!mobileQuery.matches){
-            body.hidden = false;
-            item.classList.add('mobile-expanded');
-            item.classList.remove('mobile-collapsed');
-            toggle.textContent = toggle.getAttribute('data-expanded-label') || 'Hide';
-            toggle.setAttribute('aria-expanded', 'true');
-            return;
-        }
-
         body.hidden = !expanded;
         item.classList.toggle('mobile-expanded', expanded);
         item.classList.toggle('mobile-collapsed', !expanded);
         toggle.textContent = expanded ? (toggle.getAttribute('data-expanded-label') || 'Hide') : (toggle.getAttribute('data-collapsed-label') || 'Open');
         toggle.setAttribute('aria-expanded', String(expanded));
-        if (expanded){
-            state.expandedPlaylist = playlistName;
-        } else if (state.expandedPlaylist === playlistName){
-            state.expandedPlaylist = null;
+        if (mobileQuery.matches){
+            if (expanded){
+                state.expandedPlaylist = playlistName;
+            } else if (state.expandedPlaylist === playlistName){
+                state.expandedPlaylist = null;
+            }
         }
     }
 
@@ -178,13 +171,84 @@
         const isExpanded =
             button.getAttribute('aria-expanded') === 'true'
             || item.classList.contains('mobile-expanded');
-        const willExpand = !mobileQuery.matches || !isExpanded;
+        const willExpand = !isExpanded;
         if (mobileQuery.matches && willExpand){
             document.querySelectorAll('[data-playlist-card]').forEach((card) => {
                 if (card !== item) setPlaylistExpanded(card, false);
             });
         }
         setPlaylistExpanded(item, willExpand);
+    }
+
+    function parseRefreshSettings(rawValue){
+        if (!rawValue) return {};
+        try {
+            return JSON.parse(rawValue);
+        } catch (_err) {
+            return {};
+        }
+    }
+
+    function handlePlaylistActionClick(event){
+        const actionButton = event.target.closest('[data-playlist-action]');
+        if (!actionButton || actionButton.disabled || actionButton.getAttribute('aria-disabled') === 'true'){
+            return false;
+        }
+
+        const action = actionButton.dataset.playlistAction;
+        if (action === 'toggle-card'){
+            togglePlaylistCard(actionButton);
+            return true;
+        }
+        if (action === 'edit-playlist'){
+            openEditModal(
+                actionButton.getAttribute('data-playlist-name'),
+                actionButton.getAttribute('data-start-time'),
+                actionButton.getAttribute('data-end-time'),
+                actionButton.getAttribute('data-cycle-minutes'),
+                actionButton
+            );
+            return true;
+        }
+        if (action === 'confirm-display-next'){
+            const name = actionButton.getAttribute('data-playlist');
+            openDisplayNextConfirmModal(name, actionButton);
+            return true;
+        }
+        if (action === 'delete-playlist'){
+            openDeletePlaylistModal(actionButton.getAttribute('data-playlist'), actionButton);
+            return true;
+        }
+        if (action === 'delete-instance'){
+            openDeleteInstanceModal(
+                actionButton.getAttribute('data-playlist'),
+                actionButton.getAttribute('data-plugin-id'),
+                actionButton.getAttribute('data-instance'),
+                actionButton,
+                actionButton.getAttribute('data-instance-label') || actionButton.getAttribute('data-instance'),
+            );
+            return true;
+        }
+        if (action === 'edit-refresh'){
+            openRefreshModal(
+                actionButton.getAttribute('data-playlist'),
+                actionButton.getAttribute('data-plugin-id'),
+                actionButton.getAttribute('data-instance'),
+                parseRefreshSettings(actionButton.getAttribute('data-refresh')),
+                actionButton
+            );
+            return true;
+        }
+        if (action === 'display-instance'){
+            displayPluginInstance(
+                actionButton.getAttribute('data-playlist'),
+                actionButton.getAttribute('data-plugin-id'),
+                actionButton.getAttribute('data-instance'),
+                actionButton
+            );
+            return true;
+        }
+        return false;
     }
 
     function showThumbnailPreview(playlistName, pluginId, pluginName, instanceName, instanceLabel) {
@@ -745,9 +809,12 @@
         // Bind header buttons
         const newBtn = document.getElementById('newPlaylistBtn');
         if (newBtn){ newBtn.addEventListener('click', (e) => openCreateModal(e.currentTarget)); }
-        document.querySelectorAll('[data-playlist-toggle]').forEach((button) => {
-            button.addEventListener('click', () => togglePlaylistCard(button));
-        });
+        const pageContent = document.getElementById('playlist-page-content');
+        if (pageContent){
+            pageContent.addEventListener('click', (event) => {
+                handlePlaylistActionClick(event);
+            });
+        }
         const saveBtn = document.getElementById('saveButton');
         if (saveBtn) {
             saveBtn.addEventListener('click', () => {
@@ -760,65 +827,6 @@
         document.getElementById('closeRefreshModalBtn')?.addEventListener('click', closeRefreshModal);
         document.getElementById('saveRefreshSettingsBtn')?.addEventListener('click', saveRefreshSettings);
         document.getElementById('closeThumbnailPreviewBtn')?.addEventListener('click', closeThumbnailPreview);
-        document.querySelectorAll('.edit-playlist-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const el = e.currentTarget;
-                const name = el.getAttribute('data-playlist-name');
-                const st = el.getAttribute('data-start-time');
-                const et = el.getAttribute('data-end-time');
-                const cm = el.getAttribute('data-cycle-minutes');
-                openEditModal(name, st, et, cm, el);
-            });
-        });
-        document.querySelectorAll('.run-next-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const el = e.currentTarget;
-                const name = el.getAttribute('data-playlist');
-                openDisplayNextConfirmModal(name, el);
-            });
-        });
-        document.querySelectorAll('.delete-playlist-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const el = e.currentTarget;
-                openDeletePlaylistModal(el.getAttribute('data-playlist'), el);
-            });
-        });
-        document.querySelectorAll('.delete-instance-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const t = e.currentTarget;
-                openDeleteInstanceModal(
-                    t.getAttribute('data-playlist'),
-                    t.getAttribute('data-plugin-id'),
-                    t.getAttribute('data-instance'),
-                    t,
-                    t.getAttribute('data-instance-label') || t.getAttribute('data-instance'),
-                );
-            });
-        });
-        document.querySelectorAll('.refresh-settings-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const t = e.currentTarget;
-                let refreshSettings = {};
-                try {
-                    refreshSettings = JSON.parse(t.getAttribute('data-refresh') || '{}');
-                } catch (_err) {
-                    refreshSettings = {};
-                }
-                openRefreshModal(
-                    t.getAttribute('data-playlist'),
-                    t.getAttribute('data-plugin-id'),
-                    t.getAttribute('data-instance'),
-                    refreshSettings,
-                    t
-                );
-            });
-        });
-        document.querySelectorAll('.plugin-display-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const t = e.currentTarget;
-                displayPluginInstance(t.getAttribute('data-playlist'), t.getAttribute('data-plugin-id'), t.getAttribute('data-instance'), t);
-            });
-        });
         document.querySelectorAll('.plugin-thumbnail-container').forEach(box => {
             box.addEventListener('click', (event) => {
                 const t = event.currentTarget;

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -78,15 +78,15 @@
                         </div>
                         <div class="playlist-toolbar">
                             {% if playlist.plugins %}
-                            <button class="header-button is-secondary run-next-btn" type="button" data-playlist="{{ playlist.name }}">Display Next</button>
+                            <button class="header-button is-secondary run-next-btn" type="button" data-playlist-action="confirm-display-next" data-playlist="{{ playlist.name }}">Display Next</button>
                             {% endif %}
                             {# data-test-skip-click: click-sweep leaves modals open while iterating, so
                                background Edit buttons become non-interactive by design on mobile. Dedicated
                                browser tests cover the real edit-modal path directly. #}
-                            <button class="edit-button edit-playlist-btn playlist-secondary-button" type="button" title="Edit playlist {{ playlist.name }}" data-playlist-name="{{ playlist.name }}" data-start-time="{{ playlist.start_time }}" data-end-time="{{ playlist.end_time }}" data-cycle-minutes="{{ playlist.cycle_minutes or '' }}" data-test-skip-click="true">{{ icon('pencil-simple', 'action-icon') | safe }}<span class="action-button-label">Edit</span></button>
+                            <button class="edit-button edit-playlist-btn playlist-secondary-button" type="button" title="Edit playlist {{ playlist.name }}" data-playlist-action="edit-playlist" data-playlist-name="{{ playlist.name }}" data-start-time="{{ playlist.start_time }}" data-end-time="{{ playlist.end_time }}" data-cycle-minutes="{{ playlist.cycle_minutes or '' }}" data-test-skip-click="true">{{ icon('pencil-simple', 'action-icon') | safe }}<span class="action-button-label">Edit</span></button>
                             {# data-test-skip-click: deletes the playlist #}
-                            <button class="delete-button delete-playlist-btn playlist-secondary-button" type="button" aria-label="Delete playlist {{ playlist.name }}" data-playlist="{{ playlist.name }}" data-test-skip-click="true">{{ icon('trash', 'action-icon') | safe }}<span class="action-button-label">Delete</span></button>
-                            <button class="playlist-toggle-button" type="button" data-playlist-toggle data-collapsed-label="Open" data-expanded-label="Hide" aria-expanded="false">Open</button>
+                            <button class="delete-button delete-playlist-btn playlist-secondary-button" type="button" aria-label="Delete playlist {{ playlist.name }}" data-playlist-action="delete-playlist" data-playlist="{{ playlist.name }}" data-test-skip-click="true">{{ icon('trash', 'action-icon') | safe }}<span class="action-button-label">Delete</span></button>
+                            <button class="playlist-toggle-button" type="button" data-playlist-action="toggle-card" data-playlist-toggle data-collapsed-label="Open" data-expanded-label="Hide" aria-expanded="false">Open</button>
                         </div>
                     </div>
                     <div class="playlist-card-body" data-playlist-body>
@@ -143,6 +143,7 @@
                                 </a>
                                 <button class="edit-button refresh-settings-btn" type="button"
                                         title="Edit refresh settings for {{ pi_label }}"
+                                        data-playlist-action="edit-refresh"
                                         data-playlist="{{ playlist.name }}"
                                         data-plugin-id="{{ plugin_instance.plugin_id }}"
                                         data-instance="{{ plugin_instance.name }}"
@@ -152,13 +153,13 @@
                                     <span class="action-button-label">Refresh settings</span>
                                     <span class="sr-only"> for {{ pi_label }}</span>
                                 </button>
-                                <button class="edit-button plugin-display-btn" type="button" title="Display {{ pi_label }} now" data-playlist="{{ playlist.name }}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}">
+                                <button class="edit-button plugin-display-btn" type="button" title="Display {{ pi_label }} now" data-playlist-action="display-instance" data-playlist="{{ playlist.name }}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}">
                                     {{ icon('monitor', 'action-icon') | safe }}
                                     <span class="action-button-label">Display</span>
                                     <span class="sr-only"> {{ pi_label }} now</span>
                                 </button>
                                 {# data-test-skip-click: removes a plugin instance from the playlist #}
-                                <button class="delete-button delete-instance-btn" type="button" title="Delete plugin instance {{ pi_label }}" data-playlist="{{ playlist.name }}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}" data-test-skip-click="true">
+                                <button class="delete-button delete-instance-btn" type="button" title="Delete plugin instance {{ pi_label }}" data-playlist-action="delete-instance" data-playlist="{{ playlist.name }}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}" data-test-skip-click="true">
                                     {{ icon('trash', 'action-icon') | safe }}
                                     <span class="action-button-label">Delete</span>
                                     <span class="sr-only"> plugin instance {{ pi_label }}</span>

--- a/tests/integration/test_collapsible_sections_e2e.py
+++ b/tests/integration/test_collapsible_sections_e2e.py
@@ -104,7 +104,12 @@ def test_plugin_style_accordion_chevron_flips(live_server, browser_page):
 
 
 def test_playlist_details_expand(live_server, device_config_dev, browser_page):
-    """Playlist details toggle expands and collapses on desktop."""
+    """Playlist details toggle logic expands and collapses on desktop.
+
+    The desktop stylesheet currently hides the toggle button, but the JS
+    handler still needs to reflect state correctly if the control is shown by a
+    future layout tweak or an accessibility override.
+    """
     prepare_playlist(device_config_dev)
     page = browser_page
     navigate_and_wait(page, live_server, "/playlist")
@@ -113,4 +118,20 @@ def test_playlist_details_expand(live_server, device_config_dev, browser_page):
     body = page.locator("[data-playlist-body]").first
 
     assert body.is_visible(), "Details section should be visible on desktop"
-    assert toggle.is_visible(), "Toggle button should exist"
+    assert toggle.get_attribute("aria-expanded") == "true"
+
+    page.evaluate("""() => {
+            const toggle = document.querySelector("[data-playlist-toggle]");
+            if (toggle) toggle.click();
+        }""")
+    page.wait_for_timeout(300)
+    assert toggle.get_attribute("aria-expanded") == "false"
+    assert not body.is_visible(), "Details section should collapse on desktop"
+
+    page.evaluate("""() => {
+            const toggle = document.querySelector("[data-playlist-toggle]");
+            if (toggle) toggle.click();
+        }""")
+    page.wait_for_timeout(300)
+    assert toggle.get_attribute("aria-expanded") == "true"
+    assert body.is_visible(), "Details section should expand again on desktop"

--- a/tests/static/test_display_next_confirmation.py
+++ b/tests/static/test_display_next_confirmation.py
@@ -62,20 +62,16 @@ def test_display_next_modal_has_labelledby(client):
 
 
 def test_run_next_btn_opens_confirm_modal_not_fire_directly(client):
-    """The .run-next-btn click handler must open the confirmation modal,
+    """The delegated run-next action must open the confirmation modal,
     not invoke displayNextInPlaylist immediately."""
     js = _read_playlist_js(client)
-    # New pattern: click handler routes through openDisplayNextConfirmModal.
     assert (
-        "openDisplayNextConfirmModal(name" in js
-    ), "run-next-btn click handler must open the confirmation modal"
-
-    # Old anti-pattern (bare displayNextInPlaylist from the click handler)
-    # must be gone. We look for the literal single-line call that used to
-    # live in the forEach body.
+        'action === "confirm-display-next"' in js
+        or "action === 'confirm-display-next'" in js
+    ), "delegated playlist handler must branch on confirm-display-next"
     assert (
-        "displayNextInPlaylist(name);\n            });" not in js
-    ), "run-next-btn is still wired to fire displayNextInPlaylist directly — no confirmation!"
+        "openDisplayNextConfirmModal(name, actionButton)" in js
+    ), "confirm-display-next action must open the confirmation modal with the trigger button"
 
 
 def test_display_next_helper_exists_and_is_async(client):

--- a/tests/static/test_playlist_modal_inert.py
+++ b/tests/static/test_playlist_modal_inert.py
@@ -117,18 +117,16 @@ class TestFocusManagement:
         ), "playlist.js must call _lastModalTrigger.focus() when closing a modal"
 
     def test_refresh_btn_listener_passes_trigger(self):
-        """The refresh-settings-btn click listener must pass the button element as
-        the trigger so focus can be restored after close."""
+        """The delegated refresh action must pass the button element as the
+        trigger so focus can be restored after close."""
         js = PLAYLIST_JS.read_text()
-        # Find the .refresh-settings-btn listener block
         match = re.search(
-            r"\.refresh-settings-btn.*?openRefreshModal\((.*?)\);",
+            r'action === [\'"]edit-refresh[\'"].*?openRefreshModal\((.*?)\);',
             js,
             re.DOTALL,
         )
-        assert match, "refresh-settings-btn listener calling openRefreshModal not found"
+        assert match, "delegated edit-refresh action calling openRefreshModal not found"
         call_args = match.group(1)
-        # The last arg should reference the button element (t or e.currentTarget)
         assert re.search(
-            r",\s*(t|el|e\.currentTarget)\s*$", call_args.strip()
-        ), "openRefreshModal must receive the trigger element as last argument"
+            r",\s*actionButton\s*$", call_args.strip()
+        ), "openRefreshModal must receive the delegated trigger element as last argument"

--- a/tests/static/test_playlist_refresh_btn.py
+++ b/tests/static/test_playlist_refresh_btn.py
@@ -9,20 +9,26 @@ PLAYLIST_HTML = ROOT / "src" / "templates" / "playlist.html"
 
 
 class TestRefreshSettingsBtnListener:
-    """Verify playlist.js registers a click listener for .refresh-settings-btn."""
+    """Verify playlist.js delegates refresh-settings actions from playlist cards."""
 
-    def test_js_has_refresh_settings_btn_listener(self):
+    def test_js_delegates_playlist_actions(self):
         js_text = PLAYLIST_JS.read_text()
         assert (
-            ".refresh-settings-btn" in js_text
-        ), "playlist.js must bind a click listener on .refresh-settings-btn"
+            "[data-playlist-action]" in js_text
+        ), "playlist.js must delegate playlist card clicks via data-playlist-action"
+        assert (
+            "dataset.playlistAction" in js_text
+        ), "playlist.js must read dataset.playlistAction from the delegated target"
 
-    def test_js_calls_open_refresh_modal(self):
+    def test_js_handles_refresh_action(self):
         js_text = PLAYLIST_JS.read_text()
-        # The listener block should call openRefreshModal
+        assert (
+            "action === 'edit-refresh'" in js_text
+            or 'action === "edit-refresh"' in js_text
+        ), "delegated handler must branch on the edit-refresh action"
         assert (
             "openRefreshModal" in js_text
-        ), "playlist.js must call openRefreshModal from the refresh-settings-btn listener"
+        ), "playlist.js must call openRefreshModal from the delegated refresh action"
 
     def test_js_parses_data_refresh_attribute(self):
         js_text = PLAYLIST_JS.read_text()
@@ -52,6 +58,7 @@ class TestRefreshSettingsBtnTemplate:
         ), "playlist.html must contain a button with refresh-settings-btn class"
         btn_match = btn_pattern.group(0)
         for attr in (
+            'data-playlist-action="edit-refresh"',
             "data-playlist",
             "data-plugin-id",
             "data-instance",


### PR DESCRIPTION
## Summary

- fix `JTN-692` by letting playlist toggle state actually flip on desktop code paths instead of forcing `aria-expanded="true"`
- fix `JTN-660` by delegating playlist card button clicks through one `#playlist-page-content` listener using `data-playlist-action`
- keep the existing modal flows and focus restoration intact while moving refresh/display/delete/edit actions off per-button listeners
- update static and browser coverage for delegated playlist actions and desktop toggle state reflection

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- Not applicable: this PR does not sync changes from `fatihak/InkyPi`.

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [ ] Docs updated for new flags/endpoints/UI
- [x] **Frontend changes** (`src/static/**`, `src/templates/**`): relevant browser tests passed locally

## Testing

- [x] `PYTHONPATH=src INKYPI_ENV=dev INKYPI_NO_REFRESH=1 python3 -m pytest tests/static/test_playlist_refresh_btn.py tests/static/test_playlist_modal_inert.py tests/static/test_display_next_confirmation.py -q`
- [x] `PYTHONPATH=src INKYPI_ENV=dev INKYPI_NO_REFRESH=1 python3 -m pytest tests/ui_audit/test_handler_audit.py -q`
- [x] `PYTHONPATH=src INKYPI_ENV=dev INKYPI_NO_REFRESH=1 python3 -m pytest tests/integration/test_collapsible_sections_e2e.py::test_playlist_details_expand tests/integration/test_collapsible_sections_e2e.py::test_playlist_card_toggle 'tests/integration/test_toggle_reflection.py::test_toggle_reflection[playlist]' -q`
- [x] `bash scripts/lint.sh`
- [x] `PYTHONPATH=src INKYPI_ENV=dev INKYPI_NO_REFRESH=1 .venv/bin/python -m pytest tests/static/test_playlist_refresh_btn.py tests/static/test_playlist_modal_inert.py tests/static/test_display_next_confirmation.py tests/ui_audit/test_handler_audit.py tests/integration/test_collapsible_sections_e2e.py::test_playlist_card_toggle tests/integration/test_collapsible_sections_e2e.py::test_playlist_details_expand 'tests/integration/test_toggle_reflection.py::test_toggle_reflection[playlist]' -q`
