### PR TITLE
chore: harden release gates and contributor checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,8 @@ jobs:
             --output artifacts/security/pip-audit-dev.json
       - name: Generate SBOM
         run: |
-          python -m cyclonedx_py environment python --of JSON \
+          python_path="$(python -c 'import sys; print(sys.executable)')"
+          python -m cyclonedx_py environment "$python_path" --of JSON \
             -o artifacts/security/sbom.json
       - name: Upload security artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,8 @@ jobs:
     name: Lockfile drift check
     runs-on: ubuntu-latest
     # JTN-616: migrated to `uv lock` + `uv export` for a universal cross-platform
-    # lockfile. Kept advisory for this PR so a follow-up can promote it to
-    # required after it has been stable on main.
-    continue-on-error: true
+    # lockfile. This now blocks merge because the runtime lockfile is part of
+    # the release contract and is regenerated from uv.lock.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -150,10 +149,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.11', '3.12', '3.13' ]
-        include:
-          - python-version: '3.13'
-            allow-failure: true
-    continue-on-error: ${{ matrix.allow-failure == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -480,15 +475,17 @@ jobs:
         run: |
           python -m pip install -U pip wheel
           pip install -r install/requirements.txt -r install/requirements-dev.txt
-      - name: Create venv symlink for preflash script
+      - name: Run pip-audit against hashed lockfiles
         run: |
-          python -m venv .venv
-          .venv/bin/pip install -r install/requirements.txt -r install/requirements-dev.txt
-      - name: Run security validation
-        env:
-          INKYPI_VALIDATE_SECURITY: '1'
+          mkdir -p artifacts/security
+          python -m pip_audit -r install/requirements.txt --format=json \
+            --output artifacts/security/pip-audit-runtime.json
+          python -m pip_audit -r install/requirements-dev.txt --format=json \
+            --output artifacts/security/pip-audit-dev.json
+      - name: Generate SBOM
         run: |
-          scripts/preflash_validate.sh
+          python -m cyclonedx_py environment python --of JSON \
+            -o artifacts/security/sbom.json
       - name: Upload security artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -813,9 +810,6 @@ jobs:
   ci-gate:
     name: CI gate (all checks pass)
     needs: [lint, shellcheck, lockfile-drift, tests, sonarcloud, smoke, smoke-matrix, coverage-gate, security, browser-smoke, install-smoke-memcap, install-matrix, install-crash-loop-gate]
-    # lockfile-drift is included in needs so the gate waits for it, but it is
-    # treated as advisory (not listed in the required-success loop below) until
-    # requirements.txt is regenerated. See JTN-597.
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -828,9 +822,7 @@ jobs:
           echo "$results"
 
           # Jobs that must be 'success'
-          # lockfile-drift is advisory (continue-on-error); not in this list.
-          # Add it here once requirements.txt is refreshed under the pinned Python version.
-          for job in lint shellcheck tests smoke smoke-matrix coverage-gate security browser-smoke install-smoke-memcap install-matrix install-crash-loop-gate; do
+          for job in lint shellcheck lockfile-drift tests smoke smoke-matrix coverage-gate security browser-smoke install-smoke-memcap install-matrix install-crash-loop-gate; do
             result=$(echo "$results" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$job',{}).get('result','missing'))")
             if [ "$result" != "success" ]; then
               echo "Required job '$job' did not succeed (result: $result)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,14 +40,13 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
 
-  # Warn (not block) when frontend files are staged with SKIP_BROWSER=1 set.
-  # This reminds contributors to run browser tests before opening a PR.
+  # Run the lightweight browser smoke gate automatically for staged frontend files.
   - repo: local
     hooks:
-      - id: browser-test-warning
-        name: Browser test reminder (frontend changes)
+      - id: browser-smoke-gate
+        name: Browser smoke gate (frontend changes)
         language: script
         entry: scripts/precommit_browser_warning.sh
         pass_filenames: false
-        always_run: true
+        files: ^src/(static|templates)/
         stages: [pre-commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,18 @@ Thanks for your interest in contributing to InkyPi! This guide covers setup, tes
 
 ## Prerequisites
 
-- Python 3.11+
-- A virtual environment (`venv`)
+- Python 3.11-3.13
+- A virtual environment (`.venv`)
 
 ## Dev Setup
 
 ```bash
-# Clone your fork
-git clone https://github.com/<your-username>/InkyPi.git
+# Clone the current repo or your fork
+git clone https://github.com/jtn0123/InkyPi.git
 cd InkyPi
 
 # Create and activate a virtual environment
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 
 # Install dev dependencies
@@ -37,10 +37,10 @@ This starts the web UI on port 8080 without requiring e-ink display hardware.
 
 ```bash
 # Fast iteration — skip browser/Playwright tests (headless Chromium not required)
-SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no -q
+scripts/test.sh
 
 # Run a specific test file
-.venv/bin/python -m pytest tests/unit/test_inkypi.py -v
+scripts/test.sh tests/unit/test_inkypi.py -v
 
 # Run with coverage
 SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --cov=src --cov-report=term-missing
@@ -67,6 +67,12 @@ SKIP_BROWSER=0 .venv/bin/python -m pytest tests/
 # Or simply omit SKIP_BROWSER — it defaults to unset (tests run); Chromium must
 # be installed or browser tests will fail (they are not auto-skipped on missing Chromium):
 .venv/bin/python -m pytest tests/
+```
+
+**Run the lightweight browser smoke gate used by the frontend pre-commit hook:**
+
+```bash
+scripts/test.sh browser-smoke
 ```
 
 **Fine-grained control:**
@@ -136,8 +142,8 @@ Private helpers (`_*` functions) longer than ~5 lines or with non-obvious intent
 2. Create a feature branch from `main`
 3. Write tests for new functionality
 4. Ensure all tests pass:
-   - Backend-only changes: `SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --no-header --tb=no -q`
-   - **Frontend changes** (`src/static/**`, `src/templates/**`): `SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`
+   - Backend-only changes: `scripts/test.sh`
+   - **Frontend changes** (`src/static/**`, `src/templates/**`): `scripts/test.sh browser-smoke`
 5. Run lint: `scripts/lint.sh`
 6. Open a PR against `main`
 
@@ -145,9 +151,9 @@ Private helpers (`_*` functions) longer than ~5 lines or with non-obvious intent
 
 Before marking your PR ready for review, confirm:
 
-- [ ] All pytest tests pass locally
+- [ ] `scripts/test.sh` passes locally
 - [ ] `scripts/lint.sh` passes (ruff + black are CI blockers)
-- [ ] **If touching `src/static/**` or `src/templates/**`**: ran browser tests with `SKIP_BROWSER=0 .venv/bin/python -m pytest tests/` and all passed
+- [ ] **If touching `src/static/**` or `src/templates/**`**: ran `scripts/test.sh browser-smoke` and it passed
 
 ## Dependency Management
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,15 +19,15 @@ Traditional setup method
 
 ```bash
 # 1. Clone and setup
-git clone https://github.com/fatihak/InkyPi.git
+git clone https://github.com/jtn0123/InkyPi.git
 cd InkyPi
 
 # 2. Quick start (recommended)
 ./scripts/dev.sh
 
 # Or manual setup
-python3 -m venv venv
-source venv/bin/activate  # Windows: venv\Scripts\activate
+python3 -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
 # 3. Install Python dependencies and vendor assets
 pip install -r install/requirements-dev.txt
@@ -49,7 +49,7 @@ command -v direnv >/dev/null || nix profile install "nixpkgs#direnv" \
   && source ~/.${SHELL##*/}rc # If not already present: install direnv, add hooks to shell rc and activate
 
 # 2. Clone and setup
-git clone https://github.com/fatihak/InkyPi.git
+git clone https://github.com/jtn0123/InkyPi.git
 cd InkyPi # direnv reads .envrc -> runs devbox shell -> installs deps & activates venv
 
 # 3. Run InkyPi in developer mode via devbox
@@ -196,12 +196,16 @@ To stop the container, press `Ctrl+C` or run `docker compose down`.
 ## CI Gate and Required Status Checks
 
 The CI workflow includes a `ci-gate` job that depends on all required jobs — including
-`browser-smoke`. This job is the single handle the repo owner should mark as a required
-status check in GitHub branch protection.
+`lockfile-drift`, `security`, and `browser-smoke`. This job is the single handle the repo
+owner should mark as a required status check in GitHub branch protection.
+
+Frontend changes under `src/static/**` or `src/templates/**` also trigger the local
+pre-commit browser gate, which runs `scripts/test.sh browser-smoke` before the commit is
+allowed through.
 
 ### Making `ci-gate` a required status check (repo owner steps)
 
-1. Go to **GitHub.com → fatihak/InkyPi → Settings → Branches**.
+1. Go to **GitHub.com → jtn0123/InkyPi → Settings → Branches**.
 2. Under "Branch protection rules", click **Edit** next to the `main` rule (or **Add rule**
    if none exists).
 3. Enable **"Require status checks to pass before merging"**.
@@ -230,7 +234,7 @@ InkyPi relies on system packages for some features, which are normally installed
 
 The required packages can be found in this file:
 
-https://github.com/fatihak/InkyPi/blob/main/install/debian-requirements.txt
+https://github.com/jtn0123/InkyPi/blob/main/install/debian-requirements.txt
 
 Use your favourite package manager (such as `apt`) to install them.
 

--- a/scripts/precommit_browser_warning.sh
+++ b/scripts/precommit_browser_warning.sh
@@ -1,35 +1,19 @@
 #!/usr/bin/env bash
-# precommit_browser_warning.sh — warn (not block) when frontend files are staged
-# while SKIP_BROWSER=1 is set in the environment.
+# precommit_browser_warning.sh — run the browser smoke gate when frontend files
+# are staged.
 #
 # Install via .pre-commit-config.yaml (see repo root) or run manually.
-# This hook intentionally exits 0 so it never blocks a commit — it only prints
-# a prominent warning reminding the contributor to run browser tests before
-# opening a PR.
+# This hook exits non-zero when the smoke suite fails so frontend changes
+# cannot be committed without the lightweight browser gate passing first.
 
 set -euo pipefail
 
-# Only warn when SKIP_BROWSER is explicitly set to a truthy value
-skip_browser="${SKIP_BROWSER:-0}"
-case "$skip_browser" in
-  1|true|yes) : ;;
-  *) exit 0 ;;
-esac
-
 # Check whether any staged file is under src/static/ or src/templates/
-if git diff --cached --name-only | grep -qE '^src/(static|templates)/'; then
-  echo ""
-  echo "┌──────────────────────────────────────────────────────────────────┐"
-  echo "│  WARNING: SKIP_BROWSER=1 is set but you have frontend changes    │"
-  echo "│  staged (src/static/** or src/templates/**).                     │"
-  echo "│                                                                  │"
-  echo "│  Browser tests MUST pass before opening a PR for these files.   │"
-  echo "│  Run:                                                            │"
-  echo "│    SKIP_BROWSER=0 .venv/bin/python -m pytest tests/             │"
-  echo "│                                                                  │"
-  echo "│  (This is a warning only — your commit is NOT blocked.)         │"
-  echo "└──────────────────────────────────────────────────────────────────┘"
-  echo ""
+if ! git diff --cached --name-only | grep -qE '^src/(static|templates)/'; then
+  exit 0
 fi
+
+echo "Running browser smoke gate for staged frontend changes..."
+./scripts/test.sh browser-smoke
 
 exit 0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,6 +19,12 @@ fi
 
 export PYTHONPATH="src${PYTHONPATH:+:$PYTHONPATH}"
 
+if [[ "${1:-}" == "browser-smoke" ]]; then
+    shift || true
+    REQUIRE_BROWSER_SMOKE=1 python -m pytest -q tests/integration/test_browser_smoke.py "$@"
+    exit $?
+fi
+
 BROWSER_TEST_TARGETS=(
     tests/integration/test_browser_smoke.py
     tests/integration/test_e2e_form_workflows.py


### PR DESCRIPTION
## Summary
- make `lockfile-drift` a blocking CI job and include it in the required `ci-gate` success list
- make Python 3.13 required in the pytest matrix and run `pip-audit` directly in CI alongside SBOM generation
- add a blocking frontend pre-commit browser smoke gate and refresh contributor docs to the current repo and verified commands

## Testing
- `bash -n scripts/test.sh scripts/precommit_browser_warning.sh`
- `python3 - <<'PY'`
  `import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text()); yaml.safe_load(pathlib.Path('.pre-commit-config.yaml').read_text())`
  `print('yaml-ok')`
  `PY`
- `bash scripts/check_requirements_drift.sh`
- `python3 -m pytest -q tests/unit/test_requirements_lockfile.py`
- `python3 -m pip_audit -r install/requirements.txt --format=json --output /tmp/inkypi-pip-audit-runtime.json`
- `python3 -m pip_audit -r install/requirements-dev.txt --format=json --output /tmp/inkypi-pip-audit-dev.json`
- `./scripts/test.sh browser-smoke`
