### PR TITLE
fix: swallow expected AbortError in version check (JTN-751)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -705,7 +705,12 @@
           whatsNewBtn.hidden = true;
         }
       } catch (e) {
-        console.warn("Version check failed:", e);
+        if (e?.name === "AbortError") {
+          console.debug("Version check aborted:", e);
+          return;
+        } else {
+          console.warn("Version check failed:", e);
+        }
         if (badge) { badge.textContent = "Check failed"; badge.className = "status-chip"; }
       } finally {
         // Re-enable button and hide spinner (JTN-352)

--- a/tests/static/test_settings_version_check_error.py
+++ b/tests/static/test_settings_version_check_error.py
@@ -16,7 +16,7 @@ def test_version_check_aborts_without_warning():
     assert (
         'console.debug("Version check aborted:", e);' in js
     ), "AbortError should be logged at debug level rather than warning level"
-    assert "console.debug(\"Version check aborted:\", e);\n          return;" in js, (
+    assert 'console.debug("Version check aborted:", e);\n          return;' in js, (
         "AbortError branch should return early so the badge is not marked as "
         "a failed update check for an expected abort"
     )

--- a/tests/static/test_settings_version_check_error.py
+++ b/tests/static/test_settings_version_check_error.py
@@ -1,0 +1,25 @@
+"""Regression guards for settings page version-check error handling (JTN-751)."""
+
+from pathlib import Path
+
+JS_PATH = Path("src/static/scripts/settings_page.js")
+
+
+def test_version_check_aborts_without_warning():
+    """AbortError from the version-check fetch should be treated as expected."""
+    js = JS_PATH.read_text()
+
+    assert 'e?.name === "AbortError"' in js, (
+        "Version check catch block must special-case AbortError so expected "
+        "navigation/remount aborts do not emit warnings"
+    )
+    assert (
+        'console.debug("Version check aborted:", e);' in js
+    ), "AbortError should be logged at debug level rather than warning level"
+    assert "console.debug(\"Version check aborted:\", e);\n          return;" in js, (
+        "AbortError branch should return early so the badge is not marked as "
+        "a failed update check for an expected abort"
+    )
+    assert (
+        'console.warn("Version check failed:", e);' in js
+    ), "Non-abort failures must still be visible as warnings"


### PR DESCRIPTION
## Summary

- treat version-check `AbortError`s as expected lifecycle cleanup instead of failures
- keep real version-check errors visible as warnings
- add a focused static regression guard for the abort branch and warning branch

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [ ] Docs updated for new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

## Testing

- `scripts/test.sh tests/static/test_settings_version_check_error.py tests/static/test_shutdown_fetch_error.py`
