### PR TITLE
fix: stabilize plugin image asset paths for frame icons (JTN-749)

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -33,8 +33,6 @@ from utils.security_utils import validate_file_path
 logger = logging.getLogger(__name__)
 plugin_bp = Blueprint("plugin", __name__)
 
-PLUGINS_DIR = resolve_path("plugins")
-
 # Sonar S1192 — duplicate string constants
 _CONFIG_KEY = "DEVICE_CONFIG"
 _PLUGIN_ID = "plugin_id"
@@ -46,6 +44,11 @@ _ERR_PLUGIN_INSTANCE_NOT_FOUND = "Plugin instance not found"
 _ERR_PLUGIN_NOT_FOUND = "Plugin not found"
 _ERR_PLAYLIST_NOT_FOUND = "Playlist not found"
 _MSG_CIRCUIT_BREAKER_RESET = "Circuit-breaker reset for plugin instance."
+
+
+def _plugins_dir() -> str:
+    """Resolve the current plugin source directory at request time."""
+    return resolve_path("plugins")
 
 
 def _cacheable_send_file(path: str, ttl_env: str = "INKYPI_RENDER_CACHE_TTL_S"):
@@ -168,8 +171,10 @@ def image(plugin_id: str, filename: str):
                 return entry  # returned value is from os.listdir, not user input
         return None
 
-    # Resolve plugin_id against PLUGINS_DIR contents.
-    plugin_dirname = _match_listdir(PLUGINS_DIR, plugin_id)
+    plugins_dir = _plugins_dir()
+
+    # Resolve plugin_id against the current plugin source tree.
+    plugin_dirname = _match_listdir(plugins_dir, plugin_id)
     if plugin_dirname is None:
         logger.warning(
             "plugin.image: unknown plugin_id=%s",
@@ -178,7 +183,7 @@ def image(plugin_id: str, filename: str):
         abort(404)
 
     # Build the directory path from the listdir-derived name.
-    cursor = os.path.join(PLUGINS_DIR, plugin_dirname)
+    cursor = os.path.join(plugins_dir, plugin_dirname)
     resolved_parts: list[str] = []
     for segment in segments:
         match = _match_listdir(cursor, segment)
@@ -189,14 +194,14 @@ def image(plugin_id: str, filename: str):
 
     # Defence-in-depth: reject any symlink entry that escapes PLUGINS_DIR.
     try:
-        validate_file_path(cursor, PLUGINS_DIR)
+        validate_file_path(cursor, plugins_dir)
     except ValueError:
         abort(404)
 
     if not os.path.isfile(cursor):
         abort(404)
 
-    safe_dir = os.path.join(PLUGINS_DIR, plugin_dirname)
+    safe_dir = os.path.join(plugins_dir, plugin_dirname)
     safe_name = os.path.join(*resolved_parts)
     resp = send_from_directory(safe_dir, safe_name)
     try:

--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -43,12 +43,18 @@ FONTS = {
 
 def resolve_path(file_path):
     src_dir = os.getenv("SRC_DIR")
+    repo_root = Path(__file__).resolve().parents[2]
     if src_dir is None:
         # Default to the src directory
-        src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        src_path = Path(__file__).resolve().parents[1]
+    else:
+        src_path = Path(src_dir)
+        if not src_path.is_absolute():
+            # Keep relative SRC_DIR values anchored to the repository root so
+            # callers do not depend on the current working directory.
+            src_path = (repo_root / src_path).resolve()
 
-    src_path = Path(src_dir)
-    return str(src_path / file_path)
+    return str((src_path / file_path).resolve())
 
 
 def get_ip_address():

--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -40,21 +40,23 @@ FONTS = {
     "jost-semibold": "Jost-SemiBold.ttf",
 }
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC_ROOT = Path(__file__).resolve().parents[1]
+
 
 def resolve_path(file_path):
     src_dir = os.getenv("SRC_DIR")
-    repo_root = Path(__file__).resolve().parents[2]
     if src_dir is None:
         # Default to the src directory
-        src_path = Path(__file__).resolve().parents[1]
+        src_path = _SRC_ROOT
     else:
         src_path = Path(src_dir)
         if not src_path.is_absolute():
             # Keep relative SRC_DIR values anchored to the repository root so
             # callers do not depend on the current working directory.
-            src_path = (repo_root / src_path).resolve()
+            src_path = (_REPO_ROOT / src_path).resolve()
 
-    return str((src_path / file_path).resolve())
+    return str(src_path / file_path)
 
 
 def get_ip_address():

--- a/tests/integration/test_plugin_images_route.py
+++ b/tests/integration/test_plugin_images_route.py
@@ -20,6 +20,20 @@ def test_plugin_static_image_route(client):
     assert "image" in (resp.headers.get("Content-Type") or "")
 
 
+def test_plugin_static_image_route_with_relative_src_dir(client, tmp_path, monkeypatch):
+    """Relative SRC_DIR values must stay rooted at the repo, not the cwd."""
+    monkeypatch.setenv("SRC_DIR", "src")
+    monkeypatch.chdir(tmp_path)
+
+    resp = client.get("/images/ai_text/icon.png")
+    assert resp.status_code == 200
+    assert "image" in (resp.headers.get("Content-Type") or "")
+
+    resp = client.get("/images/base_plugin/frames/blank.png")
+    assert resp.status_code == 200
+    assert "image" in (resp.headers.get("Content-Type") or "")
+
+
 # ---------------------------------------------------------------------------
 # Security – py/path-injection regression (JTN-326)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_app_utils.py
+++ b/tests/unit/test_app_utils.py
@@ -2,6 +2,7 @@ import os
 import socket
 import subprocess
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 from PIL import Image
@@ -69,6 +70,16 @@ def test_resolve_path_with_env(tmp_path, monkeypatch):
     monkeypatch.setenv("SRC_DIR", str(tmp_path))
     p = app_utils.resolve_path("static/images")
     assert str(tmp_path).replace("\\", "/") in p.replace("\\", "/")
+
+
+def test_resolve_path_with_relative_src_dir_ignores_cwd(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.setenv("SRC_DIR", "src")
+    monkeypatch.chdir(tmp_path)
+
+    p = app_utils.resolve_path("plugins")
+
+    assert p == str((repo_root / "src" / "plugins").resolve())
 
 
 def test_parse_form_list_handling():


### PR DESCRIPTION
## Summary

- fix plugin image asset serving by anchoring relative `SRC_DIR` values to the repo root
- resolve the plugin asset root at request time so `/images/<plugin>/<path>` stays stable across cwd changes
- add regression coverage for both `resolve_path()` and plugin image routes under relative `SRC_DIR`

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [ ] Docs updated for new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

## Testing

- `scripts/test.sh tests/unit/test_app_utils.py -k 'resolve_path_with_env or resolve_path_with_relative_src_dir_ignores_cwd'`
- `scripts/test.sh tests/integration/test_plugin_images_route.py`
- `python3 -m black --check src/utils/app_utils.py src/blueprints/plugin.py tests/unit/test_app_utils.py tests/integration/test_plugin_images_route.py`
- `python3 -m ruff check src/utils/app_utils.py src/blueprints/plugin.py tests/unit/test_app_utils.py tests/integration/test_plugin_images_route.py`
