### PR TITLE
fix: refuse to delete the Default playlist (JTN-781)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -45,6 +45,17 @@ _MSG_TIME_OVERLAP = "Playlist time range overlaps with existing playlist"
 _MSG_INVALID_PLAYLIST_REQUEST = "Invalid playlist request"
 _MSG_PLAYLIST_NOT_FOUND = "Playlist not found"
 
+# JTN-781: the "Default" playlist is the canonical fallback shipped with the
+# system and auto-created on startup when no playlists exist (see
+# PlaylistManager.add_default_playlist + config bootstrap). Deleting it leaves
+# the scheduler with nothing to schedule and no UI path to recreate it, so the
+# server rejects the delete outright. The match is case-sensitive because every
+# other code path (create, update, overlap-warning, plugin auto-add) keys off
+# the exact string "Default" — a lowercase "default" is just a user-created
+# playlist and is fine to delete.
+DEFAULT_PLAYLIST_NAME = "Default"
+_MSG_CANNOT_DELETE_DEFAULT = "Cannot delete the default playlist"
+
 
 def _validate_playlist_name(name, field="playlist_name"):
     """Validate playlist name format. Returns (cleaned_name, error_response) tuple.
@@ -865,6 +876,19 @@ def delete_playlist(playlist_name):
     if not playlist_name:
         return json_error(
             PLAYLIST_NAME_REQUIRED_ERROR,
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "playlist_name"},
+        )
+
+    # JTN-781: refuse to delete the canonical "Default" playlist. This match is
+    # intentionally case-sensitive to mirror how "Default" is treated elsewhere
+    # (create/update/overlap-warning/plugin auto-add all key off the exact
+    # string). A user-created playlist named "default" is a different playlist
+    # and remains deletable.
+    if playlist_name == DEFAULT_PLAYLIST_NAME:
+        return json_error(
+            _MSG_CANNOT_DELETE_DEFAULT,
             status=400,
             code=_CODE_VALIDATION,
             details={"field": "playlist_name"},

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -30,6 +30,48 @@ def test_create_update_delete_playlist_flow(client):
     assert resp.status_code == 200
 
 
+def test_delete_default_playlist_is_refused(client, device_config_dev):
+    """JTN-781: DELETE /delete_playlist/Default must return 400 and keep the playlist."""
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default", "00:00", "24:00")
+    device_config_dev.write_config()
+
+    resp = client.delete("/delete_playlist/Default")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert body["code"] == "validation_error"
+    assert "default" in body["error"].lower()
+    # Default must still exist after the rejected delete
+    assert pm.get_playlist("Default") is not None
+
+
+def test_delete_non_default_playlist_still_succeeds(client, device_config_dev):
+    """JTN-781: guard must not regress deletion of regular user-created playlists."""
+    pm = device_config_dev.get_playlist_manager()
+    pm.add_playlist("Evening", "18:00", "22:00")
+    device_config_dev.write_config()
+
+    resp = client.delete("/delete_playlist/Evening")
+    assert resp.status_code == 200
+    assert pm.get_playlist("Evening") is None
+
+
+def test_delete_lowercase_default_playlist_is_allowed(client, device_config_dev):
+    """JTN-781: the guard is case-sensitive — 'default' (lowercase) is a
+    user-created playlist and remains deletable. Matches how create/update
+    elsewhere key off the exact string 'Default'."""
+    pm = device_config_dev.get_playlist_manager()
+    # Create a lowercase 'default' that is distinct from the canonical one.
+    pm.add_playlist("default", "09:00", "10:00")
+    device_config_dev.write_config()
+
+    resp = client.delete("/delete_playlist/default")
+    assert resp.status_code == 200
+    assert pm.get_playlist("default") is None
+
+
 def test_add_plugin_to_playlist_validation(client):
     # Missing fields
     resp = client.post("/add_plugin", data={})


### PR DESCRIPTION
## Summary

- Linear: [JTN-781](https://linear.app/jtn0123/issue/JTN-781/default-playlist-can-be-deleted-with-no-safeguard-or-recovery-path)
- `DELETE /delete_playlist/Default` now returns **HTTP 400** with `code: "validation_error"` and message `"Cannot delete the default playlist"`. Previously it returned 200 and silently removed the canonical playlist, leaving the scheduler with nothing to run and no UI path to recreate it.
- The guard is case-sensitive to mirror how the rest of the codebase keys off the exact string `"Default"` (auto-create on startup, plugin auto-add, overlap warnings). A user-created `"default"` (lowercase) is treated as a distinct, regular playlist and remains deletable.
- Adds a shared module-level `DEFAULT_PLAYLIST_NAME` constant so the magic string isn't duplicated inside the route handler.

## Base Branch Confirmation

- [x] This PR is based on `origin/main`
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a fork sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (156 playlist tests green, including three new regression tests)
- [x] No breaking API route/path changes
- [x] Error response follows JSON contract (`success:false,error,code,details,request_id`)
- [x] No docs change needed (negative behavior only)
- [x] No frontend changes

## Testing

- `tests/integration/test_playlist_routes.py::test_delete_default_playlist_is_refused` — rejects 400, playlist still exists
- `tests/integration/test_playlist_routes.py::test_delete_non_default_playlist_still_succeeds` — regression guard for regular playlists
- `tests/integration/test_playlist_routes.py::test_delete_lowercase_default_playlist_is_allowed` — documents case-sensitive behavior
- Existing `test_create_update_delete_playlist_flow` still passes unchanged