### PR TITLE
test: flakiness retry + reporting for integration tests (JTN-705)

### DIFF
--- a/install/requirements-dev.in
+++ b/install/requirements-dev.in
@@ -13,6 +13,10 @@ pytest>=8.0,<10
 pytest-xdist>=3.0,<4
 pytest-cov>=5.0,<6
 pytest-benchmark>=4.0,<5
+# Flakiness retry + reporting for integration tests (JTN-705). Scoped to
+# tests/integration/ via tests/integration/conftest.py — unit tests must NOT
+# retry. 16.x is the first release with pytest 9 support.
+pytest-rerunfailures>=15.0,<17
 requests-mock>=1.12,<2
 freezegun>=1.5,<2
 pytest-flask>=1.3,<2

--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -1429,6 +1429,7 @@ packaging==25.0 \
     #   pip-audit
     #   pip-requirements-parser
     #   pytest
+    #   pytest-rerunfailures
     #   wheel
 parso==0.8.6 \
     --hash=sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd \
@@ -1849,6 +1850,10 @@ pytest-cov==5.0.0 \
 pytest-flask==1.3.0 \
     --hash=sha256:58be1c97b21ba3c4d47e0a7691eb41007748506c36bf51004f78df10691fa95e \
     --hash=sha256:c0e36e6b0fddc3b91c4362661db83fa694d1feb91fa505475be6732b5bc8c253
+    # via -r requirements-dev.in
+pytest-rerunfailures==16.1 \
+    --hash=sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86 \
+    --hash=sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e
     # via -r requirements-dev.in
 pytest-xdist==3.8.0 \
     --hash=sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88 \

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,60 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+# ---------------------------------------------------------------------------
+# Flakiness retry (JTN-705).
+#
+# Integration tests exercise Playwright, refresh loops, and cross-process
+# state that can flake for reasons unrelated to the code under test (network
+# blips, compositor jitter, file-watch races). One retry dramatically lowers
+# false-positive noise while still surfacing real regressions — a test that
+# fails twice in a row is almost certainly a genuine bug.
+#
+# IMPORTANT: reruns are scoped to ``tests/integration/`` ONLY. Unit tests
+# must stay deterministic: if a unit test flakes, that is a bug we want to
+# see on the first failure, not paper over with a silent retry. The hook
+# below explicitly gates on the collection path so retries cannot leak into
+# other suites even if this conftest is imported indirectly.
+#
+# pytest-rerunfailures prints a rerun summary in the terminal report by
+# default (``R`` progress dots and a "rerun" count in the summary line), so
+# CI captures repeated flakes without extra configuration.
+# ---------------------------------------------------------------------------
+
+_INTEGRATION_TESTS_DIR = Path(__file__).resolve().parent
+_RERUNS = 1
+_RERUNS_DELAY_SECONDS = 1
+
+
+def pytest_collection_modifyitems(config, items):  # noqa: ARG001
+    """Apply ``@pytest.mark.flaky(reruns=1, ...)`` to integration tests only.
+
+    Gating on the resolved file path (not the pytest ``nodeid``) guarantees
+    we only retry tests physically located under ``tests/integration/`` even
+    if another suite imports this conftest or if pytest is invoked from a
+    different cwd. Tests that already declare an explicit ``flaky`` marker
+    are left alone so they can opt in to a higher retry count.
+    """
+    flaky_marker = pytest.mark.flaky(
+        reruns=_RERUNS, reruns_delay=_RERUNS_DELAY_SECONDS
+    )
+    for item in items:
+        try:
+            item_path = Path(str(item.fspath)).resolve()
+        except (OSError, ValueError):
+            continue
+        try:
+            item_path.relative_to(_INTEGRATION_TESTS_DIR)
+        except ValueError:
+            # Not under tests/integration/ — do not attach a retry.
+            continue
+        if item.get_closest_marker("flaky") is not None:
+            continue
+        item.add_marker(flaky_marker)
 
 # ---------------------------------------------------------------------------
 # Client-log tripwire (JTN-680).

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,7 +32,7 @@ _RERUNS = 1
 _RERUNS_DELAY_SECONDS = 1
 
 
-def pytest_collection_modifyitems(config, items):  # noqa: ARG001
+def pytest_collection_modifyitems(items):
     """Apply ``@pytest.mark.flaky(reruns=1, ...)`` to integration tests only.
 
     Gating on the resolved file path (not the pytest ``nodeid``) guarantees
@@ -41,9 +41,7 @@ def pytest_collection_modifyitems(config, items):  # noqa: ARG001
     different cwd. Tests that already declare an explicit ``flaky`` marker
     are left alone so they can opt in to a higher retry count.
     """
-    flaky_marker = pytest.mark.flaky(
-        reruns=_RERUNS, reruns_delay=_RERUNS_DELAY_SECONDS
-    )
+    flaky_marker = pytest.mark.flaky(reruns=_RERUNS, reruns_delay=_RERUNS_DELAY_SECONDS)
     for item in items:
         try:
             item_path = Path(str(item.fspath)).resolve()
@@ -57,6 +55,7 @@ def pytest_collection_modifyitems(config, items):  # noqa: ARG001
         if item.get_closest_marker("flaky") is not None:
             continue
         item.add_marker(flaky_marker)
+
 
 # ---------------------------------------------------------------------------
 # Client-log tripwire (JTN-680).


### PR DESCRIPTION
## Summary

Adds `pytest-rerunfailures` and wires a single automatic retry for **integration tests only** so flaky browser / refresh-loop jitter no longer masks real regressions or drowns signal in CI logs.

- **Dep:** `pytest-rerunfailures>=15.0,<17` in `install/requirements-dev.in` (+ regenerated hashes in `install/requirements-dev.txt`). 16.x is the first release compatible with the pinned pytest 9.x line, so we use a floor of 15 (supports pytest 8 on Python 3.11 nodes) with a ceiling at 17 to keep majors opt-in.
- **Scope-limiting approach:** `tests/integration/conftest.py` uses `pytest_collection_modifyitems` to attach `@pytest.mark.flaky(reruns=1, reruns_delay=1)` to every collected item whose resolved file path is under `tests/integration/`. This is preferred over a global `addopts = --reruns 1` because it physically cannot leak into unit tests — the hook gates on `Path.resolve().relative_to(tests/integration)` and skips anything else, even when pytest is launched from a different cwd or the conftest is imported indirectly.
- Tests that already declare their own `@pytest.mark.flaky` are left alone so they can opt in to a higher retry count.
- `pytest-rerunfailures` prints `R` progress markers and a `"rerun"` summary count by default, so repeat-offender flakes show up in CI logs with no extra formatter plumbing.

Linear: https://linear.app/jtn0123/issue/JTN-705/test-flakiness-retry-reporting-for-integration-tests

## Test plan

- [x] Deliberately-flaky integration test (fail first call, pass second) passes on retry — verified locally: `RERUN` + `PASSED`, summary line showed `1 rerun`.
- [x] Deliberately-flaky unit test does NOT retry — verified locally: single `FAILED`, no rerun count.
- [x] `pip install --dry-run -r install/requirements-dev.txt` resolves cleanly in a fresh venv.
- [ ] CI `tests` job (pytest matrix 3.11 / 3.12 / 3.13) stays green.
- [ ] CI browser-smoke job log shows rerun summary line for any flaked integration test.

Scope is intentionally small (dep bump + conftest hook). No CI workflow changes needed — `pytest-rerunfailures` is a stdin/stdout-transparent plugin and the existing `pytest -q` invocations pick up the markers automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)