### PR TITLE
feat!: enforce conventional-commit PR titles and surface skipped releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,14 @@
+<!--
+  PR title must start with a Conventional Commits type — PRs are squash-merged
+  and the title becomes the commit subject on main, which semantic-release
+  parses for the next version. Use one of:
+    feat: / fix: / perf:                         -> triggers a release bump
+    refactor: / docs: / style: / test: / build: / ci: / chore: / revert:
+                                                 -> no bump (valid but silent)
+  BREAKING CHANGE: footer anywhere in the body   -> major bump
+  See CONTRIBUTING.md.
+-->
+
 ## Summary
 
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@
     feat: / fix: / perf:                         -> triggers a release bump
     refactor: / docs: / style: / test: / build: / ci: / chore: / revert:
                                                  -> no bump (valid but silent)
-  BREAKING CHANGE: footer anywhere in the body   -> major bump
+  BREAKING CHANGE: footer in body, OR `!` after
+  the type (e.g. `feat!:` / `fix!:`)             -> major bump
   See CONTRIBUTING.md.
 -->
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,44 @@
+name: PR Title Lint
+
+# Enforces Conventional Commits on PR titles. Because this repo squash-merges,
+# the PR title becomes the commit subject on main, which is what
+# python-semantic-release parses to decide whether to bump the version. If the
+# title doesn't start with one of the recognized types (feat/fix/perf or a
+# BREAKING CHANGE footer for a major bump), no release is cut — see
+# CONTRIBUTING.md and the release workflow.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title matches Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            style
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^[^A-Z].+$
+          subjectPatternError: |
+            The PR title subject "{subject}" should start with a lowercase
+            letter (after the `type(scope):` prefix). Example:
+              feat(playlist): add drag-and-drop reordering

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,34 @@ jobs:
             echo "No new release tag on this run."
           fi
 
+      - name: Warn loudly if no release was cut
+        if: steps.resolve_tag.outputs.released != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # python-semantic-release exits 0 when a merged commit doesn't match
+          # a bumpable conventional-commit type (feat/fix/perf or BREAKING
+          # CHANGE). A silent green here hid 5 unreleased PRs in a row. Emit
+          # a prominent annotation so future misses are visible on the commit
+          # status page and in the Actions summary.
+          SUBJECT=$(git log -1 --pretty=%s)
+          {
+            echo "## No release cut"
+            echo ""
+            echo "\`semantic-release version\` found no bumpable commits since"
+            echo "the last tag. Most recent commit subject:"
+            echo ""
+            echo "    ${SUBJECT}"
+            echo ""
+            echo "If this merge included user-facing changes, the PR title"
+            echo "probably didn't use a conventional-commits type that triggers"
+            echo "a bump (\`feat:\`, \`fix:\`, \`perf:\`, or a \`BREAKING CHANGE:\`"
+            echo "footer). See CONTRIBUTING.md."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::warning title=No release cut::semantic-release skipped this commit; subject: ${SUBJECT}"
+          # Non-failing on purpose — docs/chore/refactor PRs legitimately skip
+          # release, so we only surface the info rather than red-crossing the run.
+
       - name: Strip build-only files from GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,6 @@ jobs:
 
       - name: Warn loudly if no release was cut
         if: steps.resolve_tag.outputs.released != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # python-semantic-release exits 0 when a merged commit doesn't match
           # a bumpable conventional-commit type (feat/fix/perf or BREAKING
@@ -87,7 +85,13 @@ jobs:
             echo "a bump (\`feat:\`, \`fix:\`, \`perf:\`, or a \`BREAKING CHANGE:\`"
             echo "footer). See CONTRIBUTING.md."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::warning title=No release cut::semantic-release skipped this commit; subject: ${SUBJECT}"
+          # GitHub workflow commands require %, CR, and LF in message bodies
+          # to be URL-encoded, otherwise subjects like "bump coverage to 90%"
+          # render garbled in the annotation.
+          ESCAPED=${SUBJECT//%/%25}
+          ESCAPED=${ESCAPED//$'\r'/%0D}
+          ESCAPED=${ESCAPED//$'\n'/%0A}
+          echo "::warning title=No release cut::semantic-release skipped this commit; subject: ${ESCAPED}"
           # Non-failing on purpose — docs/chore/refactor PRs legitimately skip
           # release, so we only surface the info rather than red-crossing the run.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,13 +124,29 @@ Run this after modifying any CSS partial.
 
 ## Commit Convention
 
-We use [Conventional Commits](https://www.conventionalcommits.org/):
+We use [Conventional Commits](https://www.conventionalcommits.org/) — and
+because PRs are **squash-merged**, **the PR title becomes the commit subject
+on `main`** and is what `python-semantic-release` parses to decide the next
+version. A PR title that doesn't match a recognized type will silently skip
+the release bump. The PR Title Lint check enforces this pre-merge.
 
-- `feat:` — new feature
-- `fix:` — bug fix
+Recognized types:
+
+- `feat:` — new feature (→ minor bump)
+- `fix:` — bug fix (→ patch bump)
+- `perf:` — performance improvement (→ patch bump)
+- `refactor:` — code change that neither fixes a bug nor adds a feature
 - `docs:` — documentation only
+- `style:` — formatting, missing semicolons, etc.
 - `test:` — adding or updating tests
-- `chore:` — maintenance, dependencies, CI
+- `build:` — build system / dependencies
+- `ci:` — CI configuration
+- `chore:` — maintenance
+
+Only `feat`, `fix`, and `perf` (and `BREAKING CHANGE:` footers for majors)
+trigger a release. The other types are accepted but don't bump the version.
+Avoid ad-hoc prefixes like `security:`, `ui:`, or `css:` — they pass no-lint
+locally but produce non-releasing merges.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,11 +142,13 @@ Recognized types:
 - `build:` — build system / dependencies
 - `ci:` — CI configuration
 - `chore:` — maintenance
+- `revert:` — reverts a previous commit
 
-Only `feat`, `fix`, and `perf` (and `BREAKING CHANGE:` footers for majors)
-trigger a release. The other types are accepted but don't bump the version.
-Avoid ad-hoc prefixes like `security:`, `ui:`, or `css:` — they pass no-lint
-locally but produce non-releasing merges.
+Only `feat`, `fix`, and `perf` trigger a release. A major bump is triggered
+either by a `BREAKING CHANGE:` footer in the commit body OR by appending `!`
+to the type (e.g. `feat!: drop Python 3.10 support`). The other types are
+accepted but don't bump the version. Avoid ad-hoc prefixes like `security:`,
+`ui:`, or `css:` — they pass no-lint locally but produce non-releasing merges.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- Root-cause the release pipeline: 5 PRs merged to main since v0.64.1 without a version bump because their squash-merge subjects (`css:`, `security:`, `ui:`, `Normalize...`, `Stabilize...`) are unrecognized by python-semantic-release's Angular parser. Every release run exited "success" silently — the regression was invisible until today.
- Add `.github/workflows/pr-title-lint.yml` (amannn/action-semantic-pull-request) to block non-conventional PR titles pre-merge. Since PRs are squash-merged, the title becomes the commit subject on main and is what semantic-release parses.
- Update `.github/workflows/release.yml` to emit a `::warning` annotation + step summary when no tag is cut, so future silent skips surface on the Actions run and commit status pages.
- Update CONTRIBUTING.md and the PR template to spell out the squash-merge-title-is-the-bump-signal pitfall and list the full set of recognized types (now including `revert:` and the `type!:` shorthand).

On merge, this commit's `feat!:` + `BREAKING CHANGE:` footer forces semantic-release to cut **v1.0.0**, marking the UI/UX overhaul milestone that accumulated unreleased across #579 (render pipeline stabilization: pipe-deadlock + chromium leak + update flow), #580 (lxml CVE-2026-41066 patch), #581 (settings actions normalization), #582 (CSS partial split so every file is ≤500 lines), and #583 (sidebar update indicator + Updates tab polish). No external HTTP API or config file format changes in this release; the major bump signals project-level stability rather than a contract break.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a parent-fork sync PR (release-pipeline change only)

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (no source changes; only workflows/docs)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`) — n/a, no code changes
- [x] Docs updated for new flags/endpoints/UI — CONTRIBUTING.md + PR template reflect the new lint
- [x] **Frontend changes** (`src/static/**`, `src/templates/**`): none in this PR

## Testing

- [x] `Validate PR title` check passes on this PR — the new workflow is self-validating (title starts with `feat!:`, a recognized type with breaking marker)
- [ ] On merge: Release workflow cuts `v1.0.0` tag + GitHub release; step summary confirms a bump (no "No release cut" warning)
- [ ] Aggregated release notes include PRs #579, #580, #581, #582, #583 as the 1.0 story

🤖 Generated with [Claude Code](https://claude.com/claude-code)