### PR TITLE
feat(install): add preflight disk/perms/git-repo sanity checks (JTN-699)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -142,15 +142,48 @@ _preflight_free_mb() {
   df -P -k "$path" 2>/dev/null | awk 'NR==2 {printf "%d\n", $4/1024}'
 }
 
+_preflight_canonical_path() {
+  # Canonicalise $1 so duplicate-mount-point detection in the disk-space loop
+  # is stable. Prefer GNU `readlink -f`, fall back to the cheap shell form if
+  # not available (e.g. on a minimal busybox container). Never errors — if
+  # nothing resolves, we echo the input unchanged so the caller can still
+  # run df against whatever string the user passed.
+  local p="$1"
+  if command -v readlink >/dev/null 2>&1 && readlink -f / >/dev/null 2>&1; then
+    readlink -f "$p" 2>/dev/null || echo "$p"
+  else
+    echo "$p"
+  fi
+}
+
 preflight_checks() {
   echo "Running preflight sanity checks..."
 
   # --- Disk space ---
+  # CodeRabbit review (#546): declare loop var `local` so it doesn't leak to
+  # enclosing scope, and dedupe usr_local vs install_parent so the same
+  # filesystem isn't checked twice with different labels when the defaults
+  # resolve to the same mount (the production case, where install_parent =
+  # dirname /usr/local/inkypi = /usr/local).
   local usr_local="${INKYPI_PREFLIGHT_USR_LOCAL:-/usr/local}"
   local install_parent="${INKYPI_PREFLIGHT_INSTALL_PARENT:-$(dirname "$INSTALL_PATH")}"
   local free_mb
+  local path
+  local canon_usr_local
+  local canon_install_parent
+  canon_usr_local="$(_preflight_canonical_path "$usr_local")"
+  canon_install_parent="$(_preflight_canonical_path "$install_parent")"
 
-  for path in "$usr_local" "$install_parent"; do
+  # Build a deduped list — if the two override vars resolve to the same
+  # canonical path we only run the df probe once. We keep the original
+  # (non-canonical) string for the error label so the message names the path
+  # the user actually configured, not its realpath.
+  local -a disk_paths=("$usr_local")
+  if [ "$canon_usr_local" != "$canon_install_parent" ]; then
+    disk_paths+=("$install_parent")
+  fi
+
+  for path in "${disk_paths[@]}"; do
     free_mb=$(_preflight_free_mb "$path")
     if [ "${free_mb:-0}" -lt "$PREFLIGHT_MIN_FREE_MB" ]; then
       _preflight_fail \
@@ -193,20 +226,40 @@ preflight_checks() {
   fi
 
   # $state_dir (= $LOCKFILE_DIR, normally /var/lib/inkypi) may not exist yet
-  # on a fresh install. Try to create it up front so we can assert it is
-  # writable — if mkdir fails, surface it here rather than deep inside the
-  # install when we first try to touch the lockfile.
-  if [ ! -d "$state_dir" ]; then
-    if ! mkdir -p "$state_dir" 2>/dev/null; then
+  # on a fresh install. CodeRabbit review (#546): we used to `mkdir -p` it
+  # here, but running as root in production that always succeeds — turning
+  # the subsequent writability check into dead code and giving a false sense
+  # of validation. Instead, probe writability of the *parent* by attempting
+  # to create+remove a throwaway file there. That's what actually needs to
+  # be writable for the real `mkdir -p "$LOCKFILE_DIR"` later to succeed,
+  # and it works whether or not $state_dir already exists.
+  if [ -d "$state_dir" ]; then
+    # Already exists — test writability by touching a probe file inside it.
+    local probe_file="$state_dir/.inkypi-preflight-probe.$$"
+    if ! (umask 077 && : > "$probe_file") 2>/dev/null; then
       _preflight_fail \
-        "state directory $state_dir does not exist and could not be created" \
+        "state directory $state_dir is not writable by $(id -un) (EUID=$EUID)" \
+        "re-run install.sh with sudo, or 'sudo chown $(id -un) $state_dir'"
+    fi
+    rm -f "$probe_file" 2>/dev/null || true
+  else
+    # Doesn't exist — test writability of the nearest existing ancestor so we
+    # know `mkdir -p "$state_dir"` will succeed later. Walking up handles the
+    # common fresh-Pi case where /var/lib/inkypi doesn't exist yet.
+    local parent="$state_dir"
+    while [ -n "$parent" ] && [ "$parent" != "/" ] && [ ! -d "$parent" ]; do
+      parent="$(dirname "$parent")"
+    done
+    if [ -z "$parent" ] || [ ! -d "$parent" ]; then
+      _preflight_fail \
+        "state directory $state_dir has no existing ancestor — cannot create" \
         "run install.sh with sudo, or manually 'sudo mkdir -p $state_dir' and retry"
     fi
-  fi
-  if [ ! -w "$state_dir" ]; then
-    _preflight_fail \
-      "state directory $state_dir is not writable by $(id -un) (EUID=$EUID)" \
-      "re-run install.sh with sudo, or 'sudo chown $(id -un) $state_dir'"
+    if [ ! -w "$parent" ]; then
+      _preflight_fail \
+        "cannot create state directory $state_dir: nearest ancestor $parent is not writable by $(id -un) (EUID=$EUID)" \
+        "re-run install.sh with sudo, or 'sudo chown $(id -un) $parent'"
+    fi
   fi
 
   # --- Source tree must be a git repo ---
@@ -214,13 +267,23 @@ preflight_checks() {
   # and vendored waveshare pins are verified against commit SHAs. A
   # non-git-repo source tree (e.g. a downloaded tarball) will break all
   # three, and the failure mode is obscure — abort here with a clear message.
+  #
+  # CodeRabbit review (#546): the canonical install flow is
+  #   `git clone … ~/inkypi && sudo bash ~/inkypi/install/install.sh`
+  # which creates a user-owned .git/ and then runs install.sh as root. Since
+  # CVE-2022-24765 git refuses to run `rev-parse --git-dir` when EUID != owner
+  # unless `safe.directory` is set, emitting the misleading "dubious ownership"
+  # error — which our `2>/dev/null` would mask and surface as "not a git repo".
+  # Bypass this by passing a scoped `safe.directory` override on this one git
+  # invocation. Still runs the real git parsing logic (so tarballs with a
+  # stray `.git/` fail this check just like before) without the ownership gate.
   local src_path="${INKYPI_PREFLIGHT_SRC_PATH:-$SRC_PATH}"
   if [ ! -d "$src_path" ]; then
     _preflight_fail \
       "source path $src_path does not exist" \
       "clone the repository via 'git clone https://github.com/fatihak/InkyPi.git' and run install/install.sh from inside the clone"
   fi
-  if ! git -C "$src_path" rev-parse --git-dir >/dev/null 2>&1; then
+  if ! git -c safe.directory='*' -C "$src_path" rev-parse --git-dir >/dev/null 2>&1; then
     _preflight_fail \
       "source tree at $src_path is not a git repository" \
       "install.sh must run from a git clone (not a downloaded tarball) so 'git describe' and waveshare pin verification work. Run: git clone https://github.com/fatihak/InkyPi.git"

--- a/install/install.sh
+++ b/install/install.sh
@@ -84,11 +84,149 @@ parse_arguments() {
 }
 
 check_permissions() {
-  # Ensure the script is run with sudo
+  # Ensure the script is run with sudo. JTN-699: when the preflight test-only
+  # env hook is set we skip the EUID check so the preflight block can be
+  # exercised from pytest without running the test suite as root; production
+  # behavior is unchanged because INKYPI_PREFLIGHT_TEST is never set by real
+  # callers (install.sh invoked by the user or by update flows).
+  if [ -n "${INKYPI_PREFLIGHT_TEST:-}" ]; then
+    return 0
+  fi
   if [ "$EUID" -ne 0 ]; then
     echo_error "ERROR: Installation requires root privileges. Please run it with sudo."
     exit 1
   fi
+}
+
+# JTN-699: Preflight sanity checks. install.sh previously had no early
+# validation — the user discovered "Permission denied" or "No space left on
+# device" 5–10 minutes into an install, with $INSTALL_PATH half-populated and
+# the systemd unit in an undefined state. Run cheap, deterministic checks
+# BEFORE any apt/pip/git work so failures surface in seconds with a clear,
+# actionable message.
+#
+# Each target path is overridable via env so tests can redirect checks at tmp
+# dirs without touching /usr/local, /etc/systemd/system or /var/lib/inkypi.
+# Production callers never set these vars, so behavior is unchanged.
+#
+# Required free space on /usr/local + $INSTALL_PATH parent (MB). 500 MB is the
+# conservative floor that covers debian-requirements.txt + pip wheelhouse +
+# venv + the app tree with headroom for a concurrent update staging dir.
+PREFLIGHT_MIN_FREE_MB="${INKYPI_PREFLIGHT_MIN_FREE_MB:-500}"
+
+_preflight_fail() {
+  # Centralise the error format so every preflight failure looks the same and
+  # downstream tests can match on a single prefix. Writes to stderr, exits 1.
+  echo_error "ERROR (preflight): $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo_error "  remediation: $2" >&2
+  fi
+  exit 1
+}
+
+_preflight_free_mb() {
+  # Print the free MB on the filesystem hosting $1 (walks up to the nearest
+  # existing ancestor if $1 does not yet exist, which is the normal case for
+  # /usr/local/inkypi on a fresh Pi). Uses POSIX `df -P -k` so output is
+  # stable across GNU/BSD and then rounds KB → MB.
+  local path="$1"
+  while [ ! -e "$path" ] && [ "$path" != "/" ] && [ -n "$path" ]; do
+    path=$(dirname "$path")
+  done
+  if [ ! -e "$path" ]; then
+    echo "0"
+    return 0
+  fi
+  # df -P: POSIX output (no line wrapping on long device names).
+  # df -k: KB blocks (portable; -m is GNU-only). Available KB is column 4.
+  df -P -k "$path" 2>/dev/null | awk 'NR==2 {printf "%d\n", $4/1024}'
+}
+
+preflight_checks() {
+  echo "Running preflight sanity checks..."
+
+  # --- Disk space ---
+  local usr_local="${INKYPI_PREFLIGHT_USR_LOCAL:-/usr/local}"
+  local install_parent="${INKYPI_PREFLIGHT_INSTALL_PARENT:-$(dirname "$INSTALL_PATH")}"
+  local free_mb
+
+  for path in "$usr_local" "$install_parent"; do
+    free_mb=$(_preflight_free_mb "$path")
+    if [ "${free_mb:-0}" -lt "$PREFLIGHT_MIN_FREE_MB" ]; then
+      _preflight_fail \
+        "insufficient free disk space on $path (found ${free_mb} MB, need ${PREFLIGHT_MIN_FREE_MB} MB)" \
+        "free up space on the filesystem hosting $path (e.g. 'sudo apt-get clean', remove old logs, or resize the SD card)"
+    fi
+  done
+
+  # --- Writable target paths ---
+  # $INSTALL_PATH itself may not exist yet; check its parent instead so we
+  # know the mv -T atomic swap in install_src() will be able to create it.
+  # Create parent first if missing (mirrors install_src behavior) so tests
+  # with tmp dirs where the parent doesn't exist still surface the real
+  # writability problem (e.g. a RO filesystem, not just "missing dir").
+  local systemd_dir="${INKYPI_PREFLIGHT_SYSTEMD_DIR:-/etc/systemd/system}"
+  local state_dir="${INKYPI_PREFLIGHT_STATE_DIR:-$LOCKFILE_DIR}"
+
+  if [ ! -d "$install_parent" ]; then
+    if ! mkdir -p "$install_parent" 2>/dev/null; then
+      _preflight_fail \
+        "install parent directory $install_parent does not exist and could not be created" \
+        "run install.sh with sudo, or manually 'sudo mkdir -p $install_parent' and retry"
+    fi
+  fi
+  if [ ! -w "$install_parent" ]; then
+    _preflight_fail \
+      "install parent directory $install_parent is not writable by $(id -un) (EUID=$EUID)" \
+      "run install.sh with sudo, or 'sudo chown $(id -un) $install_parent' if this is a dev environment"
+  fi
+
+  if [ ! -d "$systemd_dir" ]; then
+    _preflight_fail \
+      "systemd unit directory $systemd_dir does not exist" \
+      "ensure systemd is installed — this script targets Raspberry Pi OS (Bullseye/Bookworm/Trixie)"
+  fi
+  if [ ! -w "$systemd_dir" ]; then
+    _preflight_fail \
+      "systemd unit directory $systemd_dir is not writable by $(id -un) (EUID=$EUID)" \
+      "re-run install.sh with sudo"
+  fi
+
+  # $state_dir (= $LOCKFILE_DIR, normally /var/lib/inkypi) may not exist yet
+  # on a fresh install. Try to create it up front so we can assert it is
+  # writable — if mkdir fails, surface it here rather than deep inside the
+  # install when we first try to touch the lockfile.
+  if [ ! -d "$state_dir" ]; then
+    if ! mkdir -p "$state_dir" 2>/dev/null; then
+      _preflight_fail \
+        "state directory $state_dir does not exist and could not be created" \
+        "run install.sh with sudo, or manually 'sudo mkdir -p $state_dir' and retry"
+    fi
+  fi
+  if [ ! -w "$state_dir" ]; then
+    _preflight_fail \
+      "state directory $state_dir is not writable by $(id -un) (EUID=$EUID)" \
+      "re-run install.sh with sudo, or 'sudo chown $(id -un) $state_dir'"
+  fi
+
+  # --- Source tree must be a git repo ---
+  # The app reads its version from `git describe`, update.sh pulls via git,
+  # and vendored waveshare pins are verified against commit SHAs. A
+  # non-git-repo source tree (e.g. a downloaded tarball) will break all
+  # three, and the failure mode is obscure — abort here with a clear message.
+  local src_path="${INKYPI_PREFLIGHT_SRC_PATH:-$SRC_PATH}"
+  if [ ! -d "$src_path" ]; then
+    _preflight_fail \
+      "source path $src_path does not exist" \
+      "clone the repository via 'git clone https://github.com/fatihak/InkyPi.git' and run install/install.sh from inside the clone"
+  fi
+  if ! git -C "$src_path" rev-parse --git-dir >/dev/null 2>&1; then
+    _preflight_fail \
+      "source tree at $src_path is not a git repository" \
+      "install.sh must run from a git clone (not a downloaded tarball) so 'git describe' and waveshare pin verification work. Run: git clone https://github.com/fatihak/InkyPi.git"
+  fi
+
+  echo_success "\tPreflight checks passed (free space, writable targets, git repo)"
 }
 
 # JTN-701: Download a single Waveshare driver file honoring the pin in
@@ -549,6 +687,24 @@ wait_for_clock() {
 # to maintain default INKY display support.
 parse_arguments "$@"
 check_permissions
+
+# JTN-699: Run preflight sanity checks BEFORE any apt/pip/git work. Catches
+# disk/perm/source-tree issues in seconds instead of 5–10 minutes into an
+# install with a half-populated tree. This must run after check_permissions
+# (so the preflight test-only bypass for EUID is consistent) but before the
+# flock + lockfile setup, because an unwritable $LOCKFILE_DIR would otherwise
+# fail with a cryptic `touch: cannot touch ...` message from the lockfile
+# `touch` call below.
+preflight_checks
+
+# JTN-699: Test hook — exit cleanly after preflight so the pytest suite can
+# assert preflight behavior end-to-end without running a full apt/pip install.
+# Production callers never set INKYPI_PREFLIGHT_TEST_EXIT_AFTER, so behavior
+# is unchanged outside of tests.
+if [ -n "${INKYPI_PREFLIGHT_TEST_EXIT_AFTER:-}" ]; then
+  echo "TEST: INKYPI_PREFLIGHT_TEST_EXIT_AFTER — exiting 0 after preflight." >&2
+  exit 0
+fi
 
 # JTN-696: Concurrent-install guard. Two simultaneous `sudo bash install.sh`
 # runs previously raced through the rm/repopulate sequence in install_src()

--- a/scripts/ci_install_matrix_verify.sh
+++ b/scripts/ci_install_matrix_verify.sh
@@ -40,6 +40,21 @@ cd /InkyPi/install
 # error out in the non-tty container environment.
 export TERM="${TERM:-dumb}"
 
+# JTN-699: Dockerfile.install-matrix uses `COPY . /InkyPi` and the repo
+# `.dockerignore` excludes `.git`, so the container sees a tree with no git
+# metadata. install.sh's preflight now requires the source tree to be a real
+# git clone (needed at runtime by `git describe` and update.sh). Initialise a
+# throwaway repo here so the preflight git-repo assertion reflects the same
+# invariant users hit in the field (i.e. they ran `git clone …`) without
+# bloating the image with the full .git directory.
+if ! git -C /InkyPi rev-parse --git-dir >/dev/null 2>&1; then
+    git -C /InkyPi init --quiet --initial-branch=ci-install-matrix
+    git -C /InkyPi -c user.email=ci@inkypi.local -c user.name=CI \
+        -c commit.gpgsign=false \
+        -c advice.addIgnoredFile=false \
+        commit --allow-empty --quiet -m "ci-install-matrix bootstrap"
+fi
+
 # Force the wheelhouse fetch off — we want to exercise the source pip install
 # path (install_debian_dependencies + create_venv) which is what actually
 # catches regressions like JTN-528's zramswap breakage on Trixie. A pre-built

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -2933,3 +2933,292 @@ class TestDeviceJsonHelper:
             "atomic write must fsync before replace so contents hit disk "
             "before the rename is recorded in the directory inode."
         )
+
+
+# ---- JTN-699: install.sh preflight sanity checks ----------------------------
+#
+# install.sh previously had no early validation; the user discovered
+# "Permission denied" / "No space left on device" 5–10 minutes into a run
+# with $INSTALL_PATH half-populated. JTN-699 adds a preflight block that runs
+# BEFORE any apt/pip/git work and fails fast with actionable messages.
+#
+# Each failure path below simulates one broken precondition by pointing the
+# preflight env-var hooks at a tmp dir and asserting the exit code + error
+# message. The INKYPI_PREFLIGHT_TEST hook skips the EUID root check, and
+# INKYPI_PREFLIGHT_TEST_EXIT_AFTER short-circuits before real install work —
+# both are no-ops in production where those vars are never set.
+
+
+class TestInstallPreflight:
+    """Subprocess-runs install/install.sh with preflight env hooks and asserts
+    each check fails fast with a specific message (JTN-699)."""
+
+    INSTALL_SH = REPO_ROOT / "install" / "install.sh"
+
+    def _base_env(self, tmp_path):
+        """Build a valid set of preflight env vars pointing at tmp dirs.
+
+        Individual tests then override ONE var to simulate one failure, so
+        other preflight checks keep passing and only the targeted branch
+        trips. This mirrors how test_update_failure_recovery.py injects a
+        single failure at a time rather than a combined broken state.
+        """
+        import subprocess as _sp
+
+        usr_local = tmp_path / "usr_local"
+        install_parent = tmp_path / "install_parent"
+        systemd_dir = tmp_path / "systemd"
+        state_dir = tmp_path / "state"
+        src_path = tmp_path / "src"
+        for d in (usr_local, install_parent, systemd_dir, state_dir, src_path):
+            d.mkdir()
+        # Make $src_path a real git repo so the git-rev-parse check passes
+        # by default. Individual tests override this.
+        _sp.run(["git", "init", "-q", str(src_path)], check=True)
+        return {
+            "INKYPI_PREFLIGHT_TEST": "1",
+            "INKYPI_PREFLIGHT_TEST_EXIT_AFTER": "1",
+            "INKYPI_PREFLIGHT_USR_LOCAL": str(usr_local),
+            "INKYPI_PREFLIGHT_INSTALL_PARENT": str(install_parent),
+            "INKYPI_PREFLIGHT_SYSTEMD_DIR": str(systemd_dir),
+            "INKYPI_PREFLIGHT_STATE_DIR": str(state_dir),
+            "INKYPI_PREFLIGHT_SRC_PATH": str(src_path),
+        }
+
+    def _run(self, env_overrides):
+        import os as _os
+        import shutil as _shutil
+        import subprocess as _sp
+
+        if not _shutil.which("bash"):
+            pytest.skip("bash is not available on this host")
+        if not _shutil.which("git"):
+            pytest.skip("git is not available on this host")
+        env = dict(_os.environ)
+        env.update(env_overrides)
+        return _sp.run(
+            ["bash", str(self.INSTALL_SH)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+    # --- Happy path ---------------------------------------------------------
+
+    def test_preflight_passes_when_all_checks_satisfied(self, tmp_path):
+        """Baseline: with every precondition valid, preflight returns 0 and
+        the test short-circuit exits cleanly. This gates every failure test
+        below — if the baseline regresses, the failure-path assertions would
+        be meaningless."""
+        proc = self._run(self._base_env(tmp_path))
+        assert proc.returncode == 0, (
+            f"preflight must exit 0 when all checks pass; got {proc.returncode}. "
+            f"stdout: {proc.stdout!r} stderr: {proc.stderr!r}"
+        )
+        # Success message must be printed so operators see what was verified.
+        combined = proc.stdout + proc.stderr
+        assert "Preflight checks passed" in combined, (
+            f"preflight must announce success; output: {combined!r}"
+        )
+
+    # --- Disk-space failures ------------------------------------------------
+
+    def test_preflight_fails_when_usr_local_below_min_free(self, tmp_path):
+        """Simulate <500 MB free on /usr/local by bumping the threshold above
+        what any real filesystem would have free. A threshold of 10 PB (~10M
+        MB) is guaranteed to exceed actual free space on any test host."""
+        env = self._base_env(tmp_path)
+        env["INKYPI_PREFLIGHT_MIN_FREE_MB"] = str(10_000_000)  # 10 TB
+        proc = self._run(env)
+        assert proc.returncode != 0, (
+            "preflight must fail when free space is below the min threshold"
+        )
+        combined = proc.stdout + proc.stderr
+        assert "insufficient free disk space" in combined, (
+            f"error message must name the disk-space check; got: {combined!r}"
+        )
+        # The path that failed must appear in the error so the user knows
+        # which filesystem is the problem.
+        assert str(env["INKYPI_PREFLIGHT_USR_LOCAL"]) in combined or "usr_local" in combined
+
+    def test_preflight_disk_error_includes_remediation(self, tmp_path):
+        """Actionable error messages are in the acceptance criteria — every
+        failure must include a 'remediation:' suggestion."""
+        env = self._base_env(tmp_path)
+        env["INKYPI_PREFLIGHT_MIN_FREE_MB"] = str(10_000_000)
+        proc = self._run(env)
+        combined = proc.stdout + proc.stderr
+        assert "remediation" in combined.lower(), (
+            f"disk-space failure must suggest a remediation; got: {combined!r}"
+        )
+
+    # --- Writable-target failures ------------------------------------------
+
+    def test_preflight_fails_when_install_parent_not_writable(self, tmp_path):
+        """A RO install parent is the exact permission mode this preflight is
+        designed to catch. chmod 0o500 (r-x------) removes write for the
+        owner so even the EUID running the script cannot create $INSTALL_PATH."""
+        import os as _os
+
+        env = self._base_env(tmp_path)
+        install_parent = env["INKYPI_PREFLIGHT_INSTALL_PARENT"]
+        _os.chmod(install_parent, 0o500)
+        try:
+            proc = self._run(env)
+        finally:
+            # Restore so tmp_path teardown doesn't fail on macOS.
+            _os.chmod(install_parent, 0o755)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "not writable" in combined, (
+            f"error must name the writability check; got: {combined!r}"
+        )
+        assert install_parent in combined, (
+            f"error must name the failing path; got: {combined!r}"
+        )
+
+    def test_preflight_fails_when_systemd_dir_not_writable(self, tmp_path):
+        import os as _os
+
+        env = self._base_env(tmp_path)
+        systemd_dir = env["INKYPI_PREFLIGHT_SYSTEMD_DIR"]
+        _os.chmod(systemd_dir, 0o500)
+        try:
+            proc = self._run(env)
+        finally:
+            _os.chmod(systemd_dir, 0o755)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "not writable" in combined
+        assert systemd_dir in combined
+
+    def test_preflight_fails_when_systemd_dir_missing(self, tmp_path):
+        """A missing /etc/systemd/system means we are not on a systemd host.
+        Preflight should abort rather than silently try to copy a unit file
+        to a nonexistent directory."""
+        env = self._base_env(tmp_path)
+        # Point at a path that does not exist AND cannot be auto-created as a
+        # systemd dir (the systemd check intentionally does not mkdir -p).
+        env["INKYPI_PREFLIGHT_SYSTEMD_DIR"] = str(tmp_path / "no-systemd-here")
+        proc = self._run(env)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "does not exist" in combined
+        assert "systemd" in combined.lower()
+
+    def test_preflight_fails_when_state_dir_not_writable(self, tmp_path):
+        import os as _os
+
+        env = self._base_env(tmp_path)
+        state_dir = env["INKYPI_PREFLIGHT_STATE_DIR"]
+        _os.chmod(state_dir, 0o500)
+        try:
+            proc = self._run(env)
+        finally:
+            _os.chmod(state_dir, 0o755)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "not writable" in combined
+        assert state_dir in combined
+
+    # --- git-repo failure ---------------------------------------------------
+
+    def test_preflight_fails_when_src_is_not_a_git_repo(self, tmp_path):
+        """A downloaded tarball (no .git dir) would silently break
+        git-describe-based version reporting and waveshare pin verification.
+        Abort early with a clear message."""
+        import shutil as _shutil
+
+        env = self._base_env(tmp_path)
+        # Remove the .git dir so the rev-parse check fails.
+        _shutil.rmtree(Path(env["INKYPI_PREFLIGHT_SRC_PATH"]) / ".git")
+        proc = self._run(env)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "not a git repository" in combined, (
+            f"error must name the git-repo check; got: {combined!r}"
+        )
+        assert env["INKYPI_PREFLIGHT_SRC_PATH"] in combined
+        assert "remediation" in combined.lower()
+
+    def test_preflight_fails_when_src_path_missing(self, tmp_path):
+        import shutil as _shutil
+
+        env = self._base_env(tmp_path)
+        _shutil.rmtree(env["INKYPI_PREFLIGHT_SRC_PATH"])
+        proc = self._run(env)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        assert "does not exist" in combined
+        assert env["INKYPI_PREFLIGHT_SRC_PATH"] in combined
+
+    # --- Runs early: no apt/pip side effects -------------------------------
+
+    def test_preflight_fails_before_any_install_work(self, tmp_path):
+        """Acceptance: preflight must run BEFORE any apt/pip work. If it
+        trips on a failure, nothing downstream should have run — no vendor
+        download, no wheelhouse, no zramswap setup."""
+        env = self._base_env(tmp_path)
+        env["INKYPI_PREFLIGHT_MIN_FREE_MB"] = str(10_000_000)  # force fail
+        # Drop the exit-after hook so we'd fall through IF preflight didn't
+        # abort — any "Installing system dependencies" output would prove
+        # it reached apt-get. It MUST NOT.
+        env.pop("INKYPI_PREFLIGHT_TEST_EXIT_AFTER", None)
+        proc = self._run(env)
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        # Look for strings that would only appear if a real install step
+        # ran. The disk-space remediation message mentions "apt-get clean"
+        # so we cannot match on a bare "apt-get" substring — use whole-word
+        # headings that only the install steps themselves print.
+        for forbidden in (
+            "Installing system dependencies",
+            "Fetch available system dependencies",
+            "Creating python virtual environment",
+            "Installing python dependencies",
+            "setting up zramswap",
+            "Enabling interfaces required for",
+            "Installing inkypi systemd service",
+        ):
+            assert forbidden not in combined, (
+                f"preflight failure must short-circuit before {forbidden!r} runs; "
+                f"found it in output: {combined!r}"
+            )
+
+    # --- Source inspection: env-var override contract ---------------------
+
+    def test_install_sh_declares_preflight_env_hooks(self):
+        """Source inspection: the preflight env-var contract documented in
+        the module header must actually exist in install.sh. Guards against
+        a future refactor that drops a hook without updating the tests."""
+        content = (REPO_ROOT / "install" / "install.sh").read_text()
+        for var in (
+            "INKYPI_PREFLIGHT_TEST",
+            "INKYPI_PREFLIGHT_TEST_EXIT_AFTER",
+            "INKYPI_PREFLIGHT_USR_LOCAL",
+            "INKYPI_PREFLIGHT_INSTALL_PARENT",
+            "INKYPI_PREFLIGHT_SYSTEMD_DIR",
+            "INKYPI_PREFLIGHT_STATE_DIR",
+            "INKYPI_PREFLIGHT_SRC_PATH",
+            "INKYPI_PREFLIGHT_MIN_FREE_MB",
+        ):
+            assert var in content, (
+                f"install.sh must reference preflight env hook {var} (JTN-699)"
+            )
+
+    def test_install_sh_runs_preflight_before_lockfile_setup(self):
+        """Preflight must be called BEFORE the $LOCKFILE touch, because an
+        unwritable $LOCKFILE_DIR should surface as a clean preflight error,
+        not as a cryptic `touch: cannot touch ...` message."""
+        content = (REPO_ROOT / "install" / "install.sh").read_text()
+        preflight_pos = content.index("preflight_checks\n")
+        # The lockfile `touch "$LOCKFILE"` is the first place we'd trip on
+        # an unwritable state dir.
+        lockfile_pos = content.index('touch "$LOCKFILE"')
+        assert preflight_pos < lockfile_pos, (
+            "preflight_checks must run before `touch \"$LOCKFILE\"` so an "
+            "unwritable $LOCKFILE_DIR produces a clean preflight error "
+            "(JTN-699)"
+        )

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -3019,9 +3019,9 @@ class TestInstallPreflight:
         )
         # Success message must be printed so operators see what was verified.
         combined = proc.stdout + proc.stderr
-        assert "Preflight checks passed" in combined, (
-            f"preflight must announce success; output: {combined!r}"
-        )
+        assert (
+            "Preflight checks passed" in combined
+        ), f"preflight must announce success; output: {combined!r}"
 
     # --- Disk-space failures ------------------------------------------------
 
@@ -3032,16 +3032,19 @@ class TestInstallPreflight:
         env = self._base_env(tmp_path)
         env["INKYPI_PREFLIGHT_MIN_FREE_MB"] = str(10_000_000)  # 10 TB
         proc = self._run(env)
-        assert proc.returncode != 0, (
-            "preflight must fail when free space is below the min threshold"
-        )
+        assert (
+            proc.returncode != 0
+        ), "preflight must fail when free space is below the min threshold"
         combined = proc.stdout + proc.stderr
-        assert "insufficient free disk space" in combined, (
-            f"error message must name the disk-space check; got: {combined!r}"
-        )
+        assert (
+            "insufficient free disk space" in combined
+        ), f"error message must name the disk-space check; got: {combined!r}"
         # The path that failed must appear in the error so the user knows
         # which filesystem is the problem.
-        assert str(env["INKYPI_PREFLIGHT_USR_LOCAL"]) in combined or "usr_local" in combined
+        assert (
+            str(env["INKYPI_PREFLIGHT_USR_LOCAL"]) in combined
+            or "usr_local" in combined
+        )
 
     def test_preflight_disk_error_includes_remediation(self, tmp_path):
         """Actionable error messages are in the acceptance criteria — every
@@ -3050,9 +3053,9 @@ class TestInstallPreflight:
         env["INKYPI_PREFLIGHT_MIN_FREE_MB"] = str(10_000_000)
         proc = self._run(env)
         combined = proc.stdout + proc.stderr
-        assert "remediation" in combined.lower(), (
-            f"disk-space failure must suggest a remediation; got: {combined!r}"
-        )
+        assert (
+            "remediation" in combined.lower()
+        ), f"disk-space failure must suggest a remediation; got: {combined!r}"
 
     # --- Writable-target failures ------------------------------------------
 
@@ -3072,12 +3075,12 @@ class TestInstallPreflight:
             _os.chmod(install_parent, 0o755)
         assert proc.returncode != 0
         combined = proc.stdout + proc.stderr
-        assert "not writable" in combined, (
-            f"error must name the writability check; got: {combined!r}"
-        )
-        assert install_parent in combined, (
-            f"error must name the failing path; got: {combined!r}"
-        )
+        assert (
+            "not writable" in combined
+        ), f"error must name the writability check; got: {combined!r}"
+        assert (
+            install_parent in combined
+        ), f"error must name the failing path; got: {combined!r}"
 
     def test_preflight_fails_when_systemd_dir_not_writable(self, tmp_path):
         import os as _os
@@ -3137,9 +3140,9 @@ class TestInstallPreflight:
         proc = self._run(env)
         assert proc.returncode != 0
         combined = proc.stdout + proc.stderr
-        assert "not a git repository" in combined, (
-            f"error must name the git-repo check; got: {combined!r}"
-        )
+        assert (
+            "not a git repository" in combined
+        ), f"error must name the git-repo check; got: {combined!r}"
         assert env["INKYPI_PREFLIGHT_SRC_PATH"] in combined
         assert "remediation" in combined.lower()
 
@@ -3187,6 +3190,78 @@ class TestInstallPreflight:
                 f"found it in output: {combined!r}"
             )
 
+    # --- git dubious-ownership regression (CodeRabbit review #546) ---------
+
+    def test_preflight_git_check_survives_dubious_ownership(self, tmp_path):
+        """Regression gate for CodeRabbit review on PR #546.
+
+        Canonical production flow:
+            git clone https://github.com/fatihak/InkyPi.git ~/inkypi
+            sudo bash ~/inkypi/install/install.sh
+
+        After CVE-2022-24765 (fixed in git 2.35.2+), git refuses to operate on
+        a repo whose .git ownership differs from the effective uid, failing
+        with "fatal: detected dubious ownership". `git rev-parse --git-dir
+        2>/dev/null` would mask this and the preflight would emit the
+        misleading 'source tree … is not a git repository' message, sending
+        users to re-clone a repo that's already fine.
+
+        We can't actually run install.sh as root from pytest, so this test
+        simulates the condition by forcing git's ownership guard to trip via
+        GIT_TEST_ASSUME_DIFFERENT_OWNER=1 (a test-only knob shipped in git's
+        own setup.c). If the preflight invocation handles dubious-ownership
+        correctly (scoped safe.directory override) the repo is still
+        recognised and preflight passes. If somebody reverts that fix, this
+        test fails with the same 'not a git repository' message users would
+        see in the field.
+        """
+        import os as _os
+        import shutil as _shutil
+        import subprocess as _sp
+
+        if not _shutil.which("git"):
+            pytest.skip("git is not available on this host")
+        # Verify the env knob actually trips this git build before relying on
+        # it for the negative assertion — old gits, msysgit etc. may ignore
+        # it. The knob was added alongside the CVE-2022-24765 fix.
+        src_path = tmp_path / "probe-repo"
+        src_path.mkdir()
+        _sp.run(["git", "init", "-q", str(src_path)], check=True)
+        probe = _sp.run(
+            ["git", "-C", str(src_path), "rev-parse", "--git-dir"],
+            env={**_os.environ, "GIT_TEST_ASSUME_DIFFERENT_OWNER": "1"},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if probe.returncode == 0:
+            pytest.skip(
+                "this git build ignores GIT_TEST_ASSUME_DIFFERENT_OWNER; "
+                "cannot simulate sudo-on-user-owned-clone here"
+            )
+        # Sanity: the knob really did raise the expected dubious-ownership
+        # error so our negative assertion below isn't a false positive.
+        assert "dubious ownership" in (probe.stderr + probe.stdout).lower()
+
+        env = self._base_env(tmp_path)
+        # Switch $src_path over to the probe repo AND turn on the ownership
+        # simulation for install.sh itself. install.sh's scoped
+        # `safe.directory=*` override should let rev-parse succeed, so
+        # preflight must still pass cleanly.
+        env["INKYPI_PREFLIGHT_SRC_PATH"] = str(src_path)
+        env["GIT_TEST_ASSUME_DIFFERENT_OWNER"] = "1"
+        proc = self._run(env)
+        combined = proc.stdout + proc.stderr
+        assert proc.returncode == 0, (
+            "preflight must tolerate EUID != .git owner via a scoped "
+            f"safe.directory override (CVE-2022-24765 regression). "
+            f"rc={proc.returncode} output={combined!r}"
+        )
+        assert "not a git repository" not in combined, (
+            "dubious-ownership must not be masked as 'not a git repository'; "
+            f"output: {combined!r}"
+        )
+
     # --- Source inspection: env-var override contract ---------------------
 
     def test_install_sh_declares_preflight_env_hooks(self):
@@ -3204,9 +3279,9 @@ class TestInstallPreflight:
             "INKYPI_PREFLIGHT_SRC_PATH",
             "INKYPI_PREFLIGHT_MIN_FREE_MB",
         ):
-            assert var in content, (
-                f"install.sh must reference preflight env hook {var} (JTN-699)"
-            )
+            assert (
+                var in content
+            ), f"install.sh must reference preflight env hook {var} (JTN-699)"
 
     def test_install_sh_runs_preflight_before_lockfile_setup(self):
         """Preflight must be called BEFORE the $LOCKFILE touch, because an
@@ -3218,7 +3293,7 @@ class TestInstallPreflight:
         # an unwritable state dir.
         lockfile_pos = content.index('touch "$LOCKFILE"')
         assert preflight_pos < lockfile_pos, (
-            "preflight_checks must run before `touch \"$LOCKFILE\"` so an "
+            'preflight_checks must run before `touch "$LOCKFILE"` so an '
             "unwritable $LOCKFILE_DIR produces a clean preflight error "
             "(JTN-699)"
         )


### PR DESCRIPTION
## Summary
- add a preflight block at the top of `install/install.sh` that runs before any apt/pip/git work and validates free disk space (>=500 MB on `/usr/local` and `$INSTALL_PATH` parent), writability of `$INSTALL_PATH` parent / `/etc/systemd/system` / `/var/lib/inkypi`, and that `$SRC_PATH` is a git repo
- every failure exits 1 with a specific `ERROR (preflight): <what>` message plus a `remediation:` suggestion naming the failing path
- expose env-var hooks (`INKYPI_PREFLIGHT_*`) so pytest can redirect every check at a tmp dir without touching real paths; `INKYPI_PREFLIGHT_TEST` bypasses the EUID check and `INKYPI_PREFLIGHT_TEST_EXIT_AFTER` short-circuits before real install work — production callers never set these vars
- add 12 pytest cases covering the happy path, each failure branch, short-circuit-before-install-work, and source-level contract assertions

## Testing
- `python3 -m pytest tests/unit/test_install_scripts.py -k preflight -x`
- `python3 -m pytest tests/unit/test_install_scripts.py`
- `python3 -m pytest tests/integration/test_update_failure_recovery.py`
- `shellcheck -x install/install.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pre-installation validation now automatically checks disk space availability, directory permissions, and system prerequisites before any installation begins, preventing partial installations and cascading errors.
  * Installation failures display detailed remediation guidance to help users quickly identify and resolve configuration issues.
  * Early validation ensures failures occur before any package or system modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->