### PR TITLE
fix: surface device-name validation inline (JTN-780)

### DIFF
--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -59,6 +59,32 @@
     return /\bWARNING\b/i.test(line);
   }
 
+  // JTN-780: Route a 4xx/5xx save response to the right surface.  Extracted
+  // from handleAction so cognitive complexity stays under Sonar's S3776 cap
+  // (the inline-error fast-path, the field_errors fallback, and the snapshot
+  // restore each add a branch that trip the threshold when inlined).
+  //
+  // Returns true when a field-level error was surfaced inline so the caller
+  // can skip restoring the last-known-good snapshot — otherwise the user's
+  // bad input gets wiped alongside the error message they need to see in
+  // order to fix it.
+  function applyFieldLevelError(fs, result) {
+    if (!fs || !result) return false;
+    if (result.field_errors && typeof result.field_errors === "object") {
+      fs.setFieldErrors(result.field_errors);
+      return true;
+    }
+    if (
+      result.code === "validation_error"
+      && result.details
+      && typeof result.details.field === "string"
+    ) {
+      fs.setFieldError(result.details.field, result.error);
+      return true;
+    }
+    return false;
+  }
+
   // JTN-710: banner rendering helpers.  Kept at module scope (outside the
   // createSettingsPage closure) so Sonar S7721/S3776 stay green and the
   // helpers can be individually tested/tree-shaken.
@@ -281,32 +307,9 @@
             if (saveBtn) saveBtn.disabled = true;
             showResponseModal("success", `Success! ${result.message}`);
           } else {
-            // JTN-780: Surface field-level errors inline so the user sees the
-            // problem next to the bad input, not just in a dismissable toast.
-            // The settings blueprint emits `details.field` for single-field
-            // validation errors (via `_field_error`). Other forms may emit
-            // `field_errors` maps; honor both shapes.
-            let fieldLevelError = false;
-            if (fs && result) {
-              if (result.field_errors && typeof result.field_errors === "object") {
-                fs.setFieldErrors(result.field_errors);
-                fieldLevelError = true;
-              } else if (
-                result.code === "validation_error"
-                && result.details
-                && typeof result.details.field === "string"
-              ) {
-                fs.setFieldError(result.details.field, result.error);
-                fieldLevelError = true;
-              }
-            }
+            const fieldLevelError = applyFieldLevelError(fs, result);
             showResponseModal("failure", `Error! ${result.error}`);
-            // Preserve the user's bad input when we surfaced the error inline
-            // so they can actually fix it; otherwise fall back to the
-            // previous behavior of restoring the last-known-good snapshot.
-            if (!fieldLevelError) {
-              restoreFormFromSnapshot(form, _formSnapshot);
-            }
+            if (!fieldLevelError) restoreFormFromSnapshot(form, _formSnapshot);
           }
         } catch (error) {
           console.error("Settings save failed:", error);

--- a/src/static/scripts/settings_page.js
+++ b/src/static/scripts/settings_page.js
@@ -281,12 +281,32 @@
             if (saveBtn) saveBtn.disabled = true;
             showResponseModal("success", `Success! ${result.message}`);
           } else {
-            // Surface field-level errors inline when the server returns them.
-            if (fs && result && result.field_errors && typeof result.field_errors === "object") {
-              fs.setFieldErrors(result.field_errors);
+            // JTN-780: Surface field-level errors inline so the user sees the
+            // problem next to the bad input, not just in a dismissable toast.
+            // The settings blueprint emits `details.field` for single-field
+            // validation errors (via `_field_error`). Other forms may emit
+            // `field_errors` maps; honor both shapes.
+            let fieldLevelError = false;
+            if (fs && result) {
+              if (result.field_errors && typeof result.field_errors === "object") {
+                fs.setFieldErrors(result.field_errors);
+                fieldLevelError = true;
+              } else if (
+                result.code === "validation_error"
+                && result.details
+                && typeof result.details.field === "string"
+              ) {
+                fs.setFieldError(result.details.field, result.error);
+                fieldLevelError = true;
+              }
             }
             showResponseModal("failure", `Error! ${result.error}`);
-            restoreFormFromSnapshot(form, _formSnapshot);
+            // Preserve the user's bad input when we surfaced the error inline
+            // so they can actually fix it; otherwise fall back to the
+            // previous behavior of restoring the last-known-good snapshot.
+            if (!fieldLevelError) {
+              restoreFormFromSnapshot(form, _formSnapshot);
+            }
           }
         } catch (error) {
           console.error("Settings save failed:", error);

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -56,7 +56,10 @@
                     <div class="section-title">Basics</div>
                     <div class="form-group">
                         <label for="deviceName" class="form-label">Device Name</label>
-                        <input type="text" id="deviceName" name="deviceName" placeholder="Enter device name" value="{{ device_settings.name }}" required class="form-input" aria-required="true" aria-invalid="false" aria-describedby="deviceName-error">
+                        {# JTN-780: mirror server-side constraints from JTN-746 so users see inline feedback
+                           before hitting Save. maxlength caps input at 64; pattern forbids control characters
+                           (Cc category) except tab, matching blueprints/settings/_config.py::_validate_device_name. #}
+                        <input type="text" id="deviceName" name="deviceName" placeholder="Enter device name" value="{{ device_settings.name }}" required maxlength="64" pattern="[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*" title="Up to 64 characters. Tabs are allowed; other control characters are not." class="form-input" aria-required="true" aria-invalid="false" aria-describedby="deviceName-error">
                         <span id="deviceName-error" class="validation-message" role="alert"></span>
                     </div>
                     <div class="form-group nowrap">

--- a/tests/static/test_settings_save_validation.py
+++ b/tests/static/test_settings_save_validation.py
@@ -105,3 +105,93 @@ def test_settings_form_declares_required_constraints():
     interval_line = next(line for line in html.splitlines() if 'id="interval"' in line)
     assert "required" in interval_line, "interval must remain required"
     assert 'min="1"' in interval_line, 'interval must keep min="1"'
+
+
+def test_device_name_declares_client_side_length_cap():
+    """JTN-780: the browser must cap deviceName at the server's 64-char limit.
+
+    Before this fix the server enforced a 64-char cap (JTN-746) but the
+    template omitted ``maxlength``, so a user could paste hundreds of
+    characters and only discover the problem via a 422 response. Pin the
+    ``maxlength="64"`` attribute here so the two validation layers cannot
+    drift apart silently.
+    """
+    html = _read_html()
+    device_line = next(line for line in html.splitlines() if 'id="deviceName"' in line)
+    assert 'maxlength="64"' in device_line, (
+        'deviceName must declare maxlength="64" to mirror the server-side '
+        "cap from JTN-746 — otherwise the browser silently accepts input "
+        "that the server will reject with 422"
+    )
+
+
+def test_device_name_declares_control_char_pattern():
+    """JTN-780: deviceName must forbid control chars (except tab) client-side.
+
+    The server rejects names containing characters in Unicode category ``Cc``
+    except ``\\t``. The HTML ``pattern`` attribute must mirror that set so
+    the browser surfaces :invalid before the request reaches the server.
+    """
+    html = _read_html()
+    device_line = next(line for line in html.splitlines() if 'id="deviceName"' in line)
+    assert "pattern=" in device_line, (
+        "deviceName must declare a pattern attribute so pasted control "
+        "characters fail HTML5 validation instead of silently 422-ing on Save"
+    )
+    # The regex must forbid \x00-\x08 and \x0A-\x1F (i.e. everything up to
+    # 0x1F except \t=0x09) plus DEL and C1 controls. Tab must remain allowed
+    # because the server accepts it (see test_device_name_tab_is_allowed).
+    assert r"\u0000-\u0008" in device_line, (
+        "pattern must exclude NUL through backspace (U+0000–U+0008)"
+    )
+    assert r"\u000A-\u001F" in device_line, (
+        "pattern must exclude LF through unit-separator (U+000A–U+001F) "
+        "while leaving tab (U+0009) allowed to match the server"
+    )
+    assert r"\u007F" in device_line, "pattern must exclude DEL (U+007F)"
+    assert "title=" in device_line, (
+        "pattern inputs should carry a title= for the native validation popup"
+    )
+
+
+def test_handle_action_surfaces_field_level_validation_errors_inline():
+    """JTN-780: server validation errors must render inline, not just in a toast.
+
+    The ``_field_error`` helper in ``src/blueprints/settings/_config.py``
+    emits ``{code: "validation_error", details: {field: <name>}}``. The
+    handler must surface that message on the matching input so the user sees
+    which field failed — a dismissable toast alone is not sufficient.
+    """
+    js = _read_js()
+    assert 'result.code === "validation_error"' in js, (
+        "handleAction must branch on the validation_error code so it can "
+        "route the error message to the field that failed"
+    )
+    assert "result.details.field" in js, (
+        "handleAction must read details.field to target the inline error"
+    )
+    assert "fs.setFieldError(" in js, (
+        "handleAction must call FormState.setFieldError so the validation "
+        "message lands next to the bad input (JTN-780)"
+    )
+
+
+def test_handle_action_preserves_bad_input_on_field_level_error():
+    """JTN-780: when a field-level error is surfaced, don't erase the bad value.
+
+    Pre-fix, every non-OK response restored the form from the last-known-good
+    snapshot. That wiped the user's invalid input alongside the inline error,
+    making the error message reference text the user could no longer see. The
+    snapshot restore must be gated so field-level errors preserve user input.
+    """
+    js = _read_js()
+    # There must be a guard that skips the snapshot restore when we've
+    # already surfaced a field-level error.
+    assert "fieldLevelError" in js, (
+        "handleAction must track whether a field-level error was surfaced "
+        "so the snapshot restore can be skipped (JTN-780)"
+    )
+    assert "if (!fieldLevelError)" in js, (
+        "restoreFormFromSnapshot must be gated on !fieldLevelError so the "
+        "user's bad input is preserved alongside the inline error message"
+    )

--- a/tests/static/test_settings_save_validation.py
+++ b/tests/static/test_settings_save_validation.py
@@ -141,17 +141,17 @@ def test_device_name_declares_control_char_pattern():
     # The regex must forbid \x00-\x08 and \x0A-\x1F (i.e. everything up to
     # 0x1F except \t=0x09) plus DEL and C1 controls. Tab must remain allowed
     # because the server accepts it (see test_device_name_tab_is_allowed).
-    assert r"\u0000-\u0008" in device_line, (
-        "pattern must exclude NUL through backspace (U+0000–U+0008)"
-    )
+    assert (
+        r"\u0000-\u0008" in device_line
+    ), "pattern must exclude NUL through backspace (U+0000–U+0008)"
     assert r"\u000A-\u001F" in device_line, (
         "pattern must exclude LF through unit-separator (U+000A–U+001F) "
         "while leaving tab (U+0009) allowed to match the server"
     )
     assert r"\u007F" in device_line, "pattern must exclude DEL (U+007F)"
-    assert "title=" in device_line, (
-        "pattern inputs should carry a title= for the native validation popup"
-    )
+    assert (
+        "title=" in device_line
+    ), "pattern inputs should carry a title= for the native validation popup"
 
 
 def test_handle_action_surfaces_field_level_validation_errors_inline():
@@ -167,9 +167,9 @@ def test_handle_action_surfaces_field_level_validation_errors_inline():
         "handleAction must branch on the validation_error code so it can "
         "route the error message to the field that failed"
     )
-    assert "result.details.field" in js, (
-        "handleAction must read details.field to target the inline error"
-    )
+    assert (
+        "result.details.field" in js
+    ), "handleAction must read details.field to target the inline error"
     assert "fs.setFieldError(" in js, (
         "handleAction must call FormState.setFieldError so the validation "
         "message lands next to the bad input (JTN-780)"


### PR DESCRIPTION
## Summary

Closes **JTN-780**. Frontend counterpart to JTN-746.

The Settings page `#deviceName` input had `maxLength: -1`, `pattern: ""`, no inline validation wiring. A user could paste hundreds of characters (or a newline) and only learn their save had failed by parsing a dismissable toast — the field itself looked fine.

This mirrors the server-side constraints into the HTML and routes field-level errors to the inline validation slot instead of burying them in a modal.

## Changes

- `src/templates/settings.html` — `#deviceName` gains `maxlength=\"64\"`, `pattern=\"[^\\u0000-\\u0008\\u000A-\\u001F\\u007F-\\u009F]*\"`, and a user-friendly `title`. The pattern mirrors `_validate_device_name` in `src/blueprints/settings/_config.py` (Unicode category `Cc`, except tab — which the server explicitly allows, verified by `tests/unit/test_dogfood_fuzz.py::test_device_name_tab_is_allowed`).
- `src/static/scripts/settings_page.js` — `handleAction` now recognizes `{code: \"validation_error\", details: {field}}` responses and forwards them to `FormState.setFieldError`, so the server's message lands in the `#deviceName-error` span that already carried `aria-describedby`. The `restoreFormFromSnapshot` call is skipped when a field-level error was surfaced so the user can still see (and correct) their input — previously it was wiped along with the error context.
- `tests/static/test_settings_save_validation.py` — four new static-analysis tests lock in the template attributes, the JS code path that reads `details.field`, and the snapshot-restore gate. Existing JTN-350 guards are unchanged.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (`tests/static/test_settings_save_validation.py`, `tests/unit/test_settings_save.py`, `tests/unit/test_dogfood_fuzz.py`, `tests/integration/test_settings_{routes,save_errors,round_trip_e2e,more,extra}.py`, `tests/integration/test_validation_routes.py`, `tests/integration/test_form_roundtrip.py`, `tests/unit/test_input_validation_hardening.py`, `tests/unit/test_api_property_based.py`, `tests/unit/test_settings_config_edge.py` — 209 tests, all green)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`) — the fix consumes this existing contract, doesn't alter it
- [ ] Docs updated for new flags/endpoints/UI — N/A (no new user-facing copy beyond the native pattern-violation popup)
- [x] **Frontend changes** (`src/static/**`, `src/templates/**`): covered by static-analysis tests; browser suite is unaffected by the added attributes (JTN-350 guards continue to pass)

## Testing

- New `tests/static/test_settings_save_validation.py` cases pin:
  - `maxlength=\"64\"` on `#deviceName`
  - `pattern` covers `\\u0000-\\u0008`, `\\u000A-\\u001F`, `\\u007F`; tab stays allowed
  - `handleAction` branches on `result.code === \"validation_error\"` and calls `fs.setFieldError(result.details.field, result.error)`
  - `restoreFormFromSnapshot` is gated on `!fieldLevelError`
- Manual repro from the issue no longer applies: typing 65+ chars is capped by the browser, pasting `Device\\nName` is rejected by the pattern before contacting the server, and the legitimate 422 path (`Device Name is required` when only whitespace is submitted) now shows the error text under the field.

## Related

- JTN-746 (server-side cap + control-char rejection) — this PR surfaces the same constraints client-side
- JTN-350 (HTML5 `checkValidity` / `reportValidity` gating) — reused, not changed
- JTN-505 (`FormState` / inline `validation-message` slots) — reused as the error channel