### PR TITLE
test: a11y sweep with axe-core Playwright baseline (JTN-740)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ UI_BROWSER_TESTS = {
     "test_device_update_ops_journeys.py",
 }
 A11Y_BROWSER_TESTS = {
+    "test_a11y_sweep.py",
     "test_axe_a11y.py",
     "test_more_a11y.py",
     "test_playlist_a11y.py",

--- a/tests/integration/a11y_allowlist.yml
+++ b/tests/integration/a11y_allowlist.yml
@@ -1,0 +1,52 @@
+# A11y sweep allowlist for JTN-740.
+#
+# This file is the single source of truth for "known, tracked a11y violations"
+# in :mod:`tests.integration.test_a11y_sweep`. The sweep runs axe-core (WCAG
+# 2.0/2.1 A + AA tags) on every entry in ``PAGES_TO_SWEEP`` + every plugin
+# page and fails on any violation whose rule id isn't listed below.
+#
+# Format
+# ------
+#
+# * ``default`` — rule ids allowlisted for every main page (``/``, ``/settings``,
+#   ``/history``, ``/playlist``, ``/api-keys``).
+# * ``plugin_default`` — rule ids allowlisted for every ``/plugin/<id>`` page.
+#   Plugin pages share one base template so violations tend to be shared.
+# * ``pages`` — per-page overrides. Each page key maps to a list of entries
+#   with ``id:`` (required) and ``reason:`` (free-text, required). Listed rules
+#   are added to the page's allowlist on top of ``default`` /
+#   ``plugin_default``. Use this for page-specific violations only.
+#
+# How to shrink the allowlist
+# ---------------------------
+#
+# 1. Fix the underlying violation in the template / CSS / component.
+# 2. Remove the rule id from ``default`` / ``plugin_default`` (or the page
+#    override) and re-run ``SKIP_A11Y=0 PYTHONPATH=src pytest
+#    tests/integration/test_a11y_sweep.py``.
+# 3. If the sweep still passes, the entry is safe to delete. If it fails on
+#    another page, add a page-specific override for the remaining page(s) and
+#    keep shrinking.
+#
+# Every entry MUST have a ``reason`` explaining why the violation is tolerated
+# and (ideally) a Linear / GitHub ticket tracking the fix. Entries without
+# a reason are treated as a lint error in review.
+
+default:
+  - id: color-contrast
+    reason: >-
+      WCAG AA contrast audit pending across chips/placeholders/dim text.
+      Tracked in JTN-510.
+
+plugin_default:
+  - id: color-contrast
+    reason: >-
+      Inherits main-app chrome contrast issues. Fixes in JTN-510 will land for
+      both main + plugin pages.
+  - id: aria-hidden-focus
+    reason: >-
+      Hidden-by-default modals (response modal, schedule modal) still contain
+      focusable children at page load. Resolved when the modals render lazily
+      or use ``inert``. Tracked in JTN-511.
+
+pages: {}

--- a/tests/integration/test_a11y_sweep.py
+++ b/tests/integration/test_a11y_sweep.py
@@ -1,0 +1,279 @@
+# pyright: reportMissingImports=false
+"""WCAG AA a11y sweep with axe-core (JTN-740).
+
+Extends the axe-core wiring introduced by JTN-507 (see
+``tests/integration/test_axe_a11y.py``) so that **every** page in the
+``PAGES_TO_SWEEP`` constant used by the click-sweep *plus* every registered
+plugin page is scanned, and the baseline is driven by a human-readable
+``a11y_allowlist.yml`` file rather than an in-code dict.
+
+Why split this from ``test_axe_a11y.py``:
+
+* ``test_axe_a11y.py`` runs the **full** axe ruleset (including best-practice
+  rules) and is tuned for the six main routes. It stays as-is so the
+  earlier violation burndown (JTN-508/509/510/511) keeps tracking.
+* This sweep runs **only** WCAG 2.0/2.1 A + AA tagged rules — the baseline
+  the issue explicitly asks for. It is parametrised over
+  :data:`PAGES_TO_SWEEP` (imported from :mod:`test_click_sweep`) *and*
+  every plugin page, so plugin-template regressions show up in CI without
+  a separate test file.
+
+Gating
+------
+Same ``SKIP_A11Y`` / ``SKIP_BROWSER`` knobs as the other a11y tests — this
+module is registered in ``tests/conftest.py::A11Y_BROWSER_TESTS`` so
+collection is skipped when either env var is truthy, or when Playwright's
+Chromium is unavailable.
+
+To run locally::
+
+    playwright install chromium
+    SKIP_A11Y=0 PYTHONPATH=src pytest tests/integration/test_a11y_sweep.py -q
+
+Acceptance flow (JTN-740)
+-------------------------
+Temporarily delete an ``aria-label`` from a real control (e.g. the
+``#settingsForm`` save button on ``/plugin/clock``) and re-run the sweep —
+it should fail with ``button-name`` (or similar). Reverting the change
+returns the suite to green without touching the allowlist.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from tests.integration.test_click_sweep import (
+    PAGES_TO_SWEEP,
+    _discover_plugin_ids,
+)
+
+# ── Allowlist ───────────────────────────────────────────────────────────────
+_ALLOWLIST_PATH = Path(__file__).parent / "a11y_allowlist.yml"
+_AXE_JS_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "axe.min.js"
+
+# axe options restricting the run to WCAG AA (plus A). These are the tags
+# the JTN-740 issue calls out ("WCAG AA baseline") — best-practice rules and
+# WCAG AAA violations are out of scope here and are covered by
+# ``test_axe_a11y.py`` where appropriate.
+_AXE_TAGS: tuple[str, ...] = ("wcag2a", "wcag2aa", "wcag21a", "wcag21aa")
+
+# Generous per-navigation timeout. Plugin pages render server-side but some
+# pull remote settings (weather tiles, unsplash previews) on first paint; we
+# only want the DOM to settle, so ``domcontentloaded`` is fine and the
+# marker wait is optional.
+_GOTO_TIMEOUT_MS = 30_000
+_MARKER_TIMEOUT_MS = 8_000
+_SETTLE_MS = 300
+
+
+def _load_allowlist() -> dict[str, Any]:
+    """Parse ``a11y_allowlist.yml`` into the runtime format.
+
+    Returns a dict with keys:
+
+    * ``"default"`` — ``set[str]`` of rule ids allowlisted on every main page.
+    * ``"plugin_default"`` — ``set[str]`` of rule ids allowlisted on every
+      ``/plugin/<id>`` page.
+    * ``"pages"`` — ``dict[str, set[str]]`` of per-page extras.
+    * ``"reasons"`` — ``dict[str, str]`` mapping ``"{scope}:{rule_id}"`` →
+      justification text, used only in failure messages.
+    """
+    raw = yaml.safe_load(_ALLOWLIST_PATH.read_text(encoding="utf-8")) or {}
+
+    def _extract(entries: Any, scope_key: str, reasons: dict[str, str]) -> set[str]:
+        ids: set[str] = set()
+        if not entries:
+            return ids
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"a11y_allowlist.yml: '{scope_key}' must be a list of "
+                f"{{id, reason}} entries, got {type(entries).__name__}."
+            )
+        for entry in entries:
+            if not isinstance(entry, dict) or "id" not in entry:
+                raise ValueError(
+                    f"a11y_allowlist.yml: '{scope_key}' entries must be "
+                    f"mappings with an 'id' field, got {entry!r}."
+                )
+            rule_id = str(entry["id"]).strip()
+            reason = str(entry.get("reason", "")).strip()
+            if not reason:
+                raise ValueError(
+                    f"a11y_allowlist.yml: '{scope_key}' entry "
+                    f"'{rule_id}' is missing a 'reason' — every allowlist "
+                    "entry must document why the violation is tolerated."
+                )
+            ids.add(rule_id)
+            reasons[f"{scope_key}:{rule_id}"] = reason
+        return ids
+
+    reasons: dict[str, str] = {}
+    default_ids = _extract(raw.get("default"), "default", reasons)
+    plugin_default_ids = _extract(raw.get("plugin_default"), "plugin_default", reasons)
+
+    pages: dict[str, set[str]] = {}
+    for page_name, entries in (raw.get("pages") or {}).items():
+        pages[page_name] = _extract(entries, f"pages.{page_name}", reasons)
+
+    return {
+        "default": default_ids,
+        "plugin_default": plugin_default_ids,
+        "pages": pages,
+        "reasons": reasons,
+    }
+
+
+def _allowlist_for(
+    page_label: str, is_plugin: bool, bundle: dict[str, Any]
+) -> set[str]:
+    base: set[str] = set(bundle["plugin_default"] if is_plugin else bundle["default"])
+    base |= bundle["pages"].get(page_label, set())
+    return base
+
+
+def _run_axe_on_page(page, url: str, marker: str | None) -> dict[str, Any]:
+    page.goto(url, wait_until="domcontentloaded", timeout=_GOTO_TIMEOUT_MS)
+    if marker:
+        try:
+            page.wait_for_selector(marker, timeout=_MARKER_TIMEOUT_MS)
+        except Exception:  # noqa: BLE001 — marker absence is not fatal
+            pass
+    page.wait_for_timeout(_SETTLE_MS)
+    page.add_script_tag(content=_AXE_JS_PATH.read_text(encoding="utf-8"))
+    options = {"runOnly": {"type": "tag", "values": list(_AXE_TAGS)}}
+    return page.evaluate("(opts) => axe.run(document, opts)", options)
+
+
+def _format_violations(violations: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for v in violations:
+        impact = v.get("impact") or "n/a"
+        description = v.get("description", "")
+        # Surface the first offending node so the failure is actionable —
+        # just the rule id isn't enough when the same rule fires on many
+        # pages and you need to know which element tripped it.
+        nodes = v.get("nodes") or []
+        snippet = ""
+        if nodes:
+            target = nodes[0].get("target") or []
+            html = (nodes[0].get("html") or "").strip().replace("\n", " ")
+            if len(html) > 180:
+                html = html[:177] + "…"
+            snippet = f"\n      target={target} html={html!r}"
+        lines.append(f"  - {v['id']} ({impact}): {description}{snippet}")
+    return "\n".join(lines)
+
+
+skip_env = pytest.mark.skipif(
+    os.getenv("SKIP_A11Y", "").lower() in ("1", "true"),
+    reason="A11y checks skipped by env",
+)
+
+
+# ── Core-page sweep ─────────────────────────────────────────────────────────
+
+# We drop ``plugin_clock`` from the core-page list because it's covered by
+# the plugin-page sweep below (which iterates over every plugin id). Keeping
+# both would just double-run the same route.
+_MAIN_PAGES = tuple(p for p in PAGES_TO_SWEEP if not p.path.startswith("/plugin/"))
+
+
+@skip_env
+@pytest.mark.parametrize("sweep", _MAIN_PAGES, ids=lambda s: s.label)
+def test_a11y_sweep_main_pages(live_server, browser_page, sweep):
+    """WCAG AA sweep over every main route in ``PAGES_TO_SWEEP``."""
+    allowlist_bundle = _load_allowlist()
+    allowed = _allowlist_for(sweep.label, is_plugin=False, bundle=allowlist_bundle)
+
+    result = _run_axe_on_page(
+        browser_page, f"{live_server}{sweep.path}", sweep.ready_marker
+    )
+    violations = [
+        v for v in (result.get("violations") or []) if v.get("id") not in allowed
+    ]
+
+    if violations:
+        pytest.fail(
+            f"A11y sweep ({sweep.label} — {sweep.path}) found "
+            f"{len(violations)} WCAG AA violation(s) not on the allowlist "
+            f"(see tests/integration/a11y_allowlist.yml):\n"
+            f"{_format_violations(violations)}"
+        )
+
+
+# ── Plugin-page sweep ───────────────────────────────────────────────────────
+
+_PLUGIN_IDS: tuple[str, ...] = _discover_plugin_ids()
+
+
+@skip_env
+@pytest.mark.plugin_sweep
+@pytest.mark.parametrize("plugin_id", _PLUGIN_IDS, ids=list(_PLUGIN_IDS))
+def test_a11y_sweep_plugin_pages(live_server, browser_page, plugin_id: str):
+    """WCAG AA sweep over every ``/plugin/<id>`` page.
+
+    Parametrised the same way as
+    :func:`tests.integration.test_click_sweep.test_click_sweep_plugin_pages`
+    so a template regression in weather/todo/comic/etc. fails CI here too.
+    """
+    allowlist_bundle = _load_allowlist()
+    label = f"plugin_{plugin_id}"
+    allowed = _allowlist_for(label, is_plugin=True, bundle=allowlist_bundle)
+
+    result = _run_axe_on_page(
+        browser_page, f"{live_server}/plugin/{plugin_id}", "#settingsForm"
+    )
+    violations = [
+        v for v in (result.get("violations") or []) if v.get("id") not in allowed
+    ]
+
+    if violations:
+        pytest.fail(
+            f"A11y sweep ({label} — /plugin/{plugin_id}) found "
+            f"{len(violations)} WCAG AA violation(s) not on the allowlist "
+            f"(see tests/integration/a11y_allowlist.yml):\n"
+            f"{_format_violations(violations)}"
+        )
+
+
+# ── Allowlist self-tests ────────────────────────────────────────────────────
+#
+# These run even when ``SKIP_A11Y=1`` (no ``@skip_env``) because parsing the
+# YAML and catching a stale page key doesn't need a browser. They're the
+# lightest line of defence against an allowlist that silently drifts out of
+# sync with the pages being swept.
+
+
+def test_a11y_allowlist_is_well_formed():
+    """The YAML parses and every entry carries a non-empty ``reason``."""
+    bundle = _load_allowlist()
+    # ``_load_allowlist`` already raises on malformed entries; the assertions
+    # below just document the expected shape.
+    assert isinstance(bundle["default"], set)
+    assert isinstance(bundle["plugin_default"], set)
+    assert isinstance(bundle["pages"], dict)
+    for reason in bundle["reasons"].values():
+        assert reason, "Every allowlist entry requires a non-empty reason."
+
+
+def test_a11y_allowlist_pages_exist():
+    """Every ``pages:`` override maps to a real page the sweep will visit.
+
+    Stops the allowlist rotting once a page is renamed or removed — a
+    page-specific override referencing a page that no longer exists is
+    almost always a sign the violation was fixed and the entry forgotten.
+    """
+    bundle = _load_allowlist()
+    if not bundle["pages"]:
+        return
+    known = {p.label for p in _MAIN_PAGES}
+    known |= {f"plugin_{pid}" for pid in _PLUGIN_IDS}
+    unknown = sorted(set(bundle["pages"]) - known)
+    assert not unknown, (
+        f"a11y_allowlist.yml references unknown pages: {unknown}. "
+        "Remove the overrides or update the page label to match."
+    )


### PR DESCRIPTION
## Summary

- Add `tests/integration/test_a11y_sweep.py` — parametrised WCAG 2.0/2.1 A+AA axe sweep that runs against every entry in `PAGES_TO_SWEEP` (imported from `test_click_sweep.py`) plus every registered plugin page. Uses the existing `browser_page` fixture and the bundled `tests/fixtures/axe.min.js`.
- Add `tests/integration/a11y_allowlist.yml` — human-readable allowlist with `default` / `plugin_default` / `pages` sections, each entry requires a written `reason`. Self-tests in the same module fail if the YAML drifts malformed or references a page the sweep no longer visits.
- Register the new file in `tests/conftest.py::A11Y_BROWSER_TESTS` so `SKIP_A11Y` / `SKIP_BROWSER` gating works consistently with the rest of the a11y suite.

## JTN-507 status

JTN-507 is **Done** (merged via [#368](https://github.com/jtn0123/InkyPi/pull/368) on 2026-04-12). That PR landed the initial axe wire-up for the six main routes in `test_axe_a11y.py`. This PR **extends** that work — it does not replace it:

- `test_axe_a11y.py` keeps running the **full** axe ruleset (incl. best-practice rules) on the six main routes so the JTN-508 / JTN-509 / JTN-510 / JTN-511 violation burndown keeps tracking.
- `test_a11y_sweep.py` (this PR) runs the **WCAG AA baseline** the issue calls for across `PAGES_TO_SWEEP` + all 20 plugin pages, backed by YAML so non-authors can review / update the allowlist without diffing Python.

## Allowlist walkthrough

`tests/integration/a11y_allowlist.yml`:

```yaml
default:            # applies to every main page (/, /settings, /history, /playlist, /api-keys)
  - id: color-contrast
    reason: >-
      WCAG AA contrast audit pending across chips/placeholders/dim text.
      Tracked in JTN-510.

plugin_default:     # applies to every /plugin/<id> page
  - id: color-contrast
    reason: ...
  - id: aria-hidden-focus
    reason: ...

pages: {}           # per-page overrides — add entries with id + reason
```

**To shrink the allowlist:**

1. Fix the underlying violation (template / CSS / component change).
2. Delete the rule id from `default` / `plugin_default` (or the page override).
3. Re-run `SKIP_A11Y=0 PYTHONPATH=src pytest tests/integration/test_a11y_sweep.py` — if it stays green, you're done. If it fails on a specific page, move the entry to a `pages: <label>:` override scoped to the remaining page(s) and keep shrinking.

Every entry MUST have a non-empty `reason`. A parse-time error fires if you forget one, so the YAML can't regress into opaque rule-id lists.

## Acceptance (per issue)

> Sweep runs on all PAGES_TO_SWEEP + plugin pages; deliberately removing an aria-label from a critical control fails the sweep.

Verified by temporarily removing `aria-label=\"Home\"` from the plugin page header (`src/templates/plugin.html`). The sweep failed with:

```
Failed: A11y sweep (plugin_clock — /plugin/clock) found 1 WCAG AA violation(s) not on the allowlist:
  - link-name (serious): Ensures links have discernible text
      target=['.header-button.icon[href=\"/\"]'] html='<a href=\"/\" class=\"header-button icon\">'
```

Re-adding the label returned the sweep to green without touching the allowlist.

## Test plan

- [x] `SKIP_A11Y=0 PYTHONPATH=src pytest tests/integration/test_a11y_sweep.py -q` — **27 passed** (5 main pages + 20 plugin pages + 2 allowlist self-tests), ~27 s wall-time.
- [x] `SKIP_A11Y=0 PYTHONPATH=src pytest tests/integration/test_axe_a11y.py -q` — existing JTN-507 suite still runs (home currently still flags `color-contrast`, pre-existing and tracked in JTN-510 — not introduced here).
- [x] Acceptance test: remove `aria-label` from `/plugin/clock` header link → sweep fails with `link-name (serious)` and node selector. Revert → sweep passes again.
- [x] `scripts/lint.sh` — ruff, black, mypy strict subset, shellcheck all pass. mypy advisory numbers unchanged (the new file adds no new `no-untyped-def` violations beyond the test-suite baseline).
- [ ] CI to confirm on GitHub runners.

Linear: https://linear.app/jtn0123/issue/JTN-740/test-a11y-sweep-with-axe-core-in-playwright-wcag-aa-baseline

Related: https://linear.app/jtn0123/issue/JTN-507 (completed via #368)

🤖 Generated with [Claude Code](https://claude.com/claude-code)