### PR TITLE
fix(playlist): return 404 for missing playlist on delete (JTN-782)

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -872,10 +872,13 @@ def delete_playlist(playlist_name):
 
     playlist = playlist_manager.get_playlist(playlist_name)
     if not playlist:
+        # JTN-782: missing playlist is a 404 Not Found, not a 400 validation
+        # error. Keep the field attribution so the UI can still surface the
+        # offending input when it wants to.
         return json_error(
             "Playlist does not exist",
-            status=400,
-            code=_CODE_VALIDATION,
+            status=404,
+            code="not_found",
             details={"field": "playlist_name"},
         )
 

--- a/tests/integration/test_playlist_more.py
+++ b/tests/integration/test_playlist_more.py
@@ -176,8 +176,12 @@ def test_update_playlist_errors_and_failure_branch(client, flask_app, monkeypatc
 
 
 def test_delete_playlist_not_exist(client):
+    # JTN-782: missing playlist returns 404 (not_found), not 400.
     resp = client.delete("/delete_playlist/NoSuch")
-    assert resp.status_code == 400
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data["success"] is False
+    assert data.get("code") == "not_found"
 
 
 def test_eta_endpoint_and_request_ids(client, device_config_dev):

--- a/tests/integration/test_routes_coverage.py
+++ b/tests/integration/test_routes_coverage.py
@@ -28,9 +28,12 @@ def test_delete_playlist_route(client, device_config_dev):
 
 
 def test_delete_playlist_nonexistent(client, device_config_dev):
-    """Deleting a nonexistent playlist returns 400."""
+    """Deleting a nonexistent playlist returns 404 with not_found (JTN-782)."""
     resp = client.delete("/delete_playlist/DoesNotExist")
-    assert resp.status_code == 400
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data["success"] is False
+    assert data.get("code") == "not_found"
 
 
 def test_reorder_plugins_route(client, device_config_dev):

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -261,9 +261,13 @@ class TestDeletePlaylist:
         assert pm.get_playlist("ToDelete") is None
 
     def test_nonexistent(self, client):
+        # JTN-782: deleting a missing playlist is a 404 with code=not_found.
         resp = client.delete("/delete_playlist/Ghost")
-        assert resp.status_code == 400
-        assert "does not exist" in resp.get_json()["error"]
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data.get("code") == "not_found"
+        assert "does not exist" in data["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -965,8 +969,15 @@ class TestValidatorFieldAttribution:
     # --- delete ---
 
     def test_delete_nonexistent(self, client):
+        # JTN-782: delete-of-missing is a 404 not_found (not a validation
+        # error), but we still attach field attribution so the UI can
+        # highlight the offending input.
         resp = client.delete("/delete_playlist/Ghost")
-        self._assert_field(resp, "playlist_name")
+        assert resp.status_code == 404, resp.get_json()
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data.get("code") == "not_found", data
+        assert data.get("details", {}).get("field") == "playlist_name", data
 
     # --- device cycle ---
 


### PR DESCRIPTION
## Summary

Fixes [JTN-782](https://linear.app/jtn0123/issue/JTN-782/delete-playlist-returns-405-on-post-and-400-not-404-for-non-existent).

`DELETE /delete_playlist/<name>` returned **HTTP 400** with `code=validation_error` when the named playlist did not exist. Semantically that is **404 Not Found**, not a validation failure. This PR changes that single branch to return **404** with `code=\"not_found\"`.

- Kept `details.field = playlist_name` so the UI can still highlight the offending input.
- No change to POST behaviour — POST continues to return 405 (no UI path sends POST here, so no regression).
- The OpenAPI spec at `src/static/openapi.json` already declares 404 as a valid response for this endpoint, so the spec is now correct by construction.

## Changes

- `src/blueprints/playlist.py` — `delete_playlist`: 400/validation_error → 404/not_found for the "playlist does not exist" branch.
- `tests/unit/test_playlist_blueprint.py` — `TestDeletePlaylist::test_nonexistent` and `TestValidatorFieldAttribution::test_delete_nonexistent` updated to assert 404 + `not_found`.
- `tests/integration/test_playlist_more.py::test_delete_playlist_not_exist` — updated.
- `tests/integration/test_routes_coverage.py::test_delete_playlist_nonexistent` — updated.

## Test plan

- [x] `pytest tests/unit/test_playlist_blueprint.py tests/integration/test_playlist_more.py tests/integration/test_routes_coverage.py tests/integration/test_playlist_xss.py` → 163 passed locally
- [x] `scripts/lint.sh` clean (pre-existing advisory mypy warnings unchanged)
- [ ] Full CI

## Related

- JTN-781 (Default playlist deletion safeguard) touches the same handler but a different branch. The two PRs should merge cleanly; whichever lands first, the other will rebase without conflict.

---

Claude agent