### PR TITLE
test(soak): real-Pi nightly soak runner + workflow (JTN-733)

### DIFF
--- a/.github/workflows/pi-soak-nightly.yml
+++ b/.github/workflows/pi-soak-nightly.yml
@@ -1,0 +1,165 @@
+name: Pi soak nightly
+
+# JTN-733: real-Pi nightly soak. Runs `scripts/soak_runner.py` against a
+# self-hosted Raspberry Pi runner for 24 hours, sampling /api/diagnostics
+# every 5 minutes, and uploads the resulting JSON report as an artifact.
+#
+# This workflow is DELIBERATELY long-running and DELIBERATELY soft-gated:
+# the whole point is to catch slow leaks, EventSource reconnect storms,
+# display-driver wedges, tempfile buildup, and refresh-task drift — all
+# phenomena that only surface after hours of continuous operation, far
+# beyond what the per-PR CI can see.
+#
+# The workflow assumes a self-hosted runner labeled `self-hosted` +
+# `pi-zero-2w` is available. Until such a runner exists, the workflow will
+# simply queue and no-op (no GitHub-hosted fallback is provided on purpose
+# — a x86 ubuntu-latest run would not be a meaningful soak signal).
+#
+# To trigger a short manual run (e.g. a smoke test of the script itself),
+# use workflow_dispatch with a `duration` input like `10m`.
+
+on:
+  schedule:
+    # 03:00 UTC daily. Off-peak for most timezones; lines up so the 24h soak
+    # finishes before the following night's run starts.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Total soak duration (e.g. 10m, 2h, 24h).'
+        required: false
+        default: '24h'
+        type: string
+      interval:
+        description: 'Sample cadence (e.g. 1m, 5m).'
+        required: false
+        default: '5m'
+        type: string
+      host:
+        description: 'Override the InkyPi host URL (default: http://127.0.0.1:8080).'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never overlap a fresh soak on top of an in-flight one — the runner is
+  # a physical Pi and can only do one thing at a time.
+  group: pi-soak-nightly
+  cancel-in-progress: false
+
+jobs:
+  soak:
+    name: Real-Pi soak (24h)
+    # The self-hosted Pi runner must carry BOTH labels. If the runner does
+    # not exist, the job will queue indefinitely and GitHub will time it
+    # out — that's acceptable until the runner is provisioned.
+    runs-on: [self-hosted, pi-zero-2w]
+    # Allow up to 26h so a full 24h soak + setup/teardown has headroom.
+    timeout-minutes: 1560
+    env:
+      # Host defaults to localhost on the self-hosted Pi — the soak runner
+      # assumes InkyPi is already running on the same box and has a fixed
+      # playlist of 5+ plugins configured on a 10-min cadence. Override via
+      # workflow_dispatch input or repository secret INKYPI_HOST.
+      INKYPI_HOST: ${{ github.event.inputs.host || secrets.INKYPI_HOST || 'http://127.0.0.1:8080' }}
+      INKYPI_TOKEN: ${{ secrets.INKYPI_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve duration + interval
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DURATION: ${{ github.event.inputs.duration }}
+          INPUT_INTERVAL: ${{ github.event.inputs.interval }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            dur="${INPUT_DURATION:-24h}"
+            ivl="${INPUT_INTERVAL:-5m}"
+          else
+            dur="24h"
+            ivl="5m"
+          fi
+          echo "duration=$dur" >> "$GITHUB_OUTPUT"
+          echo "interval=$ivl" >> "$GITHUB_OUTPUT"
+          echo "Running soak: duration=$dur interval=$ivl host=$INKYPI_HOST"
+
+      - name: Setup Python
+        # The self-hosted Pi image is expected to have Python 3.11+
+        # preinstalled. actions/setup-python does not ship arm64 Pi
+        # binaries for all versions, so we deliberately fall back to the
+        # system interpreter rather than cross-installing one here.
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 --version
+          python3 -m pip --version
+
+      - name: Install runner deps (requests only)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `requests` is already a runtime dep of InkyPi itself, so on the
+          # self-hosted Pi this should be a no-op. Install with --user just
+          # in case the systemd service uses a venv we don't share.
+          python3 -m pip install --user --disable-pip-version-check requests
+
+      - name: Run soak
+        id: soak
+        shell: bash
+        env:
+          SOAK_DURATION: ${{ steps.params.outputs.duration }}
+          SOAK_INTERVAL: ${{ steps.params.outputs.interval }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          OUT="artifacts/soak-report.json"
+          python3 scripts/soak_runner.py \
+            --host "$INKYPI_HOST" \
+            --duration "$SOAK_DURATION" \
+            --interval "$SOAK_INTERVAL" \
+            --output "$OUT" \
+            --verbose
+          echo "report=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Print summary
+        if: always() && steps.soak.outputs.report != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, sys
+          path = "artifacts/soak-report.json"
+          if not os.path.exists(path):
+              print("no report artifact found")
+              sys.exit(0)
+          with open(path) as fh:
+              rpt = json.load(fh)
+          s = rpt.get("summary", {})
+          print("=== Soak summary ===")
+          print(f"samples total       : {s.get('total_samples')}")
+          print(f"samples ok          : {s.get('successful_samples')}")
+          print(f"samples unreachable : {s.get('unreachable_samples')}")
+          print(f"unreachable_rate    : {s.get('unreachable_rate')}")
+          print(f"refresh_failure_rate: {s.get('refresh_failure_rate')}")
+          print(f"client_log_errors   : {s.get('client_log_error_total')}")
+          print(f"service_restarts    : {s.get('service_restarts')}")
+          mt = s.get("memory_pct_trend") or {}
+          dt = s.get("disk_pct_trend") or {}
+          print(f"memory slope/hour   : {mt.get('slope_per_hour')}")
+          print(f"disk   slope/hour   : {dt.get('slope_per_hour')}")
+          PY
+
+      - name: Upload soak report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pi-soak-report
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/soak_runner.py
+++ b/scripts/soak_runner.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Real-Pi nightly soak runner (JTN-733).
+
+Connects to a running InkyPi instance and samples ``/api/diagnostics`` at a
+fixed cadence for a configurable duration, then emits a JSON report covering
+memory / disk trend, refresh-task failure rate, client-log error rate, and
+the number of service restarts observed during the run.
+
+The primary target is a self-hosted Raspberry Pi runner exercising a fixed
+playlist of 5+ plugins on a 10-min cadence for 24 hours — catching slow
+leaks, wedges, and refresh drift that CI (minute-scale) cannot. The script
+is also runnable locally against any instance (``--duration 10m``).
+
+Usage
+-----
+
+    # 30-second smoke test against a local dev server
+    python scripts/soak_runner.py --duration 30s --host http://127.0.0.1:5000
+
+    # Full 24h nightly (default) against a Pi on the LAN
+    INKYPI_TOKEN=... python scripts/soak_runner.py --host http://inkypi.local
+
+Report shape
+------------
+
+The JSON report written via ``--output`` has the following top-level keys:
+
+* ``meta``   — host, duration, cadence, start/end ts, script version
+* ``samples`` — list of raw per-sample snapshots (ts, memory, disk,
+  refresh_task, recent_client_log_errors, uptime_s, version, fetch_ok,
+  fetch_error)
+* ``summary`` — aggregates: counts, rates, and linear-fit trend slopes
+  for memory_pct / disk_pct so a slow leak shows up as a monotonic
+  positive slope
+
+See ``summarize_samples`` for the exact summary fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ``requests`` is already a runtime dep of InkyPi (see pyproject.toml). The
+# test suite mocks HTTP and doesn't actually import this, so we keep the
+# import lazy-friendly but at module top-level for normal invocation.
+try:  # pragma: no cover — availability is environmental
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore[assignment]
+
+
+SCRIPT_VERSION = "1"
+
+# Default cadence: sample /api/diagnostics every 5 minutes.
+DEFAULT_SAMPLE_INTERVAL_S = 300
+# Default soak duration: 24 hours. Override via --duration.
+DEFAULT_DURATION_S = 24 * 60 * 60
+# Per-request timeout. The Pi can be slow; a wedge is 30s+.
+DEFAULT_REQUEST_TIMEOUT_S = 30
+
+logger = logging.getLogger("soak_runner")
+
+
+# ---------------------------------------------------------------------------
+# Duration parsing
+# ---------------------------------------------------------------------------
+
+_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhd]?)\s*$", re.IGNORECASE)
+_UNIT_SECONDS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_duration(value: str) -> int:
+    """Parse ``30s`` / ``10m`` / ``24h`` / ``1d`` / bare seconds into int seconds.
+
+    Raises ``ValueError`` on malformed input. The return is always >= 1.
+    """
+    if value is None:
+        raise ValueError("duration is required")
+    m = _DURATION_RE.match(str(value))
+    if not m:
+        raise ValueError(f"invalid duration: {value!r}")
+    qty = float(m.group(1))
+    unit = m.group(2).lower()
+    seconds = qty * _UNIT_SECONDS[unit]
+    if seconds < 1:
+        raise ValueError(f"duration must be >= 1s (got {value!r})")
+    return int(seconds)
+
+
+# ---------------------------------------------------------------------------
+# Sample record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Sample:
+    """One ``/api/diagnostics`` probe result.
+
+    ``fetch_ok=False`` means the HTTP call failed (timeout, connection refused,
+    5xx, etc.) — these count as "service restart / wedge" data points. The
+    remaining fields will be ``None`` in that case.
+    """
+
+    ts: str
+    elapsed_s: float
+    fetch_ok: bool
+    fetch_error: str | None = None
+    http_status: int | None = None
+    version: str | None = None
+    uptime_s: int | None = None
+    memory_pct: float | None = None
+    disk_pct: float | None = None
+    refresh_running: bool | None = None
+    refresh_last_error: str | None = None
+    client_log_count_5m: int | None = None
+    client_log_warn_count_5m: int | None = None
+    plugin_health: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ts": self.ts,
+            "elapsed_s": round(self.elapsed_s, 3),
+            "fetch_ok": self.fetch_ok,
+            "fetch_error": self.fetch_error,
+            "http_status": self.http_status,
+            "version": self.version,
+            "uptime_s": self.uptime_s,
+            "memory_pct": self.memory_pct,
+            "disk_pct": self.disk_pct,
+            "refresh_running": self.refresh_running,
+            "refresh_last_error": self.refresh_last_error,
+            "client_log_count_5m": self.client_log_count_5m,
+            "client_log_warn_count_5m": self.client_log_warn_count_5m,
+            "plugin_health": dict(self.plugin_health),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics parsing
+# ---------------------------------------------------------------------------
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_diagnostics_payload(
+    payload: dict[str, Any] | None,
+    *,
+    elapsed_s: float,
+    http_status: int | None,
+) -> Sample:
+    """Convert a ``/api/diagnostics`` JSON body into a :class:`Sample`.
+
+    Unexpected / missing fields are tolerated — the sample still records
+    whatever is parseable and leaves the rest as ``None``. This keeps the
+    soak runner compatible with future diagnostics additions.
+    """
+    ts = datetime.now(UTC).isoformat()
+    if not isinstance(payload, dict):
+        return Sample(
+            ts=ts,
+            elapsed_s=elapsed_s,
+            fetch_ok=False,
+            fetch_error="non-dict payload",
+            http_status=http_status,
+        )
+
+    memory = payload.get("memory") if isinstance(payload.get("memory"), dict) else {}
+    disk = payload.get("disk") if isinstance(payload.get("disk"), dict) else {}
+    refresh = (
+        payload.get("refresh_task")
+        if isinstance(payload.get("refresh_task"), dict)
+        else {}
+    )
+    client_log = (
+        payload.get("recent_client_log_errors")
+        if isinstance(payload.get("recent_client_log_errors"), dict)
+        else {}
+    )
+    plugin_health_raw = payload.get("plugin_health")
+    plugin_health: dict[str, str] = {}
+    if isinstance(plugin_health_raw, dict):
+        for k, v in plugin_health_raw.items():
+            if isinstance(k, str) and isinstance(v, str):
+                plugin_health[k] = v
+
+    return Sample(
+        ts=ts,
+        elapsed_s=elapsed_s,
+        fetch_ok=True,
+        fetch_error=None,
+        http_status=http_status,
+        version=payload.get("version") if isinstance(payload.get("version"), str) else None,
+        uptime_s=_safe_int(payload.get("uptime_s")),
+        memory_pct=_safe_float(memory.get("pct")),
+        disk_pct=_safe_float(disk.get("pct")),
+        refresh_running=bool(refresh.get("running")) if "running" in refresh else None,
+        refresh_last_error=refresh.get("last_error")
+        if isinstance(refresh.get("last_error"), str)
+        else None,
+        client_log_count_5m=_safe_int(client_log.get("count_5m")),
+        client_log_warn_count_5m=_safe_int(client_log.get("warn_count_5m")),
+        plugin_health=plugin_health,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Linear-fit trend summary
+# ---------------------------------------------------------------------------
+
+
+def _linear_fit_slope(
+    xs: list[float], ys: list[float]
+) -> tuple[float | None, float | None]:
+    """Return (slope, intercept) from least-squares on (xs, ys).
+
+    Returns ``(None, None)`` if fewer than 2 points or xs has zero variance
+    (all samples at the same timestamp, which shouldn't happen in practice
+    but is defensive). Slope units are ``delta-y per unit-x`` — in this
+    runner x is seconds-since-start and y is percent, so slope is "percent
+    per second". Multiply by 3600 for "percent per hour".
+    """
+    n = len(xs)
+    if n < 2 or n != len(ys):
+        return None, None
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den = sum((x - mean_x) ** 2 for x in xs)
+    if den == 0:
+        return None, None
+    slope = num / den
+    intercept = mean_y - slope * mean_x
+    return slope, intercept
+
+
+def _trend_summary(samples: list[Sample], attr: str) -> dict[str, Any]:
+    """Build a trend summary block for a single ``percent``-valued attribute.
+
+    Includes the first/last/min/max values plus a linear-fit slope (per
+    second AND per hour). The per-hour slope is the headline metric in the
+    report — a slow leak over a 24h window should show up as a clear
+    positive ``slope_per_hour``.
+    """
+    xs: list[float] = []
+    ys: list[float] = []
+    for s in samples:
+        if not s.fetch_ok:
+            continue
+        v = getattr(s, attr)
+        if v is None:
+            continue
+        xs.append(s.elapsed_s)
+        ys.append(float(v))
+
+    block: dict[str, Any] = {
+        "n": len(ys),
+        "first": ys[0] if ys else None,
+        "last": ys[-1] if ys else None,
+        "min": min(ys) if ys else None,
+        "max": max(ys) if ys else None,
+        "slope_per_second": None,
+        "slope_per_hour": None,
+    }
+    slope, _ = _linear_fit_slope(xs, ys)
+    if slope is not None:
+        block["slope_per_second"] = slope
+        block["slope_per_hour"] = slope * 3600.0
+    return block
+
+
+def _detect_restarts(samples: list[Sample]) -> int:
+    """Count apparent service restarts across the sample window.
+
+    A restart is inferred when ``uptime_s`` decreases between two successful
+    samples — the box either rebooted or inkypi was restarted. Fetch
+    failures are tracked separately as ``unreachable_samples`` because they
+    may be transient network blips rather than a full restart.
+    """
+    restarts = 0
+    prev_uptime: int | None = None
+    for s in samples:
+        if not s.fetch_ok or s.uptime_s is None:
+            prev_uptime = None
+            continue
+        if prev_uptime is not None and s.uptime_s < prev_uptime:
+            restarts += 1
+        prev_uptime = s.uptime_s
+    return restarts
+
+
+def summarize_samples(samples: list[Sample]) -> dict[str, Any]:
+    """Build the ``summary`` block of the soak report.
+
+    Key fields:
+
+    * ``total_samples`` / ``successful_samples`` / ``unreachable_samples``
+    * ``unreachable_rate`` — fraction of samples where the HTTP call failed.
+      A high rate suggests a wedge / crash-loop.
+    * ``refresh_failure_rate`` — fraction of successful samples whose
+      ``refresh_task.last_error`` is set.
+    * ``client_log_error_total`` — sum of ``count_5m`` across samples. This
+      double-counts overlapping 5-minute windows when cadence is < 5 min,
+      but is a useful directional signal.
+    * ``service_restarts`` — inferred from uptime regressions.
+    * ``memory_pct_trend`` / ``disk_pct_trend`` — linear-fit blocks with
+      ``slope_per_hour`` so reviewers can eyeball monotonic growth.
+    """
+    total = len(samples)
+    ok = [s for s in samples if s.fetch_ok]
+    unreachable = total - len(ok)
+    refresh_failures = sum(
+        1 for s in ok if s.refresh_last_error
+    )
+    client_log_error_total = sum(
+        (s.client_log_count_5m or 0) for s in ok
+    )
+    client_log_warn_total = sum(
+        (s.client_log_warn_count_5m or 0) for s in ok
+    )
+
+    return {
+        "total_samples": total,
+        "successful_samples": len(ok),
+        "unreachable_samples": unreachable,
+        "unreachable_rate": (unreachable / total) if total else 0.0,
+        "refresh_failure_count": refresh_failures,
+        "refresh_failure_rate": (refresh_failures / len(ok)) if ok else 0.0,
+        "client_log_error_total": client_log_error_total,
+        "client_log_warn_total": client_log_warn_total,
+        "service_restarts": _detect_restarts(samples),
+        "memory_pct_trend": _trend_summary(samples, "memory_pct"),
+        "disk_pct_trend": _trend_summary(samples, "disk_pct"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    *,
+    host: str,
+    duration_s: int,
+    interval_s: int,
+    samples: list[Sample],
+    started_at: str,
+    ended_at: str,
+) -> dict[str, Any]:
+    """Return the full JSON-serializable soak report."""
+    return {
+        "meta": {
+            "script_version": SCRIPT_VERSION,
+            "host": host,
+            "duration_s": duration_s,
+            "sample_interval_s": interval_s,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "sample_count": len(samples),
+        },
+        "samples": [s.to_dict() for s in samples],
+        "summary": summarize_samples(samples),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sampling loop
+# ---------------------------------------------------------------------------
+
+
+def _fetch_once(
+    session: Any,
+    url: str,
+    *,
+    headers: dict[str, str],
+    timeout_s: float,
+) -> tuple[dict[str, Any] | None, int | None, str | None, float]:
+    """Fetch ``url`` once. Returns (payload, http_status, error, elapsed_s)."""
+    t0 = time.monotonic()
+    try:
+        resp = session.get(url, headers=headers, timeout=timeout_s)
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        return None, None, f"{type(exc).__name__}: {exc}", elapsed
+
+    elapsed = time.monotonic() - t0
+    status = resp.status_code
+    if status != 200:
+        return None, status, f"HTTP {status}", elapsed
+    try:
+        return resp.json(), status, None, elapsed
+    except Exception as exc:
+        return None, status, f"json decode: {exc}", elapsed
+
+
+def run_soak(
+    *,
+    host: str,
+    duration_s: int,
+    interval_s: int,
+    token: str | None = None,
+    request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+    session: Any = None,
+    now: Any = None,
+    sleep: Any = None,
+) -> list[Sample]:
+    """Run the sampling loop and return the collected samples.
+
+    Parameters ``session`` / ``now`` / ``sleep`` are injection seams used by
+    the unit tests; at runtime they default to ``requests.Session`` /
+    ``time.monotonic`` / ``time.sleep``.
+    """
+    if session is None:
+        if requests is None:
+            raise RuntimeError(
+                "The 'requests' package is required to run the soak loop. "
+                "Install it or inject a session."
+            )
+        session = requests.Session()
+    if now is None:
+        now = time.monotonic
+    if sleep is None:
+        sleep = time.sleep
+
+    url = host.rstrip("/") + "/api/diagnostics"
+    headers: dict[str, str] = {"Accept": "application/json"}
+    if token:
+        # The diagnostics endpoint rides on InkyPi's PIN auth gate — a
+        # bearer token is not the actual auth mechanism in-tree, but most
+        # reverse proxies in front of a real Pi deployment accept one,
+        # and we forward X-InkyPi-Token for future hook-up.
+        headers["Authorization"] = f"Bearer {token}"
+        headers["X-InkyPi-Token"] = token
+
+    samples: list[Sample] = []
+    start = now()
+    deadline = start + duration_s
+    next_tick = start
+
+    while True:
+        t = now()
+        if t >= deadline:
+            break
+
+        if t < next_tick:
+            sleep(min(next_tick - t, 1.0))
+            continue
+
+        elapsed_since_start = t - start
+        payload, status, err, req_elapsed = _fetch_once(
+            session, url, headers=headers, timeout_s=request_timeout_s
+        )
+        if payload is not None:
+            sample = parse_diagnostics_payload(
+                payload, elapsed_s=elapsed_since_start, http_status=status
+            )
+        else:
+            sample = Sample(
+                ts=datetime.now(UTC).isoformat(),
+                elapsed_s=elapsed_since_start,
+                fetch_ok=False,
+                fetch_error=err,
+                http_status=status,
+            )
+        samples.append(sample)
+        logger.info(
+            "sample %d t=%.1fs ok=%s mem=%s disk=%s err=%s",
+            len(samples),
+            elapsed_since_start,
+            sample.fetch_ok,
+            sample.memory_pct,
+            sample.disk_pct,
+            sample.fetch_error,
+        )
+
+        next_tick += interval_s
+        # If we blew through the next tick (slow request, long backoff), fast-
+        # forward so we don't spin sampling back-to-back.
+        if next_tick <= now():
+            next_tick = now() + interval_s
+
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _default_output_path() -> Path:
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return Path(f"soak-report-{ts}.json")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="InkyPi real-Pi soak runner (JTN-733).",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("INKYPI_HOST", "http://127.0.0.1:8080"),
+        help="Base URL of the InkyPi instance (default: $INKYPI_HOST or http://127.0.0.1:8080).",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("INKYPI_TOKEN"),
+        help="Optional bearer token forwarded in Authorization + X-InkyPi-Token headers.",
+    )
+    parser.add_argument(
+        "--duration",
+        default="24h",
+        help="Total soak duration (e.g. 30s, 10m, 24h). Default: 24h.",
+    )
+    parser.add_argument(
+        "--interval",
+        default="5m",
+        help="Sample cadence (e.g. 1m, 5m). Default: 5m.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT_S,
+        help="Per-request timeout in seconds (default: 30).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Path to write the JSON report (default: soak-report-<utc>.json in cwd).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log each sample at INFO level (default: WARNING).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        duration_s = parse_duration(args.duration)
+        interval_s = parse_duration(args.interval)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if interval_s > duration_s:
+        print(
+            f"error: --interval ({interval_s}s) must be <= --duration ({duration_s}s)",
+            file=sys.stderr,
+        )
+        return 2
+
+    output_path = args.output or _default_output_path()
+    started_at = datetime.now(UTC).isoformat()
+
+    logger.warning(
+        "soak starting: host=%s duration=%ds interval=%ds output=%s",
+        args.host,
+        duration_s,
+        interval_s,
+        output_path,
+    )
+
+    samples = run_soak(
+        host=args.host,
+        duration_s=duration_s,
+        interval_s=interval_s,
+        token=args.token,
+        request_timeout_s=args.timeout,
+    )
+
+    ended_at = datetime.now(UTC).isoformat()
+    report = build_report(
+        host=args.host,
+        duration_s=duration_s,
+        interval_s=interval_s,
+        samples=samples,
+        started_at=started_at,
+        ended_at=ended_at,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    summary = report["summary"]
+    logger.warning(
+        "soak complete: %d samples (%d ok, %d unreachable), restarts=%d, "
+        "refresh_failure_rate=%.3f, memory_slope_per_hour=%s",
+        summary["total_samples"],
+        summary["successful_samples"],
+        summary["unreachable_samples"],
+        summary["service_restarts"],
+        summary["refresh_failure_rate"],
+        summary["memory_pct_trend"].get("slope_per_hour"),
+    )
+    print(str(output_path))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/soak_runner.py
+++ b/scripts/soak_runner.py
@@ -205,9 +205,11 @@ def parse_diagnostics_payload(
     plugin_health_raw = payload.get("plugin_health")
     plugin_health: dict[str, str] = {}
     if isinstance(plugin_health_raw, dict):
-        for k, v in plugin_health_raw.items():
-            if isinstance(k, str) and isinstance(v, str):
-                plugin_health[k] = v
+        plugin_health = {
+            k: v
+            for k, v in plugin_health_raw.items()
+            if isinstance(k, str) and isinstance(v, str)
+        }
 
     return Sample(
         ts=ts,
@@ -215,14 +217,18 @@ def parse_diagnostics_payload(
         fetch_ok=True,
         fetch_error=None,
         http_status=http_status,
-        version=payload.get("version") if isinstance(payload.get("version"), str) else None,
+        version=(
+            payload.get("version") if isinstance(payload.get("version"), str) else None
+        ),
         uptime_s=_safe_int(payload.get("uptime_s")),
         memory_pct=_safe_float(memory.get("pct")),
         disk_pct=_safe_float(disk.get("pct")),
         refresh_running=bool(refresh.get("running")) if "running" in refresh else None,
-        refresh_last_error=refresh.get("last_error")
-        if isinstance(refresh.get("last_error"), str)
-        else None,
+        refresh_last_error=(
+            refresh.get("last_error")
+            if isinstance(refresh.get("last_error"), str)
+            else None
+        ),
         client_log_count_5m=_safe_int(client_log.get("count_5m")),
         client_log_warn_count_5m=_safe_int(client_log.get("warn_count_5m")),
         plugin_health=plugin_health,
@@ -250,7 +256,7 @@ def _linear_fit_slope(
         return None, None
     mean_x = sum(xs) / n
     mean_y = sum(ys) / n
-    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys, strict=True))
     den = sum((x - mean_x) ** 2 for x in xs)
     if den == 0:
         return None, None
@@ -334,15 +340,9 @@ def summarize_samples(samples: list[Sample]) -> dict[str, Any]:
     total = len(samples)
     ok = [s for s in samples if s.fetch_ok]
     unreachable = total - len(ok)
-    refresh_failures = sum(
-        1 for s in ok if s.refresh_last_error
-    )
-    client_log_error_total = sum(
-        (s.client_log_count_5m or 0) for s in ok
-    )
-    client_log_warn_total = sum(
-        (s.client_log_warn_count_5m or 0) for s in ok
-    )
+    refresh_failures = sum(1 for s in ok if s.refresh_last_error)
+    client_log_error_total = sum((s.client_log_count_5m or 0) for s in ok)
+    client_log_warn_total = sum((s.client_log_warn_count_5m or 0) for s in ok)
 
     return {
         "total_samples": total,

--- a/tests/unit/test_soak_runner.py
+++ b/tests/unit/test_soak_runner.py
@@ -1,0 +1,459 @@
+# pyright: reportMissingImports=false
+"""Unit tests for ``scripts/soak_runner.py`` (JTN-733).
+
+These tests exercise the report-shape, duration parsing, and trend summary
+logic against canned sampled data. They do NOT hit a live InkyPi instance —
+the goal is to lock down the math and report contract that the nightly
+workflow artifact will be read against.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "soak_runner.py"
+
+
+def _load_module():
+    """Load ``scripts/soak_runner.py`` as a module regardless of sys.path."""
+    spec = importlib.util.spec_from_file_location(
+        "soak_runner_under_test", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["soak_runner_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+soak = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+
+
+class TestParseDuration:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("30s", 30),
+            ("30", 30),
+            ("10m", 600),
+            ("2h", 7200),
+            ("1d", 86400),
+            ("24h", 86400),
+            ("  5m ", 300),
+            ("1.5m", 90),
+        ],
+    )
+    def test_valid(self, text, expected):
+        assert soak.parse_duration(text) == expected
+
+    @pytest.mark.parametrize("bad", ["", "abc", "5x", "-1m", "0s", None])
+    def test_invalid(self, bad):
+        with pytest.raises(ValueError):
+            soak.parse_duration(bad)
+
+
+# ---------------------------------------------------------------------------
+# parse_diagnostics_payload
+# ---------------------------------------------------------------------------
+
+
+def _payload(**overrides):
+    """Canonical /api/diagnostics response, with overrides applied."""
+    base = {
+        "ts": "2026-04-19T00:00:00+00:00",
+        "version": "0.61.7",
+        "prev_version": "0.61.6",
+        "uptime_s": 3600,
+        "memory": {"total_mb": 512, "used_mb": 310, "pct": 60.5},
+        "disk": {"total_mb": 16000, "used_mb": 5200, "pct": 32.5, "path": "/"},
+        "refresh_task": {
+            "running": True,
+            "last_run_ts": "2026-04-19T00:00:00+00:00",
+            "last_error": None,
+        },
+        "plugin_health": {
+            "clock": "ok",
+            "weather": "ok",
+            "calendar": "ok",
+            "rss": "ok",
+            "wpotd": "ok",
+        },
+        "log_tail_100": [],
+        "last_update_failure": None,
+        "recent_client_log_errors": {
+            "count_5m": 0,
+            "warn_count_5m": 0,
+            "last_error_ts": None,
+            "window_seconds": 300,
+        },
+    }
+    for k, v in overrides.items():
+        base[k] = v
+    return base
+
+
+class TestParsePayload:
+    def test_happy_path(self):
+        s = soak.parse_diagnostics_payload(
+            _payload(), elapsed_s=1.0, http_status=200
+        )
+        assert s.fetch_ok is True
+        assert s.fetch_error is None
+        assert s.http_status == 200
+        assert s.memory_pct == 60.5
+        assert s.disk_pct == 32.5
+        assert s.uptime_s == 3600
+        assert s.version == "0.61.7"
+        assert s.refresh_running is True
+        assert s.refresh_last_error is None
+        assert s.client_log_count_5m == 0
+        assert s.plugin_health == {
+            "clock": "ok",
+            "weather": "ok",
+            "calendar": "ok",
+            "rss": "ok",
+            "wpotd": "ok",
+        }
+
+    def test_tolerates_missing_blocks(self):
+        s = soak.parse_diagnostics_payload(
+            {}, elapsed_s=0.5, http_status=200
+        )
+        assert s.fetch_ok is True
+        assert s.memory_pct is None
+        assert s.disk_pct is None
+        assert s.uptime_s is None
+        assert s.refresh_running is None
+        assert s.plugin_health == {}
+
+    def test_non_dict_is_failure(self):
+        s = soak.parse_diagnostics_payload(
+            "not-a-dict", elapsed_s=0.1, http_status=200
+        )
+        assert s.fetch_ok is False
+        assert s.fetch_error == "non-dict payload"
+
+    def test_plugin_health_filters_non_strings(self):
+        # A forward-compat diagnostics build might return richer shapes per
+        # plugin. The runner should drop those rather than crash.
+        payload = _payload(plugin_health={"clock": "ok", "weather": {"status": "fail"}})
+        s = soak.parse_diagnostics_payload(payload, elapsed_s=0.0, http_status=200)
+        assert s.plugin_health == {"clock": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Trend + summary
+# ---------------------------------------------------------------------------
+
+
+def _mk_sample(
+    *,
+    t: float,
+    ok: bool = True,
+    memory_pct: float | None = 50.0,
+    disk_pct: float | None = 30.0,
+    uptime_s: int | None = 1000,
+    refresh_last_error: str | None = None,
+    client_log_count_5m: int | None = 0,
+    client_log_warn_count_5m: int | None = 0,
+    fetch_error: str | None = None,
+) -> "soak.Sample":
+    return soak.Sample(
+        ts=f"2026-04-19T00:{int(t):02d}:00+00:00",
+        elapsed_s=t,
+        fetch_ok=ok,
+        fetch_error=fetch_error,
+        http_status=200 if ok else None,
+        version="0.61.7",
+        uptime_s=uptime_s if ok else None,
+        memory_pct=memory_pct if ok else None,
+        disk_pct=disk_pct if ok else None,
+        refresh_running=True if ok else None,
+        refresh_last_error=refresh_last_error if ok else None,
+        client_log_count_5m=client_log_count_5m if ok else None,
+        client_log_warn_count_5m=client_log_warn_count_5m if ok else None,
+        plugin_health={},
+    )
+
+
+class TestTrendSummary:
+    def test_monotonic_leak_shows_positive_slope(self):
+        # Simulate a slow leak: 50% -> 62% over 1 hour (3600s). Slope per
+        # hour must be very close to +12.
+        samples = [
+            _mk_sample(t=i * 300.0, memory_pct=50.0 + (12.0 * i / 12.0))
+            for i in range(13)  # 0..12 → 13 samples across 1 hour
+        ]
+        summary = soak.summarize_samples(samples)
+        trend = summary["memory_pct_trend"]
+        assert trend["n"] == 13
+        assert trend["first"] == pytest.approx(50.0)
+        assert trend["last"] == pytest.approx(62.0)
+        assert trend["slope_per_hour"] == pytest.approx(12.0, rel=1e-6)
+        assert trend["slope_per_second"] == pytest.approx(12.0 / 3600.0, rel=1e-6)
+
+    def test_flat_shows_zero_slope(self):
+        samples = [_mk_sample(t=i * 60.0, memory_pct=42.0) for i in range(10)]
+        trend = soak.summarize_samples(samples)["memory_pct_trend"]
+        assert trend["slope_per_hour"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_single_sample_has_no_slope(self):
+        trend = soak.summarize_samples([_mk_sample(t=0.0)])["memory_pct_trend"]
+        assert trend["n"] == 1
+        assert trend["slope_per_hour"] is None
+        assert trend["slope_per_second"] is None
+
+    def test_no_samples_safe(self):
+        summary = soak.summarize_samples([])
+        assert summary["total_samples"] == 0
+        assert summary["successful_samples"] == 0
+        assert summary["unreachable_samples"] == 0
+        assert summary["unreachable_rate"] == 0.0
+        assert summary["service_restarts"] == 0
+        assert summary["memory_pct_trend"]["n"] == 0
+        assert summary["memory_pct_trend"]["slope_per_hour"] is None
+
+
+class TestSummaryAggregates:
+    def test_unreachable_counted_but_excluded_from_trend(self):
+        # Two good samples, one unreachable between them. The unreachable
+        # must not corrupt the memory trend computation.
+        samples = [
+            _mk_sample(t=0.0, memory_pct=50.0),
+            _mk_sample(t=300.0, ok=False, fetch_error="timeout"),
+            _mk_sample(t=600.0, memory_pct=52.0),
+        ]
+        summary = soak.summarize_samples(samples)
+        assert summary["total_samples"] == 3
+        assert summary["successful_samples"] == 2
+        assert summary["unreachable_samples"] == 1
+        assert summary["unreachable_rate"] == pytest.approx(1 / 3)
+        assert summary["memory_pct_trend"]["n"] == 2
+        assert summary["memory_pct_trend"]["first"] == pytest.approx(50.0)
+        assert summary["memory_pct_trend"]["last"] == pytest.approx(52.0)
+
+    def test_refresh_failure_rate(self):
+        samples = [
+            _mk_sample(t=0.0, refresh_last_error=None),
+            _mk_sample(t=300.0, refresh_last_error="boom"),
+            _mk_sample(t=600.0, refresh_last_error="boom"),
+            _mk_sample(t=900.0, refresh_last_error=None),
+        ]
+        summary = soak.summarize_samples(samples)
+        assert summary["refresh_failure_count"] == 2
+        assert summary["refresh_failure_rate"] == pytest.approx(0.5)
+
+    def test_client_log_totals_sum(self):
+        samples = [
+            _mk_sample(t=0.0, client_log_count_5m=0, client_log_warn_count_5m=1),
+            _mk_sample(t=300.0, client_log_count_5m=3, client_log_warn_count_5m=2),
+            _mk_sample(t=600.0, client_log_count_5m=5, client_log_warn_count_5m=0),
+        ]
+        summary = soak.summarize_samples(samples)
+        assert summary["client_log_error_total"] == 8
+        assert summary["client_log_warn_total"] == 3
+
+    def test_service_restart_detected_on_uptime_regression(self):
+        samples = [
+            _mk_sample(t=0.0, uptime_s=1000),
+            _mk_sample(t=300.0, uptime_s=1300),
+            # Reboot: uptime resets to 10s.
+            _mk_sample(t=600.0, uptime_s=10),
+            _mk_sample(t=900.0, uptime_s=310),
+        ]
+        summary = soak.summarize_samples(samples)
+        assert summary["service_restarts"] == 1
+
+    def test_unreachable_samples_dont_trigger_restarts(self):
+        # An unreachable window should not be counted as a restart on its
+        # own — only a subsequent uptime regression should.
+        samples = [
+            _mk_sample(t=0.0, uptime_s=1000),
+            _mk_sample(t=300.0, ok=False, fetch_error="timeout"),
+            _mk_sample(t=600.0, uptime_s=1600),  # uptime grew through the blip
+        ]
+        summary = soak.summarize_samples(samples)
+        assert summary["service_restarts"] == 0
+        assert summary["unreachable_samples"] == 1
+
+
+# ---------------------------------------------------------------------------
+# build_report shape
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_report_shape(self):
+        samples = [
+            _mk_sample(t=0.0, memory_pct=50.0, disk_pct=30.0),
+            _mk_sample(t=300.0, memory_pct=51.0, disk_pct=30.0),
+        ]
+        report = soak.build_report(
+            host="http://pi.local",
+            duration_s=600,
+            interval_s=300,
+            samples=samples,
+            started_at="2026-04-19T00:00:00+00:00",
+            ended_at="2026-04-19T00:10:00+00:00",
+        )
+        assert set(report.keys()) == {"meta", "samples", "summary"}
+        assert report["meta"]["host"] == "http://pi.local"
+        assert report["meta"]["duration_s"] == 600
+        assert report["meta"]["sample_interval_s"] == 300
+        assert report["meta"]["sample_count"] == 2
+        assert len(report["samples"]) == 2
+        # Each sample dict carries all the documented keys.
+        sample_keys = set(report["samples"][0].keys())
+        assert {
+            "ts",
+            "elapsed_s",
+            "fetch_ok",
+            "memory_pct",
+            "disk_pct",
+            "refresh_running",
+            "refresh_last_error",
+            "client_log_count_5m",
+            "plugin_health",
+        }.issubset(sample_keys)
+        # Summary carries the trend blocks + aggregates used by reviewers.
+        summary_keys = set(report["summary"].keys())
+        assert {
+            "total_samples",
+            "successful_samples",
+            "unreachable_samples",
+            "unreachable_rate",
+            "refresh_failure_rate",
+            "client_log_error_total",
+            "service_restarts",
+            "memory_pct_trend",
+            "disk_pct_trend",
+        }.issubset(summary_keys)
+
+
+# ---------------------------------------------------------------------------
+# run_soak — integration with injected session / clock
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Session stub that serves canned payloads in order."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url, headers=None, timeout=None):  # noqa: D401 - stub
+        self.calls.append((url, dict(headers or {})))
+        if not self._responses:
+            raise RuntimeError("no more canned responses")
+        nxt = self._responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+
+class TestRunSoakLoop:
+    def test_collects_samples_and_handles_transient_failure(self):
+        # Three sample windows: success, network error, success.
+        responses = [
+            _FakeResponse(200, _payload(uptime_s=100, memory={"total_mb": 512, "used_mb": 256, "pct": 50.0}, disk={"total_mb": 16000, "used_mb": 5000, "pct": 31.0, "path": "/"})),
+            ConnectionError("simulated wedge"),
+            _FakeResponse(200, _payload(uptime_s=700, memory={"total_mb": 512, "used_mb": 280, "pct": 55.0}, disk={"total_mb": 16000, "used_mb": 5000, "pct": 31.0, "path": "/"})),
+        ]
+        session = _FakeSession(responses)
+
+        # Virtual clock: each call to `now()` steps forward by 1s so the
+        # loop's "next_tick" logic always fires a fresh sample. We return
+        # 0, 1, 2, ... and cap duration at 3s for three iterations.
+        clock = {"t": 0.0}
+
+        def fake_now():
+            return clock["t"]
+
+        def fake_sleep(seconds):
+            # Advance the virtual clock by whatever was requested.
+            clock["t"] += max(float(seconds), 0.0)
+
+        # Drive the loop by stepping the clock manually between samples.
+        # To get exactly 3 samples at interval=1s, duration=3s, we run the
+        # loop and let it terminate naturally — each `sleep()` advances time.
+        samples = soak.run_soak(
+            host="http://pi.local",
+            duration_s=3,
+            interval_s=1,
+            session=session,
+            now=fake_now,
+            sleep=fake_sleep,
+            request_timeout_s=5,
+        )
+
+        assert len(samples) == 3
+        assert samples[0].fetch_ok is True
+        assert samples[0].memory_pct == 50.0
+        assert samples[1].fetch_ok is False
+        assert "simulated wedge" in (samples[1].fetch_error or "")
+        assert samples[2].fetch_ok is True
+        assert samples[2].uptime_s == 700
+        # All calls hit the diagnostics endpoint.
+        assert all(url.endswith("/api/diagnostics") for url, _ in session.calls)
+
+    def test_token_is_forwarded_in_headers(self):
+        session = _FakeSession([_FakeResponse(200, _payload())])
+        clock = {"t": 0.0}
+
+        def fake_now():
+            return clock["t"]
+
+        def fake_sleep(seconds):
+            clock["t"] += max(float(seconds), 0.0)
+
+        soak.run_soak(
+            host="http://pi.local/",  # trailing slash should be stripped
+            duration_s=1,
+            interval_s=1,
+            token="tok-123",
+            session=session,
+            now=fake_now,
+            sleep=fake_sleep,
+        )
+        assert session.calls
+        url, headers = session.calls[0]
+        assert url == "http://pi.local/api/diagnostics"
+        assert headers.get("Authorization") == "Bearer tok-123"
+        assert headers.get("X-InkyPi-Token") == "tok-123"
+
+
+# ---------------------------------------------------------------------------
+# CLI argument handling
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_invalid_duration_returns_2(self, capsys):
+        rc = soak.main(["--duration", "nope"])
+        assert rc == 2
+        assert "invalid duration" in capsys.readouterr().err
+
+    def test_interval_larger_than_duration_rejected(self, capsys):
+        rc = soak.main(["--duration", "10s", "--interval", "1m"])
+        assert rc == 2
+        assert "interval" in capsys.readouterr().err

--- a/tests/unit/test_soak_runner.py
+++ b/tests/unit/test_soak_runner.py
@@ -21,9 +21,7 @@ SCRIPT_PATH = REPO_ROOT / "scripts" / "soak_runner.py"
 
 def _load_module():
     """Load ``scripts/soak_runner.py`` as a module regardless of sys.path."""
-    spec = importlib.util.spec_from_file_location(
-        "soak_runner_under_test", SCRIPT_PATH
-    )
+    spec = importlib.util.spec_from_file_location("soak_runner_under_test", SCRIPT_PATH)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules["soak_runner_under_test"] = module
@@ -97,16 +95,13 @@ def _payload(**overrides):
             "window_seconds": 300,
         },
     }
-    for k, v in overrides.items():
-        base[k] = v
+    base.update(overrides)
     return base
 
 
 class TestParsePayload:
     def test_happy_path(self):
-        s = soak.parse_diagnostics_payload(
-            _payload(), elapsed_s=1.0, http_status=200
-        )
+        s = soak.parse_diagnostics_payload(_payload(), elapsed_s=1.0, http_status=200)
         assert s.fetch_ok is True
         assert s.fetch_error is None
         assert s.http_status == 200
@@ -126,9 +121,7 @@ class TestParsePayload:
         }
 
     def test_tolerates_missing_blocks(self):
-        s = soak.parse_diagnostics_payload(
-            {}, elapsed_s=0.5, http_status=200
-        )
+        s = soak.parse_diagnostics_payload({}, elapsed_s=0.5, http_status=200)
         assert s.fetch_ok is True
         assert s.memory_pct is None
         assert s.disk_pct is None
@@ -137,9 +130,7 @@ class TestParsePayload:
         assert s.plugin_health == {}
 
     def test_non_dict_is_failure(self):
-        s = soak.parse_diagnostics_payload(
-            "not-a-dict", elapsed_s=0.1, http_status=200
-        )
+        s = soak.parse_diagnostics_payload("not-a-dict", elapsed_s=0.1, http_status=200)
         assert s.fetch_ok is False
         assert s.fetch_error == "non-dict payload"
 
@@ -167,7 +158,7 @@ def _mk_sample(
     client_log_count_5m: int | None = 0,
     client_log_warn_count_5m: int | None = 0,
     fetch_error: str | None = None,
-) -> "soak.Sample":
+) -> soak.Sample:
     return soak.Sample(
         ts=f"2026-04-19T00:{int(t):02d}:00+00:00",
         elapsed_s=t,
@@ -375,9 +366,23 @@ class TestRunSoakLoop:
     def test_collects_samples_and_handles_transient_failure(self):
         # Three sample windows: success, network error, success.
         responses = [
-            _FakeResponse(200, _payload(uptime_s=100, memory={"total_mb": 512, "used_mb": 256, "pct": 50.0}, disk={"total_mb": 16000, "used_mb": 5000, "pct": 31.0, "path": "/"})),
+            _FakeResponse(
+                200,
+                _payload(
+                    uptime_s=100,
+                    memory={"total_mb": 512, "used_mb": 256, "pct": 50.0},
+                    disk={"total_mb": 16000, "used_mb": 5000, "pct": 31.0, "path": "/"},
+                ),
+            ),
             ConnectionError("simulated wedge"),
-            _FakeResponse(200, _payload(uptime_s=700, memory={"total_mb": 512, "used_mb": 280, "pct": 55.0}, disk={"total_mb": 16000, "used_mb": 5000, "pct": 31.0, "path": "/"})),
+            _FakeResponse(
+                200,
+                _payload(
+                    uptime_s=700,
+                    memory={"total_mb": 512, "used_mb": 280, "pct": 55.0},
+                    disk={"total_mb": 16000, "used_mb": 5000, "pct": 31.0, "path": "/"},
+                ),
+            ),
         ]
         session = _FakeSession(responses)
 


### PR DESCRIPTION
Closes JTN-733.

## Summary

Real-Pi nightly soak: a script, a workflow, and a unit test.

- `scripts/soak_runner.py` samples `/api/diagnostics` against a running InkyPi instance at a configurable cadence (default 5 min) for a configurable duration (default 24h) and writes a JSON report artifact.
- `.github/workflows/pi-soak-nightly.yml` runs the script on a self-hosted Pi runner nightly (03:00 UTC) and uploads the report as `pi-soak-report`. Also supports `workflow_dispatch` with `duration` / `interval` / `host` inputs for manual short runs.
- `tests/unit/test_soak_runner.py` exercises duration parsing, payload parsing, trend math (including a simulated monotonic leak), summary aggregates, restart detection, and the sampling loop with a fake session.

Why: Pi freezes reported overnight have no CI repro — PR CI only runs for minutes. A 24h soak against real hardware + `/api/diagnostics` is the cheapest way to catch slow leaks, EventSource reconnect storms, display-driver wedges, tempfile buildup, and refresh-task drift.

## Metrics in the report

Each report is a JSON file with three top-level keys:

- `meta` — host, duration, cadence, start/end timestamps, script version.
- `samples` — raw per-sample records: `ts`, `elapsed_s`, `fetch_ok`, `http_status`, `version`, `uptime_s`, `memory_pct`, `disk_pct`, `refresh_running`, `refresh_last_error`, `client_log_count_5m`, `client_log_warn_count_5m`, `plugin_health`.
- `summary`:
  - `total_samples` / `successful_samples` / `unreachable_samples` / `unreachable_rate`
  - `refresh_failure_count` / `refresh_failure_rate`
  - `client_log_error_total` / `client_log_warn_total`
  - `service_restarts` — inferred from `uptime_s` regressions between successful samples
  - `memory_pct_trend` / `disk_pct_trend` — each contains `first`, `last`, `min`, `max`, `slope_per_second`, `slope_per_hour` computed via least-squares linear fit. A slow leak over 24h surfaces as a monotonic positive `slope_per_hour`.

Unreachable samples (HTTP failures) are kept as data points — they don't crash the loop and they are excluded from the trend fit so a temporary wedge doesn't skew the slope. The whole point is to catch wedges and recoveries.

## Workflow triggers

- **Scheduled**: nightly at 03:00 UTC against the self-hosted `pi-zero-2w` runner.
- **Manual**: `gh workflow run pi-soak-nightly.yml -f duration=10m -f interval=1m` for smoke tests.

The workflow requires a self-hosted runner labeled both `self-hosted` and `pi-zero-2w`. **Until that runner exists, nightly runs will queue and eventually time out — that is the intended no-op behaviour.** No x86 fallback is provided on purpose; a GitHub-hosted soak against a non-Pi box would not be a meaningful signal.

## How to read the artifact

1. From a workflow run page, download the `pi-soak-report` artifact.
2. `jq '.summary' soak-report.json` shows the headline aggregates.
3. `jq '.summary.memory_pct_trend.slope_per_hour' soak-report.json` is the leak canary — anything above roughly +0.5 percent/hour on a 24h run warrants investigation.
4. `jq '.samples | map(select(.fetch_ok == false))' soak-report.json` lists wedge windows.

## Test plan

- [x] `pytest tests/unit/test_soak_runner.py` — 32 tests pass locally.
- [x] Smoke: `python3 scripts/soak_runner.py --host http://127.0.0.1:9 --duration 3s --interval 1s --verbose --output /tmp/soak.json` — runner gracefully records three unreachable samples and writes a well-formed report.
- [ ] First real nightly run against the `pi-zero-2w` runner once it's provisioned; verify `pi-soak-report` artifact uploads and `summary.service_restarts == 0`, `unreachable_rate < 0.05`.