### PR TITLE
ci: make install matrix a reusable required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,85 +677,10 @@ jobs:
           if-no-files-found: ignore
 
   install-matrix:
-    # JTN-530: end-to-end install.sh matrix against every supported Pi OS base.
-    # JTN-528 silently broke Trixie installs for an entire release cycle
-    # because no CI job ran install.sh against each OS. This job guarantees
-    # that never happens again: every PR runs the real install.sh inside an
-    # arm64 Debian container (with the Pi OS apt repo layered on for
-    # liblgpio-dev / chromium-headless-shell) for each codename and asserts
-    # exit 0 + venv + systemd unit parse.
-    #
-    # The Dockerfile is scripts/Dockerfile.install-matrix; the verification
-    # script that runs inside the container is scripts/ci_install_matrix_verify.sh.
-    # Memory is capped at 512 MB to inherit the JTN-536 OOM regression gate so
-    # this job also catches codename-specific OOMs during install.
-    #
-    # JTN-615: bullseye (Debian 11) ships Python 3.9.2 but InkyPi's
-    # requirements.txt pins packages that require Python>=3.10 (anyio==4.13.0
-    # is the first to bomb the uv resolver; others follow). The project also
-    # declares `target-version = "py311"` in pyproject.toml's ruff + black
-    # config, so bullseye has never been a real install target — the matrix
-    # only appeared to cover it historically because install.sh silently
-    # swallowed uv/pip failures (see JTN-615 root cause analysis). Dropping
-    # bullseye here reflects reality; the standalone Install matrix (arm64 e2e)
-    # workflow still runs bullseye via test_install_memcap.sh, which uses a
-    # python:3.12-slim base image and therefore isn't blocked by Debian 11's
-    # interpreter version.
-    name: Install matrix (${{ matrix.codename }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        codename: [bookworm, trixie]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build install-matrix image (${{ matrix.codename }})
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: scripts/Dockerfile.install-matrix
-          platforms: linux/arm64
-          build-args: |
-            CODENAME=${{ matrix.codename }}
-          tags: inkypi-install-matrix:${{ matrix.codename }}
-          load: true
-          cache-from: type=gha,scope=install-matrix-${{ matrix.codename }}
-          cache-to: type=gha,mode=max,scope=install-matrix-${{ matrix.codename }}
-
-      - name: Run install.sh + verification (${{ matrix.codename }}, 512 MB cap)
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/install-matrix-logs
-          # JTN-536 parity: cap container memory at 512 MB to mimic the Pi
-          # Zero 2 W. Exit 137 = OOM kill = regression.
-          docker run \
-            --rm \
-            --platform linux/arm64 \
-            --memory=512m \
-            --memory-swap=512m \
-            --entrypoint bash \
-            inkypi-install-matrix:${{ matrix.codename }} \
-            /InkyPi/scripts/ci_install_matrix_verify.sh \
-            2>&1 | tee "/tmp/install-matrix-logs/${{ matrix.codename }}.log"
-
-      - name: Upload container logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: install-matrix-logs-${{ matrix.codename }}
-          path: /tmp/install-matrix-logs
-          if-no-files-found: ignore
+    # Keep the required install matrix in a reusable workflow so ci.yml and any
+    # manual reruns share one implementation instead of drifting apart.
+    name: Install matrix
+    uses: ./.github/workflows/install-matrix.yml
 
   install-smoke-memcap:
     name: Install smoke (512 MB memory cap)

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -1,26 +1,17 @@
-name: Install matrix (arm64 e2e)
+name: Install matrix
 
-# JTN-530: Run install/install.sh end-to-end inside an arm64 Debian container
-# under a 512 MB memory cap for each supported Pi OS base (Bullseye, Bookworm,
-# Trixie). JTN-528 (a Trixie zramswap regression) went undetected for an entire
-# release cycle because no CI job exercised the install script on each base.
-# This matrix closes that gap.
+# JTN-530: end-to-end install.sh matrix against every supported Pi OS base.
+# JTN-528 silently broke Trixie installs for an entire release cycle because
+# no CI job ran install.sh against each OS.
 #
-# Wraps scripts/test_install_memcap.sh, which already accepts the codename as
-# its first positional argument and runs the same Phase 2/3/4 install + boot
-# probes used by the existing single-codename install-smoke-memcap job in
-# ci.yml.
-#
-# This workflow is intentionally a standalone advisory job for now — it is not
-# wired into the ci-gate `needs:` list. A follow-up ticket can promote it to
-# required once we've watched it run green for a few cycles. Each matrix cell
-# runs install.sh under arm64 QEMU emulation, which is slow (hence the 30 min
-# timeout per codename).
+# This workflow is now the single source of truth for that gate. `ci.yml` calls
+# it via `workflow_call`, which makes the install matrix part of the default PR
+# merge contract through `ci-gate`, while `workflow_dispatch` keeps the exact
+# same path available for manual reruns without duplicating logic.
 
 on:
-  pull_request:
-  push:
-    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -31,13 +22,30 @@ concurrency:
 
 jobs:
   install-matrix:
+    # JTN-530: guarantee every PR runs the real install.sh inside an arm64
+    # Debian container (with the Pi OS apt repo layered on for liblgpio-dev /
+    # chromium-headless-shell) for each supported codename and asserts exit 0
+    # + venv + systemd unit parse.
+    #
+    # The Dockerfile is scripts/Dockerfile.install-matrix; the verification
+    # script that runs inside the container is scripts/ci_install_matrix_verify.sh.
+    # Memory is capped at 512 MB to inherit the JTN-536 OOM regression gate so
+    # this job also catches codename-specific OOMs during install.
+    #
+    # JTN-615: bullseye (Debian 11) ships Python 3.9.2 but InkyPi's
+    # requirements.txt pins packages that require Python>=3.10 (anyio==4.13.0
+    # is the first to bomb the uv resolver; others follow). The project also
+    # declares `target-version = "py311"` in pyproject.toml's ruff + black
+    # config, so bullseye has never been a real install target. Keeping the PR
+    # gate on bookworm + trixie reflects reality; broader drift coverage still
+    # lives in the nightly matrix and the separate memcap smoke coverage.
     name: install.sh e2e (${{ matrix.codename }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        codename: [bullseye, bookworm, trixie]
+        codename: [bookworm, trixie]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,14 +55,42 @@ jobs:
         with:
           platforms: arm64
 
-      - name: Run install smoke test (${{ matrix.codename }})
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build install-matrix image (${{ matrix.codename }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: scripts/Dockerfile.install-matrix
+          platforms: linux/arm64
+          build-args: |
+            CODENAME=${{ matrix.codename }}
+          tags: inkypi-install-matrix:${{ matrix.codename }}
+          load: true
+          cache-from: type=gha,scope=install-matrix-${{ matrix.codename }}
+          cache-to: type=gha,mode=max,scope=install-matrix-${{ matrix.codename }}
+
+      - name: Run install.sh + verification (${{ matrix.codename }}, 512 MB cap)
         run: |
-          ./scripts/test_install_memcap.sh ${{ matrix.codename }}
+          set -euo pipefail
+          mkdir -p /tmp/install-matrix-logs
+          # JTN-536 parity: cap container memory at 512 MB to mimic the Pi
+          # Zero 2 W. Exit 137 = OOM kill = regression.
+          docker run \
+            --rm \
+            --platform linux/arm64 \
+            --memory=512m \
+            --memory-swap=512m \
+            --entrypoint bash \
+            inkypi-install-matrix:${{ matrix.codename }} \
+            /InkyPi/scripts/ci_install_matrix_verify.sh \
+            2>&1 | tee "/tmp/install-matrix-logs/${{ matrix.codename }}.log"
 
       - name: Upload container logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: install-matrix-${{ matrix.codename }}-logs
-          path: /tmp/inkypi-smoke-logs
+          name: install-matrix-logs-${{ matrix.codename }}
+          path: /tmp/install-matrix-logs
           if-no-files-found: ignore

--- a/docs/development.md
+++ b/docs/development.md
@@ -195,9 +195,9 @@ To stop the container, press `Ctrl+C` or run `docker compose down`.
 
 ## CI Gate and Required Status Checks
 
-The CI workflow includes a `ci-gate` job that depends on all required jobs — including
-`lockfile-drift`, `security`, and `browser-smoke`. This job is the single handle the repo
-owner should mark as a required status check in GitHub branch protection.
+The CI workflow includes a `ci-gate` job that depends on all required jobs, including the
+install gates. This job is the single handle the repo owner should mark as a required
+status check in GitHub branch protection.
 
 Frontend changes under `src/static/**` or `src/templates/**` also trigger the local
 pre-commit browser gate, which runs `scripts/test.sh browser-smoke` before the commit is
@@ -215,9 +215,8 @@ allowed through.
 6. Click **Save changes**.
 
 Once saved, every PR must have a green `ci-gate` result before it can be merged. Because
-`ci-gate` itself `needs: [lint, shellcheck, tests, sonarcloud, smoke, smoke-matrix,
-coverage-gate, security, browser-smoke]`, any failure in any of those jobs will also fail
-the gate.
+`ci-gate` mirrors the required-job list in `.github/workflows/ci.yml`, any required-job
+failure will also fail the gate.
 
 > **Why a single gate job instead of listing each check?**
 > GitHub's required-checks list is static — adding a new CI job requires a manual settings

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -2452,38 +2452,55 @@ class TestInstallMatrixWorkflow:
     @pytest.fixture(autouse=True)
     def _load(self):
         self.ci_yaml = (WORKFLOWS_DIR / "ci.yml").read_text()
+        # JTN-616: the install matrix now lives in a reusable workflow that
+        # ci.yml calls via `workflow_call`. Structural assertions about the
+        # matrix body (codenames, arm64 platform, 512 MB cap, verify script)
+        # must inspect install-matrix.yml directly, while ci.yml is only
+        # asserted to wire the reusable workflow in as a required gate.
+        self.install_matrix_yaml = (
+            WORKFLOWS_DIR / "install-matrix.yml"
+        ).read_text()
         self.dockerfile = (SCRIPTS_DIR / "Dockerfile.install-matrix").read_text()
         self.verify_script = (SCRIPTS_DIR / "ci_install_matrix_verify.sh").read_text()
 
     def test_install_matrix_job_defined(self):
         assert "install-matrix:" in self.ci_yaml
 
+    def test_install_matrix_wired_as_reusable_workflow(self):
+        # JTN-616: ci.yml must call the reusable install-matrix workflow so
+        # the PR gate and manual reruns share a single implementation.
+        import yaml
+
+        data = yaml.safe_load(self.ci_yaml)
+        job = data["jobs"]["install-matrix"]
+        assert job.get("uses") == "./.github/workflows/install-matrix.yml"
+
     def test_install_matrix_references_supported_os_bases(self):
-        # JTN-615: bullseye was removed from the ci.yml install-matrix
-        # because Debian 11 ships Python 3.9.2 while InkyPi's requirements
-        # pin packages that need Python>=3.10 (anyio==4.13.0 is the first
-        # to bomb the uv resolver). pyproject.toml also targets py311. The
+        # JTN-615: bullseye was removed from the install-matrix because
+        # Debian 11 ships Python 3.9.2 while InkyPi's requirements pin
+        # packages that need Python>=3.10 (anyio==4.13.0 is the first to
+        # bomb the uv resolver). pyproject.toml also targets py311. The
         # standalone Install matrix (arm64 e2e) workflow still exercises
         # bullseye via test_install_memcap.sh because that path uses a
         # python:3.12-slim base image and therefore isn't blocked by the
         # codename's own interpreter version.
         import yaml
 
-        data = yaml.safe_load(self.ci_yaml)
+        data = yaml.safe_load(self.install_matrix_yaml)
         job = data["jobs"]["install-matrix"]
         codenames = job["strategy"]["matrix"]["codename"]
         assert set(codenames) == {"bookworm", "trixie"}
 
     def test_install_matrix_runs_on_arm64(self):
-        assert "linux/arm64" in self.ci_yaml
-        assert "setup-qemu-action" in self.ci_yaml
+        assert "linux/arm64" in self.install_matrix_yaml
+        assert "setup-qemu-action" in self.install_matrix_yaml
 
     def test_install_matrix_uses_512m_memory_cap(self):
-        assert "--memory=512m" in self.ci_yaml
-        assert "--memory-swap=512m" in self.ci_yaml
+        assert "--memory=512m" in self.install_matrix_yaml
+        assert "--memory-swap=512m" in self.install_matrix_yaml
 
     def test_install_matrix_invokes_verify_script(self):
-        assert "ci_install_matrix_verify.sh" in self.ci_yaml
+        assert "ci_install_matrix_verify.sh" in self.install_matrix_yaml
 
     def test_install_matrix_feeds_ci_gate(self):
         import yaml

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -2457,9 +2457,7 @@ class TestInstallMatrixWorkflow:
         # matrix body (codenames, arm64 platform, 512 MB cap, verify script)
         # must inspect install-matrix.yml directly, while ci.yml is only
         # asserted to wire the reusable workflow in as a required gate.
-        self.install_matrix_yaml = (
-            WORKFLOWS_DIR / "install-matrix.yml"
-        ).read_text()
+        self.install_matrix_yaml = (WORKFLOWS_DIR / "install-matrix.yml").read_text()
         self.dockerfile = (SCRIPTS_DIR / "Dockerfile.install-matrix").read_text()
         self.verify_script = (SCRIPTS_DIR / "ci_install_matrix_verify.sh").read_text()
 


### PR DESCRIPTION
## Summary
- implement grade `D1` by moving the install-matrix implementation into a reusable workflow
- call the reusable workflow from `ci.yml` so the required CI path and manual reruns share one source of truth
- keep `install-matrix` in `ci-gate` so it remains part of the protected merge path
- clean up the development docs so they stop hard-coding a stale CI job list

## Test plan
- `python3 - <<'PY'` YAML parse check for `.github/workflows/ci.yml` and `.github/workflows/install-matrix.yml`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest .github/workflows/ci.yml .github/workflows/install-matrix.yml`

## Notes
- `actionlint` only reported two pre-existing `SC2034` shellcheck warnings in unrelated `ci.yml` script blocks (lines 257 and 340); no install-matrix wiring issues were reported.
