### PR TITLE
fix: unblock segmented radios, update check, and copy logs

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from time import perf_counter
+from typing import Any
 
 from flask import (
     Blueprint,
@@ -79,6 +80,58 @@ def _cacheable_send_file(path: str, ttl_env: str = "INKYPI_RENDER_CACHE_TTL_S"):
     return resp
 
 
+def _resolve_multi_service_api_key(
+    api_key_meta: dict[str, Any], device_config: Any
+) -> None:
+    """Populate per-service presence + a display label for plugins that list
+    multiple providers under ``services``. Mutates *api_key_meta* in place.
+
+    Each entry of ``services`` is ``{name, env_var}``; this adds ``present``
+    to each, sets the aggregate ``present`` flag, and picks a ``service``
+    label that reflects which provider(s) are actually configured (so the
+    chip shows "OpenAI" when only OpenAI is set, not "OpenAI / Google").
+    """
+    services = api_key_meta.get("services") or []
+    resolved = []
+    any_present = False
+    for svc in services:
+        env_var = svc.get("env_var")
+        name = svc.get("name") or env_var or ""
+        present = bool(env_var) and (device_config.load_env_key(env_var) is not None)
+        resolved.append({"name": name, "env_var": env_var, "present": present})
+        any_present = any_present or present
+    api_key_meta["services"] = resolved
+    api_key_meta["present"] = any_present
+
+    configured_names = [s["name"] for s in resolved if s["present"]]
+    if configured_names:
+        api_key_meta["service"] = " · ".join(configured_names)
+    else:
+        all_names = [s["name"] for s in resolved]
+        api_key_meta["service"] = " or ".join(all_names) or api_key_meta.get(
+            "service", ""
+        )
+
+
+def _resolve_api_key_presence(
+    template_params: dict[str, Any], device_config: Any
+) -> None:
+    """Attach ``present`` and provider-aware display metadata to ``api_key``.
+
+    Single-provider plugins still use ``expected_key``; multi-provider plugins
+    supply a ``services`` list that drives per-provider presence flags.
+    """
+    api_key_meta = template_params.get("api_key")
+    if not api_key_meta or not api_key_meta.get("required"):
+        return
+    if api_key_meta.get("services"):
+        _resolve_multi_service_api_key(api_key_meta, device_config)
+        return
+    expected_key = api_key_meta.get("expected_key")
+    if expected_key:
+        api_key_meta["present"] = device_config.load_env_key(expected_key) is not None
+
+
 @plugin_bp.route("/plugin/<plugin_id>", methods=["GET"])
 def plugin_page(plugin_id: str):
     device_config = current_app.config[_CONFIG_KEY]
@@ -96,39 +149,7 @@ def plugin_page(plugin_id: str):
         plugin = get_plugin_instance(plugin_config)
         template_params = plugin.generate_settings_template()
 
-        # Check if API key is present for plugins that require it
-        if "api_key" in template_params and template_params["api_key"].get("required"):
-            api_key_meta = template_params["api_key"]
-            services = api_key_meta.get("services")
-            if services:
-                resolved = []
-                any_present = False
-                for svc in services:
-                    env_var = svc.get("env_var")
-                    name = svc.get("name") or env_var or ""
-                    present = bool(env_var) and (
-                        device_config.load_env_key(env_var) is not None
-                    )
-                    resolved.append(
-                        {"name": name, "env_var": env_var, "present": present}
-                    )
-                    any_present = any_present or present
-                api_key_meta["services"] = resolved
-                api_key_meta["present"] = any_present
-                configured_names = [s["name"] for s in resolved if s["present"]]
-                all_names = [s["name"] for s in resolved]
-                if configured_names:
-                    api_key_meta["service"] = " · ".join(configured_names)
-                else:
-                    api_key_meta["service"] = " or ".join(
-                        all_names
-                    ) or api_key_meta.get("service", "")
-            else:
-                expected_key = api_key_meta.get("expected_key")
-                if expected_key:
-                    api_key_meta["present"] = (
-                        device_config.load_env_key(expected_key) is not None
-                    )
+        _resolve_api_key_presence(template_params, device_config)
 
         # If viewing an existing instance, pre-populate its settings
         plugin_instance_name = request.args.get("instance")

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -120,9 +120,9 @@ def plugin_page(plugin_id: str):
                 if configured_names:
                     api_key_meta["service"] = " · ".join(configured_names)
                 else:
-                    api_key_meta["service"] = " or ".join(all_names) or api_key_meta.get(
-                        "service", ""
-                    )
+                    api_key_meta["service"] = " or ".join(
+                        all_names
+                    ) or api_key_meta.get("service", "")
             else:
                 expected_key = api_key_meta.get("expected_key")
                 if expected_key:

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -98,10 +98,37 @@ def plugin_page(plugin_id: str):
 
         # Check if API key is present for plugins that require it
         if "api_key" in template_params and template_params["api_key"].get("required"):
-            expected_key = template_params["api_key"].get("expected_key")
-            if expected_key:
-                key_present = device_config.load_env_key(expected_key) is not None
-                template_params["api_key"]["present"] = key_present
+            api_key_meta = template_params["api_key"]
+            services = api_key_meta.get("services")
+            if services:
+                resolved = []
+                any_present = False
+                for svc in services:
+                    env_var = svc.get("env_var")
+                    name = svc.get("name") or env_var or ""
+                    present = bool(env_var) and (
+                        device_config.load_env_key(env_var) is not None
+                    )
+                    resolved.append(
+                        {"name": name, "env_var": env_var, "present": present}
+                    )
+                    any_present = any_present or present
+                api_key_meta["services"] = resolved
+                api_key_meta["present"] = any_present
+                configured_names = [s["name"] for s in resolved if s["present"]]
+                all_names = [s["name"] for s in resolved]
+                if configured_names:
+                    api_key_meta["service"] = " · ".join(configured_names)
+                else:
+                    api_key_meta["service"] = " or ".join(all_names) or api_key_meta.get(
+                        "service", ""
+                    )
+            else:
+                expected_key = api_key_meta.get("expected_key")
+                if expected_key:
+                    api_key_meta["present"] = (
+                        device_config.load_env_key(expected_key) is not None
+                    )
 
         # If viewing an existing instance, pre-populate its settings
         plugin_instance_name = request.args.get("instance")

--- a/src/blueprints/settings/__init__.py
+++ b/src/blueprints/settings/__init__.py
@@ -822,20 +822,26 @@ def _check_latest_version(force_refresh: bool = False) -> str | None:
             _VERSION_CACHE["release_notes"] = data.get("body")
             _VERSION_CACHE["last_error"] = None
             return latest
-        # Response decoded but the tag doesn't look like a semver release.
-        # Record that so the UI can explain what went wrong.
+        # Response decoded but the tag isn't a stable X.Y.Z release (e.g. a
+        # pre-release tag like v1.2.3-rc1). That's not a network failure, it
+        # just means there's nothing auto-installable. Record a message the
+        # client can show verbatim so we don't misreport this as "couldn't
+        # reach GitHub".
         logger.warning(
-            "Latest GitHub release tag %r does not match semver format; skipping.",
+            "Latest GitHub release tag %r is not a stable X.Y.Z release; "
+            "auto-update skipped.",
             tag,
         )
         _VERSION_CACHE["last_error"] = (
-            f"Latest GitHub release tag {tag!r} is not a semver version."
+            f"Latest GitHub release ({tag!r}) is not a stable X.Y.Z tag — "
+            "nothing to auto-install yet."
         )
     except Exception as exc:
         # Bubble up a short reason to the client. Log at INFO so it lands in
         # the in-app log panel without spamming errors on every check.
-        logger.info("Version check via GitHub API failed: %s", exc)
-        _VERSION_CACHE["last_error"] = str(exc) or exc.__class__.__name__
+        reason = str(exc) or exc.__class__.__name__
+        logger.info("Version check via GitHub API failed: %s", reason)
+        _VERSION_CACHE["last_error"] = f"Couldn't reach GitHub: {reason}"
     return None
 
 

--- a/src/blueprints/settings/__init__.py
+++ b/src/blueprints/settings/__init__.py
@@ -772,6 +772,9 @@ _VERSION_CACHE: dict[str, object] = {
     "latest": None,
     "checked_at": 0.0,
     "release_notes": None,
+    # Surface why the last check failed so the UI can distinguish "on latest"
+    # from "we never managed to reach GitHub." Cleared on a successful fetch.
+    "last_error": None,
 }
 _VERSION_CACHE_TTL = 3600  # 1 hour
 
@@ -784,11 +787,21 @@ def _semver_gt(a: str, b: str) -> bool:
         return False
 
 
-def _check_latest_version() -> str | None:
-    """Fetch the latest release tag from the GitHub Releases API. Returns None on failure."""
+def _check_latest_version(force_refresh: bool = False) -> str | None:
+    """Fetch the latest release tag from the GitHub Releases API.
+
+    Returns the latest version string on success or ``None`` on any failure.
+    When the check fails, ``_VERSION_CACHE['last_error']`` is populated with a
+    short human-readable reason so the UI can report it to the user instead
+    of silently claiming "on latest".
+
+    When ``force_refresh`` is True the cache is bypassed — this is what the
+    "Check for updates" button needs so a manual click always hits GitHub.
+    """
     now = time.time()
     if (
-        _VERSION_CACHE["latest"]
+        not force_refresh
+        and _VERSION_CACHE["latest"]
         and (now - float(_VERSION_CACHE["checked_at"] or 0)) < _VERSION_CACHE_TTL
     ):
         return _VERSION_CACHE["latest"]  # type: ignore[return-value]
@@ -807,9 +820,22 @@ def _check_latest_version() -> str | None:
             _VERSION_CACHE["latest"] = latest
             _VERSION_CACHE["checked_at"] = now
             _VERSION_CACHE["release_notes"] = data.get("body")
+            _VERSION_CACHE["last_error"] = None
             return latest
-    except Exception:
-        logger.debug("Failed to check latest version via GitHub API", exc_info=True)
+        # Response decoded but the tag doesn't look like a semver release.
+        # Record that so the UI can explain what went wrong.
+        logger.warning(
+            "Latest GitHub release tag %r does not match semver format; skipping.",
+            tag,
+        )
+        _VERSION_CACHE["last_error"] = (
+            f"Latest GitHub release tag {tag!r} is not a semver version."
+        )
+    except Exception as exc:
+        # Bubble up a short reason to the client. Log at INFO so it lands in
+        # the in-app log panel without spamming errors on every check.
+        logger.info("Version check via GitHub API failed: %s", exc)
+        _VERSION_CACHE["last_error"] = str(exc) or exc.__class__.__name__
     return None
 
 

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -457,17 +457,25 @@ def start_rollback():
 
 @_mod.settings_bp.route("/api/version", methods=["GET"])
 def api_version():
-    """Return current and latest version info."""
+    """Return current and latest version info.
+
+    Accepts ``?force=1`` to bypass the in-process cache so the "Check for
+    updates" button always hits GitHub instead of serving a possibly-stale
+    result from an earlier page load. Returns ``check_succeeded`` / ``check_error``
+    so the UI can distinguish "you're on latest" from "we couldn't reach GitHub".
+    """
     with route_error_boundary(
         "version check",
         logger=_mod.logger,
         hint="Check release metadata retrieval and semver parsing.",
     ):
+        force_refresh = request.args.get("force", "").lower() in ("1", "true", "yes")
         current = current_app.config.get("APP_VERSION", "unknown")
-        latest = _mod._check_latest_version()
+        latest = _mod._check_latest_version(force_refresh=force_refresh)
         update_available = False
         if latest and current != "unknown":
             update_available = _mod._semver_gt(latest, current)
+        check_error = _mod._VERSION_CACHE.get("last_error")
         return jsonify(
             {
                 "current": current,
@@ -475,5 +483,7 @@ def api_version():
                 "update_available": update_available,
                 "update_running": bool(_mod._UPDATE_STATE.get("running")),
                 "release_notes": _mod._VERSION_CACHE.get("release_notes"),
+                "check_succeeded": latest is not None,
+                "check_error": check_error if latest is None else None,
             }
         )

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -21,10 +21,11 @@ from plugins.base_plugin.settings_schema import (
 logger = logging.getLogger(__name__)
 
 OPENAI_IMAGE_MODEL = "gpt-image-1.5"
+OPENAI_IMAGE_MODEL_2 = "gpt-image-2"
 GOOGLE_IMAGE_MODEL = "imagen-4.0-generate-001"
 
 IMAGE_MODELS_BY_PROVIDER = {
-    "openai": (OPENAI_IMAGE_MODEL,),
+    "openai": (OPENAI_IMAGE_MODEL, OPENAI_IMAGE_MODEL_2),
     "google": (GOOGLE_IMAGE_MODEL,),
 }
 IMAGE_MODELS = [
@@ -32,7 +33,7 @@ IMAGE_MODELS = [
     for provider_models in IMAGE_MODELS_BY_PROVIDER.values()
     for model in provider_models
 ]
-DEFAULT_IMAGE_MODEL = OPENAI_IMAGE_MODEL
+DEFAULT_IMAGE_MODEL = OPENAI_IMAGE_MODEL_2
 DEFAULT_IMAGE_QUALITY = "medium"
 
 
@@ -61,14 +62,15 @@ class AIImage(BasePlugin):
                     "textarea",
                     label="Prompt",
                     placeholder="A surreal breakfast floating through a neon sky.",
+                    hint="Describe the scene you want the model to render. Bold, simple compositions read best on e-ink.",
                     required=True,
                     rows=4,
                 ),
                 field(
                     "randomizePrompt",
                     "checkbox",
-                    label="Randomize Prompt",
-                    hint="Use the current prompt as a seed and let the model remix it before generating the image.",
+                    label="Remix prompt before generating",
+                    hint="Pass your prompt through a writing model first to add vivid detail and unexpected styling.",
                     submit_unchecked=True,
                     checked_value="true",
                     unchecked_value="false",
@@ -82,6 +84,7 @@ class AIImage(BasePlugin):
                         "select",
                         label="Provider",
                         default="openai",
+                        hint="Pick the AI service that should render the image. Each provider uses its own API key.",
                         options=[
                             option("openai", "OpenAI"),
                             option("google", "Google"),
@@ -97,7 +100,11 @@ class AIImage(BasePlugin):
                         options_by_value={
                             "openai": [
                                 option(
-                                    DEFAULT_IMAGE_MODEL,
+                                    OPENAI_IMAGE_MODEL_2,
+                                    "GPT Image 2 \u00b7 ~$0.08/img (recommended)",
+                                ),
+                                option(
+                                    OPENAI_IMAGE_MODEL,
                                     "GPT Image 1.5 \u00b7 ~$0.07/img",
                                 ),
                             ],
@@ -119,7 +126,12 @@ class AIImage(BasePlugin):
                         options_source="imageModel",
                         options_source_default=DEFAULT_IMAGE_MODEL,
                         options_by_value={
-                            DEFAULT_IMAGE_MODEL: [
+                            OPENAI_IMAGE_MODEL_2: [
+                                option("high", "High (~$0.24)"),
+                                option("medium", "Medium (~$0.08)"),
+                                option("low", "Low (~$0.02)"),
+                            ],
+                            OPENAI_IMAGE_MODEL: [
                                 option("high", "High (~$0.20)"),
                                 option("medium", "Medium (~$0.07)"),
                                 option("low", "Low (~$0.01)"),
@@ -141,9 +153,12 @@ class AIImage(BasePlugin):
         template_params = super().generate_settings_template()
         template_params["api_key"] = {
             "required": True,
-            "service": "OpenAI / Google",
             "expected_key": "OPEN_AI_SECRET",
             "alt_key": "GOOGLE_AI_SECRET",
+            "services": [
+                {"name": "OpenAI", "env_var": "OPEN_AI_SECRET"},
+                {"name": "Google", "env_var": "GOOGLE_AI_SECRET"},
+            ],
         }
         return template_params
 
@@ -167,17 +182,41 @@ class AIImage(BasePlugin):
     ):
         if not randomize_prompt:
             return text_prompt
-        logger.debug("Generating randomized prompt using Gemini...")
-        randomized = AIImage.fetch_image_prompt_google(google_client, text_prompt)
-        logger.info(f"Randomized prompt: '{randomized}'")
+        logger.info("Remixing prompt with Gemini before image generation...")
+        try:
+            randomized = AIImage.fetch_image_prompt_google(
+                google_client, text_prompt
+            )
+        except Exception as exc:
+            logger.warning(
+                "Prompt remix via Gemini failed (%s); using original prompt.", exc
+            )
+            return text_prompt
+        if not randomized or not randomized.strip():
+            logger.warning(
+                "Prompt remix via Gemini returned an empty result; using original prompt."
+            )
+            return text_prompt
+        logger.info(f"Remixed prompt: '{randomized}'")
         return randomized
 
     def _maybe_randomize_openai_prompt(self, ai_client, text_prompt, randomize_prompt):
         if not randomize_prompt:
             return text_prompt
-        logger.debug("Generating randomized prompt using GPT...")
-        randomized = AIImage.fetch_image_prompt(ai_client, text_prompt)
-        logger.info(f"Randomized prompt: '{randomized}'")
+        logger.info("Remixing prompt with GPT before image generation...")
+        try:
+            randomized = AIImage.fetch_image_prompt(ai_client, text_prompt)
+        except Exception as exc:
+            logger.warning(
+                "Prompt remix via GPT failed (%s); using original prompt.", exc
+            )
+            return text_prompt
+        if not randomized or not randomized.strip():
+            logger.warning(
+                "Prompt remix via GPT returned an empty result; using original prompt."
+            )
+            return text_prompt
+        logger.info(f"Remixed prompt: '{randomized}'")
         return randomized
 
     def _generate_google_image(
@@ -395,7 +434,13 @@ class AIImage(BasePlugin):
             temperature=1,
         )
 
-        prompt = response.choices[0].message.content.strip()
+        choices = getattr(response, "choices", None) or []
+        message = getattr(choices[0], "message", None) if choices else None
+        content = getattr(message, "content", None) if message else None
+        prompt = (content or "").strip()
+        if not prompt:
+            logger.warning("OpenAI returned an empty remix; caller will fall back.")
+            return ""
         logger.info(f"Generated random image prompt: {prompt}")
         return prompt
 
@@ -448,6 +493,10 @@ class AIImage(BasePlugin):
             ),
         )
 
-        prompt = response.text.strip()
+        text = getattr(response, "text", None) or ""
+        prompt = text.strip()
+        if not prompt:
+            logger.warning("Gemini returned an empty remix; caller will fall back.")
+            return ""
         logger.info(f"Generated random image prompt via Gemini: {prompt}")
         return prompt

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -184,9 +184,7 @@ class AIImage(BasePlugin):
             return text_prompt
         logger.info("Remixing prompt with Gemini before image generation...")
         try:
-            randomized = AIImage.fetch_image_prompt_google(
-                google_client, text_prompt
-            )
+            randomized = AIImage.fetch_image_prompt_google(google_client, text_prompt)
         except Exception as exc:
             logger.warning(
                 "Prompt remix via Gemini failed (%s); using original prompt.", exc

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -153,8 +153,6 @@ class AIImage(BasePlugin):
         template_params = super().generate_settings_template()
         template_params["api_key"] = {
             "required": True,
-            "expected_key": "OPEN_AI_SECRET",
-            "alt_key": "GOOGLE_AI_SECRET",
             "services": [
                 {"name": "OpenAI", "env_var": "OPEN_AI_SECRET"},
                 {"name": "Google", "env_var": "GOOGLE_AI_SECRET"},

--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -117,9 +117,12 @@ class AIText(BasePlugin):
         template_params = super().generate_settings_template()
         template_params["api_key"] = {
             "required": True,
-            "service": "OpenAI / Google",
             "expected_key": "OPEN_AI_SECRET",
             "alt_key": "GOOGLE_AI_SECRET",
+            "services": [
+                {"name": "OpenAI", "env_var": "OPEN_AI_SECRET"},
+                {"name": "Google", "env_var": "GOOGLE_AI_SECRET"},
+            ],
         }
         template_params["style_settings"] = True
         return template_params

--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -117,8 +117,6 @@ class AIText(BasePlugin):
         template_params = super().generate_settings_template()
         template_params["api_key"] = {
             "required": True,
-            "expected_key": "OPEN_AI_SECRET",
-            "alt_key": "GOOGLE_AI_SECRET",
             "services": [
                 {"name": "OpenAI", "env_var": "OPEN_AI_SECRET"},
                 {"name": "Google", "env_var": "GOOGLE_AI_SECRET"},

--- a/src/plugins/base_plugin/settings_schema.py
+++ b/src/plugins/base_plugin/settings_schema.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
 
-def option(value, label, **kwargs):
-    data = {"value": value, "label": label}
+
+def option(value: Any, label: str, **kwargs: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {"value": value, "label": label}
     data.update(kwargs)
     return data
 

--- a/src/static/scripts/settings/actions.js
+++ b/src/static/scripts/settings/actions.js
@@ -153,11 +153,17 @@
     );
   }
 
-  async function fetchVersionData(versionUrl) {
+  async function fetchVersionData(versionUrl, { force = false } = {}) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000);
     try {
-      const response = await fetch(versionUrl, {
+      // Manual "Check for updates" clicks pass ?force=1 so the server
+      // bypasses its 1h cache and actually hits GitHub. Silent/background
+      // checks leave the cache alone.
+      const url = force
+        ? versionUrl + (versionUrl.includes("?") ? "&" : "?") + "force=1"
+        : versionUrl;
+      const response = await fetch(url, {
         cache: "no-store",
         signal: controller.signal,
       });
@@ -201,9 +207,13 @@
     async function checkForUpdates(options) {
       const elements = getVersionElements();
       const silent = !!(options && options.silent);
+      // Manual clicks force a fresh server-side fetch so a stale 1h cache
+      // can't hide a release that actually exists. Silent/background
+      // refreshes reuse whatever the server already has.
+      const force = !silent;
       setCheckButtonLoading(elements.checkBtn, true);
       try {
-        const data = await fetchVersionData(config.versionUrl);
+        const data = await fetchVersionData(config.versionUrl, { force });
         renderVersionCheckResult(elements, data);
         if (!silent) {
           if (data.update_available) {
@@ -214,7 +224,13 @@
           } else if (data.latest) {
             showResponseModal("success", "You're on the latest version.");
           } else {
-            showResponseModal("failure", "Unable to check for updates.");
+            const detail = data.check_error
+              ? ` (${data.check_error})`
+              : "";
+            showResponseModal(
+              "failure",
+              `Unable to reach GitHub to check for updates${detail}. Try again in a moment.`
+            );
           }
         }
       } catch (e) {

--- a/src/static/scripts/settings/actions.js
+++ b/src/static/scripts/settings/actions.js
@@ -153,6 +153,11 @@
     );
   }
 
+  function appendForceParam(versionUrl) {
+    const separator = versionUrl.includes("?") ? "&" : "?";
+    return versionUrl + separator + "force=1";
+  }
+
   async function fetchVersionData(versionUrl, { force = false } = {}) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000);
@@ -160,9 +165,7 @@
       // Manual "Check for updates" clicks pass ?force=1 so the server
       // bypasses its 1h cache and actually hits GitHub. Silent/background
       // checks leave the cache alone.
-      const url = force
-        ? versionUrl + (versionUrl.includes("?") ? "&" : "?") + "force=1"
-        : versionUrl;
+      const url = force ? appendForceParam(versionUrl) : versionUrl;
       const response = await fetch(url, {
         cache: "no-store",
         signal: controller.signal,

--- a/src/static/scripts/settings/actions.js
+++ b/src/static/scripts/settings/actions.js
@@ -224,13 +224,15 @@
           } else if (data.latest) {
             showResponseModal("success", "You're on the latest version.");
           } else {
-            const detail = data.check_error
-              ? ` (${data.check_error})`
-              : "";
-            showResponseModal(
-              "failure",
-              `Unable to reach GitHub to check for updates${detail}. Try again in a moment.`
-            );
+            // Server produces a complete, self-contained reason in
+            // `check_error` (e.g. "Couldn't reach GitHub: timeout" or
+            // "Latest GitHub release (...) is not a stable X.Y.Z tag ..."),
+            // so show it verbatim instead of prepending a possibly-wrong
+            // "couldn't reach GitHub" preamble.
+            const message = data.check_error
+              ? data.check_error
+              : "Unable to check for updates. Try again later.";
+            showResponseModal("failure", message);
           }
         }
       } catch (e) {

--- a/src/static/scripts/settings/shared.js
+++ b/src/static/scripts/settings/shared.js
@@ -13,15 +13,58 @@
   }
 
   async function copyText(text) {
-    if (!navigator.clipboard || !globalThis.isSecureContext) {
-      return false;
+    // Prefer the async Clipboard API when the page is a secure context
+    // (HTTPS, localhost). InkyPi is commonly served on the LAN over plain
+    // HTTP, which browsers treat as insecure and therefore block the async
+    // API. We fall through to a legacy execCommand-based path below so the
+    // Copy buttons still work in that setup.
+    if (navigator.clipboard && globalThis.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (e) {
+        console.warn("Clipboard write failed, trying fallback:", e);
+      }
     }
+    return copyTextViaExecCommand(text);
+  }
+
+  function copyTextViaExecCommand(text) {
+    if (typeof document === "undefined" || !document.body) return false;
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    // Keep the textarea off-screen but selectable. iOS requires a non-zero
+    // font-size or it silently refuses to select; the rest of these styles
+    // stop the page from scrolling when we focus it.
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "0";
+    ta.style.left = "0";
+    ta.style.width = "1px";
+    ta.style.height = "1px";
+    ta.style.padding = "0";
+    ta.style.border = "0";
+    ta.style.opacity = "0";
+    ta.style.pointerEvents = "none";
+    document.body.appendChild(ta);
+    const prevActive = document.activeElement;
     try {
-      await navigator.clipboard.writeText(text);
-      return true;
+      ta.focus({ preventScroll: true });
+      ta.select();
+      ta.setSelectionRange(0, text.length);
+      return document.execCommand("copy");
     } catch (e) {
-      console.warn("Clipboard write failed:", e);
+      console.warn("execCommand copy failed:", e);
       return false;
+    } finally {
+      ta.remove();
+      if (prevActive && typeof prevActive.focus === "function") {
+        try {
+          prevActive.focus({ preventScroll: true });
+        } catch (_) {
+          /* ignore */
+        }
+      }
     }
   }
 

--- a/src/static/scripts/settings/shared.js
+++ b/src/static/scripts/settings/shared.js
@@ -29,6 +29,18 @@
     return copyTextViaExecCommand(text);
   }
 
+  function restoreFocus(prevActive) {
+    if (!prevActive || typeof prevActive.focus !== "function") return;
+    try {
+      prevActive.focus({ preventScroll: true });
+    } catch (err) {
+      // Non-fatal — the previously-focused element may have been removed
+      // from the DOM between selecting our temporary textarea and now.
+      // Log at debug so the failure is diagnosable without spamming users.
+      console.debug("Failed to restore focus after copy:", err);
+    }
+  }
+
   function copyTextViaExecCommand(text) {
     if (typeof document === "undefined" || !document.body) return false;
     const ta = document.createElement("textarea");
@@ -52,19 +64,18 @@
       ta.focus({ preventScroll: true });
       ta.select();
       ta.setSelectionRange(0, text.length);
-      return document.execCommand("copy");
+      // execCommand("copy") is deprecated but is still the only way to copy
+      // text to the clipboard from a non-secure context. The async Clipboard
+      // API requires HTTPS / localhost, and InkyPi is commonly served over
+      // plain HTTP on the LAN. Keep this fallback until browsers ship a
+      // non-secure-context replacement. NOSONAR javascript:S1874
+      return document.execCommand("copy"); // NOSONAR
     } catch (e) {
       console.warn("execCommand copy failed:", e);
       return false;
     } finally {
       ta.remove();
-      if (prevActive && typeof prevActive.focus === "function") {
-        try {
-          prevActive.focus({ preventScroll: true });
-        } catch (_) {
-          /* ignore */
-        }
-      }
+      restoreFocus(prevActive);
     }
   }
 

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -2225,8 +2225,15 @@ body[data-page="plugin"] .tweaks-panel {
 
 /* Radio-input variant — native radios inside labels, so FormData submission
    works without JS plumbing. The radio itself is visually hidden; the label
-   reflects the pressed state via :has(). */
-.seg-radio {
+   reflects the pressed state via :has().
+
+   Note: scope absolute positioning to each individual .seg-btn label, not
+   the shared .seg-radio group. A radio that stretches across the whole
+   group (inset:0 on .seg-radio {position:relative}) stacks on top of its
+   siblings and steals every click for whichever radio paints last — the
+   bug that made "Horizontal", "Fit to container", and "12 h" unclickable
+   in the Device settings panel. */
+.seg-radio .seg-btn {
   position: relative;
 }
 

--- a/src/static/styles/partials/_card.css
+++ b/src/static/styles/partials/_card.css
@@ -189,8 +189,15 @@
 
 /* Radio-input variant — native radios inside labels, so FormData submission
    works without JS plumbing. The radio itself is visually hidden; the label
-   reflects the pressed state via :has(). */
-.seg-radio {
+   reflects the pressed state via :has().
+
+   Note: scope absolute positioning to each individual .seg-btn label, not
+   the shared .seg-radio group. A radio that stretches across the whole
+   group (inset:0 on .seg-radio {position:relative}) stacks on top of its
+   siblings and steals every click for whichever radio paints last — the
+   bug that made "Horizontal", "Fit to container", and "12 h" unclickable
+   in the Device settings panel. */
+.seg-radio .seg-btn {
   position: relative;
 }
 

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -130,6 +130,8 @@
                         </div>
                     </section>
                     {% if api_key and api_key.required %}
+                    {% set api_services = api_key.services if api_key.services else None %}
+                    {% set api_multi = api_services and api_services | length > 1 %}
                     <section class="plugin-editor-card plugin-editor-card-api" aria-labelledby="pluginApiCardHeading">
                         <div class="plugin-editor-card-label">API key</div>
                         {% if api_key.present %}
@@ -145,18 +147,38 @@
                         {% endif %}
                         <div class="plugin-inline-api-row">
                             <div class="plugin-inline-api-copy">
+                                {% if api_multi %}
+                                <h3 id="pluginApiCardHeading">AI provider key</h3>
+                                {% if api_key.present %}
+                                <p>{{ api_key.service }} is configured and ready for fresh previews. Add another provider any time to switch between them.</p>
+                                {% else %}
+                                <p>This plugin needs a key from at least one of the supported providers ({{ api_services | map(attribute='name') | join(' or ') }}) before it can refresh or generate a preview.</p>
+                                {% endif %}
+                                {% else %}
                                 <h3 id="pluginApiCardHeading">{{ api_key.service }}</h3>
                                 {% if api_key.present %}
                                 <p>This provider is configured and ready for fresh previews.</p>
                                 {% else %}
                                 <p>This plugin needs a configured {{ api_key.service }} key before it can refresh or generate a preview.</p>
                                 {% endif %}
+                                {% endif %}
                             </div>
                             <div class="plugin-inline-api-actions">
+                                {% if api_multi %}
+                                {% for svc in api_services %}
+                                {% if svc.present %}
+                                {{ status_chip(svc.name, 'success', title=svc.name ~ ' API key is configured.') }}
+                                {% endif %}
+                                {% endfor %}
+                                {% if not api_key.present %}
+                                {{ status_chip('Required', 'warning') }}
+                                {% endif %}
+                                {% else %}
                                 {% if api_key.present %}
                                 {{ status_chip('Configured', 'success') }}
                                 {% else %}
                                 {{ status_chip('Required', 'warning') }}
+                                {% endif %}
                                 {% endif %}
                                 <a href="{{ url_for('settings.api_keys_page') }}" class="action-button is-secondary plugin-inline-api-link" data-api-keys-link>Manage keys</a>
                             </div>

--- a/tests/integration/journeys/test_device_update_ops_journeys.py
+++ b/tests/integration/journeys/test_device_update_ops_journeys.py
@@ -31,8 +31,14 @@ def stable_version_check(monkeypatch):
     settings_mod._VERSION_CACHE["latest"] = None
     settings_mod._VERSION_CACHE["checked_at"] = 0.0
     settings_mod._VERSION_CACHE["release_notes"] = None
+    settings_mod._VERSION_CACHE["last_error"] = None
+    # Accept the ``force_refresh`` kwarg the real implementation added so the
+    # "Check for updates" button's ?force=1 path works without 500ing.
     monkeypatch.setattr(
-        settings_mod, "_check_latest_version", lambda: _STUBBED_LATEST_TAG, raising=True
+        settings_mod,
+        "_check_latest_version",
+        lambda force_refresh=False: _STUBBED_LATEST_TAG,
+        raising=True,
     )
 
 

--- a/tests/integration/journeys/test_update_flow_happy_path.py
+++ b/tests/integration/journeys/test_update_flow_happy_path.py
@@ -143,8 +143,12 @@ def stub_latest_version(monkeypatch):
     settings_mod._VERSION_CACHE["latest"] = None
     settings_mod._VERSION_CACHE["checked_at"] = 0.0
     settings_mod._VERSION_CACHE["release_notes"] = None
+    settings_mod._VERSION_CACHE["last_error"] = None
     monkeypatch.setattr(
-        settings_mod, "_check_latest_version", lambda: _STUBBED_LATEST_TAG, raising=True
+        settings_mod,
+        "_check_latest_version",
+        lambda force_refresh=False: _STUBBED_LATEST_TAG,
+        raising=True,
     )
     # Pin APP_VERSION to a known older value so `_semver_gt` reports
     # update_available=True regardless of the repo's current VERSION file.

--- a/tests/integration/test_settings_updates_dom.py
+++ b/tests/integration/test_settings_updates_dom.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 import pytest
 from tests.integration.browser_helpers import navigate_and_wait
@@ -25,7 +26,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _stub_api_version(page, payload: dict) -> None:
-    """Route /api/version to return a known JSON payload."""
+    """Route /api/version (and /api/version?force=1) to return a known payload."""
 
     def handler(route):
         route.fulfill(
@@ -34,7 +35,9 @@ def _stub_api_version(page, payload: dict) -> None:
             body=json.dumps(payload),
         )
 
-    page.route("**/api/version", handler)
+    # Match the endpoint with or without a query string — manual "Check for
+    # updates" clicks now append ?force=1 to bypass the server cache.
+    page.route(re.compile(r".*/api/version(?:\?.*)?$"), handler)
 
 
 def _open_maintenance_tab(page):

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -552,9 +552,7 @@ def test_fetch_image_prompt_api_error_handling():
     assert AIImage.fetch_image_prompt(mock_client, "a cat") == ""
 
 
-def test_ai_image_randomize_falls_back_when_remix_fails(
-    device_config_dev, monkeypatch
-):
+def test_ai_image_randomize_falls_back_when_remix_fails(device_config_dev, monkeypatch):
     """If prompt remix raises, image generation should still succeed with the
     user's original prompt rather than aborting the whole flow."""
     from plugins.ai_image.ai_image import AIImage

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -691,3 +691,206 @@ def test_ai_image_google_raises_when_decode_returns_none(
                 },
                 device_config_dev,
             )
+
+
+# ---------------------------------------------------------------------------
+# Coverage for the remix-prompt fallback branches. PR #590 hardened these so
+# a broken prompt-rewriter cannot tank the whole image-generation flow; the
+# tests below lock in every branch (success, exception, empty string) for
+# both providers so regressions show up immediately in pytest, not as a
+# silently degraded UI.
+# ---------------------------------------------------------------------------
+
+
+def _google_modules(monkeypatch, mock_client):
+    """Stub the google.genai module tree for tests that use the Google path."""
+    import sys
+
+    mock_genai = MagicMock()
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+    mock_genai.Client.return_value = mock_client
+    monkeypatch.setitem(sys.modules, "google", mock_google)
+    monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+    monkeypatch.setitem(sys.modules, "google.genai.types", mock_genai.types)
+    return mock_genai
+
+
+def _make_b64_image() -> str:
+    img = PILImage.new("RGB", (64, 64), "green")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_maybe_randomize_openai_prompt_uses_original_when_empty(monkeypatch):
+    """Empty remix output must fall back to the user's prompt."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt", return_value="   "
+    ):
+        assert (
+            plugin._maybe_randomize_openai_prompt(MagicMock(), "keep me", True)
+            == "keep me"
+        )
+
+
+def test_maybe_randomize_google_prompt_success(monkeypatch):
+    """Success path: remixed text replaces the prompt."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt_google",
+        return_value="remixed gemini",
+    ):
+        assert (
+            plugin._maybe_randomize_google_prompt(MagicMock(), "orig", True)
+            == "remixed gemini"
+        )
+
+
+def test_maybe_randomize_google_prompt_falls_back_on_exception():
+    """Exception in Gemini remix must fall back to the user's prompt."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt_google",
+        side_effect=Exception("gemini boom"),
+    ):
+        assert (
+            plugin._maybe_randomize_google_prompt(MagicMock(), "stay calm", True)
+            == "stay calm"
+        )
+
+
+def test_maybe_randomize_google_prompt_falls_back_on_empty():
+    """Empty Gemini remix output must fall back to the user's prompt."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt_google", return_value=""
+    ):
+        assert (
+            plugin._maybe_randomize_google_prompt(MagicMock(), "orig", True) == "orig"
+        )
+
+
+def test_maybe_randomize_disabled_returns_original():
+    """When the checkbox is off, neither path should call the remixer."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt"
+    ) as mock_openai_fetch:
+        assert (
+            plugin._maybe_randomize_openai_prompt(MagicMock(), "stay", False) == "stay"
+        )
+        mock_openai_fetch.assert_not_called()
+
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt_google"
+    ) as mock_google_fetch:
+        assert (
+            plugin._maybe_randomize_google_prompt(MagicMock(), "stay", False) == "stay"
+        )
+        mock_google_fetch.assert_not_called()
+
+
+def test_fetch_image_prompt_google_empty_text_returns_empty(monkeypatch):
+    """fetch_image_prompt_google should return '' (not crash) on empty/None text."""
+    from plugins.ai_image.ai_image import AIImage
+
+    mock_client = MagicMock()
+    _google_modules(monkeypatch, mock_client)
+
+    # None response.text → ""
+    mock_resp_none = MagicMock()
+    mock_resp_none.text = None
+    mock_client.models.generate_content.return_value = mock_resp_none
+    assert AIImage.fetch_image_prompt_google(mock_client, "seed") == ""
+
+    # Whitespace-only response.text → ""
+    mock_resp_blank = MagicMock()
+    mock_resp_blank.text = "   \n  "
+    mock_client.models.generate_content.return_value = mock_resp_blank
+    assert AIImage.fetch_image_prompt_google(mock_client, "seed") == ""
+
+
+def test_ai_image_schema_exposes_gpt_image_2_and_quality_presets():
+    """build_settings_schema should wire up the GPT Image 2 model + quality
+    options added in PR #590. Traversing the schema here also gives coverage
+    credit for the option(...) lines that land inside nested dict literals."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    schema = plugin.build_settings_schema()
+
+    # Collect every field by name across all sections.
+    fields = {}
+    for section in schema["sections"]:
+        for item in section["items"]:
+            if item.get("kind") == "row":
+                for sub in item["items"]:
+                    if sub.get("kind") == "field":
+                        fields[sub["name"]] = sub
+            elif item.get("kind") == "field":
+                fields[item["name"]] = item
+
+    model_options = fields["imageModel"]["options_by_value"]["openai"]
+    model_values = [o["value"] for o in model_options]
+    assert "gpt-image-2" in model_values
+    assert "gpt-image-1.5" in model_values
+    # GPT Image 2 should be listed first (recommended/default).
+    assert model_values[0] == "gpt-image-2"
+
+    quality_by_model = fields["quality"]["options_by_value"]
+    assert "gpt-image-2" in quality_by_model
+    gpt2_qualities = [o["value"] for o in quality_by_model["gpt-image-2"]]
+    assert set(gpt2_qualities) == {"high", "medium", "low"}
+
+
+def test_ai_image_google_randomize_end_to_end_falls_back(
+    device_config_dev, monkeypatch
+):
+    """End-to-end: Google provider + randomize + remix failure → generation
+    still succeeds using the original prompt (matches the OpenAI parity test
+    just above but exercises the Gemini branch)."""
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    mock_client = MagicMock()
+    _google_modules(monkeypatch, mock_client)
+
+    # Remix blows up; image generation succeeds.
+    with patch(
+        "plugins.ai_image.ai_image.AIImage.fetch_image_prompt_google",
+        side_effect=Exception("gemini boom"),
+    ):
+        mock_generated = MagicMock()
+        mock_generated.image.image_bytes = _make_b64_image()
+        mock_response = MagicMock()
+        mock_response.generated_images = [mock_generated]
+        mock_client.models.generate_images.return_value = mock_response
+
+        result = plugin.generate_image(
+            {
+                "textPrompt": "a quiet library",
+                "provider": "google",
+                "imageModel": "imagen-4.0-generate-001",
+                "quality": "standard",
+                "randomizePrompt": "true",
+            },
+            device_config_dev,
+        )
+        assert result is not None
+        # Prompt passed to Imagen should still begin with the user's original.
+        prompt_arg = mock_client.models.generate_images.call_args[1]["prompt"]
+        assert prompt_arg.startswith("a quiet library")

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -492,12 +492,14 @@ def test_ai_image_generate_settings_template():
     template = p.generate_settings_template()
 
     assert "api_key" in template
-    assert template["api_key"]["expected_key"] == "OPEN_AI_SECRET"
-    assert template["api_key"]["alt_key"] == "GOOGLE_AI_SECRET"
     assert template["api_key"]["required"] is True
     services = template["api_key"]["services"]
     assert [s["name"] for s in services] == ["OpenAI", "Google"]
     assert [s["env_var"] for s in services] == ["OPEN_AI_SECRET", "GOOGLE_AI_SECRET"]
+    # Legacy expected_key/alt_key are now obsolete — `services` is the sole
+    # source of truth for multi-provider plugins.
+    assert "expected_key" not in template["api_key"]
+    assert "alt_key" not in template["api_key"]
     assert "settings_schema" in template
 
 

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -492,10 +492,12 @@ def test_ai_image_generate_settings_template():
     template = p.generate_settings_template()
 
     assert "api_key" in template
-    assert template["api_key"]["service"] == "OpenAI / Google"
     assert template["api_key"]["expected_key"] == "OPEN_AI_SECRET"
     assert template["api_key"]["alt_key"] == "GOOGLE_AI_SECRET"
     assert template["api_key"]["required"] is True
+    services = template["api_key"]["services"]
+    assert [s["name"] for s in services] == ["OpenAI", "Google"]
+    assert [s["env_var"] for s in services] == ["OPEN_AI_SECRET", "GOOGLE_AI_SECRET"]
     assert "settings_schema" in template
 
 
@@ -531,7 +533,7 @@ def test_ai_image_prompt_renders_as_textarea(client):
 
 
 def test_fetch_image_prompt_api_error_handling():
-    """Test fetch_image_prompt with malformed API response."""
+    """Empty/malformed API responses should return ``""`` so callers fall back."""
     from plugins.ai_image.ai_image import AIImage
 
     mock_client = MagicMock()
@@ -539,8 +541,59 @@ def test_fetch_image_prompt_api_error_handling():
     mock_response.choices = []
     mock_client.chat.completions.create.return_value = mock_response
 
-    with pytest.raises(IndexError):
-        AIImage.fetch_image_prompt(mock_client, "a cat")
+    assert AIImage.fetch_image_prompt(mock_client, "a cat") == ""
+
+    # None content (e.g. reasoning models that route output elsewhere)
+    null_choice = MagicMock()
+    null_choice.message.content = None
+    mock_response_null = MagicMock()
+    mock_response_null.choices = [null_choice]
+    mock_client.chat.completions.create.return_value = mock_response_null
+    assert AIImage.fetch_image_prompt(mock_client, "a cat") == ""
+
+
+def test_ai_image_randomize_falls_back_when_remix_fails(
+    device_config_dev, monkeypatch
+):
+    """If prompt remix raises, image generation should still succeed with the
+    user's original prompt rather than aborting the whole flow."""
+    from plugins.ai_image.ai_image import AIImage
+
+    p = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    with (
+        patch("plugins.ai_image.ai_image.OpenAI") as mock_openai,
+        patch(
+            "plugins.ai_image.ai_image.AIImage.fetch_image_prompt",
+            side_effect=Exception("remix boom"),
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        img = PILImage.new("RGB", (64, 64), "black")
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        img_b64 = base64.b64encode(buf.getvalue()).decode()
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock()]
+        mock_response.data[0].b64_json = img_b64
+        mock_client.images.generate.return_value = mock_response
+
+        settings = {
+            "textPrompt": "a calm forest at dusk",
+            "imageModel": "gpt-image-2",
+            "quality": "medium",
+            "randomizePrompt": "true",
+        }
+
+        result = p.generate_image(settings, device_config_dev)
+        assert result is not None
+
+        prompt_arg = mock_client.images.generate.call_args[1]["prompt"]
+        assert prompt_arg.startswith("a calm forest at dusk")
 
 
 def test_fetch_image_prompt_content_parsing():

--- a/tests/plugins/test_ai_text.py
+++ b/tests/plugins/test_ai_text.py
@@ -12,9 +12,11 @@ def test_ai_text_generate_settings_template(monkeypatch, device_config_dev):
 
     assert "api_key" in template
     assert template["api_key"]["required"] is True
-    assert template["api_key"]["service"] == "OpenAI / Google"
     assert template["api_key"]["expected_key"] == "OPEN_AI_SECRET"
     assert template["api_key"]["alt_key"] == "GOOGLE_AI_SECRET"
+    services = template["api_key"]["services"]
+    assert [s["name"] for s in services] == ["OpenAI", "Google"]
+    assert [s["env_var"] for s in services] == ["OPEN_AI_SECRET", "GOOGLE_AI_SECRET"]
     assert template["style_settings"] is True
     assert "settings_schema" in template
 

--- a/tests/plugins/test_ai_text.py
+++ b/tests/plugins/test_ai_text.py
@@ -12,11 +12,13 @@ def test_ai_text_generate_settings_template(monkeypatch, device_config_dev):
 
     assert "api_key" in template
     assert template["api_key"]["required"] is True
-    assert template["api_key"]["expected_key"] == "OPEN_AI_SECRET"
-    assert template["api_key"]["alt_key"] == "GOOGLE_AI_SECRET"
     services = template["api_key"]["services"]
     assert [s["name"] for s in services] == ["OpenAI", "Google"]
     assert [s["env_var"] for s in services] == ["OPEN_AI_SECRET", "GOOGLE_AI_SECRET"]
+    # Legacy expected_key/alt_key are now obsolete — `services` is the sole
+    # source of truth for multi-provider plugins.
+    assert "expected_key" not in template["api_key"]
+    assert "alt_key" not in template["api_key"]
     assert template["style_settings"] is True
     assert "settings_schema" in template
 

--- a/tests/static/test_settings_copy_text_fallback.py
+++ b/tests/static/test_settings_copy_text_fallback.py
@@ -27,9 +27,9 @@ def test_copy_text_falls_back_to_exec_command_for_http_lan():
         "copyText must fall back to a legacy execCommand path so HTTP-on-LAN "
         "deployments can still copy logs."
     )
-    assert 'document.execCommand("copy")' in js, (
-        "Fallback path should call document.execCommand('copy')."
-    )
+    assert (
+        'document.execCommand("copy")' in js
+    ), "Fallback path should call document.execCommand('copy')."
 
 
 def test_copy_text_does_not_short_circuit_on_insecure_context():

--- a/tests/static/test_settings_copy_text_fallback.py
+++ b/tests/static/test_settings_copy_text_fallback.py
@@ -1,0 +1,42 @@
+"""Regression guard: ``copyText`` must work in non-secure contexts.
+
+InkyPi is commonly served on the LAN over plain HTTP. Browsers treat that
+as an insecure context, which makes ``navigator.clipboard.writeText``
+throw / be unavailable. Without a fallback, every "Copy logs" click ends
+in a "Copy failed" toast (as the user reported on 2026-04-25). This test
+locks in the fallback path so a future refactor cannot silently regress
+the behavior.
+"""
+
+from pathlib import Path
+
+JS_PATH = Path("src/static/scripts/settings/shared.js")
+
+
+def test_copy_text_uses_clipboard_when_secure_context():
+    js = JS_PATH.read_text()
+    assert "navigator.clipboard && globalThis.isSecureContext" in js, (
+        "copyText should still prefer the async Clipboard API when the page "
+        "is a secure context (HTTPS / localhost)."
+    )
+
+
+def test_copy_text_falls_back_to_exec_command_for_http_lan():
+    js = JS_PATH.read_text()
+    assert "copyTextViaExecCommand" in js, (
+        "copyText must fall back to a legacy execCommand path so HTTP-on-LAN "
+        "deployments can still copy logs."
+    )
+    assert 'document.execCommand("copy")' in js, (
+        "Fallback path should call document.execCommand('copy')."
+    )
+
+
+def test_copy_text_does_not_short_circuit_on_insecure_context():
+    js = JS_PATH.read_text()
+    # The pre-fix code unconditionally returned false when the context was
+    # insecure. Make sure that early return is gone.
+    assert "!navigator.clipboard || !globalThis.isSecureContext" not in js, (
+        "Insecure-context early return must be gone — copyText should fall "
+        "through to the execCommand fallback instead of returning false."
+    )

--- a/tests/unit/test_check_updates_inline.py
+++ b/tests/unit/test_check_updates_inline.py
@@ -46,6 +46,7 @@ class TestApiVersionInlineResult:
         mod._VERSION_CACHE["latest"] = "99.0.0"
         mod._VERSION_CACHE["checked_at"] = time.time()
         mod._VERSION_CACHE["release_notes"] = None
+        mod._VERSION_CACHE["last_error"] = None
         original_version = client.application.config.get("APP_VERSION")
         try:
             client.application.config["APP_VERSION"] = "1.0.0"
@@ -56,9 +57,12 @@ class TestApiVersionInlineResult:
             assert "latest" in data
             assert data["latest"] == "99.0.0"
             assert data["update_available"] is True
+            assert data["check_succeeded"] is True
+            assert data["check_error"] is None
         finally:
             mod._VERSION_CACHE["latest"] = None
             mod._VERSION_CACHE["checked_at"] = 0.0
+            mod._VERSION_CACHE["last_error"] = None
             if original_version is not None:
                 client.application.config["APP_VERSION"] = original_version
             else:
@@ -101,6 +105,7 @@ class TestApiVersionInlineResult:
         # Force cache miss so it tries to fetch
         mod._VERSION_CACHE["latest"] = None
         mod._VERSION_CACHE["checked_at"] = 0.0
+        mod._VERSION_CACHE["last_error"] = None
         monkeypatch.setattr(
             "blueprints.settings.http_get",
             MagicMock(side_effect=Exception("network down")),
@@ -111,6 +116,46 @@ class TestApiVersionInlineResult:
             assert resp.status_code == 200
             data = resp.get_json()
             assert "current" in data
+            assert data["check_succeeded"] is False
+            assert data["check_error"]
+            assert "network down" in data["check_error"]
         finally:
             mod._VERSION_CACHE["latest"] = None
             mod._VERSION_CACHE["checked_at"] = 0.0
+            mod._VERSION_CACHE["last_error"] = None
+
+    def test_force_refresh_bypasses_cache(self, client, monkeypatch):
+        """?force=1 must hit the HTTP layer even if a fresh cache entry exists."""
+        import blueprints.settings as mod
+
+        mod._VERSION_CACHE["latest"] = "1.0.0"
+        mod._VERSION_CACHE["checked_at"] = time.time()
+        mod._VERSION_CACHE["release_notes"] = None
+        mod._VERSION_CACHE["last_error"] = None
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "tag_name": "v9.9.9",
+            "body": "shiny",
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get = MagicMock(return_value=mock_resp)
+        monkeypatch.setattr("blueprints.settings.http_get", mock_get)
+
+        try:
+            # Cached call should not invoke http_get
+            resp = client.get("/api/version")
+            assert mock_get.call_count == 0
+            assert resp.get_json()["latest"] == "1.0.0"
+
+            # Forced call should ignore the cache and fetch
+            resp = client.get("/api/version?force=1")
+            assert mock_get.call_count == 1
+            data = resp.get_json()
+            assert data["latest"] == "9.9.9"
+            assert data["check_succeeded"] is True
+        finally:
+            mod._VERSION_CACHE["latest"] = None
+            mod._VERSION_CACHE["checked_at"] = 0.0
+            mod._VERSION_CACHE["last_error"] = None
+            mod._VERSION_CACHE["release_notes"] = None

--- a/tests/unit/test_check_updates_inline.py
+++ b/tests/unit/test_check_updates_inline.py
@@ -118,7 +118,49 @@ class TestApiVersionInlineResult:
             assert "current" in data
             assert data["check_succeeded"] is False
             assert data["check_error"]
+            # The message should be user-facing and distinguish a network
+            # failure from a "rejected tag" outcome (JTN PR #590 review).
+            assert data["check_error"].startswith("Couldn't reach GitHub")
             assert "network down" in data["check_error"]
+        finally:
+            mod._VERSION_CACHE["latest"] = None
+            mod._VERSION_CACHE["checked_at"] = 0.0
+            mod._VERSION_CACHE["last_error"] = None
+
+    def test_pre_release_tag_is_not_reported_as_network_failure(
+        self, client, monkeypatch
+    ):
+        """A pre-release tag (v1.2.3-rc1) should produce a "not a stable
+        release" message, not a misleading "Couldn't reach GitHub" one
+        (JTN PR #590 review feedback)."""
+        import blueprints.settings as mod
+
+        mod._VERSION_CACHE["latest"] = None
+        mod._VERSION_CACHE["checked_at"] = 0.0
+        mod._VERSION_CACHE["last_error"] = None
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "tag_name": "v1.2.3-rc1",
+            "body": "release candidate",
+        }
+        mock_resp.raise_for_status = MagicMock()
+        monkeypatch.setattr(
+            "blueprints.settings.http_get", MagicMock(return_value=mock_resp)
+        )
+
+        try:
+            resp = client.get("/api/version")
+            data = resp.get_json()
+            assert data["check_succeeded"] is False
+            assert data["check_error"]
+            msg = data["check_error"]
+            # Must NOT misreport this as a network failure.
+            assert "Couldn't reach GitHub" not in msg
+            assert "network" not in msg.lower()
+            # Should identify the situation accurately.
+            assert "stable" in msg.lower()
+            assert "v1.2.3-rc1" in msg
         finally:
             mod._VERSION_CACHE["latest"] = None
             mod._VERSION_CACHE["checked_at"] = 0.0


### PR DESCRIPTION
## Summary

Three user-reported papercuts in the Settings console plus an AI Image plugin polish pass.

### 1. Segmented radios were unclickable
`.seg-radio` positioned each invisible radio at `inset:0` of the *shared* group, so the last radio in DOM order stacked on top and stole every click. The result: "Horizontal", "Fit to container", and "12 h" looked dead — every click silently selected the second option instead. Bug was not isolated to those three; it affected every `.seg-radio` group.

**Fix:** scope `position: relative` to each `.seg-btn` label so each radio is bounded by its own label and clicks land where the user expects. Verified in preview: Horizontal / Fit / 12h now toggle correctly, the `:has(input:checked)` highlight still works.

### 2. "Check for updates" kept saying "no update available" when one existed
`/api/version` cached the GitHub response for 1h and silently returned `None` on any failure (network, rate-limit, tag parse), which the client rendered as "You're on the latest version" — stale/failed state got served for the rest of the hour, even after a page refresh. Failures were also only logged at `DEBUG`, so they never reached the in-app log panel.

**Fix:**
- `_check_latest_version(force_refresh=False)` and `/api/version?force=1` bypass the cache on manual clicks.
- New `last_error` field on the cache + `check_succeeded` / `check_error` on the JSON so the UI can distinguish "on latest" from "couldn't reach GitHub."
- Failures now log at INFO (visible in the log panel) and the toast surfaces the real reason.

### 3. "Copy logs" always said "Copy failed"
`navigator.clipboard.writeText` requires a secure context. InkyPi on LAN-over-HTTP doesn't get one, so `copyText` returned `false` before even trying.

**Fix:** added a hidden-textarea + `document.execCommand('copy')` fallback so the button works on HTTP too. Async Clipboard API is still preferred when available (HTTPS / localhost).

### 4. AI Image plugin UX polish
- Added **GPT Image 2** (now default) alongside 1.5 with matching quality presets.
- Replaced the shared `"OpenAI / Google"` service label with a structured `services` list. The blueprint computes presence per provider so the inline chip and "API key" card show only the provider(s) actually configured (e.g. just "OpenAI" when only OpenAI is set) instead of the confusing `OpenAI / Google` slash combo.
- Tightened field copy and hardened the remix-prompt path — a randomize failure now falls back to the user's original prompt instead of aborting the whole generation.

## Base Branch Confirmation

- [x] This PR is based on `origin/main`
- [x] Rebased on latest `origin/main` before opening

## Compatibility / Release Checklist

- [x] `pytest` relevant suites pass locally (1097 passed, 2 skipped in a broad sweep covering version/update/settings/copy/orientation paths)
- [x] No breaking API route/path changes (`/api/version` response gained `check_succeeded` + `check_error` additively; `?force=1` is optional)
- [x] Error responses follow JSON contract
- [x] Frontend changes verified in browser preview (segmented controls + the previously-failing orientation integration test now pass)

## Test plan

- [ ] Open Settings → Device: click "Horizontal", then "Fit to container", then "12 h" — each should toggle immediately (previously the second option in each pair always won).
- [ ] Settings → Updates → "Check for updates" when a newer release exists: should show "Update available: vX.Y.Z" and populate the "What's new" section.
- [ ] Settings → Updates → "Check for updates" while offline: should show "Unable to reach GitHub to check for updates (...)" with a concrete reason, not a false "you're on latest."
- [ ] Settings → Logs → "Copy logs" on an HTTP device: should flash "Copied!" (previously "Copy failed").
- [ ] Plugins → AI Image: verify GPT Image 2 appears as default, switching to Google shows only the Imagen model, and the API-key chip shows just the configured provider name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-provider API key support: Configure OpenAI and Google credentials independently.
  * Forced version refresh: Skip cache to check for updates immediately.
  * Enhanced copy-to-clipboard: Improved fallback support for HTTP and insecure contexts.
  * Additional image generation model option.

* **Bug Fixes**
  * Fixed unclickable device settings options in segmented controls.
  * Improved robustness of prompt remixing with automatic fallback on errors.
  * Better error reporting and messaging for version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->