### PR TITLE
feat: plugin defaults so bare /update_now renders without settings (JTN-784)

### DIFF
--- a/src/plugins/comic/comic.py
+++ b/src/plugins/comic/comic.py
@@ -63,8 +63,7 @@ class Comic(BasePlugin):
 
         comic = settings.get("comic")
         if not comic or comic not in COMICS:
-            logger.error(f"Invalid comic: {comic}")
-            raise RuntimeError("Invalid comic provided.")
+            comic = "XKCD"
 
         logger.info(f"Fetching comic: {comic}")
 

--- a/src/plugins/countdown/countdown.py
+++ b/src/plugins/countdown/countdown.py
@@ -43,22 +43,24 @@ class Countdown(BasePlugin):
         return template_params
 
     def generate_image(self, settings, device_config):
-        title = settings.get("title")
-        countdown_date_str = settings.get("date")
-
-        if not countdown_date_str:
-            raise RuntimeError("Date is required.")
-
         dimensions = self.get_oriented_dimensions(device_config)
 
         tz_name = device_config.get_config("timezone", default="America/New_York")
         tz = get_timezone(tz_name)
         current_time = datetime.now(tz)
 
-        # Input is YYYY-MM-DD (no tz); we attach device tz immediately after parsing.
-        countdown_date = datetime.strptime(  # noqa: DTZ007
-            countdown_date_str, "%Y-%m-%d"
-        ).replace(tzinfo=tz)
+        title = settings.get("title") or "Countdown"
+        countdown_date_str = settings.get("date")
+        try:
+            countdown_date = datetime.strptime(  # noqa: DTZ007
+                countdown_date_str or "", "%Y-%m-%d"
+            ).replace(tzinfo=tz)
+        except ValueError:
+            # Fall back to 30 days out so the plugin renders something useful
+            # even when called with no configured date (e.g. first-run preview).
+            countdown_date = (current_time + timedelta(days=30)).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
 
         day_count = (countdown_date.date() - current_time.date()).days
         label = "Days Left" if day_count > 0 else "Days Passed"

--- a/src/plugins/newspaper/newspaper.py
+++ b/src/plugins/newspaper/newspaper.py
@@ -30,12 +30,12 @@ class Newspaper(BasePlugin):
 
     def generate_image(self, settings, device_config):
         newspaper_slug = settings.get("newspaperSlug")
-
-        if not newspaper_slug or not str(newspaper_slug).strip():
-            raise RuntimeError("Newspaper input not provided.")
-        newspaper_slug = str(newspaper_slug).strip().upper()
-        if newspaper_slug not in VALID_NEWSPAPER_SLUGS:
-            raise RuntimeError("Invalid newspaper selection.")
+        if newspaper_slug and str(newspaper_slug).strip():
+            newspaper_slug = str(newspaper_slug).strip().upper()
+            if newspaper_slug not in VALID_NEWSPAPER_SLUGS:
+                raise RuntimeError("Invalid newspaper selection.")
+        else:
+            newspaper_slug = "NY_NYT"
 
         # Get today's date
         today = datetime.now(tz=UTC)

--- a/src/plugins/rss/rss.py
+++ b/src/plugins/rss/rss.py
@@ -95,10 +95,8 @@ class Rss(BasePlugin):
         return template_params
 
     def generate_image(self, settings, device_config):
-        title = settings.get("title")
-        feed_url = settings.get("feedUrl")
-        if not feed_url:
-            raise RuntimeError("RSS Feed Url is required.")
+        title = settings.get("title") or "Top Stories"
+        feed_url = settings.get("feedUrl") or "https://feeds.bbci.co.uk/news/rss.xml"
 
         items = self.parse_rss_feed(feed_url)
 

--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -226,10 +226,12 @@ class Weather(BasePlugin):
         return template_params
 
     def generate_image(self, settings, device_config):
-        lat_str = settings.get("latitude")
-        long_str = settings.get("longitude")
-        if not lat_str or not long_str:
-            raise RuntimeError("Latitude and longitude are required.")
+        # Defaults chosen so the plugin renders with an empty settings dict
+        # (first-run preview, bare /update_now): NYC via OpenMeteo, imperial.
+        # OpenMeteo has no API key, so the default path works on fresh devices
+        # where OPEN_WEATHER_MAP_SECRET is unset.
+        lat_str = settings.get("latitude") or "40.7128"
+        long_str = settings.get("longitude") or "-74.0060"
         try:
             lat = float(lat_str)
             long = float(long_str)
@@ -240,9 +242,9 @@ class Weather(BasePlugin):
 
         units = settings.get("units")
         if not units or units not in ["metric", "imperial", "standard"]:
-            raise RuntimeError("Units are required.")
+            units = "imperial"
 
-        weather_provider = settings.get("weatherProvider", "OpenWeatherMap")
+        weather_provider = settings.get("weatherProvider") or "OpenMeteo"
         title = settings.get("customTitle", "")
 
         timezone = device_config.get_config("timezone", default="America/New_York")

--- a/tests/plugins/test_comic.py
+++ b/tests/plugins/test_comic.py
@@ -91,12 +91,26 @@ def test_generate_image_vertical_orientation(
     assert img.size == (h, w)
 
 
-def test_generate_image_invalid_comic_raises(plugin_config, device_config_dev):
+def test_generate_image_invalid_comic_falls_back_to_xkcd(
+    monkeypatch, plugin_config, device_config_dev
+):
+    """JTN-784: an invalid `comic` setting silently falls back to XKCD at
+    render time so a bare /update_now renders. Form validation is in the
+    settings schema, not here."""
+    from plugins.comic import comic as comic_mod
     from plugins.comic.comic import Comic
 
+    captured = {}
+
+    def fake_get_panel(name):
+        captured["comic"] = name
+        return {"image_url": "http://img/latest.png", "title": "", "caption": ""}
+
+    monkeypatch.setattr(comic_mod, "get_panel", fake_get_panel)
     p = Comic(plugin_config)
-    with pytest.raises(RuntimeError):
-        p.generate_image({"comic": "NotARealOne"}, device_config_dev)
+    monkeypatch.setattr(p, "_compose_image", lambda *a, **kw: object())
+    p.generate_image({"comic": "NotARealOne"}, device_config_dev)
+    assert captured["comic"] == "XKCD"
 
 
 def test_generate_image_centering(monkeypatch, plugin_config, device_config_dev):

--- a/tests/plugins/test_countdown.py
+++ b/tests/plugins/test_countdown.py
@@ -54,12 +54,16 @@ def test_countdown_today(plugin_config, device_config_dev):
     assert isinstance(result, Image.Image)
 
 
-def test_countdown_missing_date(plugin_config, device_config_dev):
+def test_countdown_missing_date_falls_back_to_default(plugin_config, device_config_dev):
+    """JTN-784: missing/empty date renders with a ~30-day default rather than
+    raising, so a bare /update_now call produces a visible render. Form-time
+    validation (validate_settings) still rejects the empty date; see
+    ``test_countdown_validate_settings_rejects_missing_date`` below."""
     from plugins.countdown.countdown import Countdown
 
     p = Countdown(plugin_config)
-    with pytest.raises(RuntimeError, match="Date is required"):
-        p.generate_image({"title": "No Date"}, device_config_dev)
+    result = p.generate_image({"title": "No Date"}, device_config_dev)
+    assert isinstance(result, Image.Image)
 
 
 def test_countdown_validate_settings_rejects_missing_date(plugin_config):

--- a/tests/plugins/test_newspaper.py
+++ b/tests/plugins/test_newspaper.py
@@ -68,23 +68,24 @@ def test_newspaper_slug_case_variants(monkeypatch, device_config_dev):
     assert img is not None
 
 
-def test_newspaper_missing_slug_raises(device_config_dev):
-    """Empty or missing slug raises RuntimeError."""
+def test_newspaper_missing_slug_falls_back_to_default(monkeypatch, device_config_dev):
+    """JTN-784: missing/empty slug falls back to NY_NYT at render time so a
+    bare /update_now produces a visible render."""
+    from plugins.newspaper import newspaper as np_mod
     from plugins.newspaper.newspaper import Newspaper
 
+    captured: dict = {}
+
+    def fake_get_image(url):
+        captured["url"] = url
+        return _png_image((400, 800))
+
+    monkeypatch.setattr(np_mod, "get_image", fake_get_image)
+
     plugin = Newspaper({"id": "newspaper"})
-
-    # Empty string slug
-    with pytest.raises(RuntimeError, match="Newspaper input not provided"):
-        plugin.generate_image({"newspaperSlug": ""}, device_config_dev)
-
-    # None slug
-    with pytest.raises(RuntimeError, match="Newspaper input not provided"):
-        plugin.generate_image({"newspaperSlug": None}, device_config_dev)
-
-    # Missing slug key
-    with pytest.raises(RuntimeError, match="Newspaper input not provided"):
-        plugin.generate_image({}, device_config_dev)
+    for empty in ({"newspaperSlug": ""}, {"newspaperSlug": None}, {}):
+        plugin.generate_image(empty, device_config_dev)
+        assert "NY_NYT" in captured["url"]
 
 
 def test_newspaper_invalid_slug_raises(device_config_dev):

--- a/tests/plugins/test_rss_errors.py
+++ b/tests/plugins/test_rss_errors.py
@@ -104,13 +104,17 @@ def test_rss_http_500():
             p.parse_rss_feed("http://example.com/feed.xml")
 
 
-def test_rss_missing_feed_url():
-    """Missing feedUrl raises RuntimeError."""
+def test_rss_missing_feed_url_falls_back_to_default():
+    """JTN-784: missing feedUrl at render time falls back to the BBC World News
+    default so a bare /update_now renders. validate_settings still rejects an
+    empty feedUrl on save — see tests/plugins/test_rss.py for that contract."""
     p = _make_rss_plugin()
     cfg = _make_device_config()
 
-    with pytest.raises(RuntimeError, match="RSS Feed Url is required"):
+    with patch.object(p, "parse_rss_feed", return_value=[]) as m_parse:
         p.generate_image({"title": "Test"}, cfg)
+    args, _kwargs = m_parse.call_args
+    assert args[0] == "https://feeds.bbci.co.uk/news/rss.xml"
 
 
 def test_rss_connection_error():

--- a/tests/plugins/test_weather_validation.py
+++ b/tests/plugins/test_weather_validation.py
@@ -1,7 +1,7 @@
 # pyright: reportMissingImports=false
 """Input validation tests (location, units, API key, provider)."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,47 +30,77 @@ def test_weather_provider_validation():
         assert "Unknown weather provider" in str(e)
 
 
-def test_weather_units_validation():
-    """Test weather units validation."""
+def test_weather_units_invalid_falls_back_to_imperial():
+    """JTN-784: invalid `units` fall back to imperial at render time so a bare
+    /update_now produces a render. Form-level validation (validate_settings)
+    enforces the allowed set on save."""
     from plugins.weather.weather import Weather
 
     weather = Weather({"id": "weather"})
-
-    # Test invalid units
     settings = {
         "latitude": "40.0",
         "longitude": "-74.0",
         "units": "invalid_units",
-        "weatherProvider": "OpenWeatherMap",
+        "weatherProvider": "OpenMeteo",
     }
     device_config = MagicMock()
     device_config.get_config.return_value = "UTC"
-    device_config.load_env_key.return_value = "fake_key"
+    device_config.load_env_key.return_value = None
+    device_config.get_resolution.return_value = (800, 480)
 
-    try:
+    # OpenMeteo path with no key; stub network + render so the assertion is
+    # about *which units the render path used*, not network behaviour.
+    with (
+        patch.object(Weather, "get_open_meteo_data", return_value={}) as m_data,
+        patch.object(Weather, "get_open_meteo_air_quality", return_value={}),
+        patch.object(
+            Weather,
+            "parse_open_meteo_data",
+            return_value={"dt": 0, "title": "-"},
+        ),
+        patch.object(Weather, "render_image", return_value=object()),
+        patch.object(Weather, "_request_timeout", return_value=None),
+        patch.object(Weather, "get_plugin_dir", return_value=""),
+    ):
         weather.generate_image(settings, device_config)
-        assert False, "Should have raised RuntimeError"
-    except RuntimeError as e:
-        assert "Units are required" in str(e)
+
+    args, _kwargs = m_data.call_args
+    # Signature: get_open_meteo_data(self, lat, long, units, forecast_days)
+    assert args[2] == "imperial"
 
 
-def test_weather_location_validation():
-    """Test weather location validation."""
+def test_weather_missing_latitude_falls_back_to_default():
+    """JTN-784: missing lat/lon default to NYC coords at render time."""
     from plugins.weather.weather import Weather
 
     weather = Weather({"id": "weather"})
-
-    # Test missing latitude
     settings = {
         "longitude": "-74.0",
         "units": "metric",
-        "weatherProvider": "OpenWeatherMap",
+        "weatherProvider": "OpenMeteo",
     }
     device_config = MagicMock()
     device_config.get_config.return_value = "UTC"
+    device_config.load_env_key.return_value = None
+    device_config.get_resolution.return_value = (800, 480)
 
-    with pytest.raises(RuntimeError, match="required"):
+    with (
+        patch.object(Weather, "get_open_meteo_data", return_value={}) as m_data,
+        patch.object(Weather, "get_open_meteo_air_quality", return_value={}),
+        patch.object(
+            Weather,
+            "parse_open_meteo_data",
+            return_value={"dt": 0, "title": "-"},
+        ),
+        patch.object(Weather, "render_image", return_value=object()),
+        patch.object(Weather, "_request_timeout", return_value=None),
+        patch.object(Weather, "get_plugin_dir", return_value=""),
+    ):
         weather.generate_image(settings, device_config)
+
+    args, _kwargs = m_data.call_args
+    # patched classmethod Mock sees (lat, long, units, forecast_days) without self.
+    assert args[0] == pytest.approx(40.7128)  # default latitude (NYC)
 
 
 def test_weather_api_key_validation():
@@ -116,15 +146,32 @@ def test_weather_missing_api_key(device_config_dev, monkeypatch):
         p.generate_image(settings, device_config_dev)
 
 
-def test_weather_missing_coordinates_raises(device_config_dev):
-    """Bug 9: Missing lat/long should raise RuntimeError, not TypeError from float(None)."""
+def test_weather_missing_coordinates_falls_back_to_default(device_config_dev):
+    """JTN-784: missing lat/long no longer raise — defaults (NYC) are applied.
+    Bug 9 regression (TypeError from ``float(None)``) is still covered by
+    ``test_weather_invalid_coordinates_raises`` below, which exercises the
+    ``float()`` path with non-numeric values."""
     from plugins.weather.weather import Weather
 
     p = Weather({"id": "weather"})
-    settings = {"units": "metric", "weatherProvider": "OpenWeatherMap"}
+    settings = {"units": "metric", "weatherProvider": "OpenMeteo"}
 
-    with pytest.raises(RuntimeError, match="required"):
+    with (
+        patch.object(Weather, "get_open_meteo_data", return_value={}) as m_data,
+        patch.object(Weather, "get_open_meteo_air_quality", return_value={}),
+        patch.object(
+            Weather,
+            "parse_open_meteo_data",
+            return_value={"dt": 0, "title": "-"},
+        ),
+        patch.object(Weather, "render_image", return_value=object()),
+        patch.object(Weather, "_request_timeout", return_value=None),
+        patch.object(Weather, "get_plugin_dir", return_value=""),
+    ):
         p.generate_image(settings, device_config_dev)
+    args, _kwargs = m_data.call_args
+    assert args[0] == pytest.approx(40.7128)
+    assert args[1] == pytest.approx(-74.0060)
 
 
 def test_weather_invalid_coordinates_raises(device_config_dev):
@@ -266,8 +313,9 @@ def test_weather_plugin_settings_template_has_numeric_inputs(client):
     assert 'max="180"' in html
 
 
-def test_weather_invalid_units(device_config_dev):
-    """Test weather plugin with invalid units."""
+def test_weather_invalid_units_falls_back_to_imperial(device_config_dev):
+    """JTN-784: invalid `units` fall back to imperial at render time; form
+    validation still rejects the bad value on save."""
     from plugins.weather.weather import Weather
 
     p = Weather({"id": "weather"})
@@ -275,11 +323,24 @@ def test_weather_invalid_units(device_config_dev):
         "latitude": "40.7128",
         "longitude": "-74.0060",
         "units": "invalid",
-        "weatherProvider": "OpenWeatherMap",
+        "weatherProvider": "OpenMeteo",
     }
 
-    with pytest.raises(RuntimeError, match="Units are required"):
+    with (
+        patch.object(Weather, "get_open_meteo_data", return_value={}) as m_data,
+        patch.object(Weather, "get_open_meteo_air_quality", return_value={}),
+        patch.object(
+            Weather,
+            "parse_open_meteo_data",
+            return_value={"dt": 0, "title": "-"},
+        ),
+        patch.object(Weather, "render_image", return_value=object()),
+        patch.object(Weather, "_request_timeout", return_value=None),
+        patch.object(Weather, "get_plugin_dir", return_value=""),
+    ):
         p.generate_image(settings, device_config_dev)
+    args, _kwargs = m_data.call_args
+    assert args[2] == "imperial"
 
 
 def test_weather_unknown_provider(device_config_dev, monkeypatch):

--- a/tests/unit/test_plugin_defaults.py
+++ b/tests/unit/test_plugin_defaults.py
@@ -1,0 +1,168 @@
+"""JTN-784: plugins with no user configuration should render via defaults.
+
+Each test stubs the network / render sink so we can assert the defaults
+selected by `generate_image` when called with an empty settings dict,
+without spinning up chromium or hitting the real feed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+
+class DummyDeviceConfig:
+    def __init__(self) -> None:
+        self._config = {"timezone": "UTC", "time_format": "24h"}
+
+    def get_config(self, key: str, default: Any = None) -> Any:
+        return self._config.get(key, default)
+
+    def load_env_key(self, key: str) -> str | None:
+        return None
+
+    def get_resolution(self) -> tuple[int, int]:
+        return (800, 480)
+
+
+def _plugin(cls, plugin_id: str):
+    return cls({"id": plugin_id})
+
+
+def test_comic_defaults_to_xkcd_when_settings_empty(monkeypatch):
+    from src.plugins.comic import comic_parser as cp
+    from src.plugins.comic.comic import Comic
+
+    captured: dict[str, Any] = {}
+
+    def fake_get_panel(name: str) -> dict[str, Any]:
+        captured["comic"] = name
+        return {
+            "image_url": "https://example.invalid/x.png",
+            "title": "",
+            "caption": "",
+        }
+
+    monkeypatch.setattr(cp, "get_panel", fake_get_panel)
+    # comic.py imports get_panel into its module namespace
+    from src.plugins.comic import comic as comic_mod
+
+    monkeypatch.setattr(comic_mod, "get_panel", fake_get_panel)
+
+    def fake_compose(*_args, **_kwargs):
+        return object()
+
+    inst = _plugin(Comic, "comic")
+    monkeypatch.setattr(inst, "_compose_image", fake_compose)
+
+    # Expected defaults: comic=XKCD. No exception.
+    inst.generate_image({}, DummyDeviceConfig())
+    assert captured["comic"] == "XKCD"
+
+
+def test_countdown_defaults_title_and_date_when_empty(monkeypatch):
+    from src.plugins.countdown.countdown import Countdown
+
+    captured: dict[str, Any] = {}
+
+    def fake_render(_dims, _html, _css, params):
+        captured["title"] = params["title"]
+        captured["day_count"] = params["day_count"]
+        captured["label"] = params["label"]
+        return object()
+
+    inst = _plugin(Countdown, "countdown")
+    monkeypatch.setattr(inst, "render_image", fake_render)
+
+    inst.generate_image({}, DummyDeviceConfig())
+    assert captured["title"] == "Countdown"
+    # Default is ~30 days out, so day_count must be positive.
+    assert captured["day_count"] > 0
+    assert captured["label"] == "Days Left"
+
+
+def test_newspaper_defaults_slug_when_empty(monkeypatch):
+    from src.plugins.newspaper import newspaper as np_mod
+    from src.plugins.newspaper.newspaper import Newspaper
+
+    captured: dict[str, Any] = {}
+
+    class _FakeImage:
+        size = (800, 480)
+
+        def resize(self, *_a, **_kw):
+            return self
+
+    def fake_get_image(url: str):
+        captured["url"] = url
+        return _FakeImage()
+
+    monkeypatch.setattr(np_mod, "get_image", fake_get_image)
+
+    inst = _plugin(Newspaper, "newspaper")
+    inst.generate_image({}, DummyDeviceConfig())
+    # Default is NY_NYT; URL contains the slug lowercased-per-format.
+    assert "NY_NYT" in captured["url"]
+
+
+def test_rss_defaults_feed_url_when_empty(monkeypatch):
+    from src.plugins.rss.rss import Rss
+
+    captured: dict[str, Any] = {}
+
+    def fake_parse(self, url: str, timeout: int = 10):  # noqa: ANN001
+        captured["url"] = url
+        return []
+
+    def fake_render(_dims, _html, _css, params):
+        captured["title"] = params["title"]
+        return object()
+
+    inst = _plugin(Rss, "rss")
+    monkeypatch.setattr(Rss, "parse_rss_feed", fake_parse)
+    monkeypatch.setattr(inst, "render_image", fake_render)
+
+    inst.generate_image({}, DummyDeviceConfig())
+    assert captured["url"] == "https://feeds.bbci.co.uk/news/rss.xml"
+    assert captured["title"] == "Top Stories"
+
+
+def test_weather_defaults_use_openmeteo_when_empty(monkeypatch):
+    from src.plugins.weather.weather import Weather
+
+    captured: dict[str, Any] = {}
+
+    def fake_get_open_meteo_data(self, lat, long, units, days):  # noqa: ANN001
+        captured["lat"] = lat
+        captured["long"] = long
+        captured["units"] = units
+        return {}
+
+    def fake_get_open_meteo_air_quality(self, lat, long):  # noqa: ANN001
+        return {}
+
+    def fake_parse_open_meteo_data(self, *_a, **_kw):
+        return {"title": "-", "dt": datetime.now(UTC).timestamp()}
+
+    def fake_render(_dims, _html, _css, params):
+        captured["title"] = params.get("title")
+        return object()
+
+    inst = _plugin(Weather, "weather")
+    monkeypatch.setattr(Weather, "get_open_meteo_data", fake_get_open_meteo_data)
+    monkeypatch.setattr(
+        Weather, "get_open_meteo_air_quality", fake_get_open_meteo_air_quality
+    )
+    monkeypatch.setattr(Weather, "parse_open_meteo_data", fake_parse_open_meteo_data)
+    monkeypatch.setattr(inst, "render_image", fake_render)
+    monkeypatch.setattr(inst, "_request_timeout", lambda: None)
+    monkeypatch.setattr(inst, "get_plugin_dir", lambda p=None: "")
+
+    inst.generate_image({}, DummyDeviceConfig())
+    # NYC defaults, imperial, and OpenMeteo path used (not OWM; load_env_key
+    # returns None here, so OWM path would raise "API Key not configured").
+    assert captured["lat"] == pytest.approx(40.7128)
+    assert captured["long"] == pytest.approx(-74.0060)
+    assert captured["units"] == "imperial"


### PR DESCRIPTION
## Summary

When `POST /update_now plugin_id=<name>` arrives with no form data (first-run preview, API-driven render, empty-playlist default), these plugins previously returned HTTP 500 with `"An internal error occurred"` and the real reason buried in the journal. They now fall back to sensible defaults and render:

| Plugin | Default |
| -- | -- |
| `comic` | `comic=XKCD` |
| `countdown` | `title=Countdown`, date 30 days out |
| `newspaper` | `newspaperSlug=NY_NYT` |
| `rss` | `feedUrl=https://feeds.bbci.co.uk/news/rss.xml`, title "Top Stories" |
| `weather` | NYC coords, imperial, OpenMeteo provider (no key) |

## Scope

- `validate_settings()` is **untouched** on every plugin — save-time form validation still rejects empty required fields. Only `generate_image()` falls back to defaults on the ephemeral render path.
- Weather uses the OpenMeteo provider as the default since it needs no API key. OpenWeatherMap still works when the user picks it explicitly and `OPEN_WEATHER_MAP_SECRET` is set.
- Plugins that fundamentally need user data (`calendar` → ICS URL, `image_folder` → folder path, `image_album` → Immich URL+key, `image_url` / `screenshot` → URL) are **not** in this PR. They'd benefit from a shared "configure-me" placeholder image rather than defaults — tracked as a follow-up on JTN-784.

## Context

This surfaced while dogfooding on my Pi Zero 2 W: of 20 plugins, only 4 (`clock`, `year_progress`, `todo_list`, `apod` with NASA key) responded to a bare `/update_now`. Every other no-token plugin 500'd on missing settings even though the code underneath would have rendered fine with a default.

Related: JTN-783 (subprocess plugin registry) blocks observing this in default isolation mode; on v0.63.0 with `INKYPI_PLUGIN_ISOLATION=none` these defaults render end-to-end. Once JTN-783 ships this works in the default config.

## Test plan

- [x] `pytest tests/unit/test_plugin_defaults.py` — 5 new regression tests, one per plugin, assert the defaults flow through to the downstream renderer (chromium/feedparser/image-fetch all mocked).
- [x] `pytest tests/unit -k "comic or countdown or newspaper or rss or weather or plugin"` — 395 related tests green.
- [x] ruff + black clean.
- [ ] On-device: render each of the 5 plugins via `/update_now plugin_id=<name>` and confirm no 500. (Blocked on JTN-783 landing; verified via in-process isolation workaround.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)