### PR TITLE
chore: ratchet mypy src baseline in lint

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -3,7 +3,9 @@
 InkyPi uses [mypy](https://mypy.readthedocs.io/) for static type analysis.
 Rather than enabling strict mode everywhere at once, we follow an **incremental
 strict** path: a small "strict subset" is enforced as a CI blocker today, with
-more modules added over time as they stabilize.
+more modules added over time as they stabilize. The broader `src/` check is now
+ratcheted against a checked-in baseline so new typing debt cannot slip in while
+we keep paying down the backlog.
 
 ## Why incremental strict?
 
@@ -33,11 +35,9 @@ ongoing feature work.
 | `src/utils/http_cache.py` | JTN-676 |
 | `src/model.py` | JTN-663 |
 
-`src/utils/http_cache.py` was deliberately deferred from the initial strict
-set because it was recently refactored (JTN-493) and is still settling. It
-will be added in a follow-up once it stabilizes. This PR extends the strict
-subset with a low-churn helper cluster instead of broadening strict mode
-repo-wide.
+This list is intentionally low-churn: the broad `src/` ratchet protects the
+rest of production code from backsliding, while the modules above are held to
+full `--strict`.
 
 ## How to add a module to the strict subset
 
@@ -65,17 +65,21 @@ repo-wide.
 4. **Update the table above** with the module path and Linear issue reference.
 5. Open a PR — CI will enforce strictness from that point forward.
 
-## Advisory checks: split `src/` vs `tests/`
+## Current CI behavior: ratcheted `src/`, advisory `tests/`
 
-`scripts/lint.sh` runs the advisory (non-strict) mypy pass as **two separate
-invocations** instead of one:
+`scripts/lint.sh` runs the non-strict mypy pass as **two separate invocations**
+plus the blocking strict subset:
 
-1. `mypy src/` — production code
-2. `mypy tests/` — test suite
+1. `mypy src/` — production code, compared against the checked-in baseline in
+   `scripts/mypy_src_baseline.txt`
+2. `mypy tests/` — test suite, advisory only
+3. `mypy --strict ...` — curated strict subset, fully blocking
 
-Both are non-blocking — failures are printed with a `⚠️` warning and the
-error counts are reported separately. The strict subset above is the only
-mypy check that blocks CI.
+`src/` is no longer purely informational. CI fails only when the `src/` count
+rises above the committed baseline, or when mypy cannot produce a summary to
+compare against. `tests/` remains non-blocking because its typing noise is
+still much higher. The strict subset above is unchanged and remains fully
+blocking.
 
 ### Why the split?
 
@@ -86,14 +90,26 @@ drowned out by thousands of test-only errors. Splitting the counts makes
 **`src/` type drift legible so we can ratchet it downward** and eventually
 promote more modules into the strict subset.
 
-### What to do if the `src/` count goes up
+### What to do if the `src/` count changes
+
+If `src/` goes up:
 
 1. Run `mypy src/` locally and look at the diff in errors vs `main`.
-2. If your PR introduced the new errors, fix them before merging — even
-   though the check is advisory, rising `src/` counts block our ability to
-   grow the strict subset.
-3. If the increase is unrelated to your change (e.g. a dependency bump),
-   open a follow-up issue and call it out in the PR description.
+2. If your PR introduced the new errors, fix them before merging.
+3. If the increase is unrelated to your change (for example a dependency or
+   typeshed shift), call it out in the PR and land a coordinated baseline
+   update only if the new debt is intentional.
+
+If `src/` goes down:
+
+1. Confirm the lower count is real by rerunning `mypy src/` or
+   `bash scripts/lint.sh`.
+2. Update `scripts/mypy_src_baseline.txt` to the new lower integer.
+3. Rerun `bash scripts/lint.sh` so the ratchet records the improvement.
+
+If `mypy src/` exits without a `Found N errors` or `Success:` summary, treat it
+as a broken type-check invocation. The ratchet will fail until the underlying
+config/import problem is fixed.
 
 Increases in the `tests/` count are lower priority but still worth a glance —
 prefer fixing them opportunistically in the same area you're already editing.

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,6 +27,8 @@ explicit_package_bases = True
 # ignore_missing_imports = False  # commented out to avoid config warnings
 
 # General settings
+# Broad src/ typing debt is ratcheted in scripts/lint.sh via
+# scripts/mypy_src_baseline.txt. The modules below are the fully strict subset.
 ignore_missing_imports = True
 follow_imports = skip
 warn_return_any = True

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,6 +3,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
+MYPY_SRC_BASELINE_FILE="${MYPY_SRC_BASELINE_FILE:-${REPO_ROOT}/scripts/mypy_src_baseline.txt}"
 cd "${REPO_ROOT}" || exit
 
 # Use existing environment in CI or when a virtualenv is active
@@ -15,6 +16,8 @@ fi
 RUFF_EXIT=0
 BLACK_EXIT=0
 MYPY_SRC_EXIT=0
+MYPY_SRC_BASELINE="?"
+MYPY_SRC_RATCHET_EXIT=0
 MYPY_TESTS_EXIT=0
 MYPY_STRICT_EXIT=0
 SHELLCHECK_EXIT=0
@@ -37,10 +40,11 @@ else
     echo "✅ Black formatting check passed"
 fi
 
-# Advisory mypy is split into two passes (src/ and tests/) so that
+# Non-strict mypy is split into two passes (src/ and tests/) so that
 # production-code type drift stays visible even when test-only typing
-# noise dominates. Both passes are non-blocking; only the strict subset
-# below is CI-blocking. See docs/typing.md.
+# noise dominates. src/ is ratcheted against a checked-in baseline;
+# tests/ remains advisory. The strict subset below stays CI-blocking.
+# See docs/typing.md.
 count_mypy_errors() {
     # Parse "Found N errors" / "Success: ..." lines from captured output.
     # Returns "?" when mypy exited non-zero without a recognizable summary
@@ -62,18 +66,45 @@ count_mypy_errors() {
     echo "$n"
 }
 
-# Run mypy on a directory as an advisory (non-blocking) check.
+# Load the checked-in src/ advisory baseline used for the ratchet.
+load_mypy_src_baseline() {
+    local baseline_value
+
+    if [ ! -f "$MYPY_SRC_BASELINE_FILE" ]; then
+        echo "❌ mypy src/ ratchet baseline missing: $MYPY_SRC_BASELINE_FILE"
+        return 1
+    fi
+
+    baseline_value="$(
+        awk '
+            /^[[:space:]]*#/ { next }
+            /^[[:space:]]*$/ { next }
+            { print $1; exit }
+        ' "$MYPY_SRC_BASELINE_FILE"
+    )"
+
+    if [[ ! "$baseline_value" =~ ^[0-9]+$ ]]; then
+        echo "❌ mypy src/ ratchet baseline is not a non-negative integer: $MYPY_SRC_BASELINE_FILE"
+        return 1
+    fi
+
+    MYPY_SRC_BASELINE="$baseline_value"
+}
+
+# Run mypy on a directory and capture its error count for either advisory
+# reporting or ratchet comparison.
 # Sets globals MYPY_<UPPER_LABEL>_EXIT and MYPY_<UPPER_LABEL>_COUNT so the
 # outer script can reference them in the summary block below.
-run_advisory_mypy() {
+run_counted_mypy() {
     local dir_path="$1"
     local label="$2"
     local var_key="$3"   # e.g. SRC or TESTS — used to build global var names
+    local mode="$4"      # ratchet or advisory
     local output
     local exit_code
     local count
 
-    echo "Running mypy type checker (advisory — ${label} only)..."
+    echo "Running mypy type checker (${mode} — ${label} only)..."
     output="$(mypy "$dir_path" 2>&1)"
     exit_code=$?
     echo "$output"
@@ -82,11 +113,13 @@ run_advisory_mypy() {
     if [ "$exit_code" -ne 0 ]; then
         if [ "$count" = "?" ]; then
             echo "⚠️  mypy ${label}: failed (see output above)"
+        elif [ "$mode" = "ratchet" ]; then
+            echo "ℹ️  mypy ${label}: ${count} issue(s) found; comparing against ratchet baseline"
         else
             echo "⚠️  mypy ${label}: advisory only — ${count} issue(s) found"
         fi
     else
-        echo "✅ mypy ${label} advisory type check passed"
+        echo "✅ mypy ${label} type check passed"
     fi
 
     # Write through to globals for the final summary.
@@ -94,8 +127,38 @@ run_advisory_mypy() {
     printf -v "MYPY_${var_key}_COUNT" '%s' "$count"
 }
 
-run_advisory_mypy src "src/" SRC
-run_advisory_mypy tests "tests/" TESTS
+enforce_mypy_src_ratchet() {
+    local display_baseline_file="${MYPY_SRC_BASELINE_FILE#${REPO_ROOT}/}"
+
+    if ! load_mypy_src_baseline; then
+        MYPY_SRC_RATCHET_EXIT=1
+        return
+    fi
+
+    if [ "$MYPY_SRC_COUNT" = "?" ]; then
+        echo "❌ mypy src/ ratchet failed: unable to determine the advisory count for comparison"
+        MYPY_SRC_RATCHET_EXIT=1
+        return
+    fi
+
+    if [ "$MYPY_SRC_COUNT" -gt "$MYPY_SRC_BASELINE" ]; then
+        echo "❌ mypy src/ ratchet failed: ${MYPY_SRC_COUNT} issue(s) exceeds baseline ${MYPY_SRC_BASELINE}"
+        MYPY_SRC_RATCHET_EXIT=1
+        return
+    fi
+
+    if [ "$MYPY_SRC_COUNT" -lt "$MYPY_SRC_BASELINE" ]; then
+        echo "✅ mypy src/ ratchet improved: ${MYPY_SRC_COUNT} issue(s) vs baseline ${MYPY_SRC_BASELINE}"
+        echo "ℹ️  Lower ${display_baseline_file} when that reduced count is ready to become the new floor."
+        return
+    fi
+
+    echo "✅ mypy src/ ratchet held at baseline ${MYPY_SRC_BASELINE}"
+}
+
+run_counted_mypy src "src/" SRC ratchet
+enforce_mypy_src_ratchet
+run_counted_mypy tests "tests/" TESTS advisory
 
 echo "Running mypy strict check (blocking — strict subset only)..."
 # Strict subset: curated low-churn helpers that are enforced at --strict.
@@ -153,13 +216,14 @@ else
     fi
 fi
 
-# Report summary — whole-codebase mypy is advisory only; the strict subset
-# (typed helper subset) is blocking. Ruff, Black, and shellcheck are blocking.
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
+# Report summary — src/ is ratcheted, tests/ stays advisory, and the strict
+# subset remains fully blocking. Ruff, Black, and shellcheck are blocking too.
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     echo ""
     echo "❌ Some checks failed:"
     [ $RUFF_EXIT -ne 0 ] && echo "  - Ruff: $RUFF_EXIT"
     [ $BLACK_EXIT -ne 0 ] && echo "  - Black: $BLACK_EXIT"
+    [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] && echo "  - mypy src/ ratchet: $MYPY_SRC_RATCHET_EXIT"
     [ $MYPY_STRICT_EXIT -ne 0 ] && echo "  - mypy strict subset: $MYPY_STRICT_EXIT"
     [ $SHELLCHECK_EXIT -ne 0 ] && echo "  - shellcheck: $SHELLCHECK_EXIT"
     echo ""
@@ -168,12 +232,18 @@ else
     echo ""
     echo "✅ All checks passed!"
 fi
-if [ $MYPY_SRC_EXIT -ne 0 ]; then
-    if [ "$MYPY_SRC_COUNT" = "?" ]; then
-        echo "⚠️  mypy src/: failed without summary (non-blocking — see output above)"
-    else
-        echo "⚠️  mypy src/: advisory only — ${MYPY_SRC_COUNT} issue(s) remain (non-blocking)"
-    fi
+if [ "$MYPY_SRC_BASELINE" = "?" ]; then
+    echo "❌ mypy src/: ratchet baseline could not be loaded"
+elif [ "$MYPY_SRC_COUNT" = "?" ]; then
+    echo "❌ mypy src/: ratchet could not compare against baseline ${MYPY_SRC_BASELINE}"
+elif [ "$MYPY_SRC_COUNT" -gt "$MYPY_SRC_BASELINE" ]; then
+    echo "❌ mypy src/: ${MYPY_SRC_COUNT} issue(s) exceeds baseline ${MYPY_SRC_BASELINE}"
+elif [ "$MYPY_SRC_COUNT" -lt "$MYPY_SRC_BASELINE" ]; then
+    echo "✅ mypy src/: ${MYPY_SRC_COUNT} issue(s) (below baseline ${MYPY_SRC_BASELINE})"
+elif [ $MYPY_SRC_EXIT -eq 0 ]; then
+    echo "✅ mypy src/: clean"
+else
+    echo "✅ mypy src/: ${MYPY_SRC_COUNT} issue(s) matches baseline ${MYPY_SRC_BASELINE}"
 fi
 if [ $MYPY_TESTS_EXIT -ne 0 ]; then
     if [ "$MYPY_TESTS_COUNT" = "?" ]; then
@@ -183,7 +253,7 @@ if [ $MYPY_TESTS_EXIT -ne 0 ]; then
     fi
 fi
 
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     exit 1
 fi
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -128,7 +128,7 @@ run_counted_mypy() {
 }
 
 enforce_mypy_src_ratchet() {
-    local display_baseline_file="${MYPY_SRC_BASELINE_FILE#${REPO_ROOT}/}"
+    local display_baseline_file="${MYPY_SRC_BASELINE_FILE#"${REPO_ROOT}"/}"
 
     if ! load_mypy_src_baseline; then
         MYPY_SRC_RATCHET_EXIT=1

--- a/scripts/mypy_src_baseline.txt
+++ b/scripts/mypy_src_baseline.txt
@@ -1,0 +1,3 @@
+# Checked-in mypy src/ advisory baseline for scripts/lint.sh.
+# Lower this number when src/ typing debt is intentionally reduced.
+1441


### PR DESCRIPTION
## Summary
- implement grade `I1` by turning the broad `mypy src/` advisory pass into a real ratchet in `scripts/lint.sh`
- add a checked-in `scripts/mypy_src_baseline.txt` so CI fails only when `src/` typing debt regresses above the current baseline
- document how the ratchet works and how to refresh the baseline after intentional improvements
- keep the existing strict mypy subset and advisory `tests/` pass intact

## Test plan
- `bash -n scripts/lint.sh`
- `shellcheck --severity=warning scripts/lint.sh`
- `PYTHONPATH="$PWD/src:$PWD" .venv/bin/mypy src`
- `PATH="$PWD/.venv/bin:$PATH" VIRTUAL_ENV="$PWD/.venv" PYTHONPATH="$PWD/src:$PWD" bash scripts/lint.sh`
