### PR TITLE
test: triage mutmut survivors on expanded paths (JTN-595)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,22 @@ jobs:
         run: |
           scripts/preflash_validate.sh
 
+  # Mutation nightly — runs every Sunday 03:00 UTC via the workflow-level
+  # ``schedule:`` trigger. See docs/mutation_testing.md.
+  #
+  # JTN-595 (2026-04-19) finding: every nightly run since the JTN-508 scope
+  # expansion has hit the 120-minute timeout without finishing, producing no
+  # ``mutmut-cache`` artifact. Two bugs compound the problem:
+  #   1. Full-scope mutmut on src/app_setup/+blueprints/+utils/+refresh_task/
+  #      does not complete inside 120 minutes on ubuntu-latest.
+  #   2. The previous upload step did not set ``include-hidden-files: true``,
+  #      so even a successful run would have silently dropped the hidden
+  #      ``.mutmut-cache`` directory (actions/upload-artifact@v4 excludes
+  #      hidden paths by default).
+  # The hidden-files flag below is the minimum fix so a successful run can
+  # publish an artifact. Sharding the mutmut scope across a matrix of
+  # directories (or tightening the runner) is tracked for follow-up —
+  # otherwise the nightly will keep producing no actionable signal.
   mutation-nightly:
     name: Mutation nightly
     if: github.event_name == 'schedule'
@@ -604,6 +620,10 @@ jobs:
           name: mutmut-cache
           path: .mutmut-cache
           if-no-files-found: ignore
+          # ``.mutmut-cache`` is a hidden directory; without this flag
+          # actions/upload-artifact@v4 silently excludes it and the
+          # artifact is never published, even on successful runs.
+          include-hidden-files: true
 
   browser-smoke:
     name: Browser smoke (tabs + plugins)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,8 +560,8 @@ jobs:
         run: |
           scripts/preflash_validate.sh
 
-  # Mutation nightly — runs every Sunday 03:00 UTC via the workflow-level
-  # ``schedule:`` trigger. See docs/mutation_testing.md.
+  # Mutation nightly — runs daily at 09:00 UTC and weekly on Sunday 03:00 UTC
+  # via the workflow-level ``schedule:`` trigger. See docs/mutation_testing.md.
   #
   # JTN-595 (2026-04-19) finding: every nightly run since the JTN-508 scope
   # expansion has hit the 120-minute timeout without finishing, producing no

--- a/tests/mutmut_suppressions.md
+++ b/tests/mutmut_suppressions.md
@@ -1,8 +1,10 @@
 # Mutmut survivor suppressions
 
-This file records surviving mutmut mutants that we have chosen **not** to kill
-with a targeted test, along with a one-line justification for each. Killed
-survivors are not listed here — they live as commits that add assertions.
+This file records mutmut-triage outcomes across three categories: surviving
+mutants we have chosen **not** to kill (with a one-line justification),
+mutants that were killed by the same PR as this file (cross-referenced to the
+assertion that catches them), and acceptable / deferred survivors. See the
+headings below for the specific sections.
 
 See `docs/mutation_testing.md` for the mutation-testing setup, CI schedule,
 and triage workflow. The source tracking issue is **JTN-595**.
@@ -81,7 +83,7 @@ interpret the short list above as complete.
 
 Format: one markdown table row under the relevant heading.
 
-```
+```md
 | file:line | mutation class | reason / killing test |
 ```
 

--- a/tests/mutmut_suppressions.md
+++ b/tests/mutmut_suppressions.md
@@ -1,0 +1,90 @@
+# Mutmut survivor suppressions
+
+This file records surviving mutmut mutants that we have chosen **not** to kill
+with a targeted test, along with a one-line justification for each. Killed
+survivors are not listed here — they live as commits that add assertions.
+
+See `docs/mutation_testing.md` for the mutation-testing setup, CI schedule,
+and triage workflow. The source tracking issue is **JTN-595**.
+
+## Status of the nightly artifact (JTN-595, 2026-04-19)
+
+The `mutation-nightly` job in `.github/workflows/ci.yml` has **never produced
+a usable `mutmut-cache` artifact** since the JTN-508 `paths_to_mutate`
+expansion. Every scheduled run since that expansion terminates with
+`The operation was canceled` at the 120-minute timeout — i.e. the full
+mutmut pass does not fit inside the job budget.
+
+Additionally, even if a run finished in time, `actions/upload-artifact@v4`
+was configured without `include-hidden-files: true`, so the hidden
+`.mutmut-cache` directory would have been silently excluded from the
+artifact. That bug is fixed in the same PR that landed this file — see
+`.github/workflows/ci.yml`.
+
+**Consequences for this triage pass:**
+
+- There is no real survivor list to load from an artifact.
+- We did not run the full mutmut pass locally — `docs/mutation_testing.md`
+  and the JTN-595 issue explicitly forbid that, since it takes hours.
+- The entries below were identified by **static inspection** of small
+  files in the expanded scope (`src/utils/`, `src/blueprints/`), targeting
+  patterns that a surface-level mutmut run would obviously surface.
+
+Once the nightly workflow is sharded so it fits in budget, a follow-up
+triage pass can replace the entries here with real mutant IDs drawn from
+the artifact.
+
+## Killed in JTN-595 (2026-04-19)
+
+These survivors were turned into kills by the same PR that added this file.
+They are recorded here so future runs that flag the same code spots can be
+cross-referenced to the assertion that catches them.
+
+| file:line | mutation class | killing test |
+|-----------|----------------|--------------|
+| `src/utils/display_names.py:42` | remove `.strip()` from `humanize_plugin_id` | `tests/unit/test_display_names.py::TestHumanizePluginId::test_humanize_strips_surrounding_whitespace` |
+| `src/blueprints/csp_report.py:47` | drop `"#"` from `_redact_url` separator tuple | `tests/test_csp_report.py::test_source_file_url_fragment_is_redacted` |
+| `src/blueprints/csp_report.py:98` | drop any entry from `_sanitise_report` url_keys set | `tests/test_csp_report.py::test_all_url_fields_are_redacted` |
+| `src/blueprints/version_info.py:50` | remove `value != "{version}"` guard | `tests/test_version_uptime.py::test_read_app_version_rejects_unexpanded_placeholder` |
+| `src/blueprints/version_info.py:50` | remove `value != "0.1.0"` guard | `tests/test_version_uptime.py::test_read_app_version_rejects_bootstrap_placeholder` |
+| `src/blueprints/version_info.py:49-51` | return-value mutation of happy path | `tests/test_version_uptime.py::test_read_app_version_accepts_real_version_string` |
+
+## Deferred / acceptable survivors
+
+No actionable survivors were identified by static inspection that we chose
+to leave unkilled; the acceptable category below is a standing policy note
+rather than a concrete survivor list.
+
+### Acceptable — log-formatting only
+
+Any mutant that changes only the *format* of a log line (punctuation,
+template string, joiner characters) without changing the logged content
+is acceptable to survive. Example pattern: mutating `"CSP violation: %s"`
+to `"CSP violation %s"`. We deliberately do not assert on log-line
+punctuation because doing so would couple tests to cosmetic details and
+add noise without catching real regressions.
+
+### Deferred — full nightly triage pending workflow fix
+
+The substantive deferred work is running a full, budgeted nightly pass
+once the mutation-nightly job is sharded and its artifact is published.
+At that point, a follow-up issue should:
+
+1. Download the `mutmut-cache` artifact from the nightly run.
+2. Iterate `mutmut results` → `mutmut show <id>` for each survivor.
+3. Append each survivor here under a **Deferred** heading, or kill it.
+
+Until then, the survivor universe is effectively unknown — do not
+interpret the short list above as complete.
+
+## How to add an entry
+
+Format: one markdown table row under the relevant heading.
+
+```
+| file:line | mutation class | reason / killing test |
+```
+
+Use short, stable descriptions in the `mutation class` column (e.g.
+``replace `>` with `>=` in bound check``) rather than raw diff output —
+line numbers shift under refactors but the mutation *class* is durable.

--- a/tests/test_csp_report.py
+++ b/tests/test_csp_report.py
@@ -147,6 +147,67 @@ def test_source_file_url_is_redacted(caplog, csp_client):
     assert "secret" not in combined, f"Query string leaked into log: {combined}"
 
 
+def test_source_file_url_fragment_is_redacted(caplog, csp_client):
+    """Fragment (#...) is stripped from source-file URLs before logging.
+
+    JTN-595 mutmut triage: kills a surviving mutant where the ``#`` entry
+    is dropped from the ``("?", "#")`` separator tuple in ``_redact_url``.
+    Without fragment stripping, anchor-style identifiers would leak into
+    logs alongside the query-string redaction.
+    """
+    report = {
+        "csp-report": {
+            "document-uri": "http://localhost/",
+            "violated-directive": "script-src 'self'",
+            "source-file": "https://localhost/page#leaked-fragment-token",
+        }
+    }
+    with caplog.at_level(logging.WARNING, logger="blueprints.csp_report"):
+        csp_client.post(
+            "/api/csp-report",
+            data=json.dumps(report),
+            content_type="application/csp-report",
+        )
+
+    combined = " ".join(r.message for r in caplog.records)
+    assert (
+        "leaked-fragment-token" not in combined
+    ), f"Fragment leaked into log: {combined}"
+    assert "https://localhost/page" in combined, f"Redacted URL missing: {combined}"
+
+
+def test_all_url_fields_are_redacted(caplog, csp_client):
+    """Every URL-bearing key (document-uri, referrer, blocked-uri, source-file)
+    must have its query string + fragment stripped before logging.
+
+    JTN-595 mutmut triage: kills surviving mutants where individual entries
+    are dropped from the ``url_keys`` set in ``_sanitise_report``. Without
+    per-field coverage, dropping e.g. ``"blocked-uri"`` from the set would
+    survive because the sample payload's other fields would still redact.
+    """
+    report = {
+        "csp-report": {
+            "document-uri": "http://localhost/doc?doctoken=A",
+            "referrer": "http://localhost/ref?reftoken=B",
+            "blocked-uri": "https://evil.example.com/x?blocktoken=C",
+            "source-file": "https://localhost/src?srctoken=D",
+            "violated-directive": "script-src 'self'",
+        }
+    }
+    with caplog.at_level(logging.WARNING, logger="blueprints.csp_report"):
+        csp_client.post(
+            "/api/csp-report",
+            data=json.dumps(report),
+            content_type="application/csp-report",
+        )
+
+    combined = " ".join(r.message for r in caplog.records)
+    for leaked_token in ("doctoken", "reftoken", "blocktoken", "srctoken"):
+        assert (
+            leaked_token not in combined
+        ), f"Query token {leaked_token!r} leaked into log: {combined}"
+
+
 def test_empty_body_returns_204(csp_client):
     """Empty POST body must not crash — returns 204."""
     resp = csp_client.post(

--- a/tests/test_version_uptime.py
+++ b/tests/test_version_uptime.py
@@ -177,15 +177,22 @@ def test_read_app_version_rejects_unexpanded_placeholder():
     release pipeline leak the raw Jinja-style placeholder into the UI.
     The function must always ignore that value and fall through to
     pyproject.toml.
+
+    The pyproject fallback is also stubbed so the assertion verifies only
+    the VERSION guard, independent of the repo's current
+    ``[project].version`` value.
     """
+    import tomllib
+
     from blueprints.version_info import _read_app_version
 
-    with patch("pathlib.Path.read_text", return_value="{version}\n"):
+    with (
+        patch("pathlib.Path.read_text", return_value="{version}\n"),
+        patch.object(tomllib, "load", return_value={"project": {"version": "7.7.7"}}),
+    ):
         result = _read_app_version()
 
-    assert result != "{version}"
-    # pyproject.toml still resolves to a real version
-    assert result not in ("", "unknown")
+    assert result == "7.7.7"
 
 
 def test_read_app_version_rejects_bootstrap_placeholder():
@@ -194,14 +201,22 @@ def test_read_app_version_rejects_bootstrap_placeholder():
     mutmut triage: kills a surviving mutant where
     ``value != "0.1.0"`` is removed. ``0.1.0`` is the project's pre-release
     bootstrap value that must never be surfaced as a real shipped version.
+
+    The pyproject fallback is also stubbed so the assertion verifies only
+    the VERSION guard, independent of the repo's current
+    ``[project].version`` value.
     """
+    import tomllib
+
     from blueprints.version_info import _read_app_version
 
-    with patch("pathlib.Path.read_text", return_value="0.1.0\n"):
+    with (
+        patch("pathlib.Path.read_text", return_value="0.1.0\n"),
+        patch.object(tomllib, "load", return_value={"project": {"version": "7.7.7"}}),
+    ):
         result = _read_app_version()
 
-    assert result != "0.1.0"
-    assert result not in ("", "unknown")
+    assert result == "7.7.7"
 
 
 def test_read_app_version_accepts_real_version_string():

--- a/tests/test_version_uptime.py
+++ b/tests/test_version_uptime.py
@@ -169,6 +169,58 @@ def test_read_app_version_falls_back_to_pyproject_when_version_missing():
     assert result
 
 
+def test_read_app_version_rejects_unexpanded_placeholder():
+    """VERSION containing the literal '{version}' placeholder falls back (JTN-595).
+
+    mutmut triage: kills a surviving mutant where
+    ``value != "{version}"`` is removed from the guard, letting a broken
+    release pipeline leak the raw Jinja-style placeholder into the UI.
+    The function must always ignore that value and fall through to
+    pyproject.toml.
+    """
+    from blueprints.version_info import _read_app_version
+
+    with patch("pathlib.Path.read_text", return_value="{version}\n"):
+        result = _read_app_version()
+
+    assert result != "{version}"
+    # pyproject.toml still resolves to a real version
+    assert result not in ("", "unknown")
+
+
+def test_read_app_version_rejects_bootstrap_placeholder():
+    """VERSION containing the bootstrap '0.1.0' placeholder falls back (JTN-595).
+
+    mutmut triage: kills a surviving mutant where
+    ``value != "0.1.0"`` is removed. ``0.1.0`` is the project's pre-release
+    bootstrap value that must never be surfaced as a real shipped version.
+    """
+    from blueprints.version_info import _read_app_version
+
+    with patch("pathlib.Path.read_text", return_value="0.1.0\n"):
+        result = _read_app_version()
+
+    assert result != "0.1.0"
+    assert result not in ("", "unknown")
+
+
+def test_read_app_version_accepts_real_version_string():
+    """A real semver value in VERSION must be returned verbatim (JTN-595).
+
+    mutmut triage: kills surviving mutants where the positive branch is
+    replaced (e.g. ``return value`` → ``return "unknown"`` or the ``if
+    value`` guard is inverted). Without this test the happy path is only
+    covered indirectly by the ``/api/version/info`` integration test that
+    reads the checked-in VERSION.
+    """
+    from blueprints.version_info import _read_app_version
+
+    with patch("pathlib.Path.read_text", return_value="9.9.9\n"):
+        result = _read_app_version()
+
+    assert result == "9.9.9"
+
+
 def test_run_git_returns_unknown_on_nonzero_returncode():
     """_run_git returns 'unknown' when git exits with non-zero."""
     from blueprints.version_info import _run_git

--- a/tests/unit/test_display_names.py
+++ b/tests/unit/test_display_names.py
@@ -48,6 +48,24 @@ class TestHumanizePluginId:
     def test_humanize(self, plugin_id, expected):
         assert humanize_plugin_id(plugin_id) == expected
 
+    @pytest.mark.parametrize(
+        ("plugin_id", "expected"),
+        [
+            # JTN-595 mutmut triage: kill a surviving mutant where
+            # ``.strip()`` is removed from humanize_plugin_id — leading /
+            # trailing whitespace must never leak into the humanised label.
+            ("  weather  ", "Weather"),
+            ("\tweather\n", "Weather"),
+            ("   image_folder   ", "Image Folder"),
+            # Whitespace-only input humanises to an empty string because
+            # the underscore/hyphen replacements produce a whitespace run
+            # that .strip() collapses to "".
+            ("   ", ""),
+        ],
+    )
+    def test_humanize_strips_surrounding_whitespace(self, plugin_id, expected):
+        assert humanize_plugin_id(plugin_id) == expected
+
 
 class TestFriendlyInstanceLabel:
     def test_user_renamed_instance_is_preserved(self):


### PR DESCRIPTION
## Summary

Triage pass for **JTN-595** ("Triage mutmut survivors on expanded paths_to_mutate" — follow-up to JTN-508 which expanded `paths_to_mutate` to cover `src/app_setup/`, `src/blueprints/`, `src/utils/`, and `src/refresh_task/`).

### Primary finding — the nightly artifact is broken

The `mutation-nightly` job in `.github/workflows/ci.yml` has **never published a usable `mutmut-cache` artifact** since the JTN-508 scope expansion. Two independent bugs compound:

1. **Timeout**: every scheduled run since 2026-04-12 ends with `The operation was canceled` at the 120-minute job timeout. The full-scope mutmut pass does not fit in the budget.
   - Spot-checked: jobs `72004423813` (2026-04-19), `71990423144` (2026-04-19), `71941278313` (2026-04-18), `71800841767` (2026-04-17). All identical failure mode.
   - Latest scheduled CI run reviewed: [#24625776110](https://github.com/jtn0123/InkyPi/actions/runs/24625776110) — mutation job cancelled at ~120min mark.
2. **Hidden-file exclusion**: even if a run finished in time, the upload step was configured without `include-hidden-files: true`, and `actions/upload-artifact@v4` silently excludes hidden paths — so `.mutmut-cache` would never be uploaded regardless.

The second bug is fixed in this PR (one-line YAML change). The first is called out in an in-line `mutation-nightly:` block comment so the next maintainer to touch the workflow has immediate context. Sharding `paths_to_mutate` across a matrix (so each shard fits under 120min) is the obvious follow-up but is out of scope for this triage PR — it would change how the job is configured, not the triage surface.

### Survivor triage

Because no artifact is available, this pass follows the **Fallback B** path described in the JTN-595 task brief: static inspection of small modules in the expanded scope, with targeted assertions added for obvious gaps, and the rest documented. Per the task brief we did **not** run a full `mutmut run` locally (explicitly forbidden — takes hours).

Files statically inspected: `src/utils/display_names.py`, `src/utils/output_validator.py`, `src/utils/paths.py`, `src/blueprints/csp_report.py`, `src/blueprints/version_info.py`, `src/blueprints/errors.py`. Existing test suites for each were read to identify under-asserted branches.

### Killed survivors (6 mutation classes across 3 files)

| file:line | mutation class | killing test |
|-----------|----------------|--------------|
| `src/utils/display_names.py:42` | remove `.strip()` from `humanize_plugin_id` | `tests/unit/test_display_names.py::TestHumanizePluginId::test_humanize_strips_surrounding_whitespace` |
| `src/blueprints/csp_report.py:47` | drop `"#"` from `_redact_url` separator tuple | `tests/test_csp_report.py::test_source_file_url_fragment_is_redacted` |
| `src/blueprints/csp_report.py:98` | drop any entry from `_sanitise_report` url_keys set | `tests/test_csp_report.py::test_all_url_fields_are_redacted` |
| `src/blueprints/version_info.py:50` | remove `value != "{version}"` guard | `tests/test_version_uptime.py::test_read_app_version_rejects_unexpanded_placeholder` |
| `src/blueprints/version_info.py:50` | remove `value != "0.1.0"` guard | `tests/test_version_uptime.py::test_read_app_version_rejects_bootstrap_placeholder` |
| `src/blueprints/version_info.py:49-51` | return-value mutation of happy path | `tests/test_version_uptime.py::test_read_app_version_accepts_real_version_string` |

Each new assertion was verified against a hand-applied mutation of the source — the test fails with the mutant applied, passes with the mutant reverted. See commit messages for per-group detail.

### Counts

| | |
|---|---|
| Survivors from nightly artifact | **0 (artifact unavailable — see finding above)** |
| Survivors found by static inspection | 6 mutation classes |
| Killed by new assertions in this PR | 6 |
| Documented as suppressed / acceptable | 0 (policy note only — log-format cosmetic mutants) |
| Deferred | All of "run full artifact-driven triage once workflow sharding lands" — tracked in `tests/mutmut_suppressions.md` |

### Files changed

- `tests/unit/test_display_names.py` — whitespace coverage for `humanize_plugin_id`
- `tests/test_csp_report.py` — fragment stripping + all-url-fields redaction
- `tests/test_version_uptime.py` — three placeholder/happy-path tests for `_read_app_version`
- `.github/workflows/ci.yml` — `include-hidden-files: true` fix + explanatory comment
- `tests/mutmut_suppressions.md` — new ledger file

## Test plan

- [x] `pytest tests/unit/test_display_names.py tests/test_csp_report.py tests/test_version_uptime.py` — all green (72 passed).
- [x] Each killing test verified to fail against a hand-applied mutation of the target and pass when the mutation is reverted.
- [x] YAML syntax check on `.github/workflows/ci.yml` (`yaml.safe_load`).
- [ ] Next scheduled `mutation-nightly` run (Sunday 03:00 UTC) will exercise the `include-hidden-files` change end-to-end, even if the 120-minute timeout prevents a complete mutmut pass — any partial cache written before cancellation will at least upload now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow to properly capture mutation testing artifacts with hidden directory support.

* **Documentation**
  * Added comprehensive guide for mutation testing suppressions and coverage tracking.

* **Tests**
  * Expanded test coverage for CSP report URL field redaction in logging.
  * Added validation tests for version file handling and fallback behavior.
  * Enhanced tests for whitespace handling in display name processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->