### PR TITLE
refactor: add typed backend route errors

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -17,9 +17,14 @@ from flask import (
 from model import Playlist
 from refresh_task import PlaylistRefresh
 from utils.app_utils import handle_request_files, parse_form
+from utils.backend_errors import (
+    ClientInputError,
+    OperationFailedError,
+    ResourceLookupError,
+    route_error_boundary,
+)
 from utils.http_utils import (
     json_error,
-    json_internal_error,
     json_success,
     reissue_json_error,
 )
@@ -388,7 +393,11 @@ def add_plugin():
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
 
-    try:
+    with route_error_boundary(
+        "add plugin to playlist",
+        logger=logger,
+        hint="Validate inputs; ensure playlist exists and instance name is not duplicated.",
+    ):
         plugin_id, plugin_settings, refresh_settings, parse_err = (
             _parse_add_plugin_form(request.form, request.files)
         )
@@ -443,14 +452,7 @@ def add_plugin():
 
         device_config.update_atomic(_do_add)
         if not add_result or not add_result[0]:
-            return json_error("Failed to add to playlist", status=500)
-    except Exception:
-        return json_internal_error(
-            "add plugin to playlist",
-            details={
-                "hint": "Validate inputs; ensure playlist exists and instance name isn’t duplicated.",
-            },
-        )
+            raise OperationFailedError("Failed to add to playlist")
     return json_success("Scheduled refresh configured.")
 
 
@@ -660,14 +662,18 @@ def create_playlist():
     if time_err:
         return time_err
 
-    try:
+    with route_error_boundary(
+        "create playlist",
+        logger=logger,
+        hint="Ensure the playlist name is unique and the config is writable.",
+    ):
         playlist = playlist_manager.get_playlist(playlist_name)
         if playlist:
-            return json_error(
+            raise ClientInputError(
                 "A playlist with that name already exists",
                 status=400,
                 code=_CODE_VALIDATION,
-                details={"field": "playlist_name"},
+                field="playlist_name",
             )
 
         # Prevent overlapping time windows
@@ -692,22 +698,13 @@ def create_playlist():
 
         device_config.update_atomic(_do_add_playlist)
         if not add_pl_result or not add_pl_result[0]:
-            return json_error("Failed to create playlist", status=500)
+            raise OperationFailedError("Failed to create playlist")
 
         warning = None
         if playlist_name != "Default":
             warning = _default_overlap_warning(
                 start_min, end_min, playlist_manager.playlists
             )
-
-    except Exception as e:
-        logger.exception("EXCEPTION CAUGHT: " + str(e))
-        return json_internal_error(
-            "create playlist",
-            details={
-                "hint": "Ensure unique name and valid time range; check config write permissions.",
-            },
-        )
 
     if warning:
         return json_success("Created new Playlist!", warning=warning)
@@ -908,17 +905,17 @@ def update_device_cycle():
             code=_CODE_VALIDATION,
             details={"field": "minutes"},
         )
-    try:
+    with route_error_boundary(
+        "update_device_cycle",
+        logger=logger,
+        hint="Check config write permissions.",
+    ):
         device_config.update_value("plugin_cycle_interval_seconds", m * 60, write=True)
         try:
             refresh_task.signal_config_change()
         except Exception:
             pass
         return json_success("Device refresh cadence updated.")
-    except Exception:
-        return json_internal_error(
-            "update_device_cycle", details={"hint": "Check config write permissions."}
-        )
 
 
 @playlist_bp.route("/reorder_plugins", methods=["POST"])
@@ -926,30 +923,34 @@ def reorder_plugins():
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
 
-    try:
+    with route_error_boundary(
+        "reorder plugins",
+        logger=logger,
+        hint="Validate payload shape and ensure the playlist exists.",
+    ):
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
-            return json_error("Invalid or missing JSON payload", status=400)
+            raise ClientInputError("Invalid or missing JSON payload", status=400)
         playlist_name = data.get("playlist_name")
         ordered = data.get("ordered")  # list of {plugin_id, name}
         if not playlist_name:
-            return json_error(
+            raise ClientInputError(
                 "playlist_name and ordered list are required",
                 status=400,
                 code=_CODE_VALIDATION,
-                details={"field": "playlist_name"},
+                field="playlist_name",
             )
         if not isinstance(ordered, list):
-            return json_error(
+            raise ClientInputError(
                 "playlist_name and ordered list are required",
                 status=400,
                 code=_CODE_VALIDATION,
-                details={"field": "ordered"},
+                field="ordered",
             )
 
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error(
+            raise ResourceLookupError(
                 _MSG_PLAYLIST_NOT_FOUND,
                 status=400,
                 code=_CODE_VALIDATION,
@@ -963,14 +964,9 @@ def reorder_plugins():
 
         device_config.update_atomic(_do_reorder)
         if not reorder_result or not reorder_result[0]:
-            return json_error("Invalid order payload", status=400)
+            raise ClientInputError("Invalid order payload", status=400)
 
         return json_success("Reordered plugins")
-    except Exception:
-        return json_internal_error(
-            "reorder plugins",
-            details={"hint": "Validate payload shape and ensure playlist exists."},
-        )
 
 
 # Trigger next eligible instance in a specific playlist immediately
@@ -980,22 +976,26 @@ def display_next_in_playlist():
     refresh_task = current_app.config["REFRESH_TASK"]
     playlist_manager = device_config.get_playlist_manager()
 
-    try:
+    with route_error_boundary(
+        "display next in playlist",
+        logger=logger,
+        hint="Ensure the playlist exists and has an eligible instance to render.",
+    ):
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
-            return json_error("Invalid or missing JSON payload", status=400)
+            raise ClientInputError("Invalid or missing JSON payload", status=400)
         playlist_name = data.get("playlist_name")
         if not playlist_name:
-            return json_error(
+            raise ClientInputError(
                 "playlist_name required",
                 status=400,
                 code=_CODE_VALIDATION,
-                details={"field": "playlist_name"},
+                field="playlist_name",
             )
 
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error(
+            raise ResourceLookupError(
                 _MSG_PLAYLIST_NOT_FOUND,
                 status=400,
                 code=_CODE_VALIDATION,
@@ -1007,11 +1007,11 @@ def display_next_in_playlist():
 
         plugin_instance = playlist.get_next_eligible_plugin(current_dt)
         if not plugin_instance:
-            return json_error(
+            raise ClientInputError(
                 "No eligible instance in playlist",
                 status=400,
                 code=_CODE_VALIDATION,
-                details={"field": "playlist_name"},
+                field="playlist_name",
             )
 
         refresh_task.manual_update(
@@ -1032,8 +1032,6 @@ def display_next_in_playlist():
             pass
 
         return json_success("Displayed next instance", metrics=metrics)
-    except Exception:
-        return json_internal_error("display next in playlist")
 
 
 @playlist_bp.route("/playlist/eta/<string:playlist_name>", methods=["GET"])
@@ -1047,7 +1045,7 @@ def playlist_eta(playlist_name: str):
 
     pl = playlist_manager.get_playlist(playlist_name)
     if not pl:
-        return json_error(
+        raise ResourceLookupError(
             _MSG_PLAYLIST_NOT_FOUND,
             status=404,
             code=_CODE_VALIDATION,
@@ -1064,7 +1062,11 @@ def playlist_eta(playlist_name: str):
         return json_success("ok", eta=cached[1])
 
     # Compute ETA for this playlist only
-    try:
+    with route_error_boundary(
+        "compute playlist eta",
+        logger=logger,
+        hint="Check playlist timing data and refresh info availability.",
+    ):
         # Determine cycle in minutes
         try:
             device_cycle_minutes = int(
@@ -1110,8 +1112,6 @@ def playlist_eta(playlist_name: str):
                     _eta_cache.pop(next(iter(_eta_cache)), None)
             _eta_cache[playlist_name] = (floor_min, eta_map)
         return json_success("ok", eta=eta_map)
-    except Exception:
-        return json_internal_error("compute playlist eta")
 
 
 @playlist_bp.app_template_filter("format_relative_time")

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -19,16 +19,16 @@ from plugins.plugin_registry import get_plugin_instance
 from refresh_task import ManualRefresh, PlaylistRefresh
 from refresh_task.job_queue import get_job_queue
 from utils.app_utils import handle_request_files, parse_form, resolve_path
-from utils.fallback_image import render_error_image
-from utils.form_utils import (
-    sanitize_log_field,
-    validate_plugin_required_fields,
-)
 from utils.backend_errors import (
     ClientInputError,
     ResourceLookupError,
     UnsupportedMediaTypeRouteError,
     route_error_boundary,
+)
+from utils.fallback_image import render_error_image
+from utils.form_utils import (
+    sanitize_log_field,
+    validate_plugin_required_fields,
 )
 from utils.http_utils import json_error, json_success
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
@@ -310,7 +310,7 @@ def delete_plugin_instance():
     playlist_manager = device_config.get_playlist_manager()
 
     if not request.is_json:
-        raise UnsupportedMediaTypeRouteError()
+        raise UnsupportedMediaTypeRouteError
     data = request.json or {}
 
     playlist_name = data.get("playlist_name")
@@ -403,13 +403,13 @@ def update_plugin_instance(instance_name: str):
         if raw_refresh is not None:
             try:
                 refresh_payload = json.loads(raw_refresh)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as exc:
                 raise ClientInputError(
                     "Refresh settings must be valid JSON",
                     status=400,
                     code="validation_error",
                     field="refresh_settings",
-                )
+                ) from exc
             if not isinstance(refresh_payload, dict):
                 raise ClientInputError(
                     "Refresh settings must be an object",
@@ -454,7 +454,7 @@ def update_plugin_instance(instance_name: str):
 
                 try:
                     settings_error = plugin.validate_settings(plugin_settings)
-                except Exception:
+                except Exception as exc:
                     logger.warning(
                         "Plugin validate_settings raised for %s",
                         sanitize_log_field(plugin_id),
@@ -463,7 +463,7 @@ def update_plugin_instance(instance_name: str):
                     raise ClientInputError(
                         "Settings validation failed. Please check your input.",
                         status=400,
-                    )
+                    ) from exc
                 else:
                     if settings_error:
                         raise ClientInputError(settings_error, status=400)
@@ -491,7 +491,7 @@ def display_plugin_instance():
     playlist_manager = device_config.get_playlist_manager()
 
     if not request.is_json:
-        raise UnsupportedMediaTypeRouteError()
+        raise UnsupportedMediaTypeRouteError
     data = request.json or {}
 
     playlist_name = data.get("playlist_name")

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -24,7 +24,13 @@ from utils.form_utils import (
     sanitize_log_field,
     validate_plugin_required_fields,
 )
-from utils.http_utils import APIError, json_error, json_success
+from utils.backend_errors import (
+    ClientInputError,
+    ResourceLookupError,
+    UnsupportedMediaTypeRouteError,
+    route_error_boundary,
+)
+from utils.http_utils import json_error, json_success
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 from utils.plugin_history import record_change as _record_plugin_change
 from utils.progress import track_progress
@@ -76,7 +82,11 @@ def plugin_page(plugin_id: str):
     if not plugin_config:
         abort(404)
 
-    try:
+    with route_error_boundary(
+        "render plugin page",
+        logger=logger,
+        hint="Check plugin configuration and template generation.",
+    ):
         plugin = get_plugin_instance(plugin_config)
         template_params = plugin.generate_settings_template()
 
@@ -99,7 +109,7 @@ def plugin_page(plugin_id: str):
                     sanitize_log_field(plugin_id),
                     sanitize_log_field(plugin_instance_name),
                 )
-                return json_error(
+                raise ResourceLookupError(
                     _ERR_PLUGIN_INSTANCE_NOT_FOUND,
                     status=404,
                 )
@@ -125,10 +135,6 @@ def plugin_page(plugin_id: str):
         )
         if plugin_latest_refresh:
             template_params["plugin_latest_refresh"] = plugin_latest_refresh
-
-    except Exception as e:  # pragma: no cover - safety net
-        logger.exception("EXCEPTION CAUGHT: %s", e)
-        return json_error(_ERR_INTERNAL, status=500)
 
     return render_template(
         "plugin.html",
@@ -304,7 +310,7 @@ def delete_plugin_instance():
     playlist_manager = device_config.get_playlist_manager()
 
     if not request.is_json:
-        return json_error("Unsupported media type", status=415)
+        raise UnsupportedMediaTypeRouteError()
     data = request.json or {}
 
     playlist_name = data.get("playlist_name")
@@ -316,13 +322,17 @@ def delete_plugin_instance():
         or not isinstance(playlist_name, str)
         or not playlist_name.strip()
     ):
-        return json_error(PLAYLIST_NAME_REQUIRED_ERROR, status=400)
+        raise ClientInputError(PLAYLIST_NAME_REQUIRED_ERROR, status=400)
     playlist_name = playlist_name.strip()
 
-    try:
+    with route_error_boundary(
+        "delete plugin instance",
+        logger=logger,
+        hint="Ensure the playlist and plugin instance exist before deleting.",
+    ):
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
-            return json_error("Playlist not found", status=400)
+            raise ResourceLookupError("Playlist not found", status=400)
 
         existing = playlist.find_plugin(plugin_id, plugin_instance)
         plugin_settings = dict(existing.settings) if existing else {}
@@ -334,13 +344,10 @@ def delete_plugin_instance():
 
         device_config.update_atomic(_do_delete)
         if not del_result or not del_result[0]:
-            return json_error("Plugin instance not found", status=400)
+            raise ResourceLookupError("Plugin instance not found", status=400)
         _cleanup_plugin_resources(
             device_config, plugin_id, plugin_instance, plugin_settings
         )
-    except Exception as e:
-        logger.exception("EXCEPTION CAUGHT: %s", e)
-        return json_error(_ERR_INTERNAL, status=500)
 
     return json_success(message="Deleted plugin instance.")
 
@@ -350,25 +357,29 @@ def update_plugin_instance(instance_name: str):
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()
 
-    try:
+    with route_error_boundary(
+        "update plugin instance",
+        logger=logger,
+        hint="Check submitted plugin settings and config persistence.",
+    ):
         form_data = parse_form(request.form)
         if not instance_name:
-            raise APIError(
+            raise ClientInputError(
                 "Instance name is required",
                 status=422,
                 code="validation_error",
-                details={"field": "instance_name"},
+                field="instance_name",
             )
         plugin_settings = form_data
         plugin_settings.update(handle_request_files(request.files, request.form))
 
         plugin_id = plugin_settings.pop(_PLUGIN_ID, None)
         if not plugin_id:
-            raise APIError(
+            raise ClientInputError(
                 _ERR_PLUGIN_ID_REQUIRED,
                 status=422,
                 code="validation_error",
-                details={"field": _PLUGIN_ID},
+                field=_PLUGIN_ID,
             )
         plugin_instance = playlist_manager.find_plugin(plugin_id, instance_name)
         if not plugin_instance:
@@ -377,7 +388,7 @@ def update_plugin_instance(instance_name: str):
                 sanitize_log_field(plugin_id),
                 sanitize_log_field(instance_name),
             )
-            return json_error(
+            raise ResourceLookupError(
                 _ERR_PLUGIN_INSTANCE_NOT_FOUND,
                 status=404,
             )
@@ -393,18 +404,18 @@ def update_plugin_instance(instance_name: str):
             try:
                 refresh_payload = json.loads(raw_refresh)
             except (TypeError, ValueError):
-                return json_error(
+                raise ClientInputError(
                     "Refresh settings must be valid JSON",
                     status=400,
                     code="validation_error",
-                    details={"field": "refresh_settings"},
+                    field="refresh_settings",
                 )
             if not isinstance(refresh_payload, dict):
-                return json_error(
+                raise ClientInputError(
                     "Refresh settings must be an object",
                     status=400,
                     code="validation_error",
-                    details={"field": "refresh_settings"},
+                    field="refresh_settings",
                 )
             from blueprints.playlist import validate_plugin_refresh_settings
 
@@ -431,29 +442,31 @@ def update_plugin_instance(instance_name: str):
                     validation_error = validate_plugin_required_fields(
                         plugin, plugin_settings
                     )
-                    if validation_error:
-                        return json_error(validation_error, status=400)
                 except Exception:
                     logger.warning(
                         "Required-field validation failed for %s",
                         sanitize_log_field(plugin_id),
                         exc_info=True,
                     )
+                else:
+                    if validation_error:
+                        raise ClientInputError(validation_error, status=400)
 
                 try:
                     settings_error = plugin.validate_settings(plugin_settings)
-                    if settings_error:
-                        return json_error(settings_error, status=400)
                 except Exception:
                     logger.warning(
                         "Plugin validate_settings raised for %s",
                         sanitize_log_field(plugin_id),
                         exc_info=True,
                     )
-                    return json_error(
+                    raise ClientInputError(
                         "Settings validation failed. Please check your input.",
                         status=400,
                     )
+                else:
+                    if settings_error:
+                        raise ClientInputError(settings_error, status=400)
 
         before_settings = dict(plugin_instance.settings or {})
 
@@ -467,10 +480,6 @@ def update_plugin_instance(instance_name: str):
         _record_plugin_change(
             config_dir, instance_name, before_settings, plugin_settings
         )
-    except APIError as e:
-        return json_error(e.message, status=e.status, code=e.code, details=e.details)
-    except Exception:
-        return json_error(_ERR_INTERNAL, status=500)
 
     return json_success(message=f"Updated plugin instance {instance_name}.")
 
@@ -482,21 +491,25 @@ def display_plugin_instance():
     playlist_manager = device_config.get_playlist_manager()
 
     if not request.is_json:
-        return json_error("Unsupported media type", status=415)
+        raise UnsupportedMediaTypeRouteError()
     data = request.json or {}
 
     playlist_name = data.get("playlist_name")
     plugin_id = data.get(_PLUGIN_ID)
     plugin_instance_name = data.get("plugin_instance")
 
-    try:
+    with route_error_boundary(
+        "display plugin instance",
+        logger=logger,
+        hint="Ensure the playlist exists and the refresh task can run the instance.",
+    ):
         playlist = playlist_manager.get_playlist(playlist_name)
         if not playlist:
             logger.warning(
                 "display_plugin_instance: playlist not found name=%s",
                 sanitize_log_field(playlist_name),
             )
-            return json_error(_ERR_PLAYLIST_NOT_FOUND, status=400)
+            raise ResourceLookupError(_ERR_PLAYLIST_NOT_FOUND, status=400)
 
         plugin_instance = playlist.find_plugin(plugin_id, plugin_instance_name)
         if not plugin_instance:
@@ -507,7 +520,7 @@ def display_plugin_instance():
                 sanitize_log_field(plugin_id),
                 sanitize_log_field(plugin_instance_name),
             )
-            return json_error(
+            raise ResourceLookupError(
                 _ERR_PLUGIN_INSTANCE_NOT_FOUND,
                 status=400,
             )
@@ -515,8 +528,6 @@ def display_plugin_instance():
         refresh_task.manual_update(
             PlaylistRefresh(playlist, plugin_instance, force=True)
         )
-    except Exception:
-        return json_error(_ERR_INTERNAL, status=500)
 
     return json_success(message=_MSG_DISPLAY_UPDATED)
 

--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -6,7 +6,8 @@ from zoneinfo import available_timezones
 from flask import current_app, redirect, render_template, request
 
 import blueprints.settings as _mod
-from utils.http_utils import json_error, json_internal_error, json_success
+from utils.backend_errors import ClientInputError, route_error_boundary
+from utils.http_utils import json_error, json_success
 from utils.time_utils import calculate_seconds
 
 _DEVICE_NAME_MAX_LEN = 64
@@ -59,7 +60,11 @@ def plugin_isolation():
 
 @_mod.settings_bp.route("/settings/safe_reset", methods=["POST"])
 def safe_reset():
-    try:
+    with route_error_boundary(
+        "safe reset",
+        logger=_mod.logger,
+        hint="Check config readability and write permissions.",
+    ):
         device_config = current_app.config["DEVICE_CONFIG"]
         config = device_config.get_config().copy()
         keep = {
@@ -79,8 +84,6 @@ def safe_reset():
         keep["isolated_plugins"] = []
         device_config.update_config(keep)
         return json_success(message="Safe reset applied.")
-    except Exception as e:
-        return json_internal_error("safe reset", details={"error": str(e)})
 
 
 @_mod.settings_bp.route("/settings", methods=["GET"])
@@ -137,7 +140,11 @@ def _include_export_keys() -> bool:
     "/settings/export", methods=["POST"], endpoint="export_settings_post"
 )
 def export_settings():
-    try:
+    with route_error_boundary(
+        "export settings",
+        logger=_mod.logger,
+        hint="Check config readability.",
+    ):
         include_keys = _include_export_keys()
         device_config = current_app.config["DEVICE_CONFIG"]
 
@@ -166,12 +173,6 @@ def export_settings():
 
         # JSON response for now; a file download route can be added if needed
         return json_success(data=data)
-    except Exception as e:
-        _mod.logger.exception("Error exporting settings")
-        return json_internal_error(
-            "export settings",
-            details={"hint": "Check config readability.", "error": str(e)},
-        )
 
 
 def _extract_import_payload():
@@ -194,12 +195,16 @@ def _extract_import_payload():
 
 @_mod.settings_bp.route("/settings/import", methods=["POST"])
 def import_settings():
-    try:
+    with route_error_boundary(
+        "import settings",
+        logger=_mod.logger,
+        hint="Verify JSON structure and file permissions.",
+    ):
         device_config = current_app.config["DEVICE_CONFIG"]
         # Accept JSON body or form upload with a JSON file
         payload = _extract_import_payload()
         if payload is None:
-            return json_error("Invalid import payload", status=400)
+            raise ClientInputError("Invalid import payload", status=400)
 
         cfg = payload.get("config")
         if isinstance(cfg, dict):
@@ -220,15 +225,6 @@ def import_settings():
                     _mod.logger.exception("Failed setting env key during import: %s", k)
 
         return json_success(message="Import completed")
-    except Exception as e:
-        _mod.logger.exception("Error importing settings")
-        return json_internal_error(
-            "import settings",
-            details={
-                "hint": "Verify JSON structure and file permissions.",
-                "error": str(e),
-            },
-        )
 
 
 @_mod.settings_bp.route("/settings/api-keys", methods=["GET"])
@@ -276,7 +272,11 @@ def api_keys_page():
 @_mod.settings_bp.route("/settings/save_api_keys", methods=["POST"])
 def save_api_keys():
     device_config = current_app.config["DEVICE_CONFIG"]
-    try:
+    with route_error_boundary(
+        "saving API keys",
+        logger=_mod.logger,
+        hint="Ensure .env is writable and values are valid; check disk space and permissions.",
+    ):
         form_data = request.form.to_dict()
         updated = []
         skipped_placeholder = []
@@ -318,14 +318,6 @@ def save_api_keys():
         if skipped_placeholder:
             extra["skipped_placeholder"] = skipped_placeholder
         return json_success(message="API keys saved.", **extra)
-    except Exception:
-        _mod.logger.exception("Error saving API keys")
-        return json_internal_error(
-            "saving API keys",
-            details={
-                "hint": "Ensure .env is writable and values are valid; check disk space/permissions.",
-            },
-        )
 
 
 @_mod.settings_bp.route("/settings/delete_api_key", methods=["POST"])
@@ -341,16 +333,14 @@ def delete_api_key():
         "GOOGLE_AI_SECRET",
     }
     if key not in valid_keys:
-        return json_error("Invalid key name", status=400)
-    try:
+        raise ClientInputError("Invalid key name", status=400)
+    with route_error_boundary(
+        "deleting API key",
+        logger=_mod.logger,
+        hint="Verify .env file permissions and that the key exists.",
+    ):
         device_config.unset_env_key(key)
         return json_success(message=f"Deleted {key}.")
-    except Exception:
-        _mod.logger.exception("Error deleting API key")
-        return json_internal_error(
-            "deleting API key",
-            details={"hint": "Verify .env file permissions and key exists."},
-        )
 
 
 def _field_error(message, field):
@@ -532,7 +522,11 @@ def _build_settings_dict(form_data, normalized_device_name):
 def save_settings():
     device_config = current_app.config["DEVICE_CONFIG"]
 
-    try:
+    with route_error_boundary(
+        "saving device settings",
+        logger=_mod.logger,
+        hint="Check numeric values and config file permissions.",
+    ):
         form_data = request.form.to_dict()
 
         error, normalized_device_name = _validate_settings_form(form_data)
@@ -551,16 +545,6 @@ def save_settings():
             # wake the background thread up to signal interval config change
             refresh_task = current_app.config["REFRESH_TASK"]
             refresh_task.signal_config_change()
-    except RuntimeError:
-        return json_error(
-            "An internal error occurred", status=500, code="internal_error"
-        )
-    except Exception:
-        _mod.logger.exception("Error saving device settings")
-        return json_internal_error(
-            "saving device settings",
-            details={"hint": "Check numeric values and config file permissions."},
-        )
     return json_success(message="Saved settings.")
 
 

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -8,7 +8,12 @@ from werkzeug.exceptions import BadRequest
 
 import blueprints.settings as _mod
 from blueprints.settings._update_status import read_last_update_failure
-from utils.http_utils import json_error, json_internal_error, json_success
+from utils.backend_errors import (
+    ClientInputError,
+    ConflictRouteError,
+    route_error_boundary,
+)
+from utils.http_utils import json_error, json_success
 
 
 def _prev_version_path() -> str:
@@ -48,7 +53,11 @@ def start_update():
     specific tag.  Returns JSON immediately; progress is visible in the Logs
     panel via /api/logs.
     """
-    try:
+    with route_error_boundary(
+        "start update",
+        logger=_mod.logger,
+        hint="Check update script availability and update process startup.",
+    ):
         # Accept optional target tag from JSON body before acquiring the lock so
         # we can validate it without holding the lock longer than necessary.
         target_tag: str | None = None
@@ -57,9 +66,9 @@ def start_update():
             try:
                 body = request.get_json(silent=False)
             except BadRequest:
-                return json_error("Invalid JSON payload", status=400)
+                raise ClientInputError("Invalid JSON payload", status=400)
             if not isinstance(body, dict):
-                return json_error("Request body must be a JSON object", status=400)
+                raise ClientInputError("Request body must be a JSON object", status=400)
         else:
             body = {}
 
@@ -72,19 +81,19 @@ def start_update():
         if "target_version" in body:
             raw = body.get("target_version")
             if raw is None or not isinstance(raw, str) or not raw.strip():
-                return json_error(
+                raise ClientInputError(
                     "target_version must be a non-empty string",
                     status=400,
                     code="validation_error",
-                    details={"field": "target_version"},
+                    field="target_version",
                 )
             target_tag = raw.strip()
             if not _mod._TAG_RE.fullmatch(target_tag):
-                return json_error(
+                raise ClientInputError(
                     "Invalid target version format",
                     status=400,
                     code="validation_error",
-                    details={"field": "target_version"},
+                    field="target_version",
                 )
 
         script_path = _mod._get_update_script_path()
@@ -141,14 +150,15 @@ def start_update():
             running=True,
             unit=_mod._UPDATE_STATE.get("unit"),
         )
-    except Exception as e:
-        _mod.logger.exception("/settings/update error")
-        return json_internal_error("start update", details={"error": str(e)})
 
 
 @_mod.settings_bp.route("/settings/update_status", methods=["GET"])
 def update_status():
-    try:
+    with route_error_boundary(
+        "update status",
+        logger=_mod.logger,
+        hint="Check systemd status access and last-update metadata files.",
+    ):
         import subprocess
 
         running = bool(_mod._UPDATE_STATE.get("running"))
@@ -208,8 +218,6 @@ def update_status():
                 "prev_version": prev_version,
             }
         )
-    except Exception as e:
-        return json_internal_error("update status", details={"error": str(e)})
 
 
 @_mod.settings_bp.route("/settings/update/rollback", methods=["POST"])
@@ -233,81 +241,89 @@ def start_rollback():
     rollback itself fails.
     """
     try:
-        # 1. Require a recorded last-update-failure.  Without one, a rollback
-        #    would be reverting a healthy install — refuse.
-        last_failure = read_last_update_failure()
-        if not last_failure:
-            return json_error(
-                "No failed update recorded; nothing to roll back.",
-                status=409,
-                code="no_failure",
-            )
-
-        # 2. Require a validated prev_version breadcrumb.
-        prev_version = _read_prev_version()
-        if not prev_version:
-            return json_error(
-                "No previous version recorded; cannot roll back.",
-                status=409,
-                code="no_prev_version",
-            )
-
-        use_systemd = _mod._systemd_available()
-        unit = f"inkypi-rollback-{int(time.time())}"
-
-        # 3. TOCTOU-safe check-and-set — mirror start_update's pattern so two
-        #    concurrent rollback clicks can't both pass the guard.
-        with _mod._update_lock:
-            if _mod._UPDATE_STATE.get("running"):
-                response, _ = json_error(
-                    "Update or rollback already in progress.", status=409
+        with route_error_boundary(
+            "start rollback",
+            logger=_mod.logger,
+            hint="Check rollback prerequisites and update runner availability.",
+        ):
+            # 1. Require a recorded last-update-failure.  Without one, a rollback
+            #    would be reverting a healthy install — refuse.
+            last_failure = read_last_update_failure()
+            if not last_failure:
+                raise ConflictRouteError(
+                    "No failed update recorded; nothing to roll back.",
+                    status=409,
+                    code="no_failure",
                 )
-                payload = response.get_json()
-                payload["running"] = True
-                payload["unit"] = _mod._UPDATE_STATE.get("unit")
-                return jsonify(payload), 409
-            new_unit = f"{unit}.service" if use_systemd else None
-            _mod._UPDATE_STATE["running"] = True
-            _mod._UPDATE_STATE["unit"] = new_unit
-            _mod._UPDATE_STATE["started_at"] = float(time.time())
 
-        if use_systemd:
-            try:
-                _mod._start_rollback_via_systemd()
-            except Exception:
-                _mod.logger.exception(
-                    "systemd-run failed for rollback; clearing running state"
+            # 2. Require a validated prev_version breadcrumb.
+            prev_version = _read_prev_version()
+            if not prev_version:
+                raise ConflictRouteError(
+                    "No previous version recorded; cannot roll back.",
+                    status=409,
+                    code="no_prev_version",
                 )
-                _mod._set_update_state(False, None)
-                return json_internal_error("start rollback")
-        else:
-            # Dev / macOS path: reuse the simulated update runner so the UI
-            # still sees log output.  Production Pi always has systemd.
-            _mod._start_update_fallback_thread(None, target_tag=prev_version)
 
-        # JTN-708: 202 Accepted lets clients/tests distinguish "rollback
-        # kicked off" from a synchronous reply; the UI polls
-        # /settings/update_status for completion.
-        return json_success(
-            message=(
-                f"Rollback to {prev_version} started. "
-                "Watch the Logs panel for progress."
-            ),
-            status=202,
-            running=True,
-            unit=_mod._UPDATE_STATE.get("unit"),
-            target_version=prev_version,
-        )
-    except Exception as e:
-        _mod.logger.exception("/settings/update/rollback error")
+            use_systemd = _mod._systemd_available()
+            unit = f"inkypi-rollback-{int(time.time())}"
+
+            # 3. TOCTOU-safe check-and-set — mirror start_update's pattern so two
+            #    concurrent rollback clicks can't both pass the guard.
+            with _mod._update_lock:
+                if _mod._UPDATE_STATE.get("running"):
+                    response, _ = json_error(
+                        "Update or rollback already in progress.", status=409
+                    )
+                    payload = response.get_json()
+                    payload["running"] = True
+                    payload["unit"] = _mod._UPDATE_STATE.get("unit")
+                    return jsonify(payload), 409
+                new_unit = f"{unit}.service" if use_systemd else None
+                _mod._UPDATE_STATE["running"] = True
+                _mod._UPDATE_STATE["unit"] = new_unit
+                _mod._UPDATE_STATE["started_at"] = float(time.time())
+
+            if use_systemd:
+                try:
+                    _mod._start_rollback_via_systemd()
+                except Exception:
+                    _mod.logger.exception(
+                        "systemd-run failed for rollback; clearing running state"
+                    )
+                    _mod._set_update_state(False, None)
+                    raise
+            else:
+                # Dev / macOS path: reuse the simulated update runner so the UI
+                # still sees log output.  Production Pi always has systemd.
+                _mod._start_update_fallback_thread(None, target_tag=prev_version)
+
+            # JTN-708: 202 Accepted lets clients/tests distinguish "rollback
+            # kicked off" from a synchronous reply; the UI polls
+            # /settings/update_status for completion.
+            return json_success(
+                message=(
+                    f"Rollback to {prev_version} started. "
+                    "Watch the Logs panel for progress."
+                ),
+                status=202,
+                running=True,
+                unit=_mod._UPDATE_STATE.get("unit"),
+                target_version=prev_version,
+            )
+    except Exception:
         _mod._set_update_state(False, None)
-        return json_internal_error("start rollback", details={"error": str(e)})
+        raise
 
 
 @_mod.settings_bp.route("/api/version", methods=["GET"])
 def api_version():
     """Return current and latest version info."""
-    try:
+    with route_error_boundary(
+        "version check",
+        logger=_mod.logger,
+        hint="Check release metadata retrieval and semver parsing.",
+    ):
         current = current_app.config.get("APP_VERSION", "unknown")
         latest = _mod._check_latest_version()
         update_available = False
@@ -322,5 +338,3 @@ def api_version():
                 "release_notes": _mod._VERSION_CACHE.get("release_notes"),
             }
         )
-    except Exception as e:
-        return json_internal_error("version check", details={"error": str(e)})

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -65,8 +65,8 @@ def start_update():
         if request.is_json and raw_body.strip():
             try:
                 body = request.get_json(silent=False)
-            except BadRequest:
-                raise ClientInputError("Invalid JSON payload", status=400)
+            except BadRequest as exc:
+                raise ClientInputError("Invalid JSON payload", status=400) from exc
             if not isinstance(body, dict):
                 raise ClientInputError("Request body must be a JSON object", status=400)
         else:

--- a/src/utils/backend_errors.py
+++ b/src/utils/backend_errors.py
@@ -1,0 +1,162 @@
+"""Typed backend route errors and a shared boundary for JSON handlers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from utils.http_utils import APIError
+
+
+class BackendRouteError(APIError):
+    """Base class for backend route errors with an explicit category."""
+
+    category = "backend"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int,
+        code: int | str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, status=status, code=code, details=details)
+
+
+class ClientInputError(BackendRouteError):
+    """Client payload, form, or validation failure."""
+
+    category = "client_input"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int = 400,
+        code: int | str | None = None,
+        details: dict[str, Any] | None = None,
+        field: str | None = None,
+    ) -> None:
+        merged_details = dict(details or {})
+        if field is not None:
+            merged_details.setdefault("field", field)
+        effective_details = merged_details or None
+        super().__init__(
+            message,
+            status=status,
+            code=code,
+            details=effective_details,
+        )
+
+
+class ResourceLookupError(BackendRouteError):
+    """Requested server-side resource could not be resolved."""
+
+    category = "resource_lookup"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int = 404,
+        code: int | str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, status=status, code=code, details=details)
+
+
+class ConflictRouteError(BackendRouteError):
+    """Request conflicts with current server state."""
+
+    category = "conflict"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int = 409,
+        code: int | str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, status=status, code=code, details=details)
+
+
+class UnsupportedMediaTypeRouteError(BackendRouteError):
+    """Request body/content type is unsupported."""
+
+    category = "unsupported_media_type"
+
+    def __init__(
+        self,
+        message: str = "Unsupported media type",
+        *,
+        code: int | str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, status=415, code=code, details=details)
+
+
+class OperationFailedError(BackendRouteError):
+    """Backend operation reported failure without throwing."""
+
+    category = "operation_failed"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int = 500,
+        code: int | str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, status=status, code=code, details=details)
+
+
+class InternalOperationError(BackendRouteError):
+    """Unexpected backend failure surfaced through the canonical JSON envelope."""
+
+    category = "internal"
+
+    def __init__(
+        self,
+        context: str,
+        *,
+        message: str = "An internal error occurred",
+        status: int = 500,
+        code: int | str | None = "internal_error",
+        hint: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        merged_details: dict[str, Any] = {"context": context}
+        if hint is not None:
+            merged_details["hint"] = hint
+        if details:
+            merged_details.update(details)
+        super().__init__(message, status=status, code=code, details=merged_details)
+
+
+@contextmanager
+def route_error_boundary(
+    context: str,
+    *,
+    logger: logging.Logger | None = None,
+    hint: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> Iterator[None]:
+    """Wrap a route body and convert unexpected exceptions to InternalOperationError."""
+
+    try:
+        yield
+    except APIError:
+        raise
+    except Exception as err:
+        if logger is not None:
+            logger.exception("%s", context)
+        raise InternalOperationError(
+            context,
+            hint=hint,
+            details=details,
+        ) from err

--- a/tests/integration/test_playlist_more.py
+++ b/tests/integration/test_playlist_more.py
@@ -407,7 +407,10 @@ def test_create_playlist_exception_handling(client, flask_app, monkeypatch):
         json={"playlist_name": "Test", "start_time": "06:00", "end_time": "09:00"},
     )
     assert resp.status_code == 500
-    assert "An internal error occurred" in resp.get_json().get("error", "")
+    body = resp.get_json()
+    assert body.get("error") == "An internal error occurred"
+    assert body.get("code") == "internal_error"
+    assert body.get("details", {}).get("context") == "create playlist"
 
 
 def test_update_playlist_rejects_equal_start_end(client):

--- a/tests/integration/test_plugin_routes.py
+++ b/tests/integration/test_plugin_routes.py
@@ -81,7 +81,10 @@ def test_delete_plugin_instance_exception_handling(client, flask_app, monkeypatc
         },
     )
     assert resp.status_code == 500
-    assert "An internal error occurred" in resp.get_json().get("error", "")
+    body = resp.get_json()
+    assert body.get("error") == "An internal error occurred"
+    assert body.get("code") == "internal_error"
+    assert body.get("details", {}).get("context") == "delete plugin instance"
 
 
 def test_update_plugin_instance_missing_instance_name(client):
@@ -136,7 +139,10 @@ def test_update_plugin_instance_exception_handling(client, flask_app, monkeypatc
 
     resp = client.put("/update_plugin_instance/test", data={"plugin_id": "ai_text"})
     assert resp.status_code == 500
-    assert "An internal error occurred" in resp.get_json().get("error", "")
+    body = resp.get_json()
+    assert body.get("error") == "An internal error occurred"
+    assert body.get("code") == "internal_error"
+    assert body.get("details", {}).get("context") == "update plugin instance"
 
 
 def test_display_plugin_instance_invalid_json(client):
@@ -221,7 +227,10 @@ def test_display_plugin_instance_exception_handling(client, flask_app, monkeypat
         },
     )
     assert resp.status_code == 500
-    assert "An internal error occurred" in resp.get_json().get("error", "")
+    body = resp.get_json()
+    assert body.get("error") == "An internal error occurred"
+    assert body.get("code") == "internal_error"
+    assert body.get("details", {}).get("context") == "display plugin instance"
 
 
 def test_update_now_plugin_not_found(client):

--- a/tests/integration/test_settings_more.py
+++ b/tests/integration/test_settings_more.py
@@ -261,6 +261,7 @@ def test_save_settings_exception_handling(client, flask_app, monkeypatch):
     body = resp.get_json()
     assert body.get("error") == "An internal error occurred"
     assert body.get("code") == "internal_error"
+    assert body.get("details", {}).get("context") == "saving device settings"
 
 
 def test_shutdown_route_reboot(client, monkeypatch):

--- a/tests/unit/test_backend_errors.py
+++ b/tests/unit/test_backend_errors.py
@@ -1,0 +1,60 @@
+# pyright: reportMissingImports=false
+"""Tests for the backend error taxonomy helpers."""
+
+import pytest
+from flask import Flask
+
+from utils.backend_errors import (
+    ClientInputError,
+    InternalOperationError,
+    route_error_boundary,
+)
+
+
+@pytest.fixture
+def app():
+    return Flask(__name__)
+
+
+def test_client_input_error_adds_field_details():
+    err = ClientInputError(
+        "Bad input",
+        status=422,
+        code="validation_error",
+        field="plugin_id",
+    )
+
+    assert err.status == 422
+    assert err.code == "validation_error"
+    assert err.details == {"field": "plugin_id"}
+
+
+def test_internal_operation_error_uses_internal_error_envelope(app):
+    with app.app_context():
+        err = InternalOperationError(
+            "save widget",
+            hint="Check filesystem permissions.",
+        )
+        assert err.status == 500
+        assert err.message == "An internal error occurred"
+        assert err.code == "internal_error"
+        assert err.details == {
+            "context": "save widget",
+            "hint": "Check filesystem permissions.",
+        }
+
+
+def test_route_error_boundary_wraps_unexpected_errors():
+    with pytest.raises(InternalOperationError) as exc_info:
+        with route_error_boundary("sync widgets"):
+            raise RuntimeError("boom")
+
+    err = exc_info.value
+    assert err.code == "internal_error"
+    assert err.details == {"context": "sync widgets"}
+
+
+def test_route_error_boundary_passthroughs_api_errors():
+    with pytest.raises(ClientInputError):
+        with route_error_boundary("sync widgets"):
+            raise ClientInputError("Bad input", status=400)

--- a/tests/unit/test_updates_rollback_route.py
+++ b/tests/unit/test_updates_rollback_route.py
@@ -439,6 +439,10 @@ class TestRollbackRouteErrorPaths:
         try:
             resp = client.post("/settings/update/rollback")
             assert resp.status_code == 500
+            body = resp.get_json()
+            assert body["error"] == "An internal error occurred"
+            assert body["code"] == "internal_error"
+            assert body["details"]["context"] == "start rollback"
             # State must be cleared so a subsequent rollback isn't locked out.
             assert mod._UPDATE_STATE["running"] is False
         finally:


### PR DESCRIPTION
## Summary
- implement grade `B1` by adding a typed backend route error taxonomy and shared `route_error_boundary(...)`
- replace blanket route-level `except Exception` handling across touched playlist, plugin, and settings routes with explicit typed failures
- preserve the canonical JSON envelope while standardizing internal error `details.context` and `details.hint`
- add unit and integration coverage for the taxonomy plus the refactored routes

## Test plan
- `python3 -m py_compile src/utils/backend_errors.py src/blueprints/plugin.py src/blueprints/playlist.py src/blueprints/settings/_config.py src/blueprints/settings/_updates.py tests/unit/test_backend_errors.py tests/integration/test_plugin_routes.py tests/integration/test_playlist_more.py tests/integration/test_settings_more.py tests/unit/test_updates_rollback_route.py`
- `python3 -m pytest tests/unit/test_backend_errors.py tests/integration/test_plugin_routes.py tests/integration/test_playlist_more.py tests/integration/test_settings_more.py tests/unit/test_settings_save.py tests/unit/test_settings_import.py tests/unit/test_settings_update.py tests/unit/test_settings_updates.py tests/unit/test_updates_rollback_route.py`
- `bash scripts/test.sh tests/integration/test_playlist_coverage.py tests/integration/test_settings_update_flows.py tests/integration/test_display_plugin_instance_errors.py tests/contracts/test_json_envelope.py tests/integration/test_jtn_381_refresh_settings_validation.py tests/integration/test_playlist_xss.py tests/integration/test_playlist_more.py`
