### PR TITLE
test: unblock mobile click-sweep for playlist + plugin_clock (JTN-743)

### DIFF
--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -67,7 +67,13 @@
                         {% endif %}
                     {% endif %}
 
-                    <button id="showLastProgressBtn" class="header-button icon" type="button" title="Last progress" aria-label="Last progress">{{ icon('clock-counter-clockwise', 'icon-image') | safe }}</button>
+                    {# data-test-skip-click: opens the fixed-position #requestProgress
+                       overlay, which on mobile (360×800) reflows to full width and
+                       covers the workflow tabs, breadcrumbs and header icons below.
+                       The sweep then silent-no-ops every later candidate (JTN-743).
+                       Dedicated coverage lives in
+                       tests/integration/test_plugin_workflow_e2e.py::test_last_progress_button_shows_overlay. #}
+                    <button id="showLastProgressBtn" class="header-button icon" type="button" title="Last progress" aria-label="Last progress" data-test-skip-click="true">{{ icon('clock-counter-clockwise', 'icon-image') | safe }}</button>
                     <div id="loadingIndicator" class="loading-indicator"></div>
                 </div>
             </div>

--- a/tests/integration/test_click_sweep.py
+++ b/tests/integration/test_click_sweep.py
@@ -135,16 +135,7 @@ _VIEWPORTS: tuple[tuple[str, str], ...] = (
 # Per-(label, viewport) xfails for mobile-only regressions. Keep empty
 # until a mobile-specific break is triaged into Linear — new entries must
 # link to a JTN issue so they get cleaned up.
-_MOBILE_XFAIL_PAGES: dict[str, str] = {
-    "playlist:mobile": (
-        "awaiting JTN-743 "
-        "(playlist mobile click-sweep still hits layered-ui no-op candidates)"
-    ),
-    "plugin_clock:mobile": (
-        "awaiting JTN-743 "
-        "(clock plugin mobile click-sweep still hits layered-ui no-op candidates)"
-    ),
-}
+_MOBILE_XFAIL_PAGES: dict[str, str] = {}
 
 # Plugin-sweep cap. Plugin settings pages are structurally similar (a single
 # settings form with a handful of presets) so 15 clicks is plenty to exercise

--- a/tests/integration/test_plugin_workflow_e2e.py
+++ b/tests/integration/test_plugin_workflow_e2e.py
@@ -61,3 +61,48 @@ def test_plugin_page_has_workflow_tabs(live_server, browser_page, tmp_path):
     page.wait_for_timeout(300)
 
     rc.assert_no_errors(str(tmp_path), "plugin_workflow_tabs")
+
+
+def test_last_progress_button_shows_overlay(live_server, browser_page, tmp_path):
+    """JTN-743: dedicated coverage for the header "Last progress" button.
+
+    Replaces the click-sweep exercise of ``#showLastProgressBtn`` — the sweep
+    is tagged ``data-test-skip-click="true"`` in ``plugin.html`` because the
+    resulting fixed overlay covers the workflow tabs and breadcrumb links on
+    mobile, silently no-op'ing every downstream click. Here we click the
+    button, assert the progress block becomes visible with the expected
+    no-data empty state, then close it via ``#closeProgressBtn`` and assert
+    the block is hidden again.
+    """
+    page = browser_page
+    rc = navigate_and_wait(page, live_server, "/plugin/clock")
+
+    progress = page.locator("#requestProgress")
+    assert progress.count() == 1, "#requestProgress block should render"
+    # Block is hidden by default until the user opens it.
+    assert progress.evaluate("(el) => el.hidden") is True, (
+        "#requestProgress should start hidden"
+    )
+
+    # Clear any cached progress so we get the deterministic empty-state copy.
+    page.evaluate(
+        "() => { try { localStorage.clear(); } catch (_) {} }"
+    )
+
+    page.locator("#showLastProgressBtn").click()
+    page.wait_for_timeout(200)
+
+    assert progress.evaluate("(el) => !el.hidden"), (
+        "#requestProgress should be visible after clicking Last Progress"
+    )
+    empty = page.locator(".progress-empty-state")
+    assert empty.count() == 1, "no-data empty state should render when unseeded"
+
+    page.locator("#closeProgressBtn").click()
+    page.wait_for_timeout(200)
+
+    assert progress.evaluate("(el) => el.hidden"), (
+        "#requestProgress should re-hide after clicking close"
+    )
+
+    rc.assert_no_errors(str(tmp_path), "plugin_last_progress_overlay")

--- a/tests/integration/test_plugin_workflow_e2e.py
+++ b/tests/integration/test_plugin_workflow_e2e.py
@@ -80,29 +80,27 @@ def test_last_progress_button_shows_overlay(live_server, browser_page, tmp_path)
     progress = page.locator("#requestProgress")
     assert progress.count() == 1, "#requestProgress block should render"
     # Block is hidden by default until the user opens it.
-    assert progress.evaluate("(el) => el.hidden") is True, (
-        "#requestProgress should start hidden"
-    )
+    assert (
+        progress.evaluate("(el) => el.hidden") is True
+    ), "#requestProgress should start hidden"
 
     # Clear any cached progress so we get the deterministic empty-state copy.
-    page.evaluate(
-        "() => { try { localStorage.clear(); } catch (_) {} }"
-    )
+    page.evaluate("() => { try { localStorage.clear(); } catch (_) {} }")
 
     page.locator("#showLastProgressBtn").click()
     page.wait_for_timeout(200)
 
-    assert progress.evaluate("(el) => !el.hidden"), (
-        "#requestProgress should be visible after clicking Last Progress"
-    )
+    assert progress.evaluate(
+        "(el) => !el.hidden"
+    ), "#requestProgress should be visible after clicking Last Progress"
     empty = page.locator(".progress-empty-state")
     assert empty.count() == 1, "no-data empty state should render when unseeded"
 
     page.locator("#closeProgressBtn").click()
     page.wait_for_timeout(200)
 
-    assert progress.evaluate("(el) => el.hidden"), (
-        "#requestProgress should re-hide after clicking close"
-    )
+    assert progress.evaluate(
+        "(el) => el.hidden"
+    ), "#requestProgress should re-hide after clicking close"
 
     rc.assert_no_errors(str(tmp_path), "plugin_last_progress_overlay")


### PR DESCRIPTION
## Summary

Mobile click-sweep xfails cleared for `playlist-mobile` and `plugin_clock-mobile` (JTN-743).

- `playlist-mobile`: xfail was stale — passes reliably on main. Drop the entry so regressions fail loudly.
- `plugin_clock-mobile`: the 4 silent-failure candidates (`Preview & Apply`, `Home` icon, breadcrumb `Home`, breadcrumb `Plugins`) all share a single root cause — clicking `#showLastProgressBtn` (the "Last progress" header icon) un-hides `#requestProgress`, a `position: fixed` full-width overlay on mobile that covers the entire header/workflow area. Subsequent clicks hit-test onto `div#requestProgress` instead of the intended control.

## Per-control decisions

| Candidate | Decision | Rationale |
|---|---|---|
| `playlist-mobile` page (11 controls) | Harness: remove xfail | Already green on main; nothing to do. |
| `#showLastProgressBtn` ("Last progress") | Harness skip via `data-test-skip-click="true"` | The overlay it opens covers every later candidate. Tagged in `plugin.html` with an HTML comment pointing at `test_last_progress_button_shows_overlay`. |
| `#previewModeBtn`, breadcrumb `Home`/`Plugins`, header Home icon | Fixed indirectly | Not skipped — their clicks work fine once the Last-progress overlay is not in the way. |

## Coverage preservation

Added `tests/integration/test_plugin_workflow_e2e.py::test_last_progress_button_shows_overlay` which directly exercises the Last Progress open + close paths (checks `#requestProgress` visibility toggle and the empty-state copy). Net sweep coverage is unchanged.

## Test plan

- [x] `pytest tests/integration/test_click_sweep.py -k "playlist-mobile or plugin_clock-mobile"` — 2 passed, stable across 5 runs
- [x] `pytest tests/integration/test_plugin_workflow_e2e.py::test_last_progress_button_shows_overlay` — 1 passed
- [x] `pytest tests/integration/test_click_sweep.py -m "not plugin_sweep"` — mobile cases all green. One unrelated pre-existing failure on `plugin_clock-desktop` ("Add to Playlist" silent no-op) reproduces on `main` without this change; out of scope for JTN-743 and likely overlaps with JTN-702's sweep work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)