### PR TITLE
fix: apt-get update before apt-get install in update.sh (JTN-788)

### DIFF
--- a/install/update.sh
+++ b/install/update.sh
@@ -292,7 +292,28 @@ stop_service
 
 _current_step="apt_install"
 _inkypi_maybe_inject_failure "apt_install"
-apt-get update -y > /dev/null &
+# JTN-788: Refresh the apt index *synchronously* before installing. The
+# previous implementation launched `apt-get update` in the background (`&`)
+# which raced with apt-get install and, in practice, meant install ran
+# against a stale /var/lib/apt/lists/ cache. When the Raspberry Pi archive
+# publishes a chromium point-release between updates, the cached index
+# refers to a version the mirror no longer serves and apt-get install
+# aborts with "Can't find a source to download version ...". Running
+# update first (and waiting for it to finish) fixes this.
+#
+# A failing `apt-get update` is treated as a soft warning, not a hard
+# abort: a transient index refresh failure (offline, DNS, mirror hiccup)
+# should not block a bugfix-only update. If no new package versions are
+# actually required, the subsequent install succeeds against the cached
+# index; if they are, the existing abort path below still fires.
+echo "Refreshing apt package index..."
+sudo apt-get update -qq
+apt_update_rc=$?
+if [ "$apt_update_rc" -ne 0 ]; then
+  echo_error "WARNING: apt-get update exited $apt_update_rc — continuing with cached index."
+else
+  echo_success "apt-get update succeeded (rc=0)."
+fi
 if [ -f "$APT_REQUIREMENTS_FILE" ]; then
   echo "Installing system dependencies... "
   if ! xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null; then

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1947,8 +1947,7 @@ class TestUpdateScript:
             and not line.strip().startswith("#")
         ]
         assert apt_update_lines, (
-            "update.sh must call apt-get update before apt-get install "
-            "(JTN-788)"
+            "update.sh must call apt-get update before apt-get install " "(JTN-788)"
         )
         for line in apt_update_lines:
             assert not line.rstrip().endswith("&"), (
@@ -1959,15 +1958,15 @@ class TestUpdateScript:
         # body so the install sees a freshly-refreshed index.
         update_pos = self.content.index("apt-get update")
         install_pos = self.content.index("apt-get install")
-        assert update_pos < install_pos, (
-            "JTN-788: apt-get update must run before apt-get install"
-        )
+        assert (
+            update_pos < install_pos
+        ), "JTN-788: apt-get update must run before apt-get install"
         # The exit code of apt-get update must be observed/logged so a
         # transient failure is visible in the journal for later debugging,
         # per the issue's "Log the update result" requirement.
-        assert "apt_update_rc" in self.content, (
-            "JTN-788: update.sh must capture apt-get update's exit code"
-        )
+        assert (
+            "apt_update_rc" in self.content
+        ), "JTN-788: update.sh must capture apt-get update's exit code"
 
     def test_update_does_not_abort_on_apt_update_failure(self):
         # JTN-788: A transient apt-get update failure (offline, DNS, mirror

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1932,6 +1932,58 @@ class TestUpdateScript:
                 "--no-cache-dir" in line
             ), f"pip install uv in update.sh missing --no-cache-dir: {line!r}"
 
+    def test_update_refreshes_apt_index_before_install(self):
+        # JTN-788: update.sh must run `apt-get update` synchronously before
+        # `apt-get install` so a stale /var/lib/apt/lists/ cache does not
+        # abort the update when the Raspberry Pi archive has published a
+        # package point-release since the last update. The previous
+        # implementation backgrounded `apt-get update` (with `&`), which
+        # raced against the install and left it reading a stale index in
+        # practice.
+        apt_update_lines = [
+            line
+            for line in self.content.splitlines()
+            if re.search(r"\bapt-get update\b", line)
+            and not line.strip().startswith("#")
+        ]
+        assert apt_update_lines, (
+            "update.sh must call apt-get update before apt-get install "
+            "(JTN-788)"
+        )
+        for line in apt_update_lines:
+            assert not line.rstrip().endswith("&"), (
+                "JTN-788: apt-get update must run synchronously; "
+                f"backgrounded invocation is the bug: {line!r}"
+            )
+        # apt-get update must precede apt-get install in the main script
+        # body so the install sees a freshly-refreshed index.
+        update_pos = self.content.index("apt-get update")
+        install_pos = self.content.index("apt-get install")
+        assert update_pos < install_pos, (
+            "JTN-788: apt-get update must run before apt-get install"
+        )
+        # The exit code of apt-get update must be observed/logged so a
+        # transient failure is visible in the journal for later debugging,
+        # per the issue's "Log the update result" requirement.
+        assert "apt_update_rc" in self.content, (
+            "JTN-788: update.sh must capture apt-get update's exit code"
+        )
+
+    def test_update_does_not_abort_on_apt_update_failure(self):
+        # JTN-788: A transient apt-get update failure (offline, DNS, mirror
+        # hiccup) must NOT abort a bugfix-only update. The failure path
+        # should warn and continue; the subsequent apt-get install decides
+        # whether the stale index is actually fatal.
+        assert "WARNING: apt-get update" in self.content, (
+            "JTN-788: update.sh must warn (not abort) when apt-get update "
+            "fails so transient index refresh errors do not block updates"
+        )
+        # Sanity: the JTN-704 /settings/update_status contract requires the
+        # apt-get install abort message format to remain unchanged.
+        assert (
+            "ERROR: apt-get install failed — aborting update." in self.content
+        ), "JTN-704 contract — apt-get install abort message must not change"
+
     def test_update_uses_uv_pip_install_for_requirements(self):
         # JTN-670 / JTN-605 parity: update.sh must prefer uv pip install when uv
         # is available, mirroring install.sh's create_venv() pattern.


### PR DESCRIPTION
## Summary

- `install/update.sh` was launching `apt-get update` in the background (`&`) and racing it against `apt-get install`. On devices whose `/var/lib/apt/lists/` cache was stale relative to the Raspberry Pi archive — the normal state between updates — install read the old index and aborted with `E: Can't find a source to download version ... of 'chromium:armhf'`. Fresh installs worked (install.sh does the update), only updates hit this.
- Switch to a synchronous `apt-get update -qq` before the install, log the exit code, and treat a failing update as a soft warning. A transient index refresh failure (offline, DNS, mirror hiccup) should not block a bugfix-only update; the existing install abort path still fires if new package versions are actually required.
- The `ERROR: apt-get install failed — aborting update.` message is preserved verbatim to keep the `/settings/update_status` contract from JTN-704 intact.

## Changes

- `install/update.sh` — replace backgrounded `apt-get update -y > /dev/null &` with a synchronous `sudo apt-get update -qq`, capture the exit code into `apt_update_rc`, and log success / warn on non-zero.
- `tests/unit/test_install_scripts.py` — add two regression tests in `TestUpdateScript`:
  - `test_update_refreshes_apt_index_before_install` — asserts `apt-get update` runs synchronously (no trailing `&`), precedes `apt-get install`, and captures an exit code.
  - `test_update_does_not_abort_on_apt_update_failure` — asserts the warning path exists and the JTN-704 install-abort message is unchanged.

## Test plan

- [x] `pytest tests/unit/test_install_scripts.py::TestUpdateScript` — 31/31 pass (29 pre-existing + 2 new)
- [x] `pytest tests/unit/test_install_scripts.py tests/unit/test_settings_update*.py tests/integration/test_update_failure_recovery.py tests/integration/journeys/test_update_flow_happy_path.py` — 319/319 pass
- [x] `shellcheck install/update.sh` — no new findings (only pre-existing SC1091 info about `_common.sh` source)

Closes JTN-788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)