### PR TITLE
test: add authenticated-session click-sweep variant (JTN-702)

### DIFF
--- a/tests/integration/browser_helpers.py
+++ b/tests/integration/browser_helpers.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -186,6 +187,91 @@ def prepare_playlist(device_config_dev):
         plugin_instance="Clock A",
     )
     device_config_dev.write_config()
+
+
+def _session_cookie_for_authed_user(flask_app) -> tuple[str, str]:
+    """Return the Flask signed-session cookie (name, value) for ``authed=True``.
+
+    Uses the app's real test client so the cookie is signed with the app's
+    ``SECRET_KEY`` and uses the configured session interface. This means the
+    resulting cookie is accepted by the live server thread without any
+    patching of cookie serialization.
+
+    Returns a tuple ``(cookie_name, cookie_value)`` suitable for passing to
+    :meth:`playwright.sync_api.BrowserContext.add_cookies`.
+    """
+    cookie_name = flask_app.config.get("SESSION_COOKIE_NAME", "session")
+    client = flask_app.test_client()
+    with client.session_transaction() as sess:
+        sess["authed"] = True
+    # Flask's test client keeps cookies on ``client.get`` responses; the
+    # session_transaction commit above stamps the signed cookie into the
+    # client's cookie jar. Pull it out directly. ``client`` exposes a
+    # ``CookieJar``-like object at ``_cookies`` across Werkzeug versions;
+    # iterate defensively to tolerate newer/older APIs.
+    raw_cookie: str | None = None
+    jar = getattr(client, "_cookies", None)
+    if jar is not None:
+        # Werkzeug >=3 exposes a dict-like mapping keyed by
+        # ``(domain, path, name)`` tuples.
+        try:
+            for key, cookie in jar.items():
+                name = key[-1] if isinstance(key, tuple) else key
+                if name == cookie_name:
+                    raw_cookie = getattr(cookie, "value", cookie)
+                    break
+        except AttributeError:
+            # Older API: jar is iterable of cookie objects.
+            for cookie in jar:
+                if getattr(cookie, "name", None) == cookie_name:
+                    raw_cookie = getattr(cookie, "value", None)
+                    break
+    if raw_cookie is None:
+        # Fallback: make a request so the Set-Cookie header is emitted and
+        # parse it from there. Any exempt route works.
+        resp = client.get("/login")
+        set_cookie = resp.headers.get("Set-Cookie", "")
+        for part in set_cookie.split(";"):
+            part = part.strip()
+            if part.startswith(f"{cookie_name}="):
+                raw_cookie = part.split("=", 1)[1]
+                break
+    if raw_cookie is None:
+        raise RuntimeError(
+            "Could not materialize a signed session cookie from the Flask test "
+            "client — authenticate_page cannot build a post_auth session."
+        )
+    return cookie_name, raw_cookie
+
+
+def authenticate_page(page, flask_app, base_url: str) -> None:
+    """Attach a signed ``authed=True`` session cookie to *page*'s context.
+
+    Reusable by any integration test that needs a logged-in session before
+    navigating. Today the app only gates routes when ``INKYPI_AUTH_PIN`` is
+    set, so on the default test bootstrap this helper is a no-op from the
+    server's perspective — it still exercises the cookie-injection plumbing
+    so future auth-gated routes get coverage automatically via the
+    ``post_auth`` parametrize variant.
+
+    The cookie is scoped to the ``live_server`` host so it is sent on every
+    request during the test. Call this BEFORE ``page.goto(...)``.
+    """
+    cookie_name, cookie_value = _session_cookie_for_authed_user(flask_app)
+    parsed = urlparse(base_url)
+    host = parsed.hostname or "127.0.0.1"
+    page.context.add_cookies(
+        [
+            {
+                "name": cookie_name,
+                "value": cookie_value,
+                "domain": host,
+                "path": "/",
+                "httpOnly": True,
+                "sameSite": "Lax",
+            }
+        ]
+    )
 
 
 def install_direct_manual_update(monkeypatch, flask_app):

--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -30,7 +30,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from tests.integration.browser_helpers import RuntimeCollector, stub_leaflet
+from tests.integration.browser_helpers import (
+    RuntimeCollector,
+    authenticate_page,
+    stub_leaflet,
+)
 
 pytestmark = pytest.mark.skipif(
     os.getenv("SKIP_UI", "").lower() in ("1", "true"),
@@ -452,6 +456,8 @@ def _run_click_sweep(
     sweep: SweepPage,
     *,
     max_clicks: int = _MAX_CLICKS_PER_PAGE,
+    flask_app=None,
+    authenticated: bool = False,
 ) -> None:
     """Shared click-sweep body used by both the core-pages and plugin-pages tests.
 
@@ -461,9 +467,25 @@ def _run_click_sweep(
     occurred. Uses the page's autouse ``client_log_capture`` fixture as
     the final tripwire for any ``console.warn``/``error`` the browser
     forwarded to ``/api/client-log``.
+
+    When ``authenticated=True`` the page's browser context is seeded with a
+    signed ``authed=True`` session cookie *before* the initial ``page.goto``
+    so logged-in-only UI branches are exercised. Today the app only gates
+    routes when ``INKYPI_AUTH_PIN`` is set, so on the default bootstrap
+    ``authenticated`` is functionally a no-op — it still locks in the
+    cookie-injection plumbing so future auth-gated routes get coverage
+    automatically (JTN-702).
     """
     stub_leaflet(page)
     collector = RuntimeCollector(page, live_server)
+
+    if authenticated:
+        if flask_app is None:
+            raise RuntimeError(
+                "authenticated=True requires flask_app so a signed session "
+                "cookie can be materialized."
+            )
+        authenticate_page(page, flask_app, live_server)
 
     page.goto(
         f"{live_server}{sweep.path}",
@@ -551,6 +573,18 @@ def _run_click_sweep(
     ), f"{sweep.path}: {len(click_errors)} click(s) errored: {click_errors[:5]}"
 
 
+# JTN-702: Each page/viewport combination runs twice — once anonymous
+# (``pre_auth``) and once with a signed ``authed=True`` session cookie set on
+# the Playwright context before navigating (``post_auth``). The default test
+# bootstrap does not set ``INKYPI_AUTH_PIN``, so ``post_auth`` is functionally
+# a no-op today — it exercises the cookie-injection plumbing so future
+# auth-gated routes get coverage automatically. See
+# :func:`tests.integration.browser_helpers.authenticate_page` for the shared
+# helper other integration tests can use when they need a logged-in session.
+_AUTH_STATES: tuple[str, ...] = ("pre_auth", "post_auth")
+
+
+@pytest.mark.parametrize("auth_state", _AUTH_STATES, ids=list(_AUTH_STATES))
 @pytest.mark.parametrize(
     "viewport,page_fixture",
     _VIEWPORTS,
@@ -558,13 +592,24 @@ def _run_click_sweep(
 )
 @pytest.mark.parametrize("sweep", PAGES_TO_SWEEP, ids=lambda sweep: sweep.label)
 def test_click_sweep(
-    live_server, request, sweep: SweepPage, viewport: str, page_fixture: str
+    live_server,
+    flask_app,
+    request,
+    sweep: SweepPage,
+    viewport: str,
+    page_fixture: str,
+    auth_state: str,
 ):
     """Click every visible clickable on the page; assert no silent failures.
 
-    Parametrized over viewport: ``desktop`` (1280×900) and ``mobile``
-    (360×800). Mobile reflows can hide or overlap controls and catch
-    handlers that only break at narrow widths.
+    Parametrized over:
+
+    * ``viewport`` — ``desktop`` (1280×900) and ``mobile`` (360×800). Mobile
+      reflows can hide or overlap controls and catch handlers that only
+      break at narrow widths.
+    * ``auth_state`` — ``pre_auth`` (anonymous) and ``post_auth`` (signed
+      ``authed=True`` session cookie set before the initial navigation).
+      See JTN-702.
     """
     if sweep.label in _XFAIL_PAGES:
         pytest.xfail(_XFAIL_PAGES[sweep.label])
@@ -573,7 +618,13 @@ def test_click_sweep(
         pytest.xfail(_MOBILE_XFAIL_PAGES[mobile_key])
 
     page = request.getfixturevalue(page_fixture)
-    _run_click_sweep(page, live_server, sweep)
+    _run_click_sweep(
+        page,
+        live_server,
+        sweep,
+        flask_app=flask_app,
+        authenticated=(auth_state == "post_auth"),
+    )
 
 
 # JTN-698: Parametrize the sweep over every registered plugin so a handler
@@ -586,14 +637,20 @@ def test_click_sweep(
 # wall-time without new signal. Mark ``plugin_sweep`` so CI can route this
 # to a dedicated job if total runtime pressure grows.
 @pytest.mark.plugin_sweep
+@pytest.mark.parametrize("auth_state", _AUTH_STATES, ids=list(_AUTH_STATES))
 @pytest.mark.parametrize("plugin_id", _PLUGIN_IDS, ids=list(_PLUGIN_IDS))
-def test_click_sweep_plugin_pages(live_server, browser_page, plugin_id: str):
+def test_click_sweep_plugin_pages(
+    live_server, flask_app, browser_page, plugin_id: str, auth_state: str
+):
     """Sweep every ``/plugin/<id>`` page for silent-failure handlers.
 
     Uses the shared :func:`_run_click_sweep` body with a tighter click cap
     (``_PLUGIN_MAX_CLICKS_PER_PAGE``) to keep the 21-plugin sweep inside
     the CI budget. Destructive controls are still honored via the existing
     ``data-test-skip-click="true"`` skip selector.
+
+    Runs twice per plugin: ``pre_auth`` (anonymous) and ``post_auth``
+    (signed session cookie set before navigation) — see JTN-702.
     """
     if plugin_id in _PLUGIN_XFAIL:
         pytest.xfail(_PLUGIN_XFAIL[plugin_id])
@@ -608,4 +665,6 @@ def test_click_sweep_plugin_pages(live_server, browser_page, plugin_id: str):
         live_server,
         sweep,
         max_clicks=_PLUGIN_MAX_CLICKS_PER_PAGE,
+        flask_app=flask_app,
+        authenticated=(auth_state == "post_auth"),
     )


### PR DESCRIPTION
## Summary
- extract a reusable `authenticate_page` helper in `tests/integration/browser_helpers.py` that materializes a signed Flask session cookie (`authed=True`) via the app's test client and attaches it to a Playwright browser context
- stack a `[pre_auth, post_auth]` parametrize layer onto both `test_click_sweep` and `test_click_sweep_plugin_pages` so every page/viewport combination runs twice — anonymous, then with a session cookie set before `page.goto`
- wrap the existing sweep body behind `authenticated=` + `flask_app=` kwargs on `_run_click_sweep` so other integration tests can reuse the helper when they need a logged-in session

The default test bootstrap doesn't set `INKYPI_AUTH_PIN`, so today the `post_auth` variant is functionally equivalent to `pre_auth` from the server's perspective — but it locks in the cookie-injection plumbing so future auth-gated routes get coverage automatically without new test wiring. See JTN-702.

## Testing
- `python3 -m pytest tests/integration/test_click_sweep.py::test_click_sweep` — 18 passed, 4 xfailed; only the pre-existing `plugin_clock-desktop` flake (same failure on `main` locally without `pytest-rerunfailures`) reproduces in both variants, confirming parity between `pre_auth` and `post_auth`
- `python3 -m pytest tests/integration/test_click_sweep.py --collect-only` — 64 cases (doubled from 32), new IDs: `[...-pre_auth]` / `[...-post_auth]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)