### PR TITLE
refactor: consolidate shared HTTP client construction

### DIFF
--- a/docs/http_cache.md
+++ b/docs/http_cache.md
@@ -129,7 +129,10 @@ The cache respects standard HTTP Cache-Control directives:
 
 ## Plugin Integration
 
-Plugins automatically benefit from caching without code changes:
+Plugins automatically benefit from caching without code changes. The cache sits on top of
+the same shared session factory used by `utils.http_client.get_http_session()`, so a
+plugin can move from the compatibility session to `http_get()` later without relearning
+new retry or pooling behavior:
 
 ### Weather Plugin Example
 

--- a/docs/http_performance.md
+++ b/docs/http_performance.md
@@ -6,9 +6,11 @@ the HTTP infrastructure available to plugins and how to use it correctly.
 
 ## Why use `get_http_session()`
 
-`get_http_session()` (`src/utils/http_client.py`, line 32) returns a process-wide
-`requests.Session` singleton. Using a shared session has three concrete benefits on Pi
-hardware:
+`get_http_session()` (`src/utils/http_client.py`, line 32) returns the plugin-facing
+compatibility session. Its pool/adapter wiring is built from the same shared helper used
+by `http_get()` in `src/utils/http_utils.py`, so the retry, pooling, and header defaults
+are easier to reason about across both entry points. Using a shared session has three
+concrete benefits on Pi hardware:
 
 1. **TLS session resumption** – once a TLS handshake has been negotiated with a host, the
    underlying SSL session can be reused across requests. A cold TLS handshake to a CDN or
@@ -88,8 +90,10 @@ response = session.get(url, timeout=(5, 30))
 ### `http_get()` wrapper
 
 `src/utils/http_utils.py` also exposes `http_get()` (line 285) which adds caching,
-latency logging, and applies the env-based default automatically. Use it when you want
-both the pool and caching without wiring them by hand:
+latency logging, and applies the env-based default automatically. It uses the same shared
+session factory as `get_http_session()`, but keeps its thread-local lifecycle because the
+request wrapper has different retry defaults. Use it when you want both the pool and
+caching without wiring them by hand:
 
 ```python
 from utils.http_utils import http_get

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -2,11 +2,8 @@
 HTTP Client with Connection Pooling for InkyPi
 
 Provides a shared requests.Session() instance for all plugins to use.
-Benefits:
-- Connection reuse (20-30% faster requests)
-- Reduced TCP handshake overhead
-- Automatic keep-alive handling
-- Consistent headers across all requests
+The session wiring is shared with ``utils.http_utils`` so pooling, retries,
+and default headers stay aligned across the two public HTTP entry points.
 
 Usage:
     from utils.http_client import get_http_session
@@ -20,9 +17,14 @@ import logging
 import threading
 
 import requests
-from urllib3.util.retry import Retry
+
+from utils.http_utils import DEFAULT_HEADERS, _build_retry, _build_session
 
 logger = logging.getLogger(__name__)
+
+_PLUGIN_RETRY_TOTAL = 3
+_PLUGIN_RETRY_BACKOFF = 0.5
+_PLUGIN_RETRY_ALLOWED_METHODS = ("GET", "HEAD", "OPTIONS")
 
 # Global session instance (singleton)
 _HTTP_SESSION: requests.Session | None = None
@@ -42,28 +44,18 @@ def get_http_session() -> requests.Session:
     with _HTTP_SESSION_LOCK:
         if _HTTP_SESSION is None:
             logger.debug("Initializing shared HTTP session with connection pooling")
-            _HTTP_SESSION = requests.Session()
-
-            # Set common headers for all InkyPi requests
-            _HTTP_SESSION.headers.update(
-                {"User-Agent": "InkyPi/1.0 (https://github.com/fatihak/InkyPi/)"}
+            _HTTP_SESSION = _build_session(
+                headers=DEFAULT_HEADERS,
+                retry=_build_retry(
+                    total=_PLUGIN_RETRY_TOTAL,
+                    connect=None,
+                    read=None,
+                    status=None,
+                    backoff_factor=_PLUGIN_RETRY_BACKOFF,
+                    allowed_methods=_PLUGIN_RETRY_ALLOWED_METHODS,
+                    raise_on_status=True,
+                ),
             )
-
-            # Configure connection pool with retries for transient network and 5xx/429 responses.
-            retry_strategy = Retry(
-                total=3,
-                backoff_factor=0.5,
-                status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=frozenset(["GET", "HEAD", "OPTIONS"]),
-            )
-            adapter = requests.adapters.HTTPAdapter(
-                pool_connections=10,
-                pool_maxsize=10,
-                max_retries=retry_strategy,
-                pool_block=False,
-            )
-            _HTTP_SESSION.mount("http://", adapter)
-            _HTTP_SESSION.mount("https://", adapter)
 
             atexit.register(close_http_session)
             logger.debug("HTTP session initialized successfully")

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -310,48 +310,73 @@ except Exception:
     logger.warning("Failed to parse HTTP split timeout env vars, using defaults")
     CONNECT_TIMEOUT_SECONDS = None
     READ_TIMEOUT_SECONDS = None
-DEFAULT_HEADERS: dict[str, str] = {
-    "User-Agent": "InkyPi/1.0 (+https://github.com/fatihak/InkyPi)"
-}
+HTTP_POOL_CONNECTIONS = 10
+HTTP_POOL_MAXSIZE = 10
+HTTP_POOL_BLOCK = False
+HTTP_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+HTTP_ALLOWED_METHODS = ("HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE")
+HTTP_DEFAULT_USER_AGENT = "InkyPi/1.0 (+https://github.com/fatihak/InkyPi)"
+DEFAULT_HEADERS: dict[str, str] = {"User-Agent": HTTP_DEFAULT_USER_AGENT}
 
 
-def _build_retry() -> Retry:
+def _build_retry(
+    *,
+    total: int,
+    connect: int | None,
+    read: int | None,
+    status: int | None,
+    backoff_factor: float,
+    allowed_methods: tuple[str, ...],
+    raise_on_status: bool,
+) -> Retry:
+    """Build a retry policy without binding it to a specific caller profile."""
     # Retry idempotent methods on common transient failures.  ``urllib3`` is
     # imported lazily to keep it off the startup path (JTN-606).
-    from urllib3.util.retry import Retry  # noqa: F811
+    from urllib3.util.retry import Retry as _Retry  # noqa: F811
 
+    return _Retry(
+        total=total,
+        connect=connect,
+        read=read,
+        status=status,
+        backoff_factor=backoff_factor,
+        status_forcelist=HTTP_STATUS_FORCELIST,
+        allowed_methods=frozenset(allowed_methods),
+        raise_on_status=raise_on_status,
+    )
+
+
+def _build_env_retry() -> Retry:
+    """Build the default retry policy used by ``http_get``."""
     retries_total = _env_int("INKYPI_HTTP_RETRIES", 3)
     retries_connect = _env_int("INKYPI_HTTP_RETRIES_CONNECT", retries_total)
     retries_read = _env_int("INKYPI_HTTP_RETRIES_READ", retries_total)
     retries_status = _env_int("INKYPI_HTTP_RETRIES_STATUS", retries_total)
     backoff = _env_float("INKYPI_HTTP_BACKOFF", 0.0)  # keep tests snappy by default
-    return Retry(
+    return _build_retry(
         total=retries_total,
         connect=retries_connect,
         read=retries_read,
         status=retries_status,
         backoff_factor=backoff,
-        status_forcelist=(429, 500, 502, 503, 504),
-        allowed_methods=(
-            "HEAD",
-            "GET",
-            "PUT",
-            "DELETE",
-            "OPTIONS",
-            "TRACE",
-        ),
+        allowed_methods=HTTP_ALLOWED_METHODS,
         raise_on_status=False,
     )
 
 
-def _build_session() -> requests.Session:
+def _build_session(*, headers: dict[str, str], retry: Retry) -> requests.Session:
     # ``requests`` / HTTPAdapter are imported lazily — see module docstring.
     import requests  # noqa: F811
     from requests.adapters import HTTPAdapter  # noqa: F811
 
     s = requests.Session()
-    adapter = HTTPAdapter(max_retries=_build_retry())
-    s.headers.update(DEFAULT_HEADERS)
+    adapter = HTTPAdapter(
+        pool_connections=HTTP_POOL_CONNECTIONS,
+        pool_maxsize=HTTP_POOL_MAXSIZE,
+        max_retries=retry,
+        pool_block=HTTP_POOL_BLOCK,
+    )
+    s.headers.update(headers)
     s.mount("http://", adapter)
     s.mount("https://", adapter)
     return s
@@ -361,7 +386,7 @@ def get_shared_session() -> requests.Session:
     """Return a requests.Session unique to the current thread."""
     session: requests.Session | None = getattr(_thread_local, "session", None)
     if session is None:
-        session = _build_session()
+        session = _build_session(headers=DEFAULT_HEADERS, retry=_build_env_retry())
         _thread_local.session = session
     return session
 

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -28,8 +28,10 @@ def test_get_http_session_singleton():
 
 
 def test_session_has_user_agent():
+    import utils.http_utils as http_utils
+
     session = get_http_session()
-    assert "InkyPi/1.0" in session.headers.get("User-Agent", "")
+    assert session.headers.get("User-Agent") == http_utils.DEFAULT_HEADERS["User-Agent"]
 
 
 def test_session_has_retry_strategy():
@@ -42,6 +44,10 @@ def test_session_has_retry_strategy():
     # Verify the retry strategy is set on the adapter
     assert http_adapter.max_retries.total == 3
     assert https_adapter.max_retries.total == 3
+    assert http_adapter.max_retries.backoff_factor == 0.5
+    assert http_adapter.max_retries.allowed_methods == frozenset(
+        {"GET", "HEAD", "OPTIONS"}
+    )
 
 
 def test_close_http_session():


### PR DESCRIPTION
## Summary
- move shared retry/header/session construction into `utils.http_utils`
- make `utils.http_client.get_http_session()` a compatibility wrapper over the same canonical session builder
- update docs and tests so the two public HTTP entry points document and verify the shared behavior

## Testing
- `python3 -m pytest -q tests/unit/test_http_client.py tests/unit/test_http_utils.py tests/unit/test_http_utils_cache_integration.py tests/unit/test_http_utils_more.py tests/unit/test_plugin_http_session_adoption.py`
- `python3 -m ruff check src/utils/http_utils.py src/utils/http_client.py tests/unit/test_http_client.py`
