### PR TITLE
fix: surface update failures when do_update.sh aborts early (JTN-787)

### DIFF
--- a/install/do_update.sh
+++ b/install/do_update.sh
@@ -136,9 +136,15 @@ echo "Repository root: $REPO_DIR"
 CURRENT_VERSION=$(git -C "$REPO_DIR" describe --tags --abbrev=0 2>/dev/null || echo "unknown")
 # JTN-787: honour INKYPI_LOCKFILE_DIR so tests can redirect state writes
 # without needing write access to /var/lib. Production callers do not set it.
+# Failure to create the state dir (e.g. running as non-root on a fresh box)
+# is non-fatal — the prev_version breadcrumb is best-effort and its absence
+# only disables the rollback button, it does not block the update itself.
 STATE_DIR="${INKYPI_LOCKFILE_DIR:-/var/lib/inkypi}"
-mkdir -p "$STATE_DIR"
-echo "$CURRENT_VERSION" > "$STATE_DIR/prev_version"
+if mkdir -p "$STATE_DIR" 2>/dev/null; then
+  echo "$CURRENT_VERSION" > "$STATE_DIR/prev_version" 2>/dev/null || true
+else
+  echo "Warning: could not create $STATE_DIR; skipping prev_version breadcrumb." >&2
+fi
 echo "Current version: $CURRENT_VERSION"
 
 # ---------------------------------------------------------------------------

--- a/install/do_update.sh
+++ b/install/do_update.sh
@@ -19,12 +19,97 @@ done
 SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
 
 # ---------------------------------------------------------------------------
+# JTN-787: EXIT trap to record failures that happen *before* delegation to
+# install/update.sh. Without this, errors in the git fetch/checkout phase
+# (e.g. a dirty working tree blocking `git checkout`) abort do_update.sh
+# before it exec's update.sh, so update.sh's JTN-704 trap never runs and
+# the UI has zero signal about why the update failed.
+#
+# The JSON shape MUST match update.sh's trap exactly so downstream readers
+# (src/blueprints/settings/_update_status.py::read_last_update_failure)
+# don't need to branch on origin. Required keys: timestamp, exit_code,
+# last_command, recent_journal_lines.
+#
+# LOCKFILE_DIR is overridable via INKYPI_LOCKFILE_DIR for tests — same
+# contract as install/update.sh (JTN-704).
+# ---------------------------------------------------------------------------
+LOCKFILE_DIR="/var/lib/inkypi"
+if [ -n "${INKYPI_LOCKFILE_DIR:-}" ]; then
+  LOCKFILE_DIR="$INKYPI_LOCKFILE_DIR"
+fi
+FAILURE_FILE="$LOCKFILE_DIR/.last-update-failure"
+
+# Track last command description so the trap can report which phase failed.
+_current_step="startup"
+
+_inkypi_do_update_exit_trap() {
+  local rc=$?
+  # Only act on non-zero exits; a successful do_update.sh exec's update.sh
+  # whose own trap takes over. If we return 0 here without exec'ing (e.g.
+  # same-version early continue followed by the exec), this branch is never
+  # reached because `exec` replaces the process.
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+  # Best-effort journal tail — same pattern as update.sh so the UI sees
+  # identical fields on either code path.
+  local journal_tail=""
+  if command -v journalctl >/dev/null 2>&1; then
+    # Prefer the transient unit name exported by systemd-run, if present.
+    local unit_for_journal="${INVOCATION_ID:+inkypi-update}"
+    [ -z "$unit_for_journal" ] && unit_for_journal="inkypi-update"
+    journal_tail=$(journalctl -u "$unit_for_journal" -n 20 --no-pager 2>/dev/null \
+      | tail -n 20 || true)
+  fi
+  local journal_json
+  if command -v python3 >/dev/null 2>&1; then
+    journal_json=$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' \
+      <<<"$journal_tail" 2>/dev/null || echo '""')
+  else
+    journal_json='"'$(printf '%s' "$journal_tail" \
+      | tr -d '\r' \
+      | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g' \
+      | tr -d '\000-\010\013\014\016-\037')'"'
+  fi
+  local step_json
+  if command -v python3 >/dev/null 2>&1; then
+    step_json=$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))' \
+      <<<"$_current_step" 2>/dev/null || echo '""')
+  else
+    step_json='"'$(printf '%s' "$_current_step" \
+      | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')'"'
+  fi
+  mkdir -p "$LOCKFILE_DIR" 2>/dev/null || true
+  local tmp="${FAILURE_FILE}.tmp"
+  {
+    printf '{'
+    printf '"timestamp":"%s",' "$ts"
+    printf '"exit_code":%d,' "$rc"
+    printf '"last_command":%s,' "$step_json"
+    printf '"recent_journal_lines":%s' "$journal_json"
+    printf '}\n'
+  } > "$tmp" 2>/dev/null || true
+  if [ -s "$tmp" ]; then
+    mv -f "$tmp" "$FAILURE_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  else
+    rm -f "$tmp" 2>/dev/null || true
+  fi
+}
+trap _inkypi_do_update_exit_trap EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+# ---------------------------------------------------------------------------
 # Resolve the git repo root
 # ---------------------------------------------------------------------------
 # In production, install.sh symlinks src/ → /usr/local/inkypi/src. Following
 # the symlink back gives us the actual git checkout directory.
 PROJECT_DIR="${PROJECT_DIR:-/usr/local/inkypi}"
 
+_current_step="resolve_repo_dir"
 if [ -L "$PROJECT_DIR/src" ] && REAL_SRC=$(realpath "$PROJECT_DIR/src" 2>/dev/null) && [ -n "$REAL_SRC" ]; then
   REPO_DIR=$(dirname "$REAL_SRC")
 elif [ -d "$SCRIPT_DIR/../.git" ]; then
@@ -37,6 +122,7 @@ else
 fi
 
 # Validate it's actually a git repo
+_current_step="validate_git_repo"
 if ! git -C "$REPO_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "ERROR: $REPO_DIR is not a git repository." >&2
   exit 1
@@ -48,7 +134,9 @@ echo "Repository root: $REPO_DIR"
 # Save current version for rollback breadcrumb
 # ---------------------------------------------------------------------------
 CURRENT_VERSION=$(git -C "$REPO_DIR" describe --tags --abbrev=0 2>/dev/null || echo "unknown")
-STATE_DIR="/var/lib/inkypi"
+# JTN-787: honour INKYPI_LOCKFILE_DIR so tests can redirect state writes
+# without needing write access to /var/lib. Production callers do not set it.
+STATE_DIR="${INKYPI_LOCKFILE_DIR:-/var/lib/inkypi}"
 mkdir -p "$STATE_DIR"
 echo "$CURRENT_VERSION" > "$STATE_DIR/prev_version"
 echo "Current version: $CURRENT_VERSION"
@@ -78,6 +166,7 @@ fi
 # ---------------------------------------------------------------------------
 # Fetch latest from origin
 # ---------------------------------------------------------------------------
+_current_step="git_fetch"
 echo "Fetching latest from origin..."
 git -C "$REPO_DIR" fetch origin --tags --prune
 
@@ -110,6 +199,19 @@ echo "Target version: $TARGET_TAG"
 if [ "$CURRENT_VERSION" = "$TARGET_TAG" ]; then
   echo "Already at $TARGET_TAG — re-running update.sh for dependency sync."
 else
+  # JTN-787: Reset the narrow allowlist of generated build artifacts before
+  # checkout so a dirty working tree cannot abort the update with
+  # "Your local changes to the following files would be overwritten by
+  # checkout". The CSS bundle is rebuilt by update.sh (build_css_bundle)
+  # immediately after this exec, so discarding it here is safe.
+  #
+  # Keep this allowlist to exactly one known-generated path — do NOT expand
+  # it, because every additional path is a chance to silently throw away
+  # legitimate user changes.
+  _current_step="reset_generated_artifacts"
+  git -C "$REPO_DIR" checkout -- src/static/styles/main.css 2>/dev/null || true
+
+  _current_step="git_checkout"
   echo "Checking out $TARGET_TAG..."
   # Pass the tag via an explicit revision argument before ``--`` so it
   # cannot be interpreted as a flag by git checkout, and add a trailing
@@ -126,5 +228,6 @@ if [ ! -f "$UPDATE_SCRIPT" ]; then
   exit 1
 fi
 
+_current_step="exec_update_sh"
 echo "Running update.sh from checked-out code..."
 exec bash "$UPDATE_SCRIPT"

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -152,6 +152,70 @@ def start_update():
         )
 
 
+def _probe_finished_unit(unit: str) -> tuple[bool, bool]:
+    """Return ``(cleared, unit_was_failed)`` for the systemd transient unit.
+
+    ``cleared`` is True if the unit has reached a terminal state (anything
+    other than ``active``/``activating``) so the caller should flip running
+    to False. ``unit_was_failed`` is True only when systemd reports
+    ``failed`` — used by JTN-787 to decide whether to synthesize a
+    last_failure from the journal.
+
+    All exceptions swallowed — status probing must never fail the endpoint.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", unit],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        status = result.stdout.strip()
+        if status in ("active", "activating"):
+            return (False, False)
+        return (True, status == "failed")
+    except Exception:
+        return (False, False)
+
+
+def _synthesize_failure_from_journal(unit: str) -> dict[str, object] | None:
+    """JTN-787: build a last_failure record from ``journalctl -u <unit>``.
+
+    Returns ``None`` when journalctl is unavailable, the unit has no
+    journal lines, or anything else goes wrong. The returned shape mirrors
+    the JTN-704 trap-written record plus a ``synthesized: True`` marker so
+    UI consumers can distinguish the two origins.
+    """
+    import datetime as _dt
+    import subprocess
+
+    try:
+        journal_result = subprocess.run(
+            ["journalctl", "-u", unit, "-n", "20", "--no-pager"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        _mod.logger.debug(
+            "Failed to synthesize last_failure from journalctl", exc_info=True
+        )
+        return None
+    journal_tail = (journal_result.stdout or "").strip()
+    if not journal_tail:
+        return None
+    return {
+        "timestamp": _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "exit_code": None,
+        "last_command": "systemd_unit_failed",
+        "recent_journal_lines": journal_tail,
+        "unit": unit,
+        "synthesized": True,
+    }
+
+
 @_mod.settings_bp.route("/settings/update_status", methods=["GET"])
 def update_status():
     with route_error_boundary(
@@ -159,45 +223,24 @@ def update_status():
         logger=_mod.logger,
         hint="Check systemd status access and last-update metadata files.",
     ):
-        import subprocess
-
         running = bool(_mod._UPDATE_STATE.get("running"))
         unit = _mod._UPDATE_STATE.get("unit")
         started_at = _mod._UPDATE_STATE.get("started_at")
 
         # Auto-clear stale update state
-        synthesized_failure: dict | None = None
         cleared_unit_was_failed = False
         cleared_unit_name: str | None = None
         if running:
             cleared = False
             # Check if the systemd transient unit has finished
             if unit and _mod._systemd_available():
-                try:
-                    result = subprocess.run(
-                        ["systemctl", "is-active", unit],
-                        capture_output=True,
-                        text=True,
-                        timeout=5,
-                    )
-                    status = result.stdout.strip()
-                    if status not in ("active", "activating"):
-                        _mod._UPDATE_STATE["last_unit"] = unit
-                        _mod._set_update_state(False, None)
-                        cleared = True
-                        # JTN-787: Remember whether the unit transitioned into
-                        # ``failed`` so that if no ``.last-update-failure`` file
-                        # was written we can still surface *something* to the
-                        # UI. The common case this catches is do_update.sh
-                        # aborting before delegating to update.sh (e.g. a dirty
-                        # working tree blocks `git checkout`), leaving the
-                        # transient systemd unit as failed with no on-disk
-                        # failure metadata.
-                        if status == "failed":
-                            cleared_unit_was_failed = True
-                            cleared_unit_name = unit
-                except Exception:
-                    pass
+                cleared, unit_failed = _probe_finished_unit(unit)
+                if cleared:
+                    _mod._UPDATE_STATE["last_unit"] = unit
+                    _mod._set_update_state(False, None)
+                    if unit_failed:
+                        cleared_unit_was_failed = True
+                        cleared_unit_name = unit
             # Timeout fallback: force-clear if started >30 min ago
             if (
                 not cleared
@@ -222,45 +265,13 @@ def update_status():
         # from the unit's journal tail. This covers the case where
         # ``install/do_update.sh`` aborts before delegating to
         # ``install/update.sh`` (e.g. a dirty working tree blocks
-        # ``git checkout``) on a pre-JTN-787 installed script, or if the
-        # failure file write itself failed for any reason. Best-effort:
-        # any exception falls through to the original ``last_failure`` value
-        # so this path never makes status worse.
+        # ``git checkout``) on a pre-JTN-787 installed script. Best-effort:
+        # the helper returns ``None`` on any failure so this path never
+        # makes status worse.
         if last_failure is None and cleared_unit_was_failed and cleared_unit_name:
-            try:
-                journal_result = subprocess.run(
-                    [
-                        "journalctl",
-                        "-u",
-                        cleared_unit_name,
-                        "-n",
-                        "20",
-                        "--no-pager",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
-                journal_tail = (journal_result.stdout or "").strip()
-                if journal_tail:
-                    import datetime as _dt
-
-                    synthesized_failure = {
-                        "timestamp": _dt.datetime.now(_dt.timezone.utc)
-                        .strftime("%Y-%m-%dT%H:%M:%SZ"),
-                        "exit_code": None,
-                        "last_command": "systemd_unit_failed",
-                        "recent_journal_lines": journal_tail,
-                        "unit": cleared_unit_name,
-                        "synthesized": True,
-                    }
-            except Exception:  # pragma: no cover — best-effort
-                _mod.logger.debug(
-                    "Failed to synthesize last_failure from journalctl",
-                    exc_info=True,
-                )
-            if synthesized_failure is not None:
-                last_failure = synthesized_failure
+            synthesized = _synthesize_failure_from_journal(cleared_unit_name)
+            if synthesized is not None:
+                last_failure = synthesized
 
         # JTN-708: surface the prev_version breadcrumb so the UI can gate the
         # "Roll back" button on whether a valid previous tag exists.  The read

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -216,6 +216,46 @@ def _synthesize_failure_from_journal(unit: str) -> dict[str, object] | None:
     }
 
 
+def _auto_clear_stale_update_state() -> tuple[str | None, bool]:
+    """Clear ``_UPDATE_STATE`` when the transient systemd unit has finished.
+
+    Extracted from ``update_status`` so the endpoint stays under the
+    15-point cognitive-complexity cap (JTN-787 / SonarCloud S3776).
+
+    Returns ``(failed_unit_name, unit_failed)`` — ``failed_unit_name`` is
+    the unit whose completion triggered the clear, returned ONLY when the
+    unit ended in ``failed`` state (for the journal-synthesis fallback).
+    ``None`` when nothing needed clearing or the unit succeeded.
+    """
+    if not _mod._UPDATE_STATE.get("running"):
+        return None, False
+
+    unit = _mod._UPDATE_STATE.get("unit")
+    started_at = _mod._UPDATE_STATE.get("started_at")
+    failed_name: str | None = None
+    unit_failed = False
+
+    cleared = False
+    if unit and _mod._systemd_available():
+        cleared, unit_failed = _probe_finished_unit(unit)
+        if cleared:
+            _mod._UPDATE_STATE["last_unit"] = unit
+            _mod._set_update_state(False, None)
+            if unit_failed:
+                failed_name = unit
+
+    # Timeout fallback: force-clear if started >30 min ago.
+    if (
+        not cleared
+        and started_at
+        and (time.time() - float(started_at)) > _mod._UPDATE_TIMEOUT_SECONDS
+    ):
+        _mod._UPDATE_STATE["last_unit"] = unit
+        _mod._set_update_state(False, None)
+
+    return failed_name, unit_failed
+
+
 @_mod.settings_bp.route("/settings/update_status", methods=["GET"])
 def update_status():
     with route_error_boundary(
@@ -223,37 +263,11 @@ def update_status():
         logger=_mod.logger,
         hint="Check systemd status access and last-update metadata files.",
     ):
+        failed_unit_name, _unit_failed = _auto_clear_stale_update_state()
+
         running = bool(_mod._UPDATE_STATE.get("running"))
         unit = _mod._UPDATE_STATE.get("unit")
         started_at = _mod._UPDATE_STATE.get("started_at")
-
-        # Auto-clear stale update state
-        cleared_unit_was_failed = False
-        cleared_unit_name: str | None = None
-        if running:
-            cleared = False
-            # Check if the systemd transient unit has finished
-            if unit and _mod._systemd_available():
-                cleared, unit_failed = _probe_finished_unit(unit)
-                if cleared:
-                    _mod._UPDATE_STATE["last_unit"] = unit
-                    _mod._set_update_state(False, None)
-                    if unit_failed:
-                        cleared_unit_was_failed = True
-                        cleared_unit_name = unit
-            # Timeout fallback: force-clear if started >30 min ago
-            if (
-                not cleared
-                and started_at
-                and (time.time() - float(started_at)) > _mod._UPDATE_TIMEOUT_SECONDS
-            ):
-                _mod._UPDATE_STATE["last_unit"] = unit
-                _mod._set_update_state(False, None)
-
-            # Re-read after potential clear
-            running = bool(_mod._UPDATE_STATE.get("running"))
-            unit = _mod._UPDATE_STATE.get("unit")
-            started_at = _mod._UPDATE_STATE.get("started_at")
 
         # JTN-710: surface the last update failure (written by the EXIT trap
         # in install/update.sh) so the UI can show *why* an update failed
@@ -265,18 +279,14 @@ def update_status():
         # from the unit's journal tail. This covers the case where
         # ``install/do_update.sh`` aborts before delegating to
         # ``install/update.sh`` (e.g. a dirty working tree blocks
-        # ``git checkout``) on a pre-JTN-787 installed script. Best-effort:
-        # the helper returns ``None`` on any failure so this path never
-        # makes status worse.
-        if last_failure is None and cleared_unit_was_failed and cleared_unit_name:
-            synthesized = _synthesize_failure_from_journal(cleared_unit_name)
+        # ``git checkout``) on a pre-JTN-787 installed script.
+        if last_failure is None and failed_unit_name:
+            synthesized = _synthesize_failure_from_journal(failed_unit_name)
             if synthesized is not None:
                 last_failure = synthesized
 
         # JTN-708: surface the prev_version breadcrumb so the UI can gate the
-        # "Roll back" button on whether a valid previous tag exists.  The read
-        # already applies the strict semver regex, so an unreadable / corrupt
-        # file is returned as ``None`` (button stays hidden).
+        # "Roll back" button on whether a valid previous tag exists.
         prev_version = _read_prev_version()
 
         return jsonify(

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -166,6 +166,9 @@ def update_status():
         started_at = _mod._UPDATE_STATE.get("started_at")
 
         # Auto-clear stale update state
+        synthesized_failure: dict | None = None
+        cleared_unit_was_failed = False
+        cleared_unit_name: str | None = None
         if running:
             cleared = False
             # Check if the systemd transient unit has finished
@@ -182,6 +185,17 @@ def update_status():
                         _mod._UPDATE_STATE["last_unit"] = unit
                         _mod._set_update_state(False, None)
                         cleared = True
+                        # JTN-787: Remember whether the unit transitioned into
+                        # ``failed`` so that if no ``.last-update-failure`` file
+                        # was written we can still surface *something* to the
+                        # UI. The common case this catches is do_update.sh
+                        # aborting before delegating to update.sh (e.g. a dirty
+                        # working tree blocks `git checkout`), leaving the
+                        # transient systemd unit as failed with no on-disk
+                        # failure metadata.
+                        if status == "failed":
+                            cleared_unit_was_failed = True
+                            cleared_unit_name = unit
                 except Exception:
                     pass
             # Timeout fallback: force-clear if started >30 min ago
@@ -202,6 +216,51 @@ def update_status():
         # in install/update.sh) so the UI can show *why* an update failed
         # without the user SSHing in to read the system journal.
         last_failure = read_last_update_failure()
+
+        # JTN-787: If the transient systemd unit transitioned to ``failed``
+        # but no ``.last-update-failure`` file was written, synthesize one
+        # from the unit's journal tail. This covers the case where
+        # ``install/do_update.sh`` aborts before delegating to
+        # ``install/update.sh`` (e.g. a dirty working tree blocks
+        # ``git checkout``) on a pre-JTN-787 installed script, or if the
+        # failure file write itself failed for any reason. Best-effort:
+        # any exception falls through to the original ``last_failure`` value
+        # so this path never makes status worse.
+        if last_failure is None and cleared_unit_was_failed and cleared_unit_name:
+            try:
+                journal_result = subprocess.run(
+                    [
+                        "journalctl",
+                        "-u",
+                        cleared_unit_name,
+                        "-n",
+                        "20",
+                        "--no-pager",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                journal_tail = (journal_result.stdout or "").strip()
+                if journal_tail:
+                    import datetime as _dt
+
+                    synthesized_failure = {
+                        "timestamp": _dt.datetime.now(_dt.timezone.utc)
+                        .strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "exit_code": None,
+                        "last_command": "systemd_unit_failed",
+                        "recent_journal_lines": journal_tail,
+                        "unit": cleared_unit_name,
+                        "synthesized": True,
+                    }
+            except Exception:  # pragma: no cover — best-effort
+                _mod.logger.debug(
+                    "Failed to synthesize last_failure from journalctl",
+                    exc_info=True,
+                )
+            if synthesized_failure is not None:
+                last_failure = synthesized_failure
 
         # JTN-708: surface the prev_version breadcrumb so the UI can gate the
         # "Roll back" button on whether a valid previous tag exists.  The read

--- a/tests/integration/test_do_update_failure_surface.py
+++ b/tests/integration/test_do_update_failure_surface.py
@@ -1,0 +1,230 @@
+# pyright: reportMissingImports=false
+"""JTN-787: do_update.sh must record failures that happen before delegating
+to update.sh (dirty checkout, not-a-repo, etc.).
+
+Before JTN-787, do_update.sh exited non-zero without writing
+``.last-update-failure``, so update.sh's JTN-704 trap never ran and the
+Settings -> Updates UI surfaced nothing. These tests exercise the new
+top-level EXIT trap in do_update.sh and the generated-artifact reset that
+prevents a dirty ``src/static/styles/main.css`` from blocking checkout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DO_UPDATE_SH = REPO_ROOT / "install" / "do_update.sh"
+
+
+def _require_bash_git() -> None:
+    if not shutil.which("bash"):
+        pytest.skip("bash not available")
+    if not shutil.which("git"):
+        pytest.skip("git not available")
+
+
+def _run(
+    env_overrides: dict[str, str],
+    cwd: Path | None = None,
+    args: list[str] | None = None,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.update(env_overrides)
+    cmd = ["bash", str(DO_UPDATE_SH)]
+    if args:
+        cmd.extend(args)
+    return subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=str(cwd) if cwd else None,
+        check=False,
+    )
+
+
+class TestFailureTrapWritesRecord:
+    """do_update.sh's EXIT trap writes ``.last-update-failure`` on abort."""
+
+    def test_aborts_with_failure_file_outside_git_repo(self, tmp_path: Path) -> None:
+        """When PROJECT_DIR/src isn't a symlink and SCRIPT_DIR/../.git is
+        missing, do_update.sh must exit non-zero AND write a parseable
+        ``.last-update-failure`` JSON record to $INKYPI_LOCKFILE_DIR."""
+        _require_bash_git()
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        # Point PROJECT_DIR at an empty tmpdir so the symlink branch fails.
+        # The script also checks $SCRIPT_DIR/../.git — our worktree has a
+        # ``.git`` *file* (not directory) there, so the `-d` test also fails
+        # and the script correctly falls through to the "cannot determine"
+        # error path.
+        empty_proj = tmp_path / "empty_proj"
+        empty_proj.mkdir()
+
+        proc = _run(
+            {
+                "INKYPI_LOCKFILE_DIR": str(state_dir),
+                "PROJECT_DIR": str(empty_proj),
+            }
+        )
+        assert proc.returncode != 0, (
+            f"do_update.sh must exit non-zero when no repo is found. "
+            f"stderr: {proc.stderr!r}"
+        )
+
+        failure_file = state_dir / ".last-update-failure"
+        assert failure_file.exists(), (
+            f"JTN-787: do_update.sh's EXIT trap must write "
+            f"{failure_file.name} on non-zero exit. stderr: {proc.stderr!r}"
+        )
+        parsed = json.loads(failure_file.read_text())
+        # Contract shape must match update.sh's JTN-704 trap so downstream
+        # readers (read_last_update_failure) don't need to branch on origin.
+        for key in ("timestamp", "exit_code", "last_command", "recent_journal_lines"):
+            assert key in parsed, f"missing required key {key!r} in {parsed!r}"
+        assert parsed["exit_code"] != 0
+        # last_command should reflect the phase that was active at failure.
+        assert parsed["last_command"] == "resolve_repo_dir", (
+            f"expected last_command='resolve_repo_dir' for the no-repo abort "
+            f"case; got {parsed['last_command']!r}"
+        )
+
+
+class TestDirtyGeneratedCssDoesNotBlockCheckout:
+    """JTN-787: a dirty src/static/styles/main.css must NOT block checkout.
+
+    This simulates the real-world failure mode: the user (or a prior build)
+    modified the generated CSS bundle, and ``git checkout <tag>`` refused
+    with "Your local changes to the following files would be overwritten by
+    checkout". do_update.sh now resets that one known-generated path before
+    checkout.
+    """
+
+    def _make_repo(self, root: Path) -> None:
+        """Build a minimal git repo with two tags, a CSS file, and the
+        worktree layout do_update.sh expects (install/ subdir)."""
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", str(root)],
+            check=True,
+            capture_output=True,
+        )
+        # Configure identity so commits work.
+        for k, v in (("user.email", "t@t"), ("user.name", "t")):
+            subprocess.run(
+                ["git", "-C", str(root), "config", k, v],
+                check=True,
+                capture_output=True,
+            )
+        css_dir = root / "src" / "static" / "styles"
+        css_dir.mkdir(parents=True)
+        css_file = css_dir / "main.css"
+        css_file.write_text("/* v1 css */\n")
+        # Minimal install/update.sh that exits 0 so the exec at the end of
+        # do_update.sh does not explode (we only care about the checkout
+        # phase for this test).
+        install_dir = root / "install"
+        install_dir.mkdir()
+        (install_dir / "update.sh").write_text(
+            "#!/bin/bash\necho 'stub update.sh'\nexit 0\n"
+        )
+        (install_dir / "update.sh").chmod(0o755)
+        subprocess.run(
+            ["git", "-C", str(root), "add", "-A"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-q", "-m", "v0.0.1"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "tag", "v0.0.1"],
+            check=True,
+            capture_output=True,
+        )
+        # Bump + second tag so TARGET_TAG differs from CURRENT_VERSION.
+        css_file.write_text("/* v2 css */\n")
+        subprocess.run(
+            ["git", "-C", str(root), "add", "-A"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-q", "-m", "v0.0.2"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "tag", "v0.0.2"],
+            check=True,
+            capture_output=True,
+        )
+        # Arrange a fake "origin" pointing at itself so `git fetch origin`
+        # succeeds without hitting the network.
+        subprocess.run(
+            ["git", "-C", str(root), "remote", "add", "origin", str(root)],
+            check=True,
+            capture_output=True,
+        )
+
+    def test_dirty_main_css_does_not_block_checkout(self, tmp_path: Path) -> None:
+        _require_bash_git()
+        repo = tmp_path / "repo"
+        self._make_repo(repo)
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        # Dirty the generated CSS bundle at HEAD (v0.0.2), then ask
+        # do_update.sh to check out v0.0.1. Without the JTN-787 reset, git
+        # checkout would abort with "local changes would be overwritten".
+        css_file = repo / "src" / "static" / "styles" / "main.css"
+        css_file.write_text("/* LOCALLY DIRTIED — should be discarded */\n")
+        assert css_file.read_text().startswith("/* LOCALLY DIRTIED")
+
+        # Point PROJECT_DIR at a tmpdir with a `src` symlink into the repo
+        # so do_update.sh's realpath-based repo resolution succeeds.
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "src").symlink_to(repo / "src")
+
+        proc = _run(
+            {
+                "INKYPI_LOCKFILE_DIR": str(state_dir),
+                "PROJECT_DIR": str(proj),
+            },
+            args=["v0.0.1"],
+        )
+        assert proc.returncode == 0, (
+            f"do_update.sh must succeed even with a dirty generated CSS "
+            f"bundle (JTN-787). exit={proc.returncode}. stderr: "
+            f"{proc.stderr!r}\nstdout: {proc.stdout!r}"
+        )
+        # After a successful run, HEAD should be at v0.0.1 and the CSS
+        # file should hold v0.0.1's content, not the dirty sentinel.
+        head_tag = subprocess.run(
+            ["git", "-C", str(repo), "describe", "--tags"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head_tag == "v0.0.1", f"expected HEAD at v0.0.1; got {head_tag!r}"
+        assert "LOCALLY DIRTIED" not in css_file.read_text(), (
+            "JTN-787 reset should have discarded the dirty main.css before "
+            "checkout; dirty content still present"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/integration/test_do_update_failure_surface.py
+++ b/tests/integration/test_do_update_failure_surface.py
@@ -59,24 +59,42 @@ class TestFailureTrapWritesRecord:
     def test_aborts_with_failure_file_outside_git_repo(self, tmp_path: Path) -> None:
         """When PROJECT_DIR/src isn't a symlink and SCRIPT_DIR/../.git is
         missing, do_update.sh must exit non-zero AND write a parseable
-        ``.last-update-failure`` JSON record to $INKYPI_LOCKFILE_DIR."""
+        ``.last-update-failure`` JSON record to $INKYPI_LOCKFILE_DIR.
+
+        We copy do_update.sh to a fresh tmpdir so its SCRIPT_DIR/../.git
+        fallback path cannot resolve to the real repo checkout (on CI the
+        runner's workdir IS a git repo, which would otherwise let the
+        script proceed past the resolve_repo_dir phase).
+        """
         _require_bash_git()
         state_dir = tmp_path / "state"
         state_dir.mkdir()
 
-        # Point PROJECT_DIR at an empty tmpdir so the symlink branch fails.
-        # The script also checks $SCRIPT_DIR/../.git — our worktree has a
-        # ``.git`` *file* (not directory) there, so the `-d` test also fails
-        # and the script correctly falls through to the "cannot determine"
-        # error path.
+        # Isolate the script from any ambient git repo so both branches of
+        # the repo-resolution logic fail cleanly.
+        install_dir = tmp_path / "isolated_install"
+        install_dir.mkdir()
+        copied_script = install_dir / "do_update.sh"
+        copied_script.write_bytes(DO_UPDATE_SH.read_bytes())
+        copied_script.chmod(0o755)
+
         empty_proj = tmp_path / "empty_proj"
         empty_proj.mkdir()
 
-        proc = _run(
+        env = dict(os.environ)
+        env.update(
             {
                 "INKYPI_LOCKFILE_DIR": str(state_dir),
                 "PROJECT_DIR": str(empty_proj),
             }
+        )
+        proc = subprocess.run(
+            ["bash", str(copied_script)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
         )
         assert proc.returncode != 0, (
             f"do_update.sh must exit non-zero when no repo is found. "

--- a/tests/unit/test_updates_surface_errors.py
+++ b/tests/unit/test_updates_surface_errors.py
@@ -105,6 +105,7 @@ class TestSynthesizeFailureFromJournal:
         import subprocess as real_subprocess
 
         import blueprints.settings as mod
+
         # Mark an update as running with a known unit so the auto-clear
         # path is reached.
         mod._UPDATE_STATE["running"] = True
@@ -167,6 +168,7 @@ class TestSynthesizeFailureFromJournal:
         import subprocess as real_subprocess
 
         import blueprints.settings as mod
+
         real_failure = {
             "timestamp": "2026-04-20T00:00:00Z",
             "exit_code": 97,

--- a/tests/unit/test_updates_surface_errors.py
+++ b/tests/unit/test_updates_surface_errors.py
@@ -92,6 +92,124 @@ class TestUpdateStatusLastFailure:
         assert data["last_failure"] == {"parse_error": True}
 
 
+class TestSynthesizeFailureFromJournal:
+    """JTN-787: when the transient systemd unit is ``failed`` but no
+    ``.last-update-failure`` file exists, synthesize one from the unit's
+    journal tail so the UI still has *something* to show. This covers the
+    case where ``install/do_update.sh`` on a pre-JTN-787 install aborts
+    before delegating to ``install/update.sh``."""
+
+    def test_synthesizes_last_failure_when_unit_failed_and_no_file(
+        self, client, monkeypatch, tmp_path
+    ):
+        import subprocess as real_subprocess
+
+        import blueprints.settings as mod
+        # Mark an update as running with a known unit so the auto-clear
+        # path is reached.
+        mod._UPDATE_STATE["running"] = True
+        mod._UPDATE_STATE["unit"] = "inkypi-update-1234.service"
+        mod._UPDATE_STATE["started_at"] = 1_000_000.0
+
+        # Isolate lockfile dir so the real ``.last-update-failure`` (if any)
+        # on the developer box doesn't leak in.
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+        monkeypatch.setattr(mod, "_systemd_available", lambda: True)
+
+        journal_output = (
+            "Apr 20 12:00:00 host do_update.sh[1234]: error: Your local "
+            "changes to the following files would be overwritten by "
+            "checkout:\n"
+            "    src/static/styles/main.css\n"
+            "Please commit your changes or stash them before you switch "
+            "branches.\nAborting\n"
+        )
+
+        def fake_run(cmd, *args, **kwargs):
+            # systemctl is-active -> "failed"
+            if cmd[:2] == ["systemctl", "is-active"]:
+                return real_subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="failed\n", stderr=""
+                )
+            # journalctl -u <unit> -n 20 --no-pager -> the tail
+            if cmd[:2] == ["journalctl", "-u"]:
+                return real_subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout=journal_output, stderr=""
+                )
+            return real_subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        # subprocess is imported lazily inside update_status; patch the
+        # module-level ``subprocess.run`` directly (the view's
+        # ``import subprocess`` returns the same cached module object).
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        try:
+            resp = client.get("/settings/update_status")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["running"] is False  # auto-cleared
+            assert data["last_failure"] is not None
+            lf = data["last_failure"]
+            assert lf.get("synthesized") is True
+            assert lf.get("last_command") == "systemd_unit_failed"
+            assert "main.css" in lf.get("recent_journal_lines", "")
+            assert lf.get("unit") == "inkypi-update-1234.service"
+        finally:
+            mod._set_update_state(False, None)
+
+    def test_does_not_synthesize_when_failure_file_already_exists(
+        self, client, monkeypatch, tmp_path
+    ):
+        """If update.sh already wrote .last-update-failure, that record wins
+        and we must not overwrite it with the journal-synthesized one."""
+        import subprocess as real_subprocess
+
+        import blueprints.settings as mod
+        real_failure = {
+            "timestamp": "2026-04-20T00:00:00Z",
+            "exit_code": 97,
+            "last_command": "pip_requirements",
+            "recent_journal_lines": "real failure record",
+        }
+        (tmp_path / ".last-update-failure").write_text(
+            json.dumps(real_failure), encoding="utf-8"
+        )
+        monkeypatch.setenv("INKYPI_LOCKFILE_DIR", str(tmp_path))
+
+        mod._UPDATE_STATE["running"] = True
+        mod._UPDATE_STATE["unit"] = "inkypi-update-5678.service"
+        mod._UPDATE_STATE["started_at"] = 1_000_000.0
+        monkeypatch.setattr(mod, "_systemd_available", lambda: True)
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:2] == ["systemctl", "is-active"]:
+                return real_subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="failed\n", stderr=""
+                )
+            if cmd[:2] == ["journalctl", "-u"]:
+                # Should NOT be called; if it is, return a sentinel the
+                # assertion below would catch.
+                return real_subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="SHOULD_NOT_APPEAR", stderr=""
+                )
+            return real_subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        try:
+            resp = client.get("/settings/update_status")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["last_failure"] == real_failure
+            assert "synthesized" not in data["last_failure"]
+        finally:
+            mod._set_update_state(False, None)
+
+
 class TestStartUpdateRejectsEmptyTargetVersion:
     """POST /settings/update validates ``target_version`` explicitly."""
 


### PR DESCRIPTION
## Summary

- Fixes a silent-failure bug where `POST /settings/update` reports success, `GET /settings/update_status` clears to `running:false` within ~2s with `last_failure:null`, and the user never sees *why* the update didn't happen (the real cause — a dirty `src/static/styles/main.css` blocking `git checkout` — was visible only in the system journal).
- Adds an EXIT trap to `install/do_update.sh` so failures that happen *before* delegation to `update.sh` write `.last-update-failure` too, matching JTN-704's JSON contract exactly.
- Resets the known-generated `src/static/styles/main.css` before the tag checkout so a stale CSS bundle cannot block the update; `update.sh` rebuilds it immediately after.
- `update_status` route now synthesizes a `last_failure` from `journalctl -u <unit> -n 20` when the transient systemd unit is `failed` but no `.last-update-failure` was written (covers pre-JTN-787 on-device installs).

Linear: https://linear.app/jtn0123/issue/JTN-787

## Changes

- `install/do_update.sh`: top-level EXIT trap mirroring `update.sh`'s JTN-704 trap (same JSON shape); `_current_step` tracked across phases; narrow allowlist reset of `src/static/styles/main.css` before `git checkout`; `INKYPI_LOCKFILE_DIR` honored for state writes so tests can redirect.
- `src/blueprints/settings/_updates.py`: when `systemctl is-active <unit>` returns `failed` and no failure file exists, synthesize a record from the unit's journal tail with `synthesized: true` marker. Best-effort — exceptions fall through to the existing path.
- `tests/integration/test_do_update_failure_surface.py`: new — drives `do_update.sh` in a tmpdir (real git repo with two tags) to assert (a) non-git-repo abort writes `.last-update-failure`, (b) a dirty `src/static/styles/main.css` no longer blocks checkout.
- `tests/unit/test_updates_surface_errors.py`: two new cases for the synthesized-failure path (fires when unit=failed + no file; does NOT overwrite an existing record).

## Test plan

- [x] New tests pass locally (`pytest tests/integration/test_do_update_failure_surface.py tests/unit/test_updates_surface_errors.py -v` -> 17 passed)
- [x] Related suites stay green (`tests/unit/test_install_scripts.py`, `tests/unit/test_settings_updates*.py`, `tests/unit/test_updates_rollback_route.py`, `tests/integration/test_update_failure_recovery.py` -> 336 passed)
- [x] `bash -n install/do_update.sh` passes
- [x] JTN-704 JSON contract preserved — the new writer in `do_update.sh` emits the same keys (`timestamp`, `exit_code`, `last_command`, `recent_journal_lines`) as `update.sh`
- [x] Does NOT touch the running-state TOCTOU guard (JTN-319 / JTN-710)

🤖 Generated with [Claude Code](https://claude.com/claude-code)