### PR TITLE
fix: align playlist name validation with ASCII UI copy (JTN-747)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -30,7 +30,11 @@ logger = logging.getLogger(__name__)
 playlist_bp = Blueprint("playlist", __name__)
 
 _PLAYLIST_NAME_MAX_LEN = 64
-_PLAYLIST_NAME_RE = re.compile(r"^[\w\s\-]+$", re.UNICODE)
+_PLAYLIST_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]+$", re.ASCII)
+_PLAYLIST_NAME_FORMAT_ERROR = (
+    "Playlist name can only contain ASCII letters, "
+    "numbers, spaces, underscores, and hyphens"
+)
 _INSTANCE_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]+$")
 
 # Shared string constants to avoid duplication
@@ -65,7 +69,7 @@ def _validate_playlist_name(name, field="playlist_name"):
         )
     if not _PLAYLIST_NAME_RE.match(name):
         return None, json_error(
-            "Playlist name may only contain letters, numbers, spaces, hyphens, and underscores",
+            _PLAYLIST_NAME_FORMAT_ERROR,
             status=400,
             code=_CODE_VALIDATION,
             details={"field": field},

--- a/src/static/scripts/playlist.js
+++ b/src/static/scripts/playlist.js
@@ -17,6 +17,8 @@
     const NEXT_IN_REFRESH_MS = 60000;      // 1 minute — countdown ticker interval
     const THUMB_PREFETCH_MARGIN = '200px';  // IntersectionObserver pre-load margin
     const PROGRESS_HIDE_DELAY_MS = 2000;    // delay before hiding progress panel
+    const PLAYLIST_NAME_RE = /^[A-Za-z0-9 _-]+$/;
+    const PLAYLIST_NAME_ERROR = "Playlist name can only contain ASCII letters, numbers, spaces, underscores, and hyphens";
 
     const C = window.PLAYLIST_CTX || {};
     const mobileQuery = window.matchMedia ? window.matchMedia("(max-width: 768px)") : { matches: false, addEventListener() {} };
@@ -619,6 +621,12 @@
         if (name.length > 64) {
             input.setAttribute("aria-invalid", "true");
             if (error) error.textContent = "Name must be 64 characters or fewer";
+            input.focus();
+            return null;
+        }
+        if (!PLAYLIST_NAME_RE.test(name)) {
+            input.setAttribute("aria-invalid", "true");
+            if (error) error.textContent = PLAYLIST_NAME_ERROR;
             input.focus();
             return null;
         }

--- a/tests/unit/test_dogfood_fuzz.py
+++ b/tests/unit/test_dogfood_fuzz.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 PLAYLIST_JS = Path(__file__).resolve().parents[2] / "src/static/scripts/playlist.js"
 EXPECTED_COPY = (
     "Playlist name can only contain ASCII letters, "

--- a/tests/unit/test_dogfood_fuzz.py
+++ b/tests/unit/test_dogfood_fuzz.py
@@ -1,0 +1,30 @@
+"""Dogfood fuzz checks for playlist-name contract alignment (JTN-747)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PLAYLIST_JS = Path(__file__).resolve().parents[2] / "src/static/scripts/playlist.js"
+EXPECTED_COPY = (
+    "Playlist name can only contain ASCII letters, "
+    "numbers, spaces, underscores, and hyphens"
+)
+
+
+def test_non_ascii_playlist_names_match_ui_copy(client):
+    """Non-ASCII playlist names should be rejected by both UI copy and server."""
+    js = PLAYLIST_JS.read_text()
+    assert "^[A-Za-z0-9 _-]+$" in js
+    assert EXPECTED_COPY in js
+
+    for name in ("Météo", "東京", "Cafe\u0301"):
+        resp = client.post(
+            "/create_playlist",
+            json={"playlist_name": name, "start_time": "08:00", "end_time": "12:00"},
+        )
+        assert resp.status_code == 400, name
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data["details"]["field"] == "playlist_name"
+        assert EXPECTED_COPY in data["error"]

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -819,11 +819,14 @@ class TestPlaylistNameValidation:
         assert "../" not in data["error"]
         assert data["details"]["field"] == "playlist_name"
 
-    def test_create_playlist_name_valid_unicode(self, client, device_config_dev):
-        r"""Unicode word characters (accented letters matched by \w) should be accepted."""
+    def test_create_playlist_name_rejects_unicode(self, client):
+        """Playlist names must stay aligned with the ASCII-only UI copy."""
         resp = _create_playlist(client, "Météo", "08:00", "12:00")
-        assert resp.status_code == 200
-        assert resp.get_json()["success"] is True
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data["details"]["field"] == "playlist_name"
+        assert "ASCII letters" in data["error"]
 
     def test_create_playlist_name_with_spaces(self, client, device_config_dev):
         """Playlist names with spaces should be accepted."""


### PR DESCRIPTION
## Summary

- tighten playlist-name validation to ASCII so the backend matches the UI contract
- mirror the same allowlist and error copy in the browser-side validator
- add regression coverage for non-ASCII names in the fuzz and playlist blueprint suites

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [ ] Docs updated for new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

## Testing

- `scripts/test.sh tests/unit/test_playlist_blueprint.py tests/unit/test_dogfood_fuzz.py tests/integration/test_playlist_more.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time client-side playlist name validation with immediate error feedback and visual indicators.

* **Bug Fixes**
  * Playlist names now restricted to ASCII characters (letters, numbers, space, underscore, hyphen) for consistency.

* **Tests**
  * Added validation tests to ensure client and server playlist name rules align.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->