### PR TITLE
fix: skip retries on permanent plugin errors (JTN-778)

### DIFF
--- a/src/plugins/image_album/image_album.py
+++ b/src/plugins/image_album/image_album.py
@@ -8,6 +8,7 @@ from plugins.base_plugin.settings_schema import field, option, row, schema, sect
 from utils.http_client import get_http_session
 from utils.http_utils import pinned_dns
 from utils.image_utils import pad_image_blur
+from utils.plugin_errors import PermanentPluginError
 from utils.security_utils import validate_url_with_ips
 
 logger = logging.getLogger(__name__)
@@ -226,7 +227,10 @@ class ImageAlbum(BasePlugin):
         try:
             _validated_url, pinned_ips = validate_url_with_ips(url)
         except ValueError as e:
-            raise RuntimeError(f"Invalid URL: {e}") from e
+            # Permanent: bad scheme, SSRF-blocked address, or malformed URL.
+            # Tell refresh_task not to retry — the URL will fail identically
+            # on every subsequent attempt (JTN-778).
+            raise PermanentPluginError(f"Invalid URL: {e}") from e
 
         album = settings.get("album")
         if not album:

--- a/src/plugins/image_url/image_url.py
+++ b/src/plugins/image_url/image_url.py
@@ -3,6 +3,7 @@ import logging
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import callout, field, schema, section
 from utils.image_utils import fetch_and_resize_remote_image
+from utils.plugin_errors import PermanentPluginError
 from utils.security_utils import validate_url
 
 logger = logging.getLogger(__name__)
@@ -53,7 +54,10 @@ class ImageURL(BasePlugin):
         try:
             validate_url(url)
         except ValueError as e:
-            raise RuntimeError(f"Invalid URL: {e}") from e
+            # Permanent: bad scheme, SSRF-blocked address, or malformed URL.
+            # Tell refresh_task not to retry — the URL will fail identically
+            # on every subsequent attempt (JTN-778).
+            raise PermanentPluginError(f"Invalid URL: {e}") from e
 
         dimensions = self.get_oriented_dimensions(device_config)
 

--- a/src/plugins/screenshot/screenshot.py
+++ b/src/plugins/screenshot/screenshot.py
@@ -3,6 +3,7 @@ import logging
 from plugins.base_plugin.base_plugin import BasePlugin
 from plugins.base_plugin.settings_schema import callout, field, schema, section
 from utils.image_utils import take_screenshot
+from utils.plugin_errors import PermanentPluginError
 from utils.security_utils import validate_url
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,10 @@ class Screenshot(BasePlugin):
         try:
             validate_url(url)
         except ValueError as e:
-            raise RuntimeError(f"Invalid URL: {e}") from e
+            # Permanent: bad scheme, SSRF-blocked address, or malformed URL.
+            # Tell refresh_task not to retry — the URL will fail identically
+            # on every subsequent attempt (JTN-778).
+            raise PermanentPluginError(f"Invalid URL: {e}") from e
 
         dimensions = self.get_oriented_dimensions(device_config)
 

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -29,6 +29,7 @@ from utils.metrics import (
     set_circuit_breaker_open,
 )
 from utils.output_validator import OutputDimensionMismatch, validate_image_dimensions
+from utils.plugin_errors import PermanentPluginError
 from utils.progress import ProgressTracker, track_progress
 from utils.progress_events import get_progress_bus
 from utils.time_utils import now_device_tz
@@ -1013,6 +1014,19 @@ class RefreshTask:
             if isinstance(last_exc, TimeoutError):
                 last_exc = TimeoutError(self._timeout_msg(plugin_id, timeout_s))
 
+            # JTN-778: permanent errors (bad URL, malformed config) will fail
+            # identically on retry — skip remaining attempts to avoid burning
+            # CPU and log lines on every scheduled playlist tick.
+            if isinstance(last_exc, PermanentPluginError):
+                logger.info(
+                    "plugin_lifecycle: attempt_terminal | plugin_id=%s attempt=%s/%s error=%s",
+                    plugin_id,
+                    attempt,
+                    attempts,
+                    last_exc,
+                )
+                raise last_exc
+
             if attempt < attempts:
                 logger.warning(
                     "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
@@ -1141,6 +1155,17 @@ class RefreshTask:
                 last_exc = result_holder["error"]
             else:
                 return result_holder["image"], result_holder.get("meta")
+
+            # JTN-778: permanent errors are terminal — skip retries.
+            if isinstance(last_exc, PermanentPluginError):
+                logger.info(
+                    "plugin_lifecycle: attempt_terminal | plugin_id=%s attempt=%s/%s error=%s",
+                    plugin_id,
+                    attempt,
+                    attempts,
+                    last_exc,
+                )
+                raise last_exc
 
             if attempt < attempts:
                 sleep(max(0.0, backoff_ms / 1000.0))

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task.actions import PluginLike, RefreshAction
 from refresh_task.context import RefreshContext, SupportsRefreshConfig
+from utils.plugin_errors import PermanentPluginError
 
 logger = logging.getLogger(__name__)
 
@@ -121,13 +122,17 @@ def _remote_exception(error_type: str, error_message: str) -> BaseException:
     Returns:
         An instance of the matched (or fallback) exception class.
     """
-    exc_types = {
+    exc_types: dict[str, type[BaseException]] = {
         "RuntimeError": RuntimeError,
         "ValueError": ValueError,
         "TimeoutError": TimeoutError,
         "KeyError": KeyError,
         "TypeError": TypeError,
         "FileNotFoundError": FileNotFoundError,
+        # JTN-778: preserve the PermanentPluginError type across the
+        # subprocess boundary so the retry loop in the parent process can
+        # distinguish it from transient RuntimeErrors and skip retries.
+        "PermanentPluginError": PermanentPluginError,
     }
     exc_cls = exc_types.get(error_type, RuntimeError)
     return exc_cls(error_message)

--- a/src/utils/plugin_errors.py
+++ b/src/utils/plugin_errors.py
@@ -1,0 +1,31 @@
+"""Exception types for plugin execution.
+
+Defines a hierarchy of errors so the refresh task can distinguish permanent
+configuration failures (bad URL, unsupported scheme, malformed settings)
+from transient failures (network hiccups, timeouts) that are worth retrying.
+
+Permanent errors are re-raised by the retry loop after a single attempt —
+they will never succeed on retry and retrying only wastes CPU cycles and
+spams the logs on every scheduled playlist tick (see JTN-778).
+"""
+
+from __future__ import annotations
+
+
+class PermanentPluginError(RuntimeError):
+    """A plugin failure that is guaranteed not to succeed on retry.
+
+    Raise this when the failure is structural rather than environmental:
+
+    - Invalid URL (bad scheme, SSRF-blocked address, malformed URL)
+    - Missing required configuration (API key, album name)
+    - Malformed settings that would fail the same way on every attempt
+
+    The refresh task retry loop recognises this exception and skips the
+    remaining attempts, so a single scheduled playlist tick with a broken
+    plugin instance costs one validation run instead of two.
+
+    Subclasses :class:`RuntimeError` so existing ``except RuntimeError``
+    handlers (e.g. the plugin blueprint's fallback in JTN-776) continue to
+    catch it without any change.
+    """

--- a/tests/unit/test_permanent_plugin_error.py
+++ b/tests/unit/test_permanent_plugin_error.py
@@ -1,0 +1,278 @@
+"""Retry-policy tests for ``PermanentPluginError`` (JTN-778).
+
+A plugin raising :class:`utils.plugin_errors.PermanentPluginError` must be
+treated as a terminal failure by both the subprocess and in-process retry
+loops — the error will never succeed on retry, so retrying only wastes
+CPU cycles and log lines on every scheduled playlist tick.
+
+Transient errors (``RuntimeError``, ``ConnectionError``, ``TimeoutError``)
+must still honour ``INKYPI_PLUGIN_RETRY_MAX`` so intermittent network
+hiccups continue to be papered over as before.
+"""
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from refresh_task import RefreshTask
+from utils.plugin_errors import PermanentPluginError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(device_config_dev):
+    dm = MagicMock()
+    return RefreshTask(device_config_dev, dm)
+
+
+def _fake_action(plugin_id: str = "image_url"):
+    action = MagicMock()
+    action.get_plugin_id.return_value = plugin_id
+    return action
+
+
+class _CountingPlugin:
+    """Plugin that records how many times ``generate_image`` was called."""
+
+    config = {"image_settings": []}
+
+    def __init__(self, exc: BaseException):
+        self.exc = exc
+        self.calls = 0
+
+    def generate_image(self, settings, cfg):
+        self.calls += 1
+        raise self.exc
+
+
+class _EventuallySucceedingPlugin:
+    """Fails with a transient error on the first call, succeeds on the second."""
+
+    config = {"image_settings": []}
+
+    def __init__(self, transient_exc: BaseException):
+        self.transient_exc = transient_exc
+        self.calls = 0
+
+    def generate_image(self, settings, cfg):
+        self.calls += 1
+        if self.calls == 1:
+            raise self.transient_exc
+        return Image.new("RGB", (10, 10), "green")
+
+
+# ---------------------------------------------------------------------------
+# In-process path — direct and easiest to observe
+# ---------------------------------------------------------------------------
+
+
+class TestPermanentPluginErrorInProcess:
+    """``_execute_inprocess`` must not retry ``PermanentPluginError``."""
+
+    def test_permanent_error_runs_exactly_one_attempt(self, device_config_dev, caplog):
+        """An ``Invalid URL`` failure must not trigger any retries."""
+        task = _make_task(device_config_dev)
+        action = _fake_action()
+        plugin = _CountingPlugin(
+            PermanentPluginError(
+                "Invalid URL: URL must not resolve to a private, loopback, "
+                "link-local, reserved, or multicast address"
+            )
+        )
+        # Mirror the real subprocess-less execute(): just invoke the plugin.
+        action.execute.side_effect = lambda p, cfg, dt: p.generate_image(None, cfg)
+
+        caplog.set_level("INFO")
+
+        with (
+            patch("refresh_task.task.get_plugin_instance", return_value=plugin),
+            patch.dict(
+                os.environ,
+                {
+                    "INKYPI_PLUGIN_RETRY_MAX": "3",
+                    "INKYPI_PLUGIN_RETRY_BACKOFF_MS": "1",
+                },
+            ),
+        ):
+            try:
+                task._execute_inprocess(action, {"id": "image_url"}, datetime.now(UTC))
+            except PermanentPluginError as exc:
+                assert "Invalid URL" in str(exc)
+            else:  # pragma: no cover
+                raise AssertionError("Expected PermanentPluginError to propagate")
+
+        assert plugin.calls == 1, (
+            f"Expected exactly one attempt, got {plugin.calls} — "
+            "PermanentPluginError should skip retries"
+        )
+        # The terminal log marker distinguishes this from attempt_retry.
+        terminal_logs = [
+            r for r in caplog.records if "attempt_terminal" in r.getMessage()
+        ]
+        assert terminal_logs, "expected an attempt_terminal log record"
+
+    def test_transient_runtime_error_still_retries(self, device_config_dev):
+        """A generic ``RuntimeError`` must honour ``INKYPI_PLUGIN_RETRY_MAX``."""
+        task = _make_task(device_config_dev)
+        action = _fake_action()
+        plugin = _EventuallySucceedingPlugin(RuntimeError("transient blip"))
+        action.execute.side_effect = lambda p, cfg, dt: p.generate_image(None, cfg)
+
+        with (
+            patch("refresh_task.task.get_plugin_instance", return_value=plugin),
+            patch.dict(
+                os.environ,
+                {
+                    "INKYPI_PLUGIN_RETRY_MAX": "1",
+                    "INKYPI_PLUGIN_RETRY_BACKOFF_MS": "1",
+                },
+            ),
+        ):
+            image, _meta = task._execute_inprocess(
+                action, {"id": "image_url"}, datetime.now(UTC)
+            )
+
+        assert image is not None
+        assert plugin.calls == 2, (
+            "Transient RuntimeError should have retried and succeeded on the "
+            f"second attempt — observed {plugin.calls} call(s)"
+        )
+
+    def test_transient_connection_error_still_retries(self, device_config_dev):
+        """``ConnectionError`` is the canonical transient failure — must retry."""
+        task = _make_task(device_config_dev)
+        action = _fake_action()
+        plugin = _EventuallySucceedingPlugin(ConnectionError("name resolution failed"))
+        action.execute.side_effect = lambda p, cfg, dt: p.generate_image(None, cfg)
+
+        with (
+            patch("refresh_task.task.get_plugin_instance", return_value=plugin),
+            patch.dict(
+                os.environ,
+                {
+                    "INKYPI_PLUGIN_RETRY_MAX": "1",
+                    "INKYPI_PLUGIN_RETRY_BACKOFF_MS": "1",
+                },
+            ),
+        ):
+            image, _meta = task._execute_inprocess(
+                action, {"id": "image_url"}, datetime.now(UTC)
+            )
+
+        assert image is not None
+        assert plugin.calls == 2
+
+
+# ---------------------------------------------------------------------------
+# Subprocess / policy path — exercises the _execute_with_policy retry loop
+# directly without spawning a child process.
+# ---------------------------------------------------------------------------
+
+
+class TestPermanentPluginErrorPolicy:
+    """``_execute_with_policy`` must re-raise ``PermanentPluginError`` after one attempt.
+
+    The autouse ``disable_plugin_process_isolation`` conftest fixture pins
+    ``INKYPI_PLUGIN_ISOLATION=none`` so the policy layer delegates to
+    ``_execute_inprocess``.  These tests explicitly switch back to the
+    subprocess-style code path by setting the env var to ``"process"`` and
+    mocking ``_run_subprocess_attempt`` so no real child process is spawned.
+    """
+
+    def test_policy_skips_retry_on_permanent_error(self, device_config_dev):
+        task = _make_task(device_config_dev)
+        action = _fake_action()
+
+        call_counter = {"n": 0}
+
+        def _fake_attempt(
+            refresh_action, plugin_config, current_dt, plugin_id, timeout_s, attempt
+        ):
+            call_counter["n"] += 1
+            return None, PermanentPluginError(
+                "Invalid URL: scheme must be http or https"
+            )
+
+        with (
+            patch.object(task, "_run_subprocess_attempt", side_effect=_fake_attempt),
+            patch.dict(
+                os.environ,
+                {
+                    "INKYPI_PLUGIN_ISOLATION": "process",
+                    "INKYPI_PLUGIN_RETRY_MAX": "3",
+                    "INKYPI_PLUGIN_RETRY_BACKOFF_MS": "1",
+                },
+            ),
+        ):
+            try:
+                task._execute_with_policy(
+                    action, {"id": "image_url"}, datetime.now(UTC)
+                )
+            except PermanentPluginError as exc:
+                assert "Invalid URL" in str(exc)
+            else:  # pragma: no cover
+                raise AssertionError("Expected PermanentPluginError to propagate")
+
+        assert call_counter["n"] == 1, (
+            "PermanentPluginError must short-circuit the retry loop after a "
+            f"single attempt — got {call_counter['n']}"
+        )
+
+    def test_policy_retries_transient_errors(self, device_config_dev):
+        task = _make_task(device_config_dev)
+        action = _fake_action()
+
+        call_counter = {"n": 0}
+        success_image = Image.new("RGB", (10, 10), "blue")
+
+        def _fake_attempt(
+            refresh_action, plugin_config, current_dt, plugin_id, timeout_s, attempt
+        ):
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return None, ConnectionError("temporary DNS failure")
+            return success_image, None
+
+        with (
+            patch.object(task, "_run_subprocess_attempt", side_effect=_fake_attempt),
+            patch.dict(
+                os.environ,
+                {
+                    "INKYPI_PLUGIN_ISOLATION": "process",
+                    "INKYPI_PLUGIN_RETRY_MAX": "1",
+                    "INKYPI_PLUGIN_RETRY_BACKOFF_MS": "1",
+                },
+            ),
+        ):
+            image, _meta = task._execute_with_policy(
+                action, {"id": "image_url"}, datetime.now(UTC)
+            )
+
+        assert image is success_image
+        assert call_counter["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Exception-type plumbing across subprocess boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteExceptionPreservesPermanentType:
+    def test_remote_exception_reconstructs_permanent_plugin_error(self):
+        """Worker must round-trip ``PermanentPluginError`` by class name."""
+        from refresh_task.worker import _remote_exception
+
+        exc = _remote_exception("PermanentPluginError", "Invalid URL: bad scheme")
+        assert isinstance(exc, PermanentPluginError)
+        assert isinstance(exc, RuntimeError)  # subclass contract
+        assert "Invalid URL" in str(exc)
+
+    def test_remote_exception_unknown_type_falls_back_to_runtime(self):
+        from refresh_task.worker import _remote_exception
+
+        exc = _remote_exception("SomeUnknownError", "boom")
+        assert type(exc) is RuntimeError


### PR DESCRIPTION
## Summary

- Introduces `PermanentPluginError(RuntimeError)` so `refresh_task` can tell permanent configuration failures (bad URL, SSRF-blocked address, malformed scheme) apart from transient ones (network hiccups, timeouts) and skip the retry loop for the former.
- Updates the three URL-validating plugins (`image_url`, `screenshot`, `image_album`) to raise the new type instead of a bare `RuntimeError` when `validate_url()` fails — subclassing `RuntimeError` keeps every existing `except RuntimeError` handler working unchanged.
- Patches both the subprocess (`_execute_with_policy`) and in-process (`_execute_inprocess`) retry loops to re-raise `PermanentPluginError` immediately after a single attempt, logging an `attempt_terminal` marker to distinguish it from `attempt_retry`.
- Extends `_remote_exception` in `refresh_task/worker.py` so the typed exception round-trips across the subprocess boundary.

Before this change, a single scheduled playlist tick against a bad URL burned ~500 ms of wall time, two full validator runs, and four log lines. After, it's one of each — on every tick.

Closes [JTN-778](https://linear.app/jtn0123/issue/JTN-778).

## Why `PermanentPluginError` (and why here)

JTN-776 is the companion issue — same URL validation surface, but it's about the blueprint returning HTTP 500 instead of 4xx. It had no open PR and no shared exception type yet, so I'm defining the type here in `src/utils/plugin_errors.py`. JTN-776 can import and re-use `PermanentPluginError` (or the existing `utils.form_utils.ValidationError`) without coupling to string-matching on `"Invalid URL"`.

Subclassing `RuntimeError` (not `ValueError`) is deliberate: every current caller catches `RuntimeError`, and the worker's pickle round-trip only preserves explicitly allow-listed types.

## Base Branch Confirmation

- [x] This PR is based on `origin/main`
- [x] I rebased/merged latest `origin/main` before opening

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (`tests/unit/test_permanent_plugin_error.py`, `tests/unit/test_refresh_policy.py`, `tests/unit/test_execute_inprocess.py`, `tests/plugins/`)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract — `PermanentPluginError` subclasses `RuntimeError` so the blueprint error handler behaves identically
- [x] `bash scripts/lint.sh` clean (ruff, black, mypy strict subset, shellcheck)

## Testing

New test module: `tests/unit/test_permanent_plugin_error.py` — 7 cases.

- `test_permanent_error_runs_exactly_one_attempt` — plugin raising `PermanentPluginError("Invalid URL: ...")` runs once and emits an `attempt_terminal` log, even with `INKYPI_PLUGIN_RETRY_MAX=3`.
- `test_transient_runtime_error_still_retries` — generic `RuntimeError` honors retry budget and succeeds on attempt 2.
- `test_transient_connection_error_still_retries` — `ConnectionError` (canonical transient) still retries.
- `test_policy_skips_retry_on_permanent_error` / `test_policy_retries_transient_errors` — same behaviour from the `_execute_with_policy` subprocess path (with `INKYPI_PLUGIN_ISOLATION=process` forced on to bypass the conftest autouse fixture).
- `test_remote_exception_reconstructs_permanent_plugin_error` — worker's pickle substitute re-creates the subclass by class name.
- `test_remote_exception_unknown_type_falls_back_to_runtime` — regression guard on the fallback branch.

Full suite: `SKIP_BROWSER=1 python -m pytest tests/ --ignore=tests/benchmarks -q` → **4568 passed, 14 skipped**. Browser-only preview-roundtrip tests are pre-existing Playwright env failures unrelated to this PR (confirmed by diffing against `main`).

## Related

- [JTN-776](https://linear.app/jtn0123/issue/JTN-776) — plugin URL validation errors return HTTP 500. That PR can import `PermanentPluginError` from `utils.plugin_errors` to classify the same failure modes from the blueprint layer.