### PR TITLE
fix: bound completed-job retention in JobQueue

### DIFF
--- a/src/refresh_task/job_queue.py
+++ b/src/refresh_task/job_queue.py
@@ -122,7 +122,7 @@ class JobQueue:
             finished_at = entry.finished_at
             if finished_at is None:
                 continue
-            if now - finished_at > self._completed_ttl_seconds:
+            if now - finished_at >= self._completed_ttl_seconds:
                 del self._jobs[job_id]
                 continue
             finished_entries.append((job_id, finished_at))

--- a/src/refresh_task/job_queue.py
+++ b/src/refresh_task/job_queue.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import logging
 import threading
 import uuid
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
+from time import monotonic
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -29,17 +31,29 @@ STATUS_ERROR = "error"
 
 # Default max workers — kept low; Pi Zero has limited resources.
 _DEFAULT_MAX_WORKERS = 2
+_DEFAULT_COMPLETED_TTL_SECONDS = 15 * 60.0
+_DEFAULT_MAX_RETAINED_FINISHED_JOBS = 128
 
 
 class JobQueue:
     """A thin wrapper around :class:`ThreadPoolExecutor` with status tracking."""
 
-    def __init__(self, max_workers: int = _DEFAULT_MAX_WORKERS) -> None:
+    def __init__(
+        self,
+        max_workers: int = _DEFAULT_MAX_WORKERS,
+        *,
+        completed_ttl_seconds: float = _DEFAULT_COMPLETED_TTL_SECONDS,
+        max_retained_finished_jobs: int = _DEFAULT_MAX_RETAINED_FINISHED_JOBS,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
         self._executor = ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="job-queue"
         )
         self._jobs: dict[str, _JobEntry] = {}
         self._lock = threading.Lock()
+        self._completed_ttl_seconds = max(0.0, completed_ttl_seconds)
+        self._max_retained_finished_jobs = max(0, max_retained_finished_jobs)
+        self._clock = clock
 
     # ------------------------------------------------------------------
     # Public API
@@ -55,6 +69,7 @@ class JobQueue:
         entry = _JobEntry(job_id)
 
         with self._lock:
+            self._prune_finished_locked()
             self._jobs[job_id] = entry
 
         future = self._executor.submit(self._run, entry, fn, *args, **kwargs)
@@ -70,6 +85,7 @@ class JobQueue:
         - ``error``:  a string description when ``status == "error"``
         """
         with self._lock:
+            self._prune_finished_locked()
             entry = self._jobs.get(job_id)
 
         if entry is None:
@@ -85,35 +101,64 @@ class JobQueue:
     def pending_jobs(self) -> int:
         """Number of jobs that have not yet completed (pending or running)."""
         with self._lock:
+            self._prune_finished_locked()
             return sum(
                 1
                 for e in self._jobs.values()
                 if e.status in (STATUS_PENDING, STATUS_RUNNING)
             )
 
+    def _prune_finished_locked(self) -> None:
+        """Drop stale or excess finished jobs.
+
+        Active jobs are never pruned. Finished entries naturally expire after a
+        bounded retention window so a long-lived device does not accumulate
+        one status record per historical render forever.
+        """
+        now = self._clock()
+        finished_entries: list[tuple[str, float]] = []
+
+        for job_id, entry in list(self._jobs.items()):
+            finished_at = entry.finished_at
+            if finished_at is None:
+                continue
+            if now - finished_at > self._completed_ttl_seconds:
+                del self._jobs[job_id]
+                continue
+            finished_entries.append((job_id, finished_at))
+
+        excess = len(finished_entries) - self._max_retained_finished_jobs
+        if excess <= 0:
+            return
+
+        finished_entries.sort(key=lambda item: item[1])
+        for job_id, _finished_at in finished_entries[:excess]:
+            self._jobs.pop(job_id, None)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _run(entry: _JobEntry, fn: Any, *args: Any, **kwargs: Any) -> Any:
+    def _run(self, entry: _JobEntry, fn: Any, *args: Any, **kwargs: Any) -> Any:
         entry.status = STATUS_RUNNING
         try:
             result = fn(*args, **kwargs)
             entry.result = result
             entry.status = STATUS_DONE
+            entry.finished_at = self._clock()
             return result
         except Exception as exc:
             logger.exception("Job %s failed", entry.job_id)
             entry.error = str(exc)
             entry.status = STATUS_ERROR
+            entry.finished_at = self._clock()
             raise
 
 
 class _JobEntry:
     """Mutable record tracking one enqueued job."""
 
-    __slots__ = ("job_id", "status", "result", "error", "future")
+    __slots__ = ("job_id", "status", "result", "error", "future", "finished_at")
 
     def __init__(self, job_id: str) -> None:
         self.job_id = job_id
@@ -121,6 +166,7 @@ class _JobEntry:
         self.result: Any = None
         self.error: str | None = None
         self.future: Future | None = None  # type: ignore[type-arg]
+        self.finished_at: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"status": self.status}

--- a/tests/unit/test_job_queue.py
+++ b/tests/unit/test_job_queue.py
@@ -145,7 +145,7 @@ class TestJobQueue:
             time.sleep(0.05)
 
         assert info["status"] == STATUS_DONE
-        clock.advance(11.0)
+        clock.advance(10.0)
         assert q.get_status(jid) == {"status": "unknown", "error": "Job not found"}
         q.shutdown()
 
@@ -193,30 +193,32 @@ class TestJobQueue:
             max_retained_finished_jobs=1,
             clock=clock,
         )
-        active_job_id = q.enqueue(_slow)
-        started.wait(timeout=5)
+        try:
+            active_job_id = q.enqueue(_slow)
+            started.wait(timeout=5)
 
-        done_job_ids: list[str] = []
-        for _idx in range(2):
-            jid = q.enqueue(lambda: "done")
-            done_job_ids.append(jid)
-            for _ in range(50):
-                info = q.get_status(jid)
-                if info["status"] == STATUS_DONE:
-                    break
-                time.sleep(0.05)
-            assert info["status"] == STATUS_DONE
-            clock.advance(1.0)
+            done_job_ids: list[str] = []
+            for _idx in range(2):
+                jid = q.enqueue(lambda: "done")
+                done_job_ids.append(jid)
+                for _ in range(50):
+                    info = q.get_status(jid)
+                    if info["status"] == STATUS_DONE:
+                        break
+                    time.sleep(0.05)
+                assert info["status"] == STATUS_DONE
+                clock.advance(1.0)
 
-        active_info = q.get_status(active_job_id)
-        assert active_info["status"] == STATUS_RUNNING
-        assert q.get_status(done_job_ids[0]) == {
-            "status": "unknown",
-            "error": "Job not found",
-        }
-        assert q.get_status(done_job_ids[1])["status"] == STATUS_DONE
-        proceed.set()
-        q.shutdown(wait=True)
+            active_info = q.get_status(active_job_id)
+            assert active_info["status"] == STATUS_RUNNING
+            assert q.get_status(done_job_ids[0]) == {
+                "status": "unknown",
+                "error": "Job not found",
+            }
+            assert q.get_status(done_job_ids[1])["status"] == STATUS_DONE
+        finally:
+            proceed.set()
+            q.shutdown(wait=True)
 
 
 class TestSingleton:

--- a/tests/unit/test_job_queue.py
+++ b/tests/unit/test_job_queue.py
@@ -18,6 +18,17 @@ from refresh_task.job_queue import (
 )
 
 
+class _FakeClock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
 @pytest.fixture(autouse=True)
 def _reset_singleton():
     """Ensure the module-level singleton is reset between tests."""
@@ -121,6 +132,91 @@ class TestJobQueue:
             time.sleep(0.05)
         assert info["result"] == 13
         q.shutdown()
+
+    def test_finished_jobs_expire_after_retention_window(self):
+        clock = _FakeClock()
+        q = JobQueue(completed_ttl_seconds=10.0, clock=clock)
+
+        jid = q.enqueue(lambda: "done")
+        for _ in range(50):
+            info = q.get_status(jid)
+            if info["status"] == STATUS_DONE:
+                break
+            time.sleep(0.05)
+
+        assert info["status"] == STATUS_DONE
+        clock.advance(11.0)
+        assert q.get_status(jid) == {"status": "unknown", "error": "Job not found"}
+        q.shutdown()
+
+    def test_finished_job_retention_cap_discards_oldest_completed_jobs(self):
+        clock = _FakeClock()
+        q = JobQueue(
+            completed_ttl_seconds=60.0,
+            max_retained_finished_jobs=2,
+            clock=clock,
+        )
+
+        job_ids: list[str] = []
+        for _idx in range(3):
+            jid = q.enqueue(lambda: "done")
+            job_ids.append(jid)
+            for _ in range(50):
+                info = q.get_status(jid)
+                if info["status"] == STATUS_DONE:
+                    break
+                time.sleep(0.05)
+            assert info["status"] == STATUS_DONE
+            clock.advance(1.0)
+
+        assert q.get_status(job_ids[0]) == {
+            "status": "unknown",
+            "error": "Job not found",
+        }
+        assert q.get_status(job_ids[1])["status"] == STATUS_DONE
+        assert q.get_status(job_ids[2])["status"] == STATUS_DONE
+        q.shutdown()
+
+    def test_finished_job_pruning_never_removes_active_jobs(self):
+        clock = _FakeClock()
+        started = threading.Event()
+        proceed = threading.Event()
+
+        def _slow():
+            started.set()
+            proceed.wait(timeout=5)
+            return "slow"
+
+        q = JobQueue(
+            max_workers=3,
+            completed_ttl_seconds=60.0,
+            max_retained_finished_jobs=1,
+            clock=clock,
+        )
+        active_job_id = q.enqueue(_slow)
+        started.wait(timeout=5)
+
+        done_job_ids: list[str] = []
+        for _idx in range(2):
+            jid = q.enqueue(lambda: "done")
+            done_job_ids.append(jid)
+            for _ in range(50):
+                info = q.get_status(jid)
+                if info["status"] == STATUS_DONE:
+                    break
+                time.sleep(0.05)
+            assert info["status"] == STATUS_DONE
+            clock.advance(1.0)
+
+        active_info = q.get_status(active_job_id)
+        assert active_info["status"] == STATUS_RUNNING
+        assert q.get_status(done_job_ids[0]) == {
+            "status": "unknown",
+            "error": "Job not found",
+        }
+        assert q.get_status(done_job_ids[1])["status"] == STATUS_DONE
+        proceed.set()
+        q.shutdown(wait=True)
 
 
 class TestSingleton:


### PR DESCRIPTION
## Summary
- bound completed-job retention in `JobQueue` with a TTL and finished-job cap
- prune stale/excess finished entries during queue access without touching active jobs
- add deterministic retention tests for expiry, cap enforcement, and active-job safety

## Testing
- `python3 -m pytest -q tests/unit/test_job_queue.py`
- `python3 -m pytest -q tests/integration/test_plugin_routes.py -k job`
- `python3 -m ruff check src/refresh_task/job_queue.py tests/unit/test_job_queue.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job queue now supports configurable retention policies for completed job status records
  * Finished job records are automatically removed after a configurable time period
  * Optional limit to cap the maximum number of retained finished job records to manage memory usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->