### PR TITLE
test(journey): defensive DOM poll in desktop playlist round-trip

### DIFF
--- a/tests/integration/journeys/test_playlist_roundtrip.py
+++ b/tests/integration/journeys/test_playlist_roundtrip.py
@@ -210,14 +210,18 @@ def test_playlist_roundtrip_create_reorder_delete_persist(
             expected_reordered[0],
             expected_reordered[2],
         ]
-        dom_after_delete = None
         for _ in range(30):
-            dom_after_delete = _dom_instance_names(page, playlist_name)
-            if dom_after_delete == expected_after_delete:
-                break
-            # The JS calls location.reload() on success — our stub swallows it,
-            # but the DOM may not re-render until a real reload. Check backend
-            # instead and then force a reload to refresh DOM.
+            # The delete handler calls location.reload(); the stub swallows it
+            # but the execution context may still churn briefly — ignore
+            # transient evaluate failures and rely on the backend check below
+            # as the load-bearing assertion. (Mirrors mobile variant in
+            # test_playlist_roundtrip_mobile.py.)
+            try:
+                dom_after_delete = _dom_instance_names(page, playlist_name)
+                if dom_after_delete == expected_after_delete:
+                    break
+            except Exception:
+                pass
             if (
                 _backend_instance_names(device_config_dev, playlist_name)
                 == expected_after_delete


### PR DESCRIPTION
## Summary
- Wrap the post-delete DOM poll in `tests/integration/journeys/test_playlist_roundtrip.py` in try/except so a transient "Execution context was destroyed" error during the stubbed `location.reload()` tear-down no longer fails the test.
- Backend-persistence check remains the load-bearing assertion; the DOM poll is defense-in-depth.
- Resolves a local-only flake (5/5 failures observed locally; not exercised in CI because journey tests are gated by `_playwright_browser_available()` in the main pytest lane).
- Mirrors the pattern introduced for the mobile variant in [#530](https://github.com/jtn0123/InkyPi/pull/530) (JTN-729).

## Test plan
- [x] `pytest tests/integration/journeys/test_playlist_roundtrip.py` — 5/5 local runs pass
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist deletion verification reliability by gracefully handling transient errors during the delete operation, ensuring more consistent test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->