### PR TITLE
fix: register plugins in refresh-task subprocess (JTN-783)

### DIFF
--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -175,16 +175,12 @@ def _execute_refresh_attempt_worker(
         # don't cross the process boundary. Re-register plugins from the
         # restored Config so `get_plugin_instance` can resolve plugin_id.
         # `load_plugins` is idempotent (overwrites under a lock), so this is
-        # safe even if the child happens to share memory with the parent
-        # (fork start method).
-        try:
-            get_plugins = getattr(child_config, "get_plugins", None)
-            if callable(get_plugins):
-                load_plugins(get_plugins())
-        except Exception:
-            # Registry repopulation is best-effort; get_plugin_instance will
-            # raise a clear ValueError below if the plugin can't be resolved.
-            logger.exception("Failed to reload plugin registry in child process")
+        # safe to call every attempt. If the restored config somehow lacks
+        # a `get_plugins` method (legacy pickled payload), skip and let
+        # `get_plugin_instance` raise a clear ValueError below.
+        get_plugins = getattr(child_config, "get_plugins", None)
+        if callable(get_plugins):
+            load_plugins(get_plugins())
         plugin_loader = cast(
             Callable[[Mapping[str, object]], PluginLike],
             get_plugin_instance,

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
-from plugins.plugin_registry import get_plugin_instance
+from plugins.plugin_registry import get_plugin_instance, load_plugins
 from refresh_task.actions import PluginLike, RefreshAction
 from refresh_task.context import RefreshContext, SupportsRefreshConfig
 from utils.plugin_errors import PermanentPluginError, URLValidationError
@@ -170,6 +170,21 @@ def _execute_refresh_attempt_worker(
     """
     try:
         child_config = _restore_child_config(refresh_context)
+        # JTN-783: spawned / forkserver children start with an empty plugin
+        # registry because module-level dicts in `plugins.plugin_registry`
+        # don't cross the process boundary. Re-register plugins from the
+        # restored Config so `get_plugin_instance` can resolve plugin_id.
+        # `load_plugins` is idempotent (overwrites under a lock), so this is
+        # safe even if the child happens to share memory with the parent
+        # (fork start method).
+        try:
+            get_plugins = getattr(child_config, "get_plugins", None)
+            if callable(get_plugins):
+                load_plugins(get_plugins())
+        except Exception:
+            # Registry repopulation is best-effort; get_plugin_instance will
+            # raise a clear ValueError below if the plugin can't be resolved.
+            logger.exception("Failed to reload plugin registry in child process")
         plugin_loader = cast(
             Callable[[Mapping[str, object]], PluginLike],
             get_plugin_instance,

--- a/tests/unit/test_refresh_task_critical.py
+++ b/tests/unit/test_refresh_task_critical.py
@@ -30,6 +30,16 @@ from refresh_task import (
 # ---------------------------------------------------------------------------
 
 
+class _SpawnableAction:
+    """Module-scope so `multiprocessing.spawn` can pickle instances
+    across the subprocess boundary (local classes are unpicklable).
+    Used only by `test_worker_reloads_plugin_registry_in_real_spawned_child`.
+    """
+
+    def execute(self, plugin, cfg, dt):
+        return Image.new("RGB", (10, 10), "green")
+
+
 class TestRemoteException:
     def test_known_types(self):
         for name, cls in [
@@ -252,12 +262,6 @@ class TestExecuteRefreshAttemptWorker:
         from refresh_task import _execute_refresh_attempt_worker
         from refresh_task.context import RefreshContext
 
-        class SpawnableAction:
-            """Picklable so the spawned child can unpickle it."""
-
-            def execute(self, plugin, cfg, dt):
-                return Image.new("RGB", (10, 10), "green")
-
         plugin_config = {"id": "clock", "class": "Clock"}
         refresh_context = RefreshContext.from_config(device_config_dev)
 
@@ -268,7 +272,7 @@ class TestExecuteRefreshAttemptWorker:
             args=(
                 result_queue,
                 plugin_config,
-                SpawnableAction(),
+                _SpawnableAction(),
                 refresh_context,
                 datetime.now(UTC),
             ),

--- a/tests/unit/test_refresh_task_critical.py
+++ b/tests/unit/test_refresh_task_critical.py
@@ -235,6 +235,66 @@ class TestExecuteRefreshAttemptWorker:
             plugin_registry.PLUGIN_CLASSES.update(saved_classes)
             plugin_registry._PLUGIN_CONFIGS.update(saved_configs)
 
+    def test_worker_reloads_plugin_registry_in_real_spawned_child(
+        self, device_config_dev
+    ):
+        """JTN-783: end-to-end variant that spawns a real subprocess.
+
+        The inline variant above simulates a cold registry by clearing the
+        parent's module-level dicts, but it still executes in the parent's
+        address space. This variant drives the full multiprocessing start
+        method (``spawn`` on macOS + the production systemd service), which
+        is the path that actually shipped the JTN-783 bug to users. If the
+        worker ever regresses back to calling ``get_plugin_instance`` on
+        the spawned child's empty registry, this test fails with the exact
+        production error instead of the simulation.
+        """
+        from refresh_task import _execute_refresh_attempt_worker
+        from refresh_task.context import RefreshContext
+
+        class SpawnableAction:
+            """Picklable so the spawned child can unpickle it."""
+
+            def execute(self, plugin, cfg, dt):
+                return Image.new("RGB", (10, 10), "green")
+
+        plugin_config = {"id": "clock", "class": "Clock"}
+        refresh_context = RefreshContext.from_config(device_config_dev)
+
+        ctx = _get_mp_context()
+        result_queue = ctx.Queue(maxsize=1)
+        proc = ctx.Process(
+            target=_execute_refresh_attempt_worker,
+            args=(
+                result_queue,
+                plugin_config,
+                SpawnableAction(),
+                refresh_context,
+                datetime.now(UTC),
+            ),
+            daemon=True,
+        )
+        proc.start()
+        # 30s is generous for spawn + plugin-info.json discovery + one fake
+        # action call; well below the per-attempt 60s default in production.
+        proc.join(timeout=30)
+        try:
+            assert not proc.is_alive(), (
+                "spawned worker did not exit within 30s — "
+                "probably stuck before result_queue.put()"
+            )
+            payload = result_queue.get(timeout=5)
+        finally:
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=5)
+
+        assert payload["ok"] is True, (
+            f"Real spawned child failed to resolve plugin from cold "
+            f"registry — JTN-783 regression. payload={payload}"
+        )
+        assert "image_bytes" in payload
+
 
 # ---------------------------------------------------------------------------
 # RefreshTask.stop()

--- a/tests/unit/test_refresh_task_critical.py
+++ b/tests/unit/test_refresh_task_critical.py
@@ -175,6 +175,66 @@ class TestExecuteRefreshAttemptWorker:
         assert "bad config" in payload["error_message"]
         assert "traceback" in payload
 
+    def test_worker_reloads_plugin_registry_in_child(self, device_config_dev):
+        """JTN-783: spawned subprocess starts with empty plugin registry.
+
+        Simulates the real bug: when multiprocessing spawn/forkserver starts a
+        child process, the module-level `PLUGIN_CLASSES` / `_PLUGIN_CONFIGS`
+        dicts in `plugins.plugin_registry` are empty. The worker must call
+        `load_plugins(child_config.get_plugins())` so `get_plugin_instance`
+        can resolve the plugin_id, otherwise every manual `/update_now` in
+        the default `process` isolation mode raises
+        `ValueError: Plugin 'clock' is not registered.`.
+
+        This test fails on main (before the fix) because the worker calls
+        `get_plugin_instance` against an empty registry.
+        """
+        # Simulate a freshly-spawned child: wipe the module-level registries
+        # the same way `spawn` would (child gets a fresh interpreter).
+        from plugins import plugin_registry
+        from refresh_task import _execute_refresh_attempt_worker
+        from refresh_task.context import RefreshContext
+
+        saved_classes = dict(plugin_registry.PLUGIN_CLASSES)
+        saved_configs = dict(plugin_registry._PLUGIN_CONFIGS)
+        plugin_registry.PLUGIN_CLASSES.clear()
+        plugin_registry._PLUGIN_CONFIGS.clear()
+
+        # Use a real plugin_id the bundled Config will discover from the
+        # plugins/ directory tree. `clock` is a stable, always-present plugin.
+        plugin_config = {"id": "clock", "class": "Clock"}
+        refresh_context = RefreshContext.from_config(device_config_dev)
+
+        class FakeAction:
+            def execute(self, plugin, cfg, dt):
+                return Image.new("RGB", (10, 10), "blue")
+
+        result_queue = queue.Queue()
+        try:
+            _execute_refresh_attempt_worker(
+                result_queue,
+                plugin_config,
+                FakeAction(),
+                refresh_context,
+                datetime.now(UTC),
+            )
+            payload = result_queue.get_nowait()
+            # With the fix: worker calls load_plugins(child_config.get_plugins())
+            # before get_plugin_instance, so the clock plugin resolves and the
+            # fake action returns a valid image.
+            assert (
+                payload["ok"] is True
+            ), f"Expected ok=True after registry reload; got: {payload}"
+            assert "image_bytes" in payload
+            # Registry should now contain clock (populated by load_plugins).
+            assert "clock" in plugin_registry.get_registered_plugin_ids()
+        finally:
+            # Restore whatever the suite had before this test ran.
+            plugin_registry.PLUGIN_CLASSES.clear()
+            plugin_registry._PLUGIN_CONFIGS.clear()
+            plugin_registry.PLUGIN_CLASSES.update(saved_classes)
+            plugin_registry._PLUGIN_CONFIGS.update(saved_configs)
+
 
 # ---------------------------------------------------------------------------
 # RefreshTask.stop()


### PR DESCRIPTION
## Summary

Every manual `/update_now` was failing in the default plugin-isolation mode (`process`) with:

```
ValueError: Plugin 'clock' is not registered.
```

### Root cause

`_execute_refresh_attempt_worker` in `src/refresh_task/worker.py` runs inside a subprocess spawned via `multiprocessing`. On Linux the context is `forkserver` (preferred) or `spawn` — both give the child a fresh Python interpreter, so the module-level registries in `plugins.plugin_registry` (`PLUGIN_CLASSES`, `_PLUGIN_CONFIGS`) are empty. The parent populates them at startup via `load_plugins(device_config.get_plugins())` in `src/inkypi.py`, but those dicts don't cross the process boundary.

The worker was calling `get_plugin_instance(plugin_config)` directly against the empty child-side registry, so `plugin_registry.py:186` raised `ValueError`.

### Fix

In `_execute_refresh_attempt_worker`, after `_restore_child_config(...)` returns, call `load_plugins(child_config.get_plugins())` before `get_plugin_instance`. `load_plugins` is idempotent (overwrites under a lock), so calling it per-attempt is safe — each spawned subprocess is short-lived anyway.

The in-process path (`_run_in_process` in `refresh_task/task.py`) already works because it reuses the parent's populated registry — intentionally not touched here.

### Notes

This bug was masked on the live device by a `/etc/systemd/system/inkypi.service.d/plugin-isolation.conf` drop-in containing `Environment=INKYPI_PLUGIN_ISOLATION=none`, which forces the in-process path. **That drop-in can be removed once this ships** so prod runs the default isolation mode (subprocess) with proper OOM / timeout isolation.

## Changes

- `src/refresh_task/worker.py` — import `load_plugins` and invoke it on the restored child `Config` before loading the plugin instance.
- `tests/unit/test_refresh_task_critical.py` — regression test `test_worker_reloads_plugin_registry_in_child` that simulates a cold-registry child by clearing `PLUGIN_CLASSES` / `_PLUGIN_CONFIGS`, runs the worker, and asserts the plugin resolves. Fails on `main` with the exact `ValueError: Plugin 'clock' is not registered.`, passes with the fix.

## Test plan

- [x] New regression test fails on `main`, passes with the fix
- [x] Full unit suite: `PYTHONPATH=src pytest tests/unit -q` — 2694 passed
- [x] Lint: `ruff check` + `black --check` on changed files
- [ ] On-device verification: after this ships, remove the `INKYPI_PLUGIN_ISOLATION=none` drop-in and confirm manual updates still succeed

Closes JTN-783.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved plugin loading reliability in worker processes to ensure plugins are properly available when needed.

* **Tests**
  * Added test coverage for plugin registry behavior in worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->