### PR TITLE
fix: refresh pinned raspios_lite_arm64 SHA256

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -48,7 +48,7 @@ concurrency:
 # =============================================================================
 env:
   PI_OS_IMAGE_URL: https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2025-05-13/2025-05-13-raspios-bookworm-arm64-lite.img.xz
-  PI_OS_IMAGE_SHA256: 7ecb0943c0c0a2f0a21d47ad1193ad403fa9d0c8e4e9bc41e7c99fc0b4b90f6e
+  PI_OS_IMAGE_SHA256: 62d025b9bc7ca0e1facfec74ae56ac13978b6745c58177f081d39fbb8041ed45
   PI_OS_IMAGE_FILENAME: 2025-05-13-raspios-bookworm-arm64-lite.img.xz
   # pishrink.sh pinned by commit SHA — upstream has no tagged releases.
   # https://github.com/Drewsif/PiShrink


### PR DESCRIPTION
## Summary

- `build-pi-image.yml` pins the base OS image by SHA256; Raspberry Pi Foundation re-uploaded the artifact at the same URL, so the `Download pinned Pi OS Lite base image` step now fails checksum verification on every run (latest hit: run [24869204223](https://github.com/jtn0123/InkyPi/actions/runs/24869204223) from the v1.0.1 release dispatch).
- Refreshed the pin to `62d025b9bc7ca0e1facfec74ae56ac13978b6745c58177f081d39fbb8041ed45`. Verified against Raspberry Pi Foundation's own published `.sha256` at the same URL path, and re-computed locally over the downloaded 443 MB `.img.xz`; both match.

## Supply-chain note

```
curl -fsSL https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2025-05-13/2025-05-13-raspios-bookworm-arm64-lite.img.xz.sha256
# → 62d025b9bc7ca0e1facfec74ae56ac13978b6745c58177f081d39fbb8041ed45  2025-05-13-raspios-bookworm-arm64-lite.img.xz
```

## Test plan

- [ ] CI passes on this branch (no image build; Pi image workflow only runs on release dispatch).
- [ ] After merge, next release dispatch (or `workflow_dispatch`) on `build-pi-image.yml` downloads + verifies the image without sha256 mismatch.
- [ ] This PR's `fix:` title lets the release pipeline cut `v1.0.2` — a test of the post-mess release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)