### PR TITLE
ci: call build-pi-image from release.yml on semantic-release cuts

### DIFF
--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -22,6 +22,20 @@ name: Build pre-installed Pi image
 # Does NOT modify install.sh — option 2 (source install) stays self-contained.
 
 on:
+  # JTN-745 FIX: semantic-release publishes via GITHUB_TOKEN, so the standalone
+  # `release` trigger does not fire for automated releases (GitHub's anti-loop
+  # rule blocks GITHUB_TOKEN-originated events from starting new workflows).
+  # Mirroring build-wheelhouse.yml, this workflow is now reusable via
+  # `workflow_call`, and release.yml invokes it directly after publish so the
+  # parent Release workflow goes red if Pi image build fails. We keep the
+  # release/manual triggers for maintainers who publish or rebuild outside the
+  # default semantic-release path.
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to build an image for (e.g. v0.42.3)
+        required: true
+        type: string
   release:
     types: [published]
   # Manual trigger so maintainers can rebuild against an existing tag
@@ -37,7 +51,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: build-pi-image-${{ github.event.release.tag_name || inputs.tag }}
+  group: build-pi-image-${{ github.event.release.tag_name || inputs.tag || github.run_id }}
   cancel-in-progress: false
 
 # =============================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,11 @@ jobs:
     uses: ./.github/workflows/build-wheelhouse.yml
     with:
       tag: ${{ needs.release.outputs.tag }}
+
+  pi-image:
+    name: Build pre-installed Pi image
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: ./.github/workflows/build-pi-image.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
## Summary

- `build-pi-image.yml` triggers on `release: [published]`, but semantic-release publishes via `GITHUB_TOKEN` — GitHub's anti-loop rule blocks `GITHUB_TOKEN`-originated events from starting new workflow runs. So Pi image builds never auto-fire on releases the Release workflow cuts.
- `build-wheelhouse.yml` already solved this (JTN-745) by exposing itself as a reusable workflow and letting `release.yml` invoke it after publish. This PR mirrors that pattern for Pi image builds.
- After this PR merges, every semantic-release cut will build the Pi image automatically. A failed Pi image build will also turn the parent Release run red instead of silently skipping.

## Changes

- `.github/workflows/build-pi-image.yml`: add `workflow_call` trigger with a `tag` input. Keep `release: [published]` and `workflow_dispatch` for maintainers publishing outside semantic-release (PAT-auth `gh release create`) or rebuilding an older tag. Extend concurrency group with `github.run_id` as the final fallback (same shape as `build-wheelhouse.yml`).
- `.github/workflows/release.yml`: add a `pi-image` job that mirrors the existing `wheelhouse` job — `needs: release`, `if: needs.release.outputs.released == 'true'`, `uses: ./.github/workflows/build-pi-image.yml`.

## Background — how we got here

Today's v1.0.1 release didn't auto-build a Pi image because the release was cut by the Release workflow (semantic-release). Investigated in a live session, verified against [GitHub's docs on `GITHUB_TOKEN` permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) — any workflow run that was itself triggered by `GITHUB_TOKEN` cannot trigger further workflow runs via push/release/etc. events. The existing wheelhouse JTN-745 fix is the canonical pattern for this repo.

## Test plan

- [ ] After merge, the next semantic-release cut (this PR is a `ci:` so it won't bump — next `fix:`/`feat:` will) should show a Pi image job running alongside wheelhouse under the parent Release workflow run.
- [ ] Confirm the attached `inkypi-<tag>.img.xz` + `.sha256` appear on that release.
- [ ] Confirm manual `workflow_dispatch` with `tag=<existing tag>` still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Pi image builds into the automated release workflow, ensuring builds are triggered automatically when releases are published.
  * Enhanced workflow flexibility to support tag-scoped Pi image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->