### PR TITLE
fix: post-PR589 dogfood — restore flow, mobile/light-theme polish, validation gaps

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -638,8 +638,13 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
                 sanitize_log_field(plugin_id),
                 sanitize_log_field(safe_msg),
             )
+            # ISSUE-006: still surface the error image on the device, but
+            # do NOT write a history sidecar — the user just typed an
+            # invalid URL, no render was actually attempted, and we
+            # shouldn't bump Dashboard "Refreshes / Errors" for a typo.
             _push_update_now_fallback(
-                plugin_id, plugin_config, device_config, display_manager, e
+                plugin_id, plugin_config, device_config, display_manager, e,
+                record_history=False,
             )
             return json_error(
                 safe_msg,
@@ -751,9 +756,19 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
 
 
 def _push_update_now_fallback(
-    plugin_id, plugin_config, device_config, display_manager, exc
+    plugin_id, plugin_config, device_config, display_manager, exc, *,
+    record_history: bool = True,
 ):
-    """Best-effort: render and push an error-card image so the display updates on failure."""
+    """Best-effort: render and push an error-card image so the display updates on failure.
+
+    ``record_history``: when False, the fallback is *displayed* but no
+    history sidecar is written, so the failure does not get counted by
+    :mod:`utils.refresh_stats` toward the dashboard "Refreshes / Errors"
+    KPIs. Use False for failures that are pre-render input rejections
+    (e.g. URLValidationError) — those didn't actually attempt a real
+    render, and counting them inflates both the refresh and error
+    counters for what was just a typo (ISSUE-006).
+    """
     try:
         w, h = device_config.get_resolution()
         fallback = render_error_image(
@@ -764,17 +779,22 @@ def _push_update_now_fallback(
             error_class=type(exc).__name__,
             error_message=str(exc),
         )
-        _safe_display_image(
-            display_manager,
-            fallback,
-            plugin_config.get("image_settings", []),
+        history_meta = (
             {
                 "refresh_type": "Manual Update",
                 "plugin_id": plugin_id,
                 "playlist": None,
                 "plugin_instance": None,
                 "error_class": type(exc).__name__,
-            },
+            }
+            if record_history
+            else None
+        )
+        _safe_display_image(
+            display_manager,
+            fallback,
+            plugin_config.get("image_settings", []),
+            history_meta,
         )
     except Exception:
         logger.warning(

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -643,7 +643,11 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
             # invalid URL, no render was actually attempted, and we
             # shouldn't bump Dashboard "Refreshes / Errors" for a typo.
             _push_update_now_fallback(
-                plugin_id, plugin_config, device_config, display_manager, e,
+                plugin_id,
+                plugin_config,
+                device_config,
+                display_manager,
+                e,
                 record_history=False,
             )
             return json_error(
@@ -756,7 +760,12 @@ def _update_now_direct(plugin_id, plugin_settings, device_config, display_manage
 
 
 def _push_update_now_fallback(
-    plugin_id, plugin_config, device_config, display_manager, exc, *,
+    plugin_id,
+    plugin_config,
+    device_config,
+    display_manager,
+    exc,
+    *,
     record_history: bool = True,
 ):
     """Best-effort: render and push an error-card image so the display updates on failure.

--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -210,14 +210,18 @@ def import_settings():
         if payload is None:
             raise ClientInputError("Invalid import payload", status=400)
 
+        cfg_keys_applied = 0
         cfg = payload.get("config")
         if isinstance(cfg, dict):
             # Filter to allowed keys only
             filtered_cfg = {
                 k: v for k, v in cfg.items() if k in _mod._ALLOWED_IMPORT_CONFIG_KEYS
             }
-            device_config.update_config(filtered_cfg)
+            if filtered_cfg:
+                device_config.update_config(filtered_cfg)
+                cfg_keys_applied = len(filtered_cfg)
 
+        env_keys_applied = 0
         env_keys = payload.get("env_keys") or {}
         if isinstance(env_keys, dict):
             for k, v in env_keys.items():
@@ -225,10 +229,26 @@ def import_settings():
                     continue
                 try:
                     device_config.set_env_key(k, str(v))
+                    env_keys_applied += 1
                 except Exception:
                     _mod.logger.exception("Failed setting env key during import: %s", k)
 
-        return json_success(message="Import completed")
+        if cfg_keys_applied == 0 and env_keys_applied == 0:
+            raise ClientInputError(
+                "Backup contained no recognizable settings or API keys",
+                status=400,
+            )
+
+        parts = []
+        if cfg_keys_applied:
+            parts.append(
+                f"{cfg_keys_applied} setting{'s' if cfg_keys_applied != 1 else ''}"
+            )
+        if env_keys_applied:
+            parts.append(
+                f"{env_keys_applied} API key{'s' if env_keys_applied != 1 else ''}"
+            )
+        return json_success(message=f"Restored {' and '.join(parts)}")
 
 
 @_mod.settings_bp.route("/settings/api-keys", methods=["GET"])

--- a/src/display/display_manager.py
+++ b/src/display/display_manager.py
@@ -129,7 +129,15 @@ class DisplayManager:
                 logger.debug("Could not prune history directory", exc_info=True)
 
     def _save_history_entry(self, processed_image, history_meta=None):
-        """Persist a processed image snapshot and optional JSON sidecar metadata."""
+        """Persist a processed image snapshot and optional JSON sidecar metadata.
+
+        When ``history_meta`` is None (or empty) we still write the PNG —
+        callers like the URL-validation fallback path want the device to
+        show the error image — but we skip the JSON sidecar so the
+        non-render does NOT count toward Dashboard "Refreshes / Errors"
+        KPIs (ISSUE-006). ``utils.refresh_stats.compute_stats`` derives
+        those numbers by counting sidecar files; no sidecar = no count.
+        """
         history_dir = getattr(self.device_config, "history_image_dir", None)
         if not history_dir:
             return
@@ -157,8 +165,13 @@ class DisplayManager:
         except (OSError, ValueError, RuntimeError):
             logger.exception("Failed to save history snapshot image")
             return
+        # Skip the sidecar entirely when there's no metadata to record
+        # (callers explicitly opting out). The PNG above is still on disk.
+        if not history_meta:
+            self._prune_history(history_dir)
+            return
         try:
-            meta_payload = dict(history_meta or {})
+            meta_payload = dict(history_meta)
             meta_payload.setdefault("refresh_time", timestamp.isoformat())
             with open(
                 os.path.join(history_dir, f"{base_name}.json"),

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -248,7 +248,11 @@
         const key = row.querySelector(".apikey-key")?.value.trim() || "";
         if (!key) continue;
         providers += 1;
-        const value = row.querySelector(".apikey-value")?.value || "";
+        // Use the trimmed value so a whitespace-only field does NOT bump
+        // the "saved" badge — `saveGenericKeys` rejects whitespace-only
+        // entries the same way; keeping all three in sync (badge,
+        // input-listener clear, validator) avoids false reassurance.
+        const value = row.querySelector(".apikey-value")?.value.trim() || "";
         const wasSaved = row.dataset.existing === "true";
         if (wasSaved || value.length > 0) configured += 1;
       }
@@ -411,10 +415,14 @@
         updateRowAriaLabels(row, keyInput.value);
         refreshKeyCounts();
       });
-      // Clear inline aria-invalid as soon as the user types into a previously
-      // flagged-empty value field, and also bump the "configured" count.
+      // Clear inline aria-invalid as soon as the user types real (non-
+      // whitespace) content into a previously flagged-empty value field,
+      // and also bump the "configured" count. Trim so this stays in sync
+      // with `saveGenericKeys` and `refreshKeyCounts`, which both reject
+      // whitespace-only — otherwise typing spaces would falsely clear the
+      // error state right before the validator re-flags the field on save.
       valInput.addEventListener("input", () => {
-        if (valInput.value.length > 0 && valInput.getAttribute("aria-invalid") === "true") {
+        if (valInput.value.trim().length > 0 && valInput.getAttribute("aria-invalid") === "true") {
           valInput.setAttribute("aria-invalid", "false");
           const errorId = valInput.getAttribute("aria-describedby");
           if (errorId) {

--- a/src/static/scripts/api_keys_page.js
+++ b/src/static/scripts/api_keys_page.js
@@ -231,6 +231,37 @@
       if (saveBtn) saveBtn.disabled = true;
     }
 
+    // Recompute the "X providers" / "Y configured" badges from the current
+    // DOM. In generic mode the page-load template sets both counts equal to
+    // entries|length; once the user adds a preset row (key set, value still
+    // empty) the counts must diverge, otherwise the badges are stale and
+    // the pair is also redundantly identical (ISSUE-003 / ISSUE-004).
+    //  - "providers" = rows with a non-empty key in the editor
+    //  - "configured" = rows that already have a saved value (existing rows
+    //    or new rows whose value field is filled)
+    function refreshKeyCounts() {
+      if (config.mode !== "generic") return;
+      const rows = Array.from(document.querySelectorAll(".apikey-row"));
+      let providers = 0;
+      let configured = 0;
+      for (const row of rows) {
+        const key = row.querySelector(".apikey-key")?.value.trim() || "";
+        if (!key) continue;
+        providers += 1;
+        const value = row.querySelector(".apikey-value")?.value || "";
+        const wasSaved = row.dataset.existing === "true";
+        if (wasSaved || value.length > 0) configured += 1;
+      }
+      const providersChip = document.getElementById("providerCountSummary");
+      if (providersChip) {
+        providersChip.textContent = `${providers} provider${providers === 1 ? "" : "s"}`;
+      }
+      const configuredChip = document.getElementById("configuredCountSummary");
+      if (configuredChip) {
+        configuredChip.textContent = `${configured} saved`;
+      }
+    }
+
     // Extracted to keep saveManagedKeys below the cognitive-complexity
     // threshold (SonarCloud javascript:S3776). Shows the appropriate modal
     // for a successful resp.ok response and refreshes the configured-status
@@ -376,10 +407,25 @@
       // Initialize aria-labels now; re-run on every keyInput change so the
       // label tracks the key name the user just typed.
       updateRowAriaLabels(row, key);
-      keyInput.addEventListener("input", () =>
-        updateRowAriaLabels(row, keyInput.value)
-      );
+      keyInput.addEventListener("input", () => {
+        updateRowAriaLabels(row, keyInput.value);
+        refreshKeyCounts();
+      });
+      // Clear inline aria-invalid as soon as the user types into a previously
+      // flagged-empty value field, and also bump the "configured" count.
+      valInput.addEventListener("input", () => {
+        if (valInput.value.length > 0 && valInput.getAttribute("aria-invalid") === "true") {
+          valInput.setAttribute("aria-invalid", "false");
+          const errorId = valInput.getAttribute("aria-describedby");
+          if (errorId) {
+            const err = document.getElementById(errorId);
+            if (err) err.textContent = "";
+          }
+        }
+        refreshKeyCounts();
+      });
       list.appendChild(row);
+      refreshKeyCounts();
       (key ? row.querySelector(".apikey-value") : row.querySelector(".apikey-key")).focus();
     }
 
@@ -421,6 +467,7 @@
       }
       markDirty();
       row?.remove();
+      refreshKeyCounts();
       if (deletedKey) {
         const presetBtn = document.querySelector(
           `.btn-preset[data-key="${deletedKey}"]`
@@ -465,11 +512,23 @@
     async function saveGenericKeys() {
       const rows = document.querySelectorAll(".apikey-row");
       const entries = [];
-      let missingValue = false;
+      const missingValueInputs = [];
       rows.forEach((row) => {
-        const key = row.querySelector(".apikey-key")?.value.trim();
-        const value = row.querySelector(".apikey-value")?.value.trim();
+        const keyInput = row.querySelector(".apikey-key");
+        const valueInput = row.querySelector(".apikey-value");
+        const key = keyInput?.value.trim();
+        const value = valueInput?.value.trim();
         const isExisting = row.dataset.existing === "true";
+        // Reset any prior inline error state for the value field. A fresh
+        // submit re-validates from scratch.
+        if (valueInput) {
+          valueInput.setAttribute("aria-invalid", "false");
+          const errorId = valueInput.getAttribute("aria-describedby");
+          if (errorId) {
+            const err = document.getElementById(errorId);
+            if (err) err.textContent = "";
+          }
+        }
         if (!key) return;
         if (isExisting) {
           if (value) {
@@ -478,12 +537,35 @@
             entries.push({ key, value: null, keepExisting: true });
           }
         } else if (!value) {
-          missingValue = true;
+          if (valueInput) missingValueInputs.push(valueInput);
         } else {
           entries.push({ key, value });
         }
       });
-      if (missingValue) {
+      if (missingValueInputs.length > 0) {
+        // Surface inline errors on the offending input(s) so AT users see the
+        // problem on the field itself, not just in the corner toast (ISSUE-005).
+        // Ensure each input has an associated validation-message element.
+        for (const input of missingValueInputs) {
+          input.setAttribute("aria-invalid", "true");
+          let errorId = input.getAttribute("aria-describedby");
+          let errorEl = errorId ? document.getElementById(errorId) : null;
+          if (!errorEl) {
+            errorId = `${input.id || "apikey-value"}-error`;
+            errorEl = document.createElement("span");
+            errorEl.id = errorId;
+            errorEl.className = "validation-message";
+            errorEl.setAttribute("role", "alert");
+            input.insertAdjacentElement("afterend", errorEl);
+            input.setAttribute("aria-describedby", errorId);
+          }
+          errorEl.textContent = "Enter a value or delete this row";
+        }
+        try {
+          missingValueInputs[0].focus();
+        } catch {
+          // focus() can throw if the input was just detached; ignore.
+        }
         showResponseModal("failure", "Please enter a value for new API keys");
         return;
       }
@@ -535,6 +617,12 @@
     function init() {
       if (config.mode === "generic") {
         hideExistingPresets();
+        // Sync the badge labels with the JS-rendered form once on load. The
+        // server-side template renders provider/configured counts as
+        // "X providers" / "Y configured", but the JS now uses
+        // "X provider(s)" / "Y saved" — keep terminology consistent on first
+        // paint instead of waiting until the user edits a row.
+        refreshKeyCounts();
       }
       // Add show/hide toggle buttons next to password inputs
       document.querySelectorAll('input[type="password"].form-input').forEach((input) => {

--- a/src/static/scripts/settings/actions.js
+++ b/src/static/scripts/settings/actions.js
@@ -410,15 +410,15 @@
 
     async function importConfig() {
       const btn = document.getElementById("importConfigBtn");
-      if (btn) {
-        btn.disabled = true;
-        btn.textContent = "Restoring…";
-      }
       const fileInput = document.getElementById("importFile");
       const file = fileInput?.files?.[0];
       if (!file) {
         showResponseModal("failure", "Choose a backup file first");
         return;
+      }
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = "Restoring…";
       }
       const form = new FormData();
       form.append("file", file);
@@ -438,11 +438,9 @@
         showResponseModal("failure", "Import failed");
       } finally {
         if (btn) {
-          btn.disabled = false;
-          btn.textContent = "Restore from File";
+          btn.textContent = "Restore from file";
+          btn.disabled = !fileInput?.files?.length;
         }
-        const input = document.getElementById("importFile");
-        if (btn) btn.disabled = !input?.files?.length;
       }
     }
 

--- a/src/static/scripts/settings/form.js
+++ b/src/static/scripts/settings/form.js
@@ -82,6 +82,25 @@
     const { getFormSnapshot, restoreFormFromSnapshot } = shared;
     const snapshotState = { current: null };
 
+    // Server caps the cycle interval at "less than 24 hours" — see
+    // _validate_settings_form. Without a client-side `max`, users can type
+    // 999999 hours, click Save, and only then learn the limit (ISSUE-009).
+    // Bind `max` to whichever unit is currently selected so the failure
+    // surfaces inline.
+    function _maxIntervalForUnit(unit) {
+      if (unit === "hour") return 23;
+      // minutes (default): 23h59 = 1439, but the server interpretation is
+      // "strictly less than 24 hours" so 1440 would be invalid; use 1439.
+      return 1439;
+    }
+
+    function refreshIntervalMax() {
+      const intervalInput = document.getElementById("interval");
+      const unitSelect = document.getElementById("unit");
+      if (!intervalInput || !unitSelect) return;
+      intervalInput.max = String(_maxIntervalForUnit(unitSelect.value));
+    }
+
     function populateIntervalFields() {
       const intervalInput = document.getElementById("interval");
       const unitSelect = document.getElementById("unit");
@@ -96,6 +115,7 @@
         intervalInput.value = String(Math.max(1, intervalInMinutes));
         unitSelect.value = "minute";
       }
+      refreshIntervalMax();
     }
 
     function checkDirty() {
@@ -213,6 +233,12 @@
         ?.addEventListener("change", (event) => {
           toggleUseDeviceLocation(event.currentTarget);
         });
+      // ISSUE-009: re-cap the plugin-cycle-interval field whenever the unit
+      // changes, so the inline browser validation reflects the server's
+      // "<24h" rule for the currently-selected unit.
+      document
+        .getElementById("unit")
+        ?.addEventListener("change", refreshIntervalMax);
       for (const slider of document.querySelectorAll(".settings-slider")) {
         slider.addEventListener("input", () => updateSliderValue(slider));
       }

--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -1625,9 +1625,15 @@ main[data-page-shell="workflow"] .frame {
   .mobile-site-nav-panel {
     position: absolute;
     top: calc(100% + 8px);
-    left: 0;
+    /* Anchor to the right edge of the (narrow, middle-column) Menu button
+     * and let the dropdown grow leftward into the brand column. With only
+     * `left: 0; right: 0` the panel was constrained to the middle grid
+     * column at 390px viewports, clipping item labels (e.g. "API Keys"). */
     right: 0;
+    min-width: max(100%, 220px);
+    max-width: calc(100vw - 28px);
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 6px;
     padding: 8px;
     border: 1px solid var(--surface-border);
@@ -5600,6 +5606,15 @@ body[data-page="plugin"] .workflow-help p {
     font-weight: 600;
     color: var(--text);
     letter-spacing: -0.01em;
+    /* Long names (up to maxlength=64) must visibly truncate at narrow widths
+     * — otherwise they overflow the card without ellipsis. The Dashboard's
+     * Quick switch panel already truncates the same value; keep parity here.
+     * `min-width: 0` lets the heading shrink below content size when nested
+     * in flex/grid parents (.playlist-heading, .playlist-title-row). */
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .playlist-heading {

--- a/src/static/styles/partials/_playlists.css
+++ b/src/static/styles/partials/_playlists.css
@@ -117,6 +117,15 @@
     font-weight: 600;
     color: var(--text);
     letter-spacing: -0.01em;
+    /* Long names (up to maxlength=64) must visibly truncate at narrow widths
+     * — otherwise they overflow the card without ellipsis. The Dashboard's
+     * Quick switch panel already truncates the same value; keep parity here.
+     * `min-width: 0` lets the heading shrink below content size when nested
+     * in flex/grid parents (.playlist-heading, .playlist-title-row). */
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .playlist-heading {

--- a/src/static/styles/partials/_sidebar.css
+++ b/src/static/styles/partials/_sidebar.css
@@ -448,9 +448,15 @@
   .mobile-site-nav-panel {
     position: absolute;
     top: calc(100% + 8px);
-    left: 0;
+    /* Anchor to the right edge of the (narrow, middle-column) Menu button
+     * and let the dropdown grow leftward into the brand column. With only
+     * `left: 0; right: 0` the panel was constrained to the middle grid
+     * column at 390px viewports, clipping item labels (e.g. "API Keys"). */
     right: 0;
+    min-width: max(100%, 220px);
+    max-width: calc(100vw - 28px);
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 6px;
     padding: 8px;
     border: 1px solid var(--surface-border);

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -116,8 +116,15 @@
                                 <div class="loading-indicator small left-align"></div>
                             </div>
 
+                            {# ISSUE-010: only emit the thumb wrapper when we have an
+                               actual refresh image to show. Previously the wrapper
+                               was emitted unconditionally with whitespace-only
+                               content, which made `.pl-item-thumb:empty` not
+                               match (whitespace text nodes count) so the
+                               wrapper rendered as a hardcoded-black 96×56
+                               box that looked broken in the light theme. #}
+                            {% if plugin_instance.latest_refresh_time %}
                             <div class="pl-item-thumb">
-                                {% if plugin_instance.latest_refresh_time %}
                                 <div class="plugin-thumbnail-container lightboxable"
                                      data-thumbnail-playlist="{{ playlist.name }}"
                                      data-thumbnail-plugin="{{ plugin_instance.plugin_id }}"
@@ -133,8 +140,8 @@
                                         loading="lazy"
                                     >
                                 </div>
-                                {% endif %}
                             </div>
+                            {% endif %}
 
                             <div class="plugin-actions pl-item-actions">
                                 <button class="header-button is-secondary plugin-display-btn playlist-row-display-btn" type="button" title="Display {{ pi_label }} now" data-playlist-action="display-instance" data-playlist="{{ playlist.name }}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}">

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -96,8 +96,10 @@
                         <label for="deviceName" class="form-label">Device name</label>
                         {# JTN-780: mirror server-side constraints from JTN-746 so users see inline feedback
                            before hitting Save. maxlength caps input at 64; pattern forbids control characters
-                           (Cc category) except tab, matching blueprints/settings/_config.py::_validate_device_name. #}
-                        <input type="text" id="deviceName" name="deviceName" placeholder="Enter device name" value="{{ device_settings.name }}" required maxlength="64" pattern="[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*" title="Up to 64 characters. Tabs are allowed; other control characters are not." class="form-input" aria-required="true" aria-invalid="false" aria-describedby="deviceName-error">
+                           (Cc category) except tab, matching blueprints/settings/_config.py::_validate_device_name.
+                           ISSUE-008: the central `\S` requires at least one non-whitespace character so a value
+                           of "   " fails client-side instead of round-tripping to the server's whitespace check. #}
+                        <input type="text" id="deviceName" name="deviceName" placeholder="Enter device name" value="{{ device_settings.name }}" required maxlength="64" pattern="[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*\S[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*" title="Up to 64 characters with at least one non-space character. Tabs are allowed; other control characters are not." class="form-input" aria-required="true" aria-invalid="false" aria-describedby="deviceName-error">
                         <span id="deviceName-error" class="validation-message" role="alert"></span>
                     </div>
                     {# Handoff parity: Orientation | Preview size sit in a

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -97,9 +97,11 @@
                         {# JTN-780: mirror server-side constraints from JTN-746 so users see inline feedback
                            before hitting Save. maxlength caps input at 64; pattern forbids control characters
                            (Cc category) except tab, matching blueprints/settings/_config.py::_validate_device_name.
-                           ISSUE-008: the central `\S` requires at least one non-whitespace character so a value
-                           of "   " fails client-side instead of round-tripping to the server's whitespace check. #}
-                        <input type="text" id="deviceName" name="deviceName" placeholder="Enter device name" value="{{ device_settings.name }}" required maxlength="64" pattern="[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*\S[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*" title="Up to 64 characters with at least one non-space character. Tabs are allowed; other control characters are not." class="form-input" aria-required="true" aria-invalid="false" aria-describedby="deviceName-error">
+                           ISSUE-008 / CodeRabbit follow-up: the central character class requires at least one
+                           character that is neither whitespace nor a Cc control character, so a value of "   " or
+                           a lone control char fails client-side instead of round-tripping to the server's
+                           whitespace + Cc-category checks in _validate_device_name. #}
+                        <input type="text" id="deviceName" name="deviceName" placeholder="Enter device name" value="{{ device_settings.name }}" required maxlength="64" pattern="[^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*[^\s\u0000-\u0008\u000A-\u001F\u007F-\u009F][^\u0000-\u0008\u000A-\u001F\u007F-\u009F]*" title="Up to 64 characters with at least one non-space character. Tabs are allowed; other control characters are not." class="form-input" aria-required="true" aria-invalid="false" aria-describedby="deviceName-error">
                         <span id="deviceName-error" class="validation-message" role="alert"></span>
                     </div>
                     {# Handoff parity: Orientation | Preview size sit in a

--- a/tests/integration/test_browser_smoke.py
+++ b/tests/integration/test_browser_smoke.py
@@ -403,7 +403,12 @@ def test_jtn_730_settings_deep_high_risk_paths(live_server, tmp_path):
             page.set_input_files("#importFile", str(import_file))
             assert page.locator("#importConfigBtn").is_enabled()
             page.locator("#importConfigBtn").click()
-            _wait_for_toast_text(page, "Import completed")
+            # Server now reports the count of applied keys ("Restored 5
+            # settings" rather than the older "Import completed") so the
+            # user knows the restore actually did something. Look for the
+            # "settings" suffix that's stable across whatever count the
+            # import_payload above produces.
+            _wait_for_toast_text(page, "settings")
             page.reload(wait_until="domcontentloaded")
             page.wait_for_selector("[data-page-shell]", timeout=10000)
             assert page.locator("#deviceName").input_value() == "JTN730 Imported Device"

--- a/tests/integration/test_update_now_url_validation.py
+++ b/tests/integration/test_update_now_url_validation.py
@@ -137,9 +137,7 @@ class TestImageUrlValidation:
         os.makedirs(history_dir, exist_ok=True)
         # Snapshot existing sidecars so the test isn't fragile to fixture state.
         sidecars_before = {
-            name
-            for name in os.listdir(history_dir)
-            if name.endswith(".json")
+            name for name in os.listdir(history_dir) if name.endswith(".json")
         }
 
         resp = client.post(
@@ -149,9 +147,7 @@ class TestImageUrlValidation:
         assert resp.status_code == 422
 
         sidecars_after = {
-            name
-            for name in os.listdir(history_dir)
-            if name.endswith(".json")
+            name for name in os.listdir(history_dir) if name.endswith(".json")
         }
         new_sidecars = sidecars_after - sidecars_before
         assert not new_sidecars, (

--- a/tests/integration/test_update_now_url_validation.py
+++ b/tests/integration/test_update_now_url_validation.py
@@ -121,6 +121,52 @@ class TestImageUrlValidation:
         details = body.get("details") or {}
         assert details.get("field") == "url"
 
+    def test_url_validation_failure_does_not_record_history_sidecar(
+        self, client, device_config_dev
+    ):
+        """ISSUE-006 — a rejected URL must NOT bump Dashboard "Refreshes" /
+        "Errors" KPIs.  The dashboard derives those numbers by counting
+        history JSON sidecars in ``device_config.history_image_dir``;
+        URL validation errors are user input rejected pre-render, so we
+        push a fallback image to the device but skip the sidecar.
+        """
+        import json
+        import os
+
+        history_dir = device_config_dev.history_image_dir
+        os.makedirs(history_dir, exist_ok=True)
+        # Snapshot existing sidecars so the test isn't fragile to fixture state.
+        sidecars_before = {
+            name
+            for name in os.listdir(history_dir)
+            if name.endswith(".json")
+        }
+
+        resp = client.post(
+            "/update_now",
+            data={"plugin_id": "image_url", "url": "javascript:alert(1)"},
+        )
+        assert resp.status_code == 422
+
+        sidecars_after = {
+            name
+            for name in os.listdir(history_dir)
+            if name.endswith(".json")
+        }
+        new_sidecars = sidecars_after - sidecars_before
+        assert not new_sidecars, (
+            f"URL validation failure should not write a history sidecar — "
+            f"would inflate Dashboard refresh/error counts. New: {new_sidecars}"
+        )
+
+        # And just to double-check: any sidecar that *would* have been
+        # written would have included a Manual Update + URLValidationError
+        # marker.  Make sure nothing matching that ended up on disk either.
+        for name in sidecars_after:
+            with open(os.path.join(history_dir, name), encoding="utf-8") as fh:
+                payload = json.load(fh)
+            assert payload.get("error_class") != "URLValidationError"
+
 
 # ---------------------------------------------------------------------------
 # screenshot plugin

--- a/tests/integration/test_update_now_url_validation.py
+++ b/tests/integration/test_update_now_url_validation.py
@@ -155,10 +155,13 @@ class TestImageUrlValidation:
             f"would inflate Dashboard refresh/error counts. New: {new_sidecars}"
         )
 
-        # And just to double-check: any sidecar that *would* have been
-        # written would have included a Manual Update + URLValidationError
-        # marker.  Make sure nothing matching that ended up on disk either.
-        for name in sidecars_after:
+        # And just to double-check: any sidecar this request *could* have
+        # written would have included a URLValidationError marker.  Scope the
+        # loop to *new* sidecars only — iterating over `sidecars_after` would
+        # also read pre-existing fixture files unrelated to this request,
+        # making this guard either toothless (nothing in scope) or fragile
+        # to unrelated fixture state.
+        for name in new_sidecars:
             with open(os.path.join(history_dir, name), encoding="utf-8") as fh:
                 payload = json.load(fh)
             assert payload.get("error_class") != "URLValidationError"

--- a/tests/static/test_api_keys_page_counts_and_validation.py
+++ b/tests/static/test_api_keys_page_counts_and_validation.py
@@ -26,9 +26,9 @@ def test_refresh_key_counts_function_exists_and_updates_both_chips():
     """The page must have a function that recomputes both badges from the
     current DOM. Without this the labels stay stale after add/delete."""
     js = _read_js()
-    assert "function refreshKeyCounts" in js, (
-        "refreshKeyCounts() helper missing — badges will not update on add/delete"
-    )
+    assert (
+        "function refreshKeyCounts" in js
+    ), "refreshKeyCounts() helper missing — badges will not update on add/delete"
     # Make sure both chip ids are touched.
     assert 'getElementById("providerCountSummary")' in js
     assert 'getElementById("configuredCountSummary")' in js
@@ -94,15 +94,15 @@ def test_save_generic_keys_marks_empty_value_input_aria_invalid():
     assert save_match, "saveGenericKeys function not found"
     body = save_match.group("body")
     # Must collect inputs (not just a boolean) and mark them invalid.
-    assert "missingValueInputs" in body or "missingValueInput" in body, (
-        "saveGenericKeys should track WHICH inputs were empty so it can mark them"
-    )
-    assert 'setAttribute("aria-invalid", "true")' in body, (
-        "Empty value inputs must get aria-invalid='true' on submit"
-    )
-    assert "validation-message" in body, (
-        "An inline validation-message element must be inserted/used"
-    )
+    assert (
+        "missingValueInputs" in body or "missingValueInput" in body
+    ), "saveGenericKeys should track WHICH inputs were empty so it can mark them"
+    assert (
+        'setAttribute("aria-invalid", "true")' in body
+    ), "Empty value inputs must get aria-invalid='true' on submit"
+    assert (
+        "validation-message" in body
+    ), "An inline validation-message element must be inserted/used"
     # Toast still fires for visual users.
     assert "Please enter a value for new API keys" in body
     # Focus moves to the first invalid input so keyboard users land there.

--- a/tests/static/test_api_keys_page_counts_and_validation.py
+++ b/tests/static/test_api_keys_page_counts_and_validation.py
@@ -1,0 +1,126 @@
+"""Regression guards for the API Keys page (`/api-keys`, generic mode).
+
+Covers three related dogfood findings:
+  - ISSUE-003: the "X providers / Y configured" badges did not update when
+    the user added a preset row, even though the editor row was visible.
+  - ISSUE-004: the badges always rendered identical numbers (because both
+    were derived from `entries|length` server-side), so the pair was
+    redundant.
+  - ISSUE-005: clicking Save with an empty new-row value showed only a
+    corner toast and never set `aria-invalid` / inline error on the
+    offending input.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+API_KEYS_JS = ROOT / "src" / "static" / "scripts" / "api_keys_page.js"
+
+
+def _read_js() -> str:
+    return API_KEYS_JS.read_text(encoding="utf-8")
+
+
+def test_refresh_key_counts_function_exists_and_updates_both_chips():
+    """The page must have a function that recomputes both badges from the
+    current DOM. Without this the labels stay stale after add/delete."""
+    js = _read_js()
+    assert "function refreshKeyCounts" in js, (
+        "refreshKeyCounts() helper missing — badges will not update on add/delete"
+    )
+    # Make sure both chip ids are touched.
+    assert 'getElementById("providerCountSummary")' in js
+    assert 'getElementById("configuredCountSummary")' in js
+
+
+def test_refresh_key_counts_uses_distinct_semantics_for_provider_vs_configured():
+    """The two badges MUST distinguish 'has a key entered' from 'has a value
+    saved'. Otherwise they remain redundantly identical (ISSUE-004)."""
+    js = _read_js()
+    # Heuristic: the function should evaluate both the key field and either
+    # the existing-saved flag or the value field length to bump 'configured'
+    # separately from 'providers'.
+    func_match = re.search(
+        r"function refreshKeyCounts\(\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert func_match, "refreshKeyCounts body not found"
+    body = func_match.group("body")
+    assert "providers" in body and "configured" in body
+    # Configured logic must check value content or existing-saved flag.
+    assert (
+        'dataset.existing === "true"' in body
+        or "wasSaved" in body
+        or ".value.length" in body
+    ), "configured count must depend on value/existing state, not just key presence"
+
+
+def test_refresh_key_counts_called_after_add_delete_and_value_input():
+    """The badges must update on every state-change path: addRow,
+    deleteRow, value input. Otherwise they go stale."""
+    js = _read_js()
+    # addRow wires both name-input and value-input listeners that call refresh.
+    add_match = re.search(
+        r"function addRow\([^)]*\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert add_match, "addRow function not found"
+    add_body = add_match.group("body")
+    assert add_body.count("refreshKeyCounts()") >= 2, (
+        "addRow should call refreshKeyCounts at least twice "
+        "(after appending the row and inside an input listener)"
+    )
+    delete_match = re.search(
+        r"function deleteRow\([^)]*\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert delete_match, "deleteRow function not found"
+    assert "refreshKeyCounts()" in delete_match.group("body")
+
+
+def test_save_generic_keys_marks_empty_value_input_aria_invalid():
+    """On submit, an empty new-row value must produce an inline aria-invalid
+    + validation-message on the field — not just a corner toast (ISSUE-005)."""
+    js = _read_js()
+    save_match = re.search(
+        r"async function saveGenericKeys\(\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert save_match, "saveGenericKeys function not found"
+    body = save_match.group("body")
+    # Must collect inputs (not just a boolean) and mark them invalid.
+    assert "missingValueInputs" in body or "missingValueInput" in body, (
+        "saveGenericKeys should track WHICH inputs were empty so it can mark them"
+    )
+    assert 'setAttribute("aria-invalid", "true")' in body, (
+        "Empty value inputs must get aria-invalid='true' on submit"
+    )
+    assert "validation-message" in body, (
+        "An inline validation-message element must be inserted/used"
+    )
+    # Toast still fires for visual users.
+    assert "Please enter a value for new API keys" in body
+    # Focus moves to the first invalid input so keyboard users land there.
+    assert ".focus()" in body
+
+
+def test_save_generic_clears_prior_aria_invalid_at_start_of_each_submit():
+    """Each new submit must clear stale aria-invalid from the previous run
+    so a fixed input doesn't keep its old error state visually."""
+    js = _read_js()
+    save_match = re.search(
+        r"async function saveGenericKeys\(\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert save_match
+    body = save_match.group("body")
+    assert 'setAttribute("aria-invalid", "false")' in body, (
+        "saveGenericKeys must reset aria-invalid='false' on every submit "
+        "before re-validating, otherwise old errors stick around."
+    )

--- a/tests/static/test_mobile_site_nav_panel.py
+++ b/tests/static/test_mobile_site_nav_panel.py
@@ -1,0 +1,75 @@
+"""Regression guard: mobile site nav dropdown must not clip items at the
+viewport right edge.
+
+Background: at narrow viewports (≤900px), `.shell-sidebar` becomes a 3-column
+grid and `.mobile-site-nav` lives in the middle column. The dropdown
+`.mobile-site-nav-panel` was previously positioned with `left: 0; right: 0`,
+which clipped its width to that narrow middle column — at a 390px viewport
+the right edge of every nav item (notably "API Keys") was visibly cut off.
+
+The fix anchors the panel to the right edge of the button column, gives it
+a `min-width` that lets it grow leftward into the brand column, and caps it
+at viewport width minus the page padding.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SIDEBAR_CSS = ROOT / "src" / "static" / "styles" / "partials" / "_sidebar.css"
+
+CSS_COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _block_for_selector(css: str, selector: str) -> str:
+    """Return the body of the *first* CSS rule whose selector list contains
+    `selector` exactly. Comments are stripped first so `/*…*/` text inside
+    declarations doesn't confuse the regex."""
+    cleaned = CSS_COMMENT_RE.sub("", css)
+    normalized = " ".join(selector.split())
+    for match in re.finditer(
+        r"(?P<sels>[^{}]+)\{(?P<body>[^}]*)\}",
+        cleaned,
+        re.S,
+    ):
+        sels = [
+            " ".join(s.split())
+            for s in match.group("sels").split(",")
+            if s.strip()
+        ]
+        if normalized in sels:
+            return match.group("body")
+    raise AssertionError(f"selector {selector!r} not found in CSS")
+
+
+def test_mobile_site_nav_panel_does_not_clip_to_grid_column():
+    """The panel must NOT use `left: 0` paired with `right: 0` — that pins
+    its width to the narrow middle column of the sidebar grid and clips
+    items. It should anchor to one edge with a `min-width`/`max-width`
+    that lets the dropdown spill across the parent column boundaries."""
+    css = SIDEBAR_CSS.read_text(encoding="utf-8")
+    block = _block_for_selector(css, ".mobile-site-nav-panel")
+
+    has_left_zero = re.search(r"\bleft:\s*0\b", block)
+    has_right_zero = re.search(r"\bright:\s*0\b", block)
+    assert not (has_left_zero and has_right_zero), (
+        "Panel must not pin BOTH left:0 and right:0 — that constrains it "
+        "to the narrow middle grid column and clips item labels at 390px."
+    )
+    # Must declare some width-affordance so the dropdown can outgrow the column.
+    assert "min-width" in block, (
+        "Panel needs a min-width so it can extend beyond the narrow column"
+    )
+    assert "max-width" in block and "100vw" in block, (
+        "Panel needs a viewport-bounded max-width so it doesn't spill off-screen"
+    )
+
+
+def test_mobile_site_nav_panel_anchors_to_right_edge():
+    """We anchor to the right edge so the panel grows leftward (into the
+    brand column) on narrow viewports — an explicit choice worth pinning."""
+    css = SIDEBAR_CSS.read_text(encoding="utf-8")
+    block = _block_for_selector(css, ".mobile-site-nav-panel")
+    assert re.search(r"\bright:\s*0\b", block), (
+        "Panel should anchor to right:0; if you change anchor side, update this test."
+    )

--- a/tests/static/test_mobile_site_nav_panel.py
+++ b/tests/static/test_mobile_site_nav_panel.py
@@ -33,9 +33,7 @@ def _block_for_selector(css: str, selector: str) -> str:
         re.S,
     ):
         sels = [
-            " ".join(s.split())
-            for s in match.group("sels").split(",")
-            if s.strip()
+            " ".join(s.split()) for s in match.group("sels").split(",") if s.strip()
         ]
         if normalized in sels:
             return match.group("body")
@@ -57,12 +55,12 @@ def test_mobile_site_nav_panel_does_not_clip_to_grid_column():
         "to the narrow middle grid column and clips item labels at 390px."
     )
     # Must declare some width-affordance so the dropdown can outgrow the column.
-    assert "min-width" in block, (
-        "Panel needs a min-width so it can extend beyond the narrow column"
-    )
-    assert "max-width" in block and "100vw" in block, (
-        "Panel needs a viewport-bounded max-width so it doesn't spill off-screen"
-    )
+    assert (
+        "min-width" in block
+    ), "Panel needs a min-width so it can extend beyond the narrow column"
+    assert (
+        "max-width" in block and "100vw" in block
+    ), "Panel needs a viewport-bounded max-width so it doesn't spill off-screen"
 
 
 def test_mobile_site_nav_panel_anchors_to_right_edge():
@@ -70,6 +68,6 @@ def test_mobile_site_nav_panel_anchors_to_right_edge():
     brand column) on narrow viewports — an explicit choice worth pinning."""
     css = SIDEBAR_CSS.read_text(encoding="utf-8")
     block = _block_for_selector(css, ".mobile-site-nav-panel")
-    assert re.search(r"\bright:\s*0\b", block), (
-        "Panel should anchor to right:0; if you change anchor side, update this test."
-    )
+    assert re.search(
+        r"\bright:\s*0\b", block
+    ), "Panel should anchor to right:0; if you change anchor side, update this test."

--- a/tests/static/test_playlist_thumb_empty_state.py
+++ b/tests/static/test_playlist_thumb_empty_state.py
@@ -1,0 +1,56 @@
+"""Regression guard: an unrendered playlist instance must not paint a black
+box in the light theme (ISSUE-010).
+
+Background: when `plugin_instance.latest_refresh_time` is None the playlist
+template used to emit `<div class="pl-item-thumb"></div>` with whitespace
+between the tags. The CSS rule `.pl-item-thumb:empty { display: none }` only
+matches elements with NO child nodes (text nodes count), so the whitespace
+defeated the hide rule. The wrapper rendered with `background: var(--preview-bg)`
+which is a hardcoded `#000` for both themes — fine on dark, jarringly black
+on the light theme cream backdrop.
+
+The fix moves the `{% if latest_refresh_time %}` guard outside the wrapper
+so the entire `<div>` is omitted from the DOM when there's nothing to show.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PLAYLIST_HTML = ROOT / "src" / "templates" / "playlist.html"
+
+
+def test_thumb_wrapper_only_emitted_when_there_is_a_refresh_image():
+    """The `pl-item-thumb` div must be inside the latest_refresh_time guard,
+    not the other way around. Otherwise the wrapper renders empty-but-non-empty
+    and shows a hardcoded-black box in the light theme."""
+    src = PLAYLIST_HTML.read_text(encoding="utf-8")
+    # Find the position of the latest_refresh_time check and the thumb div.
+    refresh_guard = src.find("plugin_instance.latest_refresh_time")
+    thumb_div = src.find('<div class="pl-item-thumb">')
+    assert refresh_guard != -1, "latest_refresh_time guard removed from template"
+    assert thumb_div != -1, "pl-item-thumb wrapper removed from template"
+    # The Jinja `if` must come BEFORE the wrapper div, so the wrapper itself
+    # is conditionally rendered.
+    assert refresh_guard < thumb_div, (
+        "the {% if plugin_instance.latest_refresh_time %} guard must wrap the "
+        "<div class=\"pl-item-thumb\"> wrapper, not just its inner content. "
+        "Otherwise an unrefreshed instance leaves the wrapper in the DOM and "
+        "paints a hardcoded-black 96×56 box in light theme."
+    )
+
+
+def test_thumb_wrapper_does_not_appear_with_unconditional_whitespace_content():
+    """Defensive: the template must NOT have a `<div class="pl-item-thumb">`
+    immediately followed (after only whitespace + comments) by the
+    `{% if plugin_instance.latest_refresh_time %}` opener. That's the
+    pre-fix shape we're guarding against."""
+    src = PLAYLIST_HTML.read_text(encoding="utf-8")
+    bad_shape = re.search(
+        r'<div class="pl-item-thumb">\s*\{%\s*if\s+plugin_instance\.latest_refresh_time',
+        src,
+    )
+    assert bad_shape is None, (
+        "Found the regressed shape: thumb wrapper opens before the "
+        "latest_refresh_time guard. Move the guard outside the wrapper."
+    )

--- a/tests/static/test_playlist_thumb_empty_state.py
+++ b/tests/static/test_playlist_thumb_empty_state.py
@@ -34,7 +34,7 @@ def test_thumb_wrapper_only_emitted_when_there_is_a_refresh_image():
     # is conditionally rendered.
     assert refresh_guard < thumb_div, (
         "the {% if plugin_instance.latest_refresh_time %} guard must wrap the "
-        "<div class=\"pl-item-thumb\"> wrapper, not just its inner content. "
+        '<div class="pl-item-thumb"> wrapper, not just its inner content. '
         "Otherwise an unrefreshed instance leaves the wrapper in the DOM and "
         "paints a hardcoded-black 96×56 box in light theme."
     )

--- a/tests/static/test_playlist_title_truncation.py
+++ b/tests/static/test_playlist_title_truncation.py
@@ -29,9 +29,7 @@ def _block_for_selector(css: str, selector: str) -> str:
         re.S,
     ):
         sels = [
-            " ".join(s.split())
-            for s in match.group("sels").split(",")
-            if s.strip()
+            " ".join(s.split()) for s in match.group("sels").split(",") if s.strip()
         ]
         if normalized in sels:
             return match.group("body")
@@ -41,7 +39,9 @@ def _block_for_selector(css: str, selector: str) -> str:
 def test_playlist_title_truncates_with_ellipsis_in_partial():
     """Source-of-truth: the partial that the build pulls in must declare
     truncation on `.playlist-title`."""
-    block = _block_for_selector(PLAYLISTS_CSS.read_text(encoding="utf-8"), ".playlist-title")
+    block = _block_for_selector(
+        PLAYLISTS_CSS.read_text(encoding="utf-8"), ".playlist-title"
+    )
     assert "overflow: hidden" in block
     assert "text-overflow: ellipsis" in block
     assert "white-space: nowrap" in block

--- a/tests/static/test_playlist_title_truncation.py
+++ b/tests/static/test_playlist_title_truncation.py
@@ -1,0 +1,59 @@
+"""Regression guard: playlist card heading must truncate long names.
+
+Background: a 64-char playlist name (the maxlength of the input) rendered
+without `text-overflow: ellipsis` on the playlist-page card heading,
+overflowing the card on mobile. The Dashboard's Quick-switch panel already
+truncated the same value, so behavior was inconsistent. The fix puts
+ellipsis-truncation on `.playlist-title` itself, which is the only place
+that uses the long playlist name as a heading.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PLAYLISTS_CSS = ROOT / "src" / "static" / "styles" / "partials" / "_playlists.css"
+MAIN_CSS = ROOT / "src" / "static" / "styles" / "main.css"
+
+CSS_COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _block_for_selector(css: str, selector: str) -> str:
+    """Return the body of the *first* CSS rule whose selector list contains
+    `selector` exactly (no `:hover`, no descendant combinator)."""
+    cleaned = CSS_COMMENT_RE.sub("", css)
+    normalized = " ".join(selector.split())
+    for match in re.finditer(
+        r"(?P<sels>[^{}]+)\{(?P<body>[^}]*)\}",
+        cleaned,
+        re.S,
+    ):
+        sels = [
+            " ".join(s.split())
+            for s in match.group("sels").split(",")
+            if s.strip()
+        ]
+        if normalized in sels:
+            return match.group("body")
+    raise AssertionError(f"selector {selector!r} not found in CSS")
+
+
+def test_playlist_title_truncates_with_ellipsis_in_partial():
+    """Source-of-truth: the partial that the build pulls in must declare
+    truncation on `.playlist-title`."""
+    block = _block_for_selector(PLAYLISTS_CSS.read_text(encoding="utf-8"), ".playlist-title")
+    assert "overflow: hidden" in block
+    assert "text-overflow: ellipsis" in block
+    assert "white-space: nowrap" in block
+    assert "min-width: 0" in block, (
+        "min-width: 0 is required so the heading can shrink below its "
+        "intrinsic content width inside flex/grid parents"
+    )
+
+
+def test_playlist_title_truncation_made_it_into_main_css_bundle():
+    """Build sanity: scripts/build_css.py must have inlined the truncation
+    rule into the bundled main.css. Catches a forgotten rebuild."""
+    block = _block_for_selector(MAIN_CSS.read_text(encoding="utf-8"), ".playlist-title")
+    assert "text-overflow: ellipsis" in block
+    assert "white-space: nowrap" in block

--- a/tests/static/test_settings_device_name_validation.py
+++ b/tests/static/test_settings_device_name_validation.py
@@ -48,6 +48,6 @@ def test_device_name_title_documents_non_space_requirement():
     title_match = re.search(r'title="([^"]*)"', tag)
     assert title_match, "device name input has no title attribute"
     title = title_match.group(1).lower()
-    assert "non-space" in title or "non-whitespace" in title or "at least one" in title, (
-        f"device name title {title!r} should mention the non-whitespace requirement"
-    )
+    assert (
+        "non-space" in title or "non-whitespace" in title or "at least one" in title
+    ), f"device name title {title!r} should mention the non-whitespace requirement"

--- a/tests/static/test_settings_device_name_validation.py
+++ b/tests/static/test_settings_device_name_validation.py
@@ -26,19 +26,43 @@ def _device_name_input_tag() -> str:
     return match.group(0)
 
 
-def test_device_name_pattern_requires_non_whitespace_character():
-    """The HTML pattern must require at least one non-whitespace char.
-    Otherwise `"   "` is accepted client-side and only the server rejects it."""
+def _make_pattern_regex(pattern: str) -> re.Pattern[str]:
+    """Translate the HTML5 `pattern` attribute into a fullmatch Python regex.
+
+    HTML5 anchors `pattern` implicitly at both ends; `re.fullmatch` mirrors
+    that. The `\\u####` escapes inside the attribute string are real two-char
+    sequences (`\\` + `u####`); decode them to actual code points so Python's
+    regex engine sees the same character classes the browser sees.
+    """
+    decoded = pattern.encode("utf-8").decode("unicode_escape")
+    return re.compile(decoded, re.S)
+
+
+def test_device_name_pattern_rejects_whitespace_only_and_lone_control_chars():
+    """The HTML pattern must reject:
+       - empty / whitespace-only input  (ISSUE-008)
+       - a single control character     (CodeRabbit follow-up — closes a
+         consistency gap with the server's `_validate_device_name`
+         `unicodedata.category(ch) == "Cc"` check)
+    while still accepting normal names.
+    """
     tag = _device_name_input_tag()
     pattern_match = re.search(r'pattern="([^"]*)"', tag)
     assert pattern_match, "device name input has no pattern attribute"
     pattern = pattern_match.group(1)
-    # The simplest reliable signal: the pattern must contain `\S` somewhere
-    # (anchored or otherwise). Without it, whitespace-only is admissible.
-    assert r"\S" in pattern, (
-        f"device name pattern {pattern!r} does not require any non-whitespace "
-        "character — whitespace-only input would pass client validation"
+    rx = _make_pattern_regex(pattern)
+    # Negative cases — must fail client validation:
+    assert rx.fullmatch("") is None, "empty value must not match"
+    assert rx.fullmatch("   ") is None, "whitespace-only must not match"
+    assert rx.fullmatch("\t\t") is None, "tab-only must not match"
+    assert rx.fullmatch("\x01") is None, (
+        "a lone control character must not match — would otherwise pass the "
+        "client and only fail server-side at unicodedata.category 'Cc'"
     )
+    # Positive cases — normal names must match:
+    assert rx.fullmatch("InkyPi Development") is not None
+    assert rx.fullmatch("Kitchen #2") is not None
+    assert rx.fullmatch("a") is not None, "single non-space char is fine"
 
 
 def test_device_name_title_documents_non_space_requirement():

--- a/tests/static/test_settings_device_name_validation.py
+++ b/tests/static/test_settings_device_name_validation.py
@@ -1,0 +1,53 @@
+"""Regression guard for the device-name input client validation (ISSUE-008).
+
+Background: in dogfood we discovered that "   " (three spaces) was
+accepted by the client as a valid device name and round-tripped to the
+server, which then rejected it with 422. The native HTML5 `required`
+constraint considers whitespace as truthy length, so the gate has to be
+on the `pattern` attribute.
+
+This test verifies the rendered template carries a pattern that
+*requires* at least one non-whitespace character, so the failure surfaces
+inline before the user clicks Save.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SETTINGS_HTML = ROOT / "src" / "templates" / "settings.html"
+
+
+def _device_name_input_tag() -> str:
+    """Return the raw `<input id="deviceName" …>` tag from settings.html."""
+    src = SETTINGS_HTML.read_text(encoding="utf-8")
+    match = re.search(r'<input[^>]*\bid="deviceName"[^>]*>', src, flags=re.S)
+    assert match, "deviceName <input> not found in settings.html"
+    return match.group(0)
+
+
+def test_device_name_pattern_requires_non_whitespace_character():
+    """The HTML pattern must require at least one non-whitespace char.
+    Otherwise `"   "` is accepted client-side and only the server rejects it."""
+    tag = _device_name_input_tag()
+    pattern_match = re.search(r'pattern="([^"]*)"', tag)
+    assert pattern_match, "device name input has no pattern attribute"
+    pattern = pattern_match.group(1)
+    # The simplest reliable signal: the pattern must contain `\S` somewhere
+    # (anchored or otherwise). Without it, whitespace-only is admissible.
+    assert r"\S" in pattern, (
+        f"device name pattern {pattern!r} does not require any non-whitespace "
+        "character — whitespace-only input would pass client validation"
+    )
+
+
+def test_device_name_title_documents_non_space_requirement():
+    """The user-facing tooltip should explain the constraint we just added,
+    so the rejection message is self-explanatory if the pattern fails."""
+    tag = _device_name_input_tag()
+    title_match = re.search(r'title="([^"]*)"', tag)
+    assert title_match, "device name input has no title attribute"
+    title = title_match.group(1).lower()
+    assert "non-space" in title or "non-whitespace" in title or "at least one" in title, (
+        f"device name title {title!r} should mention the non-whitespace requirement"
+    )

--- a/tests/static/test_settings_interval_max.py
+++ b/tests/static/test_settings_interval_max.py
@@ -1,0 +1,71 @@
+"""Regression guard: plugin-cycle interval must have a unit-aware client max
+(ISSUE-009).
+
+Without `max`, users could type 999999 hours, click Save, and only then learn
+the server's "less than 24 hours" cap when the request returned 422. The fix
+sets `max` dynamically on the `#interval` input based on which `#unit` is
+selected (23 for hours, 1439 for minutes).
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FORM_JS = ROOT / "src" / "static" / "scripts" / "settings" / "form.js"
+
+
+def _read() -> str:
+    return FORM_JS.read_text(encoding="utf-8")
+
+
+def test_form_js_caps_interval_max_per_unit():
+    """The form module must compute a unit-specific max and apply it on
+    page load + on unit change. Otherwise the field has no max and the
+    server has to backstop typos."""
+    js = _read()
+    assert "_maxIntervalForUnit" in js, (
+        "missing _maxIntervalForUnit() helper that maps unit -> interval cap"
+    )
+    # The two unit values are "hour" and "minute" — the helper must map both.
+    fn_match = re.search(
+        r"function _maxIntervalForUnit\([^)]*\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert fn_match, "helper body not found"
+    body = fn_match.group("body")
+    assert '"hour"' in body, "must distinguish hours specifically"
+    # Hours: 23 (server allows < 24 hours). Minutes: 1439 (= 23h59).
+    assert " 23" in body
+    assert "1439" in body
+
+
+def test_unit_change_listener_refreshes_max():
+    """The unit <select> must trigger refreshIntervalMax on change so the
+    cap reflects whichever unit the user just picked."""
+    js = _read()
+    assert "refreshIntervalMax" in js
+    # Match the bind() listener: unit -> refreshIntervalMax
+    bind_match = re.search(
+        r'getElementById\("unit"\)\s*\?\.addEventListener\("change",\s*refreshIntervalMax\)',
+        js,
+    )
+    assert bind_match, (
+        "unit <select> must listen for change and call refreshIntervalMax"
+    )
+
+
+def test_populate_interval_fields_sets_initial_max():
+    """First paint must already have the max set so the user sees the cap
+    immediately, not only after they wiggle the unit."""
+    js = _read()
+    populate_match = re.search(
+        r"function populateIntervalFields\(\)\s*\{(?P<body>.*?)\n {4}\}",
+        js,
+        flags=re.S,
+    )
+    assert populate_match
+    assert "refreshIntervalMax()" in populate_match.group("body"), (
+        "populateIntervalFields should call refreshIntervalMax after setting "
+        "the value/unit so the cap is in place on initial render."
+    )

--- a/tests/static/test_settings_interval_max.py
+++ b/tests/static/test_settings_interval_max.py
@@ -23,9 +23,9 @@ def test_form_js_caps_interval_max_per_unit():
     page load + on unit change. Otherwise the field has no max and the
     server has to backstop typos."""
     js = _read()
-    assert "_maxIntervalForUnit" in js, (
-        "missing _maxIntervalForUnit() helper that maps unit -> interval cap"
-    )
+    assert (
+        "_maxIntervalForUnit" in js
+    ), "missing _maxIntervalForUnit() helper that maps unit -> interval cap"
     # The two unit values are "hour" and "minute" — the helper must map both.
     fn_match = re.search(
         r"function _maxIntervalForUnit\([^)]*\)\s*\{(?P<body>.*?)\n {4}\}",
@@ -50,9 +50,9 @@ def test_unit_change_listener_refreshes_max():
         r'getElementById\("unit"\)\s*\?\.addEventListener\("change",\s*refreshIntervalMax\)',
         js,
     )
-    assert bind_match, (
-        "unit <select> must listen for change and call refreshIntervalMax"
-    )
+    assert (
+        bind_match
+    ), "unit <select> must listen for change and call refreshIntervalMax"
 
 
 def test_populate_interval_fields_sets_initial_max():

--- a/tests/static/test_settings_interval_max.py
+++ b/tests/static/test_settings_interval_max.py
@@ -36,8 +36,16 @@ def test_form_js_caps_interval_max_per_unit():
     body = fn_match.group("body")
     assert '"hour"' in body, "must distinguish hours specifically"
     # Hours: 23 (server allows < 24 hours). Minutes: 1439 (= 23h59).
-    assert " 23" in body
-    assert "1439" in body
+    # Match the actual return statements rather than a bare `" 23"` /
+    # `"1439"` substring, because comments inside the helper happen to
+    # mention "23h59" / "1439" — a regression that dropped the literal
+    # `return 23;` would otherwise still pass on comment text alone.
+    assert re.search(
+        r"return\s+23\b", body
+    ), "hour branch must `return 23` (server cap is < 24 hours)"
+    assert re.search(
+        r"return\s+1439\b", body
+    ), "minute branch must `return 1439` (server cap is < 24h = 1440 min)"
 
 
 def test_unit_change_listener_refreshes_max():

--- a/tests/static/test_settings_restore_button_state.py
+++ b/tests/static/test_settings_restore_button_state.py
@@ -1,0 +1,63 @@
+"""Regression guards for the Restore-from-file button (`#importConfigBtn`).
+
+Background: an earlier version of `importConfig` flipped the button to
+`disabled=true` and `textContent="Restoring…"` *before* checking whether
+a file was attached. If the user clicked the button without a file, the
+function showed an error toast and returned — leaving the button stuck in
+the disabled "Restoring…" state until the user re-picked a file. The
+fix is to validate the file *first*, then disable + relabel the button only
+on the path that actually goes to the network. This test guards against
+regression by checking the source structure.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTIONS_JS = ROOT / "src" / "static" / "scripts" / "settings" / "actions.js"
+
+
+def _import_config_body() -> str:
+    """Return the JS source text of `async function importConfig() { ... }`."""
+    src = ACTIONS_JS.read_text(encoding="utf-8")
+    match = re.search(
+        r"async function importConfig\(\)\s*\{(?P<body>.*?)\n {4}\}\n",
+        src,
+        flags=re.S,
+    )
+    assert match, "importConfig function not found in actions.js"
+    return match.group("body")
+
+
+def test_import_config_validates_file_before_disabling_button():
+    """The 'no file' early-return must run *before* the button is flipped to
+    `disabled` + `Restoring…`, otherwise the button stays stuck on the
+    failure path."""
+    body = _import_config_body()
+    file_check_pos = body.find('"Choose a backup file first"')
+    relabel_pos = body.find('"Restoring')
+    assert file_check_pos != -1, (
+        "missing-file early return is gone — restoring it is the whole point of this test"
+    )
+    assert relabel_pos != -1, '"Restoring..." label not found in importConfig'
+    assert file_check_pos < relabel_pos, (
+        f"file-presence check (pos {file_check_pos}) must run BEFORE the "
+        f"button is disabled with 'Restoring…' (pos {relabel_pos}); "
+        "otherwise the button gets stuck on the early-return path."
+    )
+
+
+def test_import_config_finally_block_restores_label_and_disabled_state():
+    """The finally block must restore the button text and reflect the
+    file-input state (disabled iff no file selected). It must not leave the
+    button stuck on "Restoring…"."""
+    body = _import_config_body()
+    finally_match = re.search(r"finally\s*\{(?P<finally>.*?)\}\s*$", body, flags=re.S)
+    assert finally_match, "importConfig has no finally block"
+    finally_body = finally_match.group("finally")
+    assert '"Restore from file"' in finally_body, (
+        "finally must reset the button label to 'Restore from file'"
+    )
+    assert "fileInput?.files?.length" in finally_body or "files?.length" in finally_body, (
+        "finally must re-derive the disabled state from the current file input"
+    )

--- a/tests/static/test_settings_restore_button_state.py
+++ b/tests/static/test_settings_restore_button_state.py
@@ -18,15 +18,41 @@ ACTIONS_JS = ROOT / "src" / "static" / "scripts" / "settings" / "actions.js"
 
 
 def _import_config_body() -> str:
-    """Return the JS source text of `async function importConfig() { ... }`."""
+    """Return the JS source text of `async function importConfig() { ... }`.
+
+    Uses brace counting rather than a hard-coded ``\\n {4}\\}\\n`` tail so
+    the test isn't coupled to the formatter's chosen indentation or to the
+    presence of a trailing newline. Skips braces inside `'…'`, `"…"`, and
+    template strings ``…`` so embedded ``{`` / ``}`` literals don't throw
+    the depth counter off.
+    """
     src = ACTIONS_JS.read_text(encoding="utf-8")
-    match = re.search(
-        r"async function importConfig\(\)\s*\{(?P<body>.*?)\n {4}\}\n",
-        src,
-        flags=re.S,
-    )
-    assert match, "importConfig function not found in actions.js"
-    return match.group("body")
+    head = re.search(r"async function importConfig\(\)\s*\{", src)
+    assert head, "importConfig function not found in actions.js"
+    i = head.end()  # cursor sits just past the opening `{`
+    depth = 1
+    in_str: str | None = None  # which quote char are we inside, if any
+    escape = False
+    body_start = i
+    while i < len(src) and depth > 0:
+        ch = src[i]
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == in_str:
+                in_str = None
+        elif ch in ("'", '"', "`"):
+            in_str = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[body_start:i]
+        i += 1
+    raise AssertionError("unbalanced braces in importConfig — could not find end")
 
 
 def test_import_config_validates_file_before_disabling_button():

--- a/tests/static/test_settings_restore_button_state.py
+++ b/tests/static/test_settings_restore_button_state.py
@@ -36,9 +36,9 @@ def test_import_config_validates_file_before_disabling_button():
     body = _import_config_body()
     file_check_pos = body.find('"Choose a backup file first"')
     relabel_pos = body.find('"Restoring')
-    assert file_check_pos != -1, (
-        "missing-file early return is gone — restoring it is the whole point of this test"
-    )
+    assert (
+        file_check_pos != -1
+    ), "missing-file early return is gone — restoring it is the whole point of this test"
     assert relabel_pos != -1, '"Restoring..." label not found in importConfig'
     assert file_check_pos < relabel_pos, (
         f"file-presence check (pos {file_check_pos}) must run BEFORE the "
@@ -55,9 +55,9 @@ def test_import_config_finally_block_restores_label_and_disabled_state():
     finally_match = re.search(r"finally\s*\{(?P<finally>.*?)\}\s*$", body, flags=re.S)
     assert finally_match, "importConfig has no finally block"
     finally_body = finally_match.group("finally")
-    assert '"Restore from file"' in finally_body, (
-        "finally must reset the button label to 'Restore from file'"
-    )
-    assert "fileInput?.files?.length" in finally_body or "files?.length" in finally_body, (
-        "finally must re-derive the disabled state from the current file input"
-    )
+    assert (
+        '"Restore from file"' in finally_body
+    ), "finally must reset the button label to 'Restore from file'"
+    assert (
+        "fileInput?.files?.length" in finally_body or "files?.length" in finally_body
+    ), "finally must re-derive the disabled state from the current file input"

--- a/tests/unit/test_settings_import.py
+++ b/tests/unit/test_settings_import.py
@@ -46,7 +46,11 @@ class TestImportSettings:
         assert data["success"] is True
 
     def test_import_filters_disallowed_env_keys(self, client, device_config_dev):
+        # Pair a disallowed env key with at least one allowed config key so
+        # the request still has *something* to apply; otherwise it would 400
+        # (see test_import_rejects_payload_with_no_recognized_keys below).
         payload = {
+            "config": {"name": "Filters Test"},
             "env_keys": {"EVIL_KEY": "hacked"},
         }
         resp = client.post("/settings/import", json=payload)
@@ -87,6 +91,43 @@ class TestImportSettings:
         )
         assert resp.status_code == 200
         assert resp.get_json()["success"] is True
+
+    def test_import_rejects_payload_with_no_recognized_keys(
+        self, client, device_config_dev
+    ):
+        """A payload that survives JSON parse but contains no whitelisted
+        config keys and no whitelisted env_keys must fail loudly (400),
+        not silently return 'Import completed'. Otherwise users uploading
+        a stranger's export or a malformed backup get a green success
+        toast while their device config is unchanged.
+        """
+        original_name = device_config_dev.get_config("name")
+        payload = {
+            "config": {"dangerous_key": "ignored"},
+            "env_keys": {"EVIL_KEY": "ignored"},
+        }
+        resp = client.post("/settings/import", json=payload)
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["success"] is False
+        assert "no recognizable" in body["error"].lower()
+        # Device config must be untouched.
+        assert device_config_dev.get_config("name") == original_name
+
+    def test_import_success_message_reports_counts(self, client, device_config_dev):
+        """Success message should reflect what was applied so the user
+        knows the restore actually did something."""
+        resp = client.post(
+            "/settings/import",
+            json={
+                "config": {"name": "MsgTest", "timezone": "UTC"},
+                "env_keys": {"OPEN_AI_SECRET": "sk-msg-test"},
+            },
+        )
+        assert resp.status_code == 200
+        message = resp.get_json()["message"]
+        assert "2 settings" in message
+        assert "1 API key" in message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundle of fixes for 10 issues surfaced during a `/dogfood` pass run after PR #589 landed. Each fix has a dedicated regression test (18 new test cases in 7 files).

| # | Severity | Surface | Fix |
|---|---|---|---|
| 001 | medium | `/playlist` (mobile) | Long playlist names truncate with ellipsis on `.playlist-title` — Dashboard "Quick switch" already did this; surfaces are now consistent. |
| 002 | medium | `/` (mobile menu) | `<details>` Menu dropdown anchored right + viewport-bounded `max-width` — items (notably "API Keys") no longer clip at 390px viewports. |
| 003 | medium | `/api-keys` | New `refreshKeyCounts()` recomputes "X providers / Y saved" from the DOM on add/delete/value-input — badges no longer go stale when an inline editor opens. |
| 004 | low | `/api-keys` | "PROVIDERS" / "CONFIGURED" no longer show identical numbers — relabeled to "providers" / "saved" with distinct semantics (key entered vs. value persisted). |
| 005 | low | `/api-keys` | Empty-value submit sets `aria-invalid` + inserts a `validation-message` + focuses the offending input — not just a corner toast. |
| 006 | low | `/plugin/image_url` → `/` | Rejected-URL previews no longer write a history sidecar, so they don't inflate Dashboard "Refreshes / Errors" KPIs. The error image still surfaces on the device. |
| 007a | medium | `/settings` Updates → Backup & restore | `importConfig()` validates file presence **before** disabling the button — empty-file early-return no longer strands it in `disabled="Restoring…"` state. |
| 007b | medium | `/settings/import` | Server now rejects payloads with no recognized config or env keys (HTTP 400), and reports counts on success ("Restored 5 settings and 1 API key") — previously a stranger's export silently returned "Import completed" with nothing applied. |
| 008 | low | `/settings` Device | Device-name pattern requires at least one non-whitespace char so `"   "` fails client-side instead of round-tripping to the server backstop. |
| 009 | low | `/settings` Scheduling | Plugin cycle interval gets a unit-aware client `max` (23 hours / 1439 minutes), refreshed whenever the unit `<select>` changes. |
| 010 | medium | `/playlist` (light theme) | Empty thumb wrapper omitted from DOM when there's no refresh image — the `:empty` hide rule was defeated by Jinja whitespace, so the wrapper rendered as a hardcoded-black box on the cream theme. |

> **Re-investigated and corrected during fix work**: ISSUE-007 as originally written ("Restore button POSTs `/save_settings`") does not reproduce. The wiring is correct (`importConfig()` → `/settings/import`). Re-investigation surfaced the two real-but-smaller bugs above (007a + 007b). Original dogfood report updated to reflect this.

The full dogfood report with screenshots and repro evidence lives at [dogfood-output/report.md](dogfood-output/report.md) on the branch (not committed — local artifact only).

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (2,744 unit + 1,021/1,029 integration; the 8 integration failures are all pre-existing on `origin/main`, verified via `git stash`)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`) — `/settings/import` returns 400 with the standard envelope when no recognized keys are present
- [ ] Docs updated for new flags/endpoints/UI — no new flags or endpoints; copy changes only
- [x] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests via `agent-browser` at 390×844 and 1280×720 in both themes; visible fixes (mobile menu, light-theme thumb, restore button state) all confirmed.

## Testing

```bash
# 18 new regression tests
.venv/bin/python -m pytest \
  tests/static/test_api_keys_page_counts_and_validation.py \
  tests/static/test_mobile_site_nav_panel.py \
  tests/static/test_playlist_thumb_empty_state.py \
  tests/static/test_playlist_title_truncation.py \
  tests/static/test_settings_device_name_validation.py \
  tests/static/test_settings_interval_max.py \
  tests/static/test_settings_restore_button_state.py

# Updated existing tests
.venv/bin/python -m pytest \
  tests/unit/test_settings_import.py \
  tests/integration/test_update_now_url_validation.py \
  tests/integration/test_browser_smoke.py::test_jtn_730_settings_deep_high_risk_paths

# Wider sweeps
.venv/bin/python -m pytest tests/unit          # 2,744 passed
.venv/bin/python -m pytest tests/static        # 423 passed (incl. new ones)
.venv/bin/python -m pytest tests/integration   # 1,021 passed, 8 pre-existing failures
```

One self-introduced regression was caught and fixed during verification: changing the `/settings/import` success message from "Import completed" to "Restored {N} settings…" broke `test_jtn_730_settings_deep_high_risk_paths`'s exact-text wait. That test now asserts on the "settings" substring (stable across whatever count the import payload produces).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mobile navigation panel layout to expand properly on narrow screens.
  * Improved playlist thumbnail wrapper rendering when no refresh data is available.
  * Settings import now provides detailed feedback on the number of restored settings and API keys.

* **Validation Improvements**
  * Device name now requires at least one non-whitespace character.
  * Plugin cycle interval maximum is now enforced in the browser before form submission.
  * API key validation now displays inline error messages with improved accessibility feedback.

* **Style**
  * Playlist titles now properly truncate with ellipsis on narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->