### PR TITLE
fix: sanitize plugin error card to hide exception class (JTN-779)

### DIFF
--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -384,11 +384,15 @@ class RefreshTask:
                 )
             except Exception as exc:
                 retain_path = self._stale_display_path()
+                # JTN-779: log the full exception class + message so operators
+                # can diagnose.  The user-visible fallback image is sanitised
+                # via utils.fallback_image.sanitize_error_message.
                 logger.error(
-                    "plugin_lifecycle: failure | plugin_id=%s instance=%s retained_display=%s error=%s",
+                    "plugin_lifecycle: failure | plugin_id=%s instance=%s retained_display=%s error_class=%s error=%s",
                     plugin_id,
                     instance_name,
                     bool(retain_path),
+                    type(exc).__name__,
                     exc,
                 )
                 self._update_plugin_health(

--- a/src/utils/fallback_image.py
+++ b/src/utils/fallback_image.py
@@ -4,9 +4,15 @@ When a plugin's generate_image() raises, the display would otherwise stay
 frozen on the previous image (silent lie).  This module provides a small
 helper that renders a human-readable error card so the user sees *something*
 changed, rather than stale content.
+
+JTN-779: the card must not leak implementation details (e.g. Python exception
+class names) to end users.  We render a friendly message derived from the raw
+exception via :func:`sanitize_error_message`, while the caller keeps the raw
+class + message in logs for operators.
 """
 
 import logging
+import re
 from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
@@ -15,6 +21,129 @@ logger = logging.getLogger(__name__)
 _MAX_MSG_LEN = 120
 # Fallback font size as a fraction of image width
 _FONT_SCALE = 0.028
+
+# Generic message used when no known pattern matches.  Intentionally avoids
+# Python-specific jargon ("RuntimeError", "exception", "traceback") so the
+# user sees something actionable but neutral.
+_GENERIC_FALLBACK = (
+    "This plugin failed to render. Check its configuration or try again later."
+)
+
+# Ordered list of (regex pattern, friendly message) tuples.  The first pattern
+# to match the raw error message wins.  Patterns are matched case-insensitively
+# against the raw exception string (after any ``ClassName:`` prefix has been
+# stripped).  Keep this list short and focused on user-visible validation
+# errors — deep technical errors should fall through to the generic message.
+_FRIENDLY_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # URL validation (JTN-776 / JTN-779) — screenshot, image_url, image_album
+    (
+        re.compile(r"URL scheme must be http or https", re.IGNORECASE),
+        "The URL you entered is not allowed. It must start with http:// or https://.",
+    ),
+    (
+        re.compile(r"URL host is required", re.IGNORECASE),
+        "The URL you entered is missing a host. Please enter a full URL like https://example.com.",
+    ),
+    (
+        re.compile(
+            r"URL host resolves to a (?:loopback|private|reserved|link-local|multicast|unspecified) address",
+            re.IGNORECASE,
+        ),
+        "That URL points to a private or local address, which is not allowed.",
+    ),
+    (
+        re.compile(r"^Invalid URL\b", re.IGNORECASE),
+        "The URL you entered is not valid. Please check it and try again.",
+    ),
+    # Network timeouts / connection errors — common across HTTP plugins
+    (
+        re.compile(
+            r"\b(?:timed out|timeout|ReadTimeout|ConnectTimeout)\b", re.IGNORECASE
+        ),
+        "The request timed out. The remote server did not respond in time.",
+    ),
+    (
+        re.compile(
+            r"\b(?:ConnectionError|Failed to establish a new connection|Name or service not known|NameResolutionError)\b",
+            re.IGNORECASE,
+        ),
+        "Could not reach the remote server. Check your network or the configured URL.",
+    ),
+    # Auth / API-key style errors
+    (
+        re.compile(
+            r"\b(?:API key|api_key|apikey)\b.*(?:missing|required|invalid|unauthorized)",
+            re.IGNORECASE,
+        ),
+        "This plugin is missing a valid API key. Update its settings.",
+    ),
+    (
+        re.compile(r"\b(?:401|Unauthorized|Forbidden|403)\b"),
+        "The remote service rejected the request (authentication failed).",
+    ),
+)
+
+# Matches a leading "ExceptionClassName: " prefix, e.g. "RuntimeError: boom".
+# Anchored at the start of the string; the class must be a valid Python
+# identifier ending with ``Error``, ``Exception``, or ``Warning`` to avoid
+# stripping legitimate user text that happens to contain a colon.
+_CLASS_PREFIX_RE = re.compile(
+    r"^\s*(?P<cls>[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning))\s*:\s*"
+)
+
+
+def strip_class_prefix(message: str) -> str:
+    """Remove a leading ``ExceptionClass:`` prefix from ``message``.
+
+    Examples:
+        >>> strip_class_prefix("RuntimeError: boom")
+        'boom'
+        >>> strip_class_prefix("some user text: with colon")
+        'some user text: with colon'
+    """
+    if not message:
+        return ""
+    return _CLASS_PREFIX_RE.sub("", message, count=1).strip()
+
+
+def sanitize_error_message(raw_message: str, *, error_class: str | None = None) -> str:
+    """Convert a raw exception message into a user-friendly string.
+
+    The returned string:
+
+    * never includes a ``ClassName:`` prefix,
+    * is a plain-English sentence when the raw message matches a known
+      validation pattern,
+    * otherwise falls back to a generic "plugin failed to render" line.
+
+    Args:
+        raw_message: The raw ``str(exc)`` string.
+        error_class: Optional exception class name.  Only used to decide
+            whether to strip a leading ``cls:`` prefix; never surfaces in the
+            returned string.
+
+    Returns:
+        A user-friendly message with no Python-specific jargon.
+    """
+    if raw_message is None:
+        raw_message = ""
+
+    # Strip a "ClassName: " prefix if present (e.g. when the raw message was
+    # formatted with ``f"{type(exc).__name__}: {exc}"`` somewhere upstream).
+    cleaned = strip_class_prefix(str(raw_message))
+
+    # Defensive: if the caller passed only the class name and nothing else,
+    # fall through to the generic message.
+    if not cleaned or (error_class and cleaned == error_class):
+        return _GENERIC_FALLBACK
+
+    for pattern, friendly in _FRIENDLY_PATTERNS:
+        if pattern.search(cleaned):
+            return friendly
+
+    # No known pattern matched — don't echo the raw message back to the user.
+    # The raw text is still available in logs for operators to diagnose.
+    return _GENERIC_FALLBACK
 
 
 def render_error_image(
@@ -32,7 +161,8 @@ def render_error_image(
     missing font files.  The card shows:
       - "Plugin Error" header
       - plugin id / instance name
-      - error class + truncated message
+      - a **sanitised**, user-friendly message (never the Python exception
+        class name — see :func:`sanitize_error_message` and JTN-779)
       - ISO timestamp
 
     Args:
@@ -40,8 +170,11 @@ def render_error_image(
         height: Target image height in pixels.
         plugin_id: Plugin identifier string.
         instance_name: Instance name or None.
-        error_class: Exception class name (e.g. ``"RuntimeError"``).
-        error_message: Exception message, truncated to ``_MAX_MSG_LEN`` chars.
+        error_class: Exception class name (e.g. ``"RuntimeError"``).  Retained
+            in the signature for call-site clarity and for logging upstream,
+            but deliberately **not** rendered on the card.
+        error_message: Raw ``str(exc)``.  Will be passed through
+            :func:`sanitize_error_message` before display.
         timestamp: ISO timestamp string; defaults to current UTC time.
 
     Returns:
@@ -52,8 +185,9 @@ def render_error_image(
     if timestamp is None:
         timestamp = datetime.now(UTC).isoformat(timespec="seconds")
 
-    short_msg = error_message[:_MAX_MSG_LEN]
-    if len(error_message) > _MAX_MSG_LEN:
+    friendly = sanitize_error_message(error_message, error_class=error_class)
+    short_msg = friendly[:_MAX_MSG_LEN]
+    if len(friendly) > _MAX_MSG_LEN:
         short_msg += "…"
 
     img = Image.new("RGBA", (width, height), (255, 255, 255, 255))
@@ -73,7 +207,7 @@ def render_error_image(
         f"Plugin:   {plugin_id}",
         f"Instance: {instance_name or '(none)'}",
         "",
-        f"{error_class}: {short_msg}",
+        short_msg,
         "",
         f"Time: {timestamp}",
     ]

--- a/tests/unit/test_fallback_image_sanitization.py
+++ b/tests/unit/test_fallback_image_sanitization.py
@@ -1,0 +1,336 @@
+# pyright: reportMissingImports=false
+"""Tests for user-visible error sanitisation in the fallback image (JTN-779).
+
+The plugin error fallback card must not leak Python implementation details
+(e.g. ``RuntimeError:`` prefixes) to end users. These tests lock in:
+
+* ``strip_class_prefix`` removes an ``ExceptionClass:`` prefix cleanly.
+* ``sanitize_error_message`` maps known validation errors to plain-English
+  sentences and falls back to a neutral message otherwise.
+* ``render_error_image`` bakes the sanitised text (not the class name) into
+  the rendered card's pixels.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from utils.fallback_image import (
+    _GENERIC_FALLBACK,
+    render_error_image,
+    sanitize_error_message,
+    strip_class_prefix,
+)
+
+# ---------------------------------------------------------------------------
+# strip_class_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestStripClassPrefix:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("RuntimeError: boom", "boom"),
+            ("ValueError: bad value", "bad value"),
+            ("TypeError: wrong type", "wrong type"),
+            ("  FileNotFoundError: missing  ", "missing"),
+            ("CustomError: details: more", "details: more"),
+            # Warning classes also stripped
+            ("DeprecationWarning: old api", "old api"),
+        ],
+    )
+    def test_strips_known_prefixes(self, raw: str, expected: str) -> None:
+        assert strip_class_prefix(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # Not a class-looking token — keep the message intact.
+            "some user text: with colon",
+            "status: failed",
+            # Lowercase tokens are not Python class names by convention.
+            "runtimeerror: boom",
+            "",
+        ],
+    )
+    def test_leaves_non_class_prefixes_untouched(self, raw: str) -> None:
+        assert strip_class_prefix(raw) == raw.strip()
+
+    def test_none_input_becomes_empty(self) -> None:
+        assert strip_class_prefix("") == ""
+
+
+# ---------------------------------------------------------------------------
+# sanitize_error_message
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeErrorMessage:
+    def test_known_url_scheme_pattern_becomes_friendly(self) -> None:
+        raw = "Invalid URL: URL scheme must be http or https"
+        friendly = sanitize_error_message(raw, error_class="RuntimeError")
+        assert "http://" in friendly
+        assert "RuntimeError" not in friendly
+        assert "URL scheme" not in friendly  # raw validator text hidden
+
+    def test_private_address_pattern(self) -> None:
+        raw = "URL host resolves to a loopback address: 127.0.0.1"
+        friendly = sanitize_error_message(raw)
+        assert "private" in friendly.lower() or "local" in friendly.lower()
+        assert "127.0.0.1" not in friendly
+
+    def test_missing_host_pattern(self) -> None:
+        raw = "URL host is required"
+        friendly = sanitize_error_message(raw)
+        assert "host" in friendly.lower() or "full URL" in friendly
+
+    def test_generic_invalid_url_pattern(self) -> None:
+        raw = "Invalid URL: something else"
+        friendly = sanitize_error_message(raw)
+        assert "URL" in friendly
+        assert "not valid" in friendly.lower() or "check" in friendly.lower()
+
+    def test_timeout_pattern(self) -> None:
+        raw = "HTTPSConnectionPool(host='x'): Read timed out. (read timeout=30)"
+        friendly = sanitize_error_message(raw)
+        assert "timed out" in friendly.lower()
+        assert "HTTPSConnectionPool" not in friendly
+
+    def test_connection_error_pattern(self) -> None:
+        raw = "ConnectionError: Failed to establish a new connection"
+        friendly = sanitize_error_message(raw)
+        assert "reach" in friendly.lower() or "network" in friendly.lower()
+        # Ensure no Python identifier leaks through.
+        assert "ConnectionError" not in friendly
+
+    def test_unauthorized_pattern(self) -> None:
+        raw = "401 Unauthorized"
+        friendly = sanitize_error_message(raw)
+        assert "authentication" in friendly.lower() or "rejected" in friendly.lower()
+
+    def test_unknown_error_falls_back_to_generic(self) -> None:
+        raw = "RuntimeError: some completely novel failure xyzzy"
+        friendly = sanitize_error_message(raw, error_class="RuntimeError")
+        assert friendly == _GENERIC_FALLBACK
+        assert "xyzzy" not in friendly
+        assert "RuntimeError" not in friendly
+
+    def test_empty_message_returns_generic(self) -> None:
+        assert sanitize_error_message("") == _GENERIC_FALLBACK
+        assert sanitize_error_message(None) == _GENERIC_FALLBACK  # type: ignore[arg-type]
+
+    def test_bare_class_name_returns_generic(self) -> None:
+        # Some exceptions stringify to just the class name when they carry no
+        # message — make sure we never echo that.
+        assert (
+            sanitize_error_message("RuntimeError", error_class="RuntimeError")
+            == _GENERIC_FALLBACK
+        )
+
+    def test_class_prefix_stripped_before_matching(self) -> None:
+        """A raw "ClassName: ..." string should still match URL patterns."""
+        raw = "RuntimeError: URL scheme must be http or https"
+        friendly = sanitize_error_message(raw, error_class="RuntimeError")
+        assert "http://" in friendly
+        assert "RuntimeError" not in friendly
+
+    def test_sanitized_output_never_contains_class_prefix(self) -> None:
+        """Fuzz-lite: for a wide range of raw inputs, we never echo class name."""
+        raw_inputs = [
+            "RuntimeError: boom",
+            "ValueError: bad value here",
+            "TypeError",
+            "KeyError: 'missing'",
+            "OSError: [Errno 2] No such file or directory: '/nope'",
+            "SystemExit: 1",
+        ]
+        for raw in raw_inputs:
+            friendly = sanitize_error_message(raw)
+            # No known Python exception class name should survive.
+            for bad in (
+                "RuntimeError",
+                "ValueError",
+                "TypeError",
+                "KeyError",
+                "OSError",
+            ):
+                assert (
+                    bad not in friendly
+                ), f"{bad!r} leaked through for {raw!r}: {friendly!r}"
+
+
+# ---------------------------------------------------------------------------
+# render_error_image
+# ---------------------------------------------------------------------------
+
+
+class TestRenderErrorImageSanitised:
+    def test_does_not_render_exception_class_name(self) -> None:
+        """The raw ``RuntimeError`` class token must not appear in the image.
+
+        We can't easily OCR the image, so we rely on ``PIL.ImageDraw.Draw``'s
+        ``text`` method being the single channel that writes strings.  Monkey-
+        patch it to capture the strings and assert the class name never
+        appears.
+        """
+        captured: list[str] = []
+
+        original_draw_cls_attr = "PIL.ImageDraw.ImageDraw.text"
+        # Rather than monkey-patching PIL globally (risky across parallel
+        # tests), we verify indirectly by rendering and re-deriving the
+        # rendered sentences from what sanitize_error_message would produce.
+        img = render_error_image(
+            width=800,
+            height=480,
+            plugin_id="screenshot",
+            instance_name=None,
+            error_class="RuntimeError",
+            error_message="Invalid URL: URL scheme must be http or https",
+        )
+        assert isinstance(img, Image.Image)
+
+        # Exercise the sanitiser directly to assert the contract — the
+        # renderer is a thin wrapper over it.
+        friendly = sanitize_error_message(
+            "Invalid URL: URL scheme must be http or https",
+            error_class="RuntimeError",
+        )
+        assert "RuntimeError" not in friendly
+        assert "URL scheme" not in friendly
+        del captured, original_draw_cls_attr
+
+    def test_render_uses_sanitized_message_via_draw_text(self, monkeypatch) -> None:
+        """Capture draw.text calls to verify the rendered lines.
+
+        This confirms the image renderer uses ``sanitize_error_message``'s
+        output (not the raw exception text) when composing the card.
+        """
+        from PIL import ImageDraw
+
+        captured: list[str] = []
+        original_text = ImageDraw.ImageDraw.text
+
+        def _capture(self, xy, text, *args, **kwargs):  # noqa: ANN001
+            captured.append(text)
+            return original_text(self, xy, text, *args, **kwargs)
+
+        monkeypatch.setattr(ImageDraw.ImageDraw, "text", _capture)
+
+        render_error_image(
+            width=800,
+            height=480,
+            plugin_id="screenshot",
+            instance_name=None,
+            error_class="RuntimeError",
+            error_message="Invalid URL: URL scheme must be http or https",
+        )
+
+        joined = "\n".join(captured)
+        # User-visible message is present in sanitised form.
+        assert "http://" in joined
+        # No leakage of the implementation language.
+        assert "RuntimeError" not in joined
+        # And the raw validator string is not echoed verbatim either.
+        assert "URL scheme must be http or https" not in joined
+
+    def test_unknown_error_renders_generic_message(self, monkeypatch) -> None:
+        from PIL import ImageDraw
+
+        captured: list[str] = []
+        original_text = ImageDraw.ImageDraw.text
+
+        def _capture(self, xy, text, *args, **kwargs):  # noqa: ANN001
+            captured.append(text)
+            return original_text(self, xy, text, *args, **kwargs)
+
+        monkeypatch.setattr(ImageDraw.ImageDraw, "text", _capture)
+
+        render_error_image(
+            width=600,
+            height=400,
+            plugin_id="weather",
+            instance_name="my_weather",
+            error_class="RuntimeError",
+            error_message="something totally unexpected blew up",
+        )
+
+        joined = "\n".join(captured)
+        assert "RuntimeError" not in joined
+        assert "something totally unexpected" not in joined
+        # Generic fallback copy should be present (we check a substring to
+        # keep this robust against wording tweaks).
+        assert "plugin" in joined.lower() and "failed" in joined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Integration with refresh_task logging (JTN-779: raw detail kept in logs)
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingKeepsRawDetail:
+    def test_logger_receives_class_and_raw_message(
+        self, device_config_dev, monkeypatch, caplog
+    ) -> None:
+        """The operator log line must contain the raw exception class + message,
+        even though the user-visible card hides them."""
+        from datetime import UTC, datetime
+
+        from model import PluginInstance
+        from refresh_task import RefreshTask
+        from refresh_task.actions import PlaylistRefresh
+
+        monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "none")
+        monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "0")
+        monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+
+        dm = MagicMock()
+        dm.display_image.return_value = {"display_ms": 10, "preprocess_ms": 5}
+        task = RefreshTask(device_config_dev, dm)
+
+        pi = PluginInstance(
+            plugin_id="dummy",
+            name="my_dummy",
+            settings={},
+            refresh={"interval": 3600},
+        )
+        pm = device_config_dev.get_playlist_manager()
+        playlist = pm.get_playlist("Default")
+        if playlist is None:
+            pm.add_default_playlist()
+            playlist = pm.get_playlist("Default")
+        playlist.plugins.append(pi)
+
+        dummy_cfg = {"id": "dummy", "class": "Dummy", "image_settings": []}
+        monkeypatch.setattr(device_config_dev, "get_plugin", lambda pid: dummy_cfg)
+
+        class AlwaysRaisesPlugin:
+            def generate_image(self, settings, cfg):
+                raise RuntimeError("Invalid URL: URL scheme must be http or https")
+
+            def get_latest_metadata(self):
+                return None
+
+        monkeypatch.setattr(
+            "refresh_task.task.get_plugin_instance",
+            lambda cfg: AlwaysRaisesPlugin(),
+        )
+
+        refresh_action = PlaylistRefresh(playlist, pi)
+        current_dt = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+        with caplog.at_level(logging.ERROR, logger="refresh_task.task"):
+            with pytest.raises(RuntimeError):
+                task._perform_refresh(refresh_action, current_dt, current_dt)
+
+        # The operator log line must surface the raw class + message so the
+        # information isn't actually lost — it's only hidden from the UI.
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "RuntimeError" in joined, f"class missing from logs: {joined!r}"
+        assert (
+            "URL scheme must be http or https" in joined
+        ), f"raw message missing from logs: {joined!r}"


### PR DESCRIPTION
## Summary

- The plugin error fallback card rendered to the display previously showed the raw Python exception class + message (e.g. `RuntimeError: Invalid URL: URL scheme must be http or https`). That leaks implementation language and surfaces internal validator strings instead of actionable guidance to end users.
- Introduces `utils.fallback_image.sanitize_error_message()` which strips `ExceptionClass:` prefixes, maps known validation/network/auth patterns to plain-English sentences, and falls back to a neutral "This plugin failed to render..." message for anything it doesn't recognise.
- `render_error_image` now routes `error_message` through the sanitiser and no longer prepends the class name to the rendered card.
- `refresh_task.task` log line now includes `error_class` as a structured field so operators still see the exception type + raw message in logs — only the UI surface is sanitised.

Cross-references **JTN-776**, which fixes the underlying 500-vs-4xx issue for the same URL validation path; this PR handles the UI-level exposure that persists regardless of the HTTP status code.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] N/A — not a fork sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (2530 unit tests + full fallback/integration suites)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (unchanged by this PR)
- [x] Docs updated — docstrings on new functions; no external docs needed
- [x] **Frontend changes**: none (the fallback card is a PIL-rendered image written to the e-paper display, not an HTML template). Existing browser smoke tests untouched.

## Testing

- New `tests/unit/test_fallback_image_sanitization.py`:
  - `strip_class_prefix` parametrised over known Error/Exception/Warning classes and negative cases (`status: failed`, lowercase, empty).
  - `sanitize_error_message` covers URL scheme, missing host, private address, generic invalid URL, timeout, connection error, unauthorized, unknown-error generic fallback, bare class name, and a fuzz-lite pass ensuring no common Python exception class name ever leaks.
  - `render_error_image` monkey-patches `PIL.ImageDraw.ImageDraw.text` to capture every string drawn on the card and asserts no class name or raw validator text appears.
  - A refresh-task integration test raises `RuntimeError("Invalid URL: URL scheme must be http or https")`, triggers `_perform_refresh`, and verifies the operator log still contains the exception class + raw message.
- Existing `tests/unit/test_plugin_failure_fallback.py` (15 tests) still passes — signature of `render_error_image` is unchanged.
- Full `tests/unit/` sweep: 2530 passed.

## Repro verified by tests

1. Plugin raises `RuntimeError("Invalid URL: URL scheme must be http or https")` → card now reads `"The URL you entered is not allowed. It must start with http:// or https://."` with no `RuntimeError:` prefix.
2. Plugin raises a generic exception → card reads `"This plugin failed to render. Check its configuration or try again later."` — no class name, no raw message.
3. Server log line still includes `error_class=RuntimeError` and the full raw message for operators.

Closes JTN-779.