### PR TITLE
refactor: move URLValidationError to plugin_errors module

### DIFF
--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -12,8 +12,7 @@ from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task.actions import PluginLike, RefreshAction
 from refresh_task.context import RefreshContext, SupportsRefreshConfig
-from utils.plugin_errors import PermanentPluginError
-from utils.security_utils import URLValidationError
+from utils.plugin_errors import PermanentPluginError, URLValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/plugin_errors.py
+++ b/src/utils/plugin_errors.py
@@ -11,6 +11,38 @@ spams the logs on every scheduled playlist tick (see JTN-778).
 
 from __future__ import annotations
 
+# Canonical URL validator messages. Keeping these as module constants gives us
+# an explicit whitelist that :meth:`URLValidationError.safe_message` can check
+# against before any validator text reaches an HTTP response body — this is
+# what lets the blueprint return a specific error reason without tripping
+# CodeQL's ``py/stack-trace-exposure`` rule (JTN-776).
+#
+# The hierarchy lives here (rather than in ``utils.security_utils``) so that
+# modules which need to name-check the exception type — most notably the
+# subprocess worker and tests pinning the cross-process contract — can do so
+# without importing ``security_utils``. That separation is enforced by a
+# SonarCloud architecture rule; see JTN-776 PR #563.
+URL_ERR_EMPTY = "URL must not be empty"
+URL_ERR_SCHEME = "URL scheme must be http or https"
+URL_ERR_NO_HOST = "URL must include a hostname"
+URL_ERR_LOCALHOST = "URL must not target localhost"
+URL_ERR_UNRESOLVABLE = "Cannot resolve hostname"
+URL_ERR_PRIVATE = (
+    "URL must not resolve to a private, loopback, link-local, "
+    "reserved, or multicast address"
+)
+URL_VALIDATOR_MESSAGES: frozenset[str] = frozenset(
+    {
+        URL_ERR_EMPTY,
+        URL_ERR_SCHEME,
+        URL_ERR_NO_HOST,
+        URL_ERR_LOCALHOST,
+        URL_ERR_UNRESOLVABLE,
+        URL_ERR_PRIVATE,
+    }
+)
+_URL_ERR_GENERIC = "URL failed validation"
+
 
 class PermanentPluginError(RuntimeError):
     """A plugin failure that is guaranteed not to succeed on retry.
@@ -29,3 +61,53 @@ class PermanentPluginError(RuntimeError):
     handlers (e.g. the plugin blueprint's fallback in JTN-776) continue to
     catch it without any change.
     """
+
+
+class URLValidationError(PermanentPluginError):
+    """Raised by plugins when a user-supplied URL fails SSRF/scheme validation.
+
+    Subclasses :class:`PermanentPluginError` (itself a :class:`RuntimeError`)
+    so the refresh-task retry loop skips extra attempts (JTN-778) and
+    existing ``except RuntimeError`` blocks in plugin code keep working.
+    The plugin blueprint catches this subclass specifically to return HTTP
+    4xx with the validator message instead of a generic 500 (JTN-776).
+
+    Callers returning this error to an HTTP client MUST use
+    :meth:`safe_message` rather than ``str(self)`` — the former looks the
+    reason up in a whitelist of known hardcoded validator strings, breaking
+    any accidental information-exposure taint flow.
+    """
+
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message)
+        # ``reason`` is the raw validator string from :func:`validate_url`.
+        # When the plugin wraps ``ValueError`` the message is "Invalid URL: X"
+        # where X is from :data:`URL_VALIDATOR_MESSAGES`; callers can pass the
+        # validator text directly via ``reason`` to avoid string parsing.
+        self.reason = reason if reason is not None else _extract_reason(message)
+
+    def safe_message(self) -> str:
+        """Return a response-safe description of the validation failure.
+
+        The returned string is always one of two things:
+
+        * ``"Invalid URL: <validator text>"`` where ``<validator text>`` is a
+          member of :data:`URL_VALIDATOR_MESSAGES` (an immutable set of
+          hardcoded strings in this module), or
+        * ``"Invalid URL: URL failed validation"`` as a fallback.
+
+        Because the output is selected from a constant set rather than derived
+        from the exception instance, this satisfies CodeQL's
+        ``py/stack-trace-exposure`` rule.
+        """
+        if self.reason in URL_VALIDATOR_MESSAGES:
+            return f"Invalid URL: {self.reason}"
+        return f"Invalid URL: {_URL_ERR_GENERIC}"
+
+
+def _extract_reason(message: str) -> str:
+    """Extract the validator text from a wrapped "Invalid URL: X" message."""
+    prefix = "Invalid URL: "
+    if message.startswith(prefix):
+        return message[len(prefix) :]
+    return message

--- a/src/utils/security_utils.py
+++ b/src/utils/security_utils.py
@@ -5,83 +5,28 @@ import os
 import socket
 import urllib.parse
 
-from utils.plugin_errors import PermanentPluginError
-
-# Canonical validator messages. Keeping these as module constants gives us an
-# explicit whitelist that :meth:`URLValidationError.safe_message` can check
-# against before any validator text reaches an HTTP response body — this is
-# what lets the blueprint return a specific error reason without tripping
-# CodeQL's ``py/stack-trace-exposure`` rule (JTN-776).
-_URL_ERR_EMPTY = "URL must not be empty"
-_URL_ERR_SCHEME = "URL scheme must be http or https"
-_URL_ERR_NO_HOST = "URL must include a hostname"
-_URL_ERR_LOCALHOST = "URL must not target localhost"
-_URL_ERR_UNRESOLVABLE = "Cannot resolve hostname"
-_URL_ERR_PRIVATE = (
-    "URL must not resolve to a private, loopback, link-local, "
-    "reserved, or multicast address"
+# URLValidationError — and the whitelist of hardcoded validator messages —
+# live in ``utils.plugin_errors`` so the subprocess worker and cross-process
+# tests can reference the exception type without importing ``security_utils``
+# (SonarCloud architecture rule S7788; JTN-776 PR #563). The class is
+# re-exported here for backward compatibility with the blueprint and plugin
+# call sites that also use the validator functions.
+from utils.plugin_errors import (
+    URL_ERR_EMPTY as _URL_ERR_EMPTY,
+    URL_ERR_LOCALHOST as _URL_ERR_LOCALHOST,
+    URL_ERR_NO_HOST as _URL_ERR_NO_HOST,
+    URL_ERR_PRIVATE as _URL_ERR_PRIVATE,
+    URL_ERR_SCHEME as _URL_ERR_SCHEME,
+    URL_ERR_UNRESOLVABLE as _URL_ERR_UNRESOLVABLE,
+    URLValidationError,
 )
-_URL_VALIDATOR_MESSAGES: frozenset[str] = frozenset(
-    {
-        _URL_ERR_EMPTY,
-        _URL_ERR_SCHEME,
-        _URL_ERR_NO_HOST,
-        _URL_ERR_LOCALHOST,
-        _URL_ERR_UNRESOLVABLE,
-        _URL_ERR_PRIVATE,
-    }
-)
-_URL_ERR_GENERIC = "URL failed validation"
 
-
-class URLValidationError(PermanentPluginError):
-    """Raised by plugins when a user-supplied URL fails SSRF/scheme validation.
-
-    Subclasses :class:`PermanentPluginError` (itself a :class:`RuntimeError`)
-    so the refresh-task retry loop skips extra attempts (JTN-778) and
-    existing ``except RuntimeError`` blocks in plugin code keep working.
-    The plugin blueprint catches this subclass specifically to return HTTP
-    4xx with the validator message instead of a generic 500 (JTN-776).
-
-    Callers returning this error to an HTTP client MUST use
-    :meth:`safe_message` rather than ``str(self)`` — the former looks the
-    reason up in a whitelist of known hardcoded validator strings, breaking
-    any accidental information-exposure taint flow.
-    """
-
-    def __init__(self, message: str, *, reason: str | None = None) -> None:
-        super().__init__(message)
-        # ``reason`` is the raw validator string from :func:`validate_url`.
-        # When the plugin wraps ``ValueError`` the message is "Invalid URL: X"
-        # where X is from :data:`_URL_VALIDATOR_MESSAGES`; callers can pass
-        # the validator text directly via ``reason`` to avoid string parsing.
-        self.reason = reason if reason is not None else _extract_reason(message)
-
-    def safe_message(self) -> str:
-        """Return a response-safe description of the validation failure.
-
-        The returned string is always one of two things:
-
-        * ``"Invalid URL: <validator text>"`` where ``<validator text>`` is a
-          member of :data:`_URL_VALIDATOR_MESSAGES` (an immutable set of
-          hardcoded strings in this module), or
-        * ``"Invalid URL: URL failed validation"`` as a fallback.
-
-        Because the output is selected from a constant set rather than derived
-        from the exception instance, this satisfies CodeQL's
-        ``py/stack-trace-exposure`` rule.
-        """
-        if self.reason in _URL_VALIDATOR_MESSAGES:
-            return f"Invalid URL: {self.reason}"
-        return f"Invalid URL: {_URL_ERR_GENERIC}"
-
-
-def _extract_reason(message: str) -> str:
-    """Extract the validator text from a wrapped "Invalid URL: X" message."""
-    prefix = "Invalid URL: "
-    if message.startswith(prefix):
-        return message[len(prefix) :]
-    return message
+__all__ = [
+    "URLValidationError",
+    "validate_url",
+    "validate_url_with_ips",
+    "validate_file_path",
+]
 
 
 def validate_url(url: str) -> str:

--- a/tests/plugins/test_image_url.py
+++ b/tests/plugins/test_image_url.py
@@ -94,7 +94,7 @@ def test_image_url_raises_url_validation_error(bad_url, expected_fragment):
     """JTN-776: plugins must raise URLValidationError (not bare RuntimeError)
     on bad URLs so the blueprint can map it to HTTP 422."""
     from plugins.image_url.image_url import ImageURL
-    from utils.security_utils import URLValidationError
+    from utils.plugin_errors import URLValidationError
 
     plugin = ImageURL({"id": "image_url"})
     with pytest.raises(URLValidationError) as exc_info:

--- a/tests/unit/test_permanent_plugin_error.py
+++ b/tests/unit/test_permanent_plugin_error.py
@@ -286,7 +286,7 @@ class TestRemoteExceptionPreservesPermanentType:
         subprocess path would regress to HTTP 500.
         """
         from refresh_task.worker import _remote_exception
-        from utils.security_utils import URLValidationError
+        from utils.plugin_errors import URLValidationError
 
         exc = _remote_exception(
             "URLValidationError", "Invalid URL: URL scheme must be http or https"


### PR DESCRIPTION
## Summary
Follow-up to #563 (JTN-776). SonarCloud's S7788 architecture rule flagged three imports of `security_utils.py` that landed with the merged PR — from `refresh_task/worker.py` and the two test files that pin the cross-process exception contract. The class has no real dependency on the validator implementation; it was just co-located with it.

This PR relocates `URLValidationError` (and its validator-message whitelist) into `utils/plugin_errors.py` so cross-process callers can reference the type without importing `security_utils`. The class is re-exported from `security_utils` for backward compatibility with the blueprint and plugin call sites that already use the validator functions.

No behaviour change — the exception hierarchy, `safe_message()` whitelist, and every validator error message are preserved verbatim.

## Changes
- `src/utils/plugin_errors.py`: now hosts `URLValidationError`, the `URL_VALIDATOR_MESSAGES` frozenset, and the `URL_ERR_*` message constants.
- `src/utils/security_utils.py`: imports the constants + class from `plugin_errors` (with `_URL_ERR_*` module-private aliases so `validate_url_with_ips` is unchanged). Re-exports `URLValidationError` via `__all__`.
- `src/refresh_task/worker.py`: single-line import swap (`utils.security_utils` -> `utils.plugin_errors`).
- `tests/unit/test_permanent_plugin_error.py` + `tests/plugins/test_image_url.py`: same single-line import swap.

## Test plan
- [x] Local: `pytest tests/unit/test_permanent_plugin_error.py tests/unit/test_security_utils.py tests/plugins/test_image_url.py tests/integration/test_update_now_url_validation.py` -> 57 passed
- [x] Local: `mypy --strict` on the strict subset (including the now-larger `plugin_errors.py`) -> Success, no issues
- [x] Local: `mypy src` -> 1442 (matches baseline)
- [x] Local: `ruff check`, `black --check` clean
- [ ] SonarCloud PR scan: 0 new S7788 issues against this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized URL validation error handling by consolidating error classes and constants into a dedicated module for improved maintainability.
  * Updated internal dependencies and imports across modules for better code organization.

* **Tests**
  * Updated test imports to reflect internal module restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->