### PR TITLE
fix: polish playlists and image plugin flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,8 +561,10 @@ jobs:
         run: |
           scripts/preflash_validate.sh
 
-  # Mutation nightly — runs daily at 09:00 UTC and weekly on Sunday 03:00 UTC
-  # via the workflow-level ``schedule:`` trigger. See docs/mutation_testing.md.
+  # Mutation nightly — runs via the workflow-level ``schedule:`` trigger
+  # (daily 09:00 UTC and weekly Sunday 03:00 UTC) and manual
+  # ``workflow_dispatch`` for ad-hoc artifact collection. Sharded by package
+  # so each shard fits in the 120-minute budget. See docs/mutation_testing.md.
   #
   mutation-nightly:
     name: Mutation nightly (${{ matrix.label }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_dispatch:
   schedule:
     - cron: '0 9 * * *'
     - cron: '0 3 * * 0'
@@ -563,24 +564,23 @@ jobs:
   # Mutation nightly — runs daily at 09:00 UTC and weekly on Sunday 03:00 UTC
   # via the workflow-level ``schedule:`` trigger. See docs/mutation_testing.md.
   #
-  # JTN-595 (2026-04-19) finding: every nightly run since the JTN-508 scope
-  # expansion has hit the 120-minute timeout without finishing, producing no
-  # ``mutmut-cache`` artifact. Two bugs compound the problem:
-  #   1. Full-scope mutmut on src/app_setup/+blueprints/+utils/+refresh_task/
-  #      does not complete inside 120 minutes on ubuntu-latest.
-  #   2. The previous upload step did not set ``include-hidden-files: true``,
-  #      so even a successful run would have silently dropped the hidden
-  #      ``.mutmut-cache`` directory (actions/upload-artifact@v4 excludes
-  #      hidden paths by default).
-  # The hidden-files flag below is the minimum fix so a successful run can
-  # publish an artifact. Sharding the mutmut scope across a matrix of
-  # directories (or tightening the runner) is tracked for follow-up —
-  # otherwise the nightly will keep producing no actionable signal.
   mutation-nightly:
-    name: Mutation nightly
-    if: github.event_name == 'schedule'
+    name: Mutation nightly (${{ matrix.label }})
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: app-setup
+            path: src/app_setup/
+          - label: blueprints
+            path: src/blueprints/
+          - label: utils
+            path: src/utils/
+          - label: refresh-task
+            path: src/refresh_task/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -608,7 +608,7 @@ jobs:
           INKYPI_NO_REFRESH: '1'
           PYTHONPATH: src
         run: |
-          mutmut run --CI
+          mutmut run --CI --paths-to-mutate "${{ matrix.path }}"
       - name: Show mutation results
         if: always()
         run: |
@@ -617,7 +617,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mutmut-cache
+          name: mutmut-cache-${{ matrix.label }}
           path: .mutmut-cache
           if-no-files-found: ignore
           # ``.mutmut-cache`` is a hidden directory; without this flag

--- a/docs/mutation_testing.md
+++ b/docs/mutation_testing.md
@@ -46,6 +46,13 @@ Run the mutation pass against the configured files:
 INKYPI_ENV=dev INKYPI_NO_REFRESH=1 PYTHONPATH=src mutmut run
 ```
 
+Run a narrower shard when you are triaging one package locally:
+
+```bash
+INKYPI_ENV=dev INKYPI_NO_REFRESH=1 PYTHONPATH=src \
+  mutmut run --paths-to-mutate src/utils/
+```
+
 Check the summary after the run completes:
 
 ```bash
@@ -83,13 +90,21 @@ mutmut unapply
 
 ## CI schedule
 
-The `mutation-nightly` job in `.github/workflows/ci.yml` runs every **Sunday at
-03:00 UTC** (`cron: '0 3 * * 0'`). It is gated by
-`if: github.event_name == 'schedule'` and will never trigger on a push or pull
-request.
+The `mutation-nightly` job in `.github/workflows/ci.yml` runs on scheduled
+workflow events and can be started manually with `workflow_dispatch`. It will
+never trigger on a push or pull request.
 
-Results are uploaded as the `mutmut-cache` artifact and can be downloaded from
-the GitHub Actions run summary.
+The job is sharded by package so each package has its own runtime budget:
+
+| Shard | Path |
+|-------|------|
+| `app-setup` | `src/app_setup/` |
+| `blueprints` | `src/blueprints/` |
+| `utils` | `src/utils/` |
+| `refresh-task` | `src/refresh_task/` |
+
+Results are uploaded as `mutmut-cache-<shard>` artifacts and can be downloaded
+from the GitHub Actions run summary.
 
 ## Interpreting results
 

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -4,8 +4,9 @@ InkyPi uses [mypy](https://mypy.readthedocs.io/) for static type analysis.
 Rather than enabling strict mode everywhere at once, we follow an **incremental
 strict** path: a small "strict subset" is enforced as a CI blocker today, with
 more modules added over time as they stabilize. The broader `src/` check is now
-ratcheted against a checked-in baseline so new typing debt cannot slip in while
-we keep paying down the backlog.
+expected to stay clean, while `tests/` is ratcheted against a checked-in
+baseline so new test typing debt cannot slip in while we keep paying down the
+backlog.
 
 ## Why incremental strict?
 
@@ -33,6 +34,7 @@ ongoing feature work.
 | `src/utils/sri.py` | Quality guards follow-up PR |
 | `src/utils/time_utils.py` | Quality guards PR |
 | `src/utils/http_cache.py` | JTN-676 |
+| `src/utils/request_models.py` | Request-model ratchet PR |
 | `src/model.py` | JTN-663 |
 
 This list is intentionally low-churn: the broad `src/` ratchet protects the
@@ -65,54 +67,67 @@ full `--strict`.
 4. **Update the table above** with the module path and Linear issue reference.
 5. Open a PR — CI will enforce strictness from that point forward.
 
-## Current CI behavior: ratcheted `src/`, advisory `tests/`
+## Current CI behavior: clean `src/`, ratcheted `tests/`
 
 `scripts/lint.sh` runs the non-strict mypy pass as **two separate invocations**
 plus the blocking strict subset:
 
 1. `mypy src/` — production code, compared against the checked-in baseline in
-   `scripts/mypy_src_baseline.txt`
-2. `mypy tests/` — test suite, advisory only
+   `scripts/mypy_src_baseline.txt`; this baseline should remain `0`
+2. `mypy tests/` — test suite, compared against the checked-in baseline in
+   `scripts/mypy_tests_baseline.txt`
 3. `mypy --strict ...` — curated strict subset, fully blocking
 
-`src/` is no longer purely informational. CI fails only when the `src/` count
-rises above the committed baseline, or when mypy cannot produce a summary to
-compare against. `tests/` remains non-blocking because its typing noise is
-still much higher. The strict subset above is unchanged and remains fully
-blocking.
+`src/` is no longer purely informational. Now that the production baseline is
+zero, CI fails if `mypy src/` reports any issue or cannot produce a summary.
+`tests/` still has much higher typing noise, but it is no longer unbounded:
+CI fails if the test error count rises above the committed baseline, or if
+mypy cannot produce a summary to compare against. The strict subset above is
+unchanged and remains fully blocking.
 
 ### Why the split?
 
-The test suite carries far more advisory typing noise than `src/` (fixtures,
+The test suite carries far more typing noise than `src/` (fixtures,
 monkeypatching, duck-typed stubs). When both were combined into a single
-`mypy src tests` run, a small regression in production code was invisible —
-drowned out by thousands of test-only errors. Splitting the counts makes
-**`src/` type drift legible so we can ratchet it downward** and eventually
-promote more modules into the strict subset.
+`mypy src tests` run, a small regression in production code was invisible,
+drowned out by thousands of test-only errors. Splitting the counts keeps
+**`src/` clean and makes `tests/` type drift legible** so we can ratchet it
+down over time.
 
 ### What to do if the `src/` count changes
 
-If `src/` goes up:
+If `src/` goes above zero:
 
 1. Run `mypy src/` locally and look at the diff in errors vs `main`.
 2. If your PR introduced the new errors, fix them before merging.
-3. If the increase is unrelated to your change (for example a dependency or
-   typeshed shift), call it out in the PR and land a coordinated baseline
-   update only if the new debt is intentional.
+3. If the increase is unrelated to your change, call it out in the PR and fix
+   the underlying dependency/config issue rather than raising the baseline.
 
-If `src/` goes down:
+If `src/` stays at zero:
 
-1. Confirm the lower count is real by rerunning `mypy src/` or
-   `bash scripts/lint.sh`.
-2. Update `scripts/mypy_src_baseline.txt` to the new lower integer.
-3. Rerun `bash scripts/lint.sh` so the ratchet records the improvement.
+1. Leave `scripts/mypy_src_baseline.txt` at `0`.
+2. Prefer adding newly stable modules to the strict subset instead of changing
+   the production baseline.
 
 If `mypy src/` exits without a `Found N errors` or `Success:` summary, treat it
 as a broken type-check invocation. The ratchet will fail until the underlying
 config/import problem is fixed.
 
-Increases in the `tests/` count are lower priority but still worth a glance —
-prefer fixing them opportunistically in the same area you're already editing.
+### What to do if the `tests/` count changes
+
+If `tests/` goes up:
+
+1. Run `mypy tests/` locally and inspect the new errors.
+2. Fix errors introduced by the PR before merging.
+3. Treat baseline increases as exceptional and coordinated, not as routine.
+
+If `tests/` goes down:
+
+1. Confirm the lower count is real by rerunning `mypy tests/` or
+   `bash scripts/lint.sh`.
+2. Update `scripts/mypy_tests_baseline.txt` to the new lower integer.
+3. Prefer paying down errors in clusters: shared fixtures, contract/security
+   tests, then browser/integration tests.
 
 ## Coding guidelines for typed modules
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -46,6 +46,9 @@ strict_equality = True
 [mypy-jsonschema.*]
 ignore_missing_imports = True
 
+[mypy-waitress.*]
+ignore_missing_imports = True
+
 # ---- Strict subset ----
 # Modules listed here are held to --strict standards.
 # CI will fail if they regress. See docs/typing.md for how to expand this list.

--- a/mypy.ini
+++ b/mypy.ini
@@ -89,6 +89,9 @@ strict = True
 [mypy-utils.http_cache]
 strict = True
 
+[mypy-utils.request_models]
+strict = True
+
 [mypy-refresh_task.actions]
 strict = True
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,6 +4,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
 MYPY_SRC_BASELINE_FILE="${MYPY_SRC_BASELINE_FILE:-${REPO_ROOT}/scripts/mypy_src_baseline.txt}"
+MYPY_TESTS_BASELINE_FILE="${MYPY_TESTS_BASELINE_FILE:-${REPO_ROOT}/scripts/mypy_tests_baseline.txt}"
 cd "${REPO_ROOT}" || exit
 
 # Use existing environment in CI or when a virtualenv is active
@@ -19,6 +20,8 @@ MYPY_SRC_EXIT=0
 MYPY_SRC_BASELINE="?"
 MYPY_SRC_RATCHET_EXIT=0
 MYPY_TESTS_EXIT=0
+MYPY_TESTS_BASELINE="?"
+MYPY_TESTS_RATCHET_EXIT=0
 MYPY_STRICT_EXIT=0
 SHELLCHECK_EXIT=0
 
@@ -42,8 +45,9 @@ fi
 
 # Non-strict mypy is split into two passes (src/ and tests/) so that
 # production-code type drift stays visible even when test-only typing
-# noise dominates. src/ is ratcheted against a checked-in baseline;
-# tests/ remains advisory. The strict subset below stays CI-blocking.
+# noise dominates. src/ must stay clean, while tests/ is ratcheted against
+# a checked-in baseline so new test typing debt cannot slip in silently.
+# The strict subset below stays CI-blocking.
 # See docs/typing.md.
 count_mypy_errors() {
     # Parse "Found N errors" / "Success: ..." lines from captured output.
@@ -66,12 +70,13 @@ count_mypy_errors() {
     echo "$n"
 }
 
-# Load the checked-in src/ advisory baseline used for the ratchet.
-load_mypy_src_baseline() {
+load_mypy_baseline() {
+    local baseline_file="$1"
+    local label="$2"
     local baseline_value
 
-    if [ ! -f "$MYPY_SRC_BASELINE_FILE" ]; then
-        echo "❌ mypy src/ ratchet baseline missing: $MYPY_SRC_BASELINE_FILE"
+    if [ ! -f "$baseline_file" ]; then
+        echo "❌ mypy ${label} ratchet baseline missing: $baseline_file" >&2
         return 1
     fi
 
@@ -80,15 +85,31 @@ load_mypy_src_baseline() {
             /^[[:space:]]*#/ { next }
             /^[[:space:]]*$/ { next }
             { print $1; exit }
-        ' "$MYPY_SRC_BASELINE_FILE"
+        ' "$baseline_file"
     )"
 
     if [[ ! "$baseline_value" =~ ^[0-9]+$ ]]; then
-        echo "❌ mypy src/ ratchet baseline is not a non-negative integer: $MYPY_SRC_BASELINE_FILE"
+        echo "❌ mypy ${label} ratchet baseline is not a non-negative integer: $baseline_file" >&2
         return 1
     fi
 
+    echo "$baseline_value"
+}
+
+# Load the checked-in src/ baseline. This should remain zero now that
+# production-code mypy debt has been cleared.
+load_mypy_src_baseline() {
+    local baseline_value
+
+    baseline_value="$(load_mypy_baseline "$MYPY_SRC_BASELINE_FILE" "src/")" || return 1
     MYPY_SRC_BASELINE="$baseline_value"
+}
+
+load_mypy_tests_baseline() {
+    local baseline_value
+
+    baseline_value="$(load_mypy_baseline "$MYPY_TESTS_BASELINE_FILE" "tests/")" || return 1
+    MYPY_TESTS_BASELINE="$baseline_value"
 }
 
 # Run mypy on a directory and capture its error count for either advisory
@@ -147,18 +168,58 @@ enforce_mypy_src_ratchet() {
         return
     fi
 
+    if [ "$MYPY_SRC_BASELINE" -eq 0 ] && [ "$MYPY_SRC_EXIT" -ne 0 ]; then
+        echo "❌ mypy src/ must remain clean now that the baseline is zero"
+        MYPY_SRC_RATCHET_EXIT=1
+        return
+    fi
+
     if [ "$MYPY_SRC_COUNT" -lt "$MYPY_SRC_BASELINE" ]; then
         echo "✅ mypy src/ ratchet improved: ${MYPY_SRC_COUNT} issue(s) vs baseline ${MYPY_SRC_BASELINE}"
         echo "ℹ️  Lower ${display_baseline_file} when that reduced count is ready to become the new floor."
         return
     fi
 
-    echo "✅ mypy src/ ratchet held at baseline ${MYPY_SRC_BASELINE}"
+    if [ "$MYPY_SRC_BASELINE" -eq 0 ]; then
+        echo "✅ mypy src/ remains clean"
+    else
+        echo "✅ mypy src/ ratchet held at baseline ${MYPY_SRC_BASELINE}"
+    fi
+}
+
+enforce_mypy_tests_ratchet() {
+    local display_baseline_file="${MYPY_TESTS_BASELINE_FILE#"${REPO_ROOT}"/}"
+
+    if ! load_mypy_tests_baseline; then
+        MYPY_TESTS_RATCHET_EXIT=1
+        return
+    fi
+
+    if [ "$MYPY_TESTS_COUNT" = "?" ]; then
+        echo "❌ mypy tests/ ratchet failed: unable to determine the advisory count for comparison"
+        MYPY_TESTS_RATCHET_EXIT=1
+        return
+    fi
+
+    if [ "$MYPY_TESTS_COUNT" -gt "$MYPY_TESTS_BASELINE" ]; then
+        echo "❌ mypy tests/ ratchet failed: ${MYPY_TESTS_COUNT} issue(s) exceeds baseline ${MYPY_TESTS_BASELINE}"
+        MYPY_TESTS_RATCHET_EXIT=1
+        return
+    fi
+
+    if [ "$MYPY_TESTS_COUNT" -lt "$MYPY_TESTS_BASELINE" ]; then
+        echo "✅ mypy tests/ ratchet improved: ${MYPY_TESTS_COUNT} issue(s) vs baseline ${MYPY_TESTS_BASELINE}"
+        echo "ℹ️  Lower ${display_baseline_file} when that reduced count is ready to become the new floor."
+        return
+    fi
+
+    echo "✅ mypy tests/ ratchet held at baseline ${MYPY_TESTS_BASELINE}"
 }
 
 run_counted_mypy src "src/" SRC ratchet
 enforce_mypy_src_ratchet
-run_counted_mypy tests "tests/" TESTS advisory
+run_counted_mypy tests "tests/" TESTS ratchet
+enforce_mypy_tests_ratchet
 
 echo "Running mypy strict check (blocking — strict subset only)..."
 # Strict subset: curated low-churn helpers that are enforced at --strict.
@@ -180,6 +241,7 @@ mypy --strict \
     src/utils/sri.py \
     src/utils/time_utils.py \
     src/utils/http_cache.py \
+    src/utils/request_models.py \
     src/model.py
 MYPY_STRICT_EXIT=$?
 if [ $MYPY_STRICT_EXIT -ne 0 ]; then
@@ -217,14 +279,15 @@ else
     fi
 fi
 
-# Report summary — src/ is ratcheted, tests/ stays advisory, and the strict
+# Report summary — src/ must stay clean, tests/ is ratcheted, and the strict
 # subset remains fully blocking. Ruff, Black, and shellcheck are blocking too.
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] || [ $MYPY_TESTS_RATCHET_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     echo ""
     echo "❌ Some checks failed:"
     [ $RUFF_EXIT -ne 0 ] && echo "  - Ruff: $RUFF_EXIT"
     [ $BLACK_EXIT -ne 0 ] && echo "  - Black: $BLACK_EXIT"
     [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] && echo "  - mypy src/ ratchet: $MYPY_SRC_RATCHET_EXIT"
+    [ $MYPY_TESTS_RATCHET_EXIT -ne 0 ] && echo "  - mypy tests/ ratchet: $MYPY_TESTS_RATCHET_EXIT"
     [ $MYPY_STRICT_EXIT -ne 0 ] && echo "  - mypy strict subset: $MYPY_STRICT_EXIT"
     [ $SHELLCHECK_EXIT -ne 0 ] && echo "  - shellcheck: $SHELLCHECK_EXIT"
     echo ""
@@ -246,15 +309,21 @@ elif [ $MYPY_SRC_EXIT -eq 0 ]; then
 else
     echo "✅ mypy src/: ${MYPY_SRC_COUNT} issue(s) matches baseline ${MYPY_SRC_BASELINE}"
 fi
-if [ $MYPY_TESTS_EXIT -ne 0 ]; then
-    if [ "$MYPY_TESTS_COUNT" = "?" ]; then
-        echo "⚠️  mypy tests/: failed without summary (non-blocking — see output above)"
-    else
-        echo "⚠️  mypy tests/: advisory only — ${MYPY_TESTS_COUNT} issue(s) remain (non-blocking)"
-    fi
+if [ "$MYPY_TESTS_BASELINE" = "?" ]; then
+    echo "❌ mypy tests/: ratchet baseline could not be loaded"
+elif [ "$MYPY_TESTS_COUNT" = "?" ]; then
+    echo "❌ mypy tests/: ratchet could not compare against baseline ${MYPY_TESTS_BASELINE}"
+elif [ "$MYPY_TESTS_COUNT" -gt "$MYPY_TESTS_BASELINE" ]; then
+    echo "❌ mypy tests/: ${MYPY_TESTS_COUNT} issue(s) exceeds baseline ${MYPY_TESTS_BASELINE}"
+elif [ "$MYPY_TESTS_COUNT" -lt "$MYPY_TESTS_BASELINE" ]; then
+    echo "✅ mypy tests/: ${MYPY_TESTS_COUNT} issue(s) (below baseline ${MYPY_TESTS_BASELINE})"
+elif [ $MYPY_TESTS_EXIT -eq 0 ]; then
+    echo "✅ mypy tests/: clean"
+else
+    echo "✅ mypy tests/: ${MYPY_TESTS_COUNT} issue(s) matches baseline ${MYPY_TESTS_BASELINE}"
 fi
 
-if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
+if [ $RUFF_EXIT -ne 0 ] || [ $BLACK_EXIT -ne 0 ] || [ $MYPY_SRC_RATCHET_EXIT -ne 0 ] || [ $MYPY_TESTS_RATCHET_EXIT -ne 0 ] || [ $MYPY_STRICT_EXIT -ne 0 ] || [ $SHELLCHECK_EXIT -ne 0 ]; then
     exit 1
 fi
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -207,6 +207,12 @@ enforce_mypy_tests_ratchet() {
         return
     fi
 
+    if [ "$MYPY_TESTS_BASELINE" -eq 0 ] && [ "$MYPY_TESTS_EXIT" -ne 0 ]; then
+        echo "❌ mypy tests/ must remain clean now that the baseline is zero"
+        MYPY_TESTS_RATCHET_EXIT=1
+        return
+    fi
+
     if [ "$MYPY_TESTS_COUNT" -lt "$MYPY_TESTS_BASELINE" ]; then
         echo "✅ mypy tests/ ratchet improved: ${MYPY_TESTS_COUNT} issue(s) vs baseline ${MYPY_TESTS_BASELINE}"
         echo "ℹ️  Lower ${display_baseline_file} when that reduced count is ready to become the new floor."

--- a/scripts/mypy_tests_baseline.txt
+++ b/scripts/mypy_tests_baseline.txt
@@ -1,3 +1,3 @@
 # Checked-in mypy tests/ advisory baseline for scripts/lint.sh.
 # Lower this number when tests/ typing debt is intentionally reduced.
-7446
+7450

--- a/scripts/mypy_tests_baseline.txt
+++ b/scripts/mypy_tests_baseline.txt
@@ -1,0 +1,3 @@
+# Checked-in mypy tests/ advisory baseline for scripts/lint.sh.
+# Lower this number when tests/ typing debt is intentionally reduced.
+7446

--- a/src/blueprints/apikeys.py
+++ b/src/blueprints/apikeys.py
@@ -8,6 +8,7 @@ from dotenv import dotenv_values
 from flask import Blueprint, Response, render_template, request
 
 from utils.http_utils import json_error, json_internal_error, json_success
+from utils.request_models import parse_api_keys_save_request
 
 logger = logging.getLogger(__name__)
 apikeys_bp = Blueprint("apikeys", __name__)
@@ -197,20 +198,19 @@ def apikeys_page() -> Response | str:
 def save_apikeys() -> tuple[Response | dict[str, Any], int] | Response | dict[str, Any]:
     """Save API keys to .env file."""
     try:
-        data = request.get_json(silent=True)
-        if not isinstance(data, dict):
+        parsed, parse_error = parse_api_keys_save_request(request.get_json(silent=True))
+        if parse_error is not None:
+            return json_error(parse_error.message, status=parse_error.status)
+        if parsed is None:
             return json_error("Invalid JSON payload", status=400)
-        entries = data.get("entries", [])
-        if not isinstance(entries, list):
-            return json_error("Invalid entries format", status=400)
 
         # Load existing values for keys marked as keepExisting
         env_path = get_env_path()
         existing_values = dict(parse_env_file(env_path))
 
         # Validate and process entries
-        valid_entries = []
-        for entry in entries:
+        valid_entries: list[tuple[str, str]] = []
+        for entry in parsed.entries:
             key, value, err = _validate_api_key_entry(entry, existing_values)
             if err is not None:
                 return json_error(API_KEY_VALIDATION_ERROR, status=400)

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -25,6 +25,7 @@ from utils.display_names import (
 from utils.http_utils import json_error, json_success
 from utils.image_serving import maybe_serve_webp
 from utils.rate_limiter import CooldownLimiter
+from utils.request_models import parse_plugin_order_request
 
 logger = logging.getLogger(__name__)
 
@@ -423,14 +424,13 @@ def next_up() -> Any:
 def save_plugin_order() -> Any:
     """Save custom plugin order from dashboard drag-and-drop."""
     device_config = current_app.config["DEVICE_CONFIG"]
-    data = request.get_json(silent=True)
-    if not isinstance(data, dict):
+    parsed, parse_error = parse_plugin_order_request(request.get_json(silent=True))
+    if parse_error is not None:
+        return json_error(parse_error.message, status=parse_error.status)
+    if parsed is None:
         return json_error("Invalid JSON payload", status=400)
-    order = data.get("order", [])
-    if not isinstance(order, list):
-        return json_error("Order must be a list", status=400)
-    if any(not isinstance(item, str) for item in order):
-        return json_error("Order entries must be strings", status=400)
+
+    order = parsed.order
     registered_ids = {p["id"] for p in device_config.get_plugins()}
     if len(order) != len(set(order)):
         return json_error("Order must not contain duplicate plugin IDs", status=400)

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -630,6 +630,9 @@ def create_playlist() -> Any:
                     parsed.playlist_name, parsed.start_time, parsed.end_time
                 )
             )
+            _apply_cycle_override(
+                playlist_manager, parsed.playlist_name, parsed.cycle_minutes_int
+            )
 
         device_config.update_atomic(_do_add_playlist)
         if not add_pl_result or not add_pl_result[0]:
@@ -714,6 +717,15 @@ def update_playlist(playlist_name: str) -> Any:
             status=400,
             code=_CODE_VALIDATION,
             details={"field": "playlist_name"},
+        )
+
+    existing_with_new_name = playlist_manager.get_playlist(new_name)
+    if existing_with_new_name is not None and existing_with_new_name is not playlist:
+        return json_error(
+            "A playlist with that name already exists",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "new_name"},
         )
 
     # Prevent overlapping (exclude the playlist being updated)

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -719,15 +719,6 @@ def update_playlist(playlist_name: str) -> Any:
             details={"field": "playlist_name"},
         )
 
-    existing_with_new_name = playlist_manager.get_playlist(new_name)
-    if existing_with_new_name is not None and existing_with_new_name is not playlist:
-        return json_error(
-            "A playlist with that name already exists",
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": "new_name"},
-        )
-
     # Prevent overlapping (exclude the playlist being updated)
     try:
         overlap_err = _check_playlist_overlap(
@@ -739,8 +730,16 @@ def update_playlist(playlist_name: str) -> Any:
         pass
 
     upd_result: list[bool] = []
+    duplicate_name_result: list[bool] = []
 
     def _do_update_playlist(cfg: Any) -> None:
+        existing_with_new_name = playlist_manager.get_playlist(new_name)
+        if (
+            existing_with_new_name is not None
+            and existing_with_new_name is not playlist
+        ):
+            duplicate_name_result.append(True)
+            return
         upd_result.append(
             playlist_manager.update_playlist(
                 playlist_name, new_name, start_time, end_time
@@ -749,6 +748,13 @@ def update_playlist(playlist_name: str) -> Any:
         _apply_cycle_override(playlist_manager, new_name, cycle_minutes_int)
 
     device_config.update_atomic(_do_update_playlist)
+    if duplicate_name_result:
+        return json_error(
+            "A playlist with that name already exists",
+            status=400,
+            code=_CODE_VALIDATION,
+            details={"field": "new_name"},
+        )
     if not upd_result or not upd_result[0]:
         return json_error("Failed to update playlist", status=500)
 

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -32,23 +32,25 @@ from utils.http_utils import (
     reissue_json_error,
 )
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
+from utils.request_models import (
+    CODE_VALIDATION,
+    RequestModelError,
+    parse_device_cycle_request,
+    parse_playlist_create_request,
+    parse_playlist_name_request,
+    parse_playlist_reorder_request,
+    parse_playlist_update_request,
+    validate_playlist_name as validate_playlist_name_request,
+)
 from utils.time_utils import calculate_seconds, now_device_tz
 
 logger = logging.getLogger(__name__)
 playlist_bp = Blueprint("playlist", __name__)
 
-_PLAYLIST_NAME_MAX_LEN = 64
-_PLAYLIST_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]+$", re.ASCII)
-_PLAYLIST_NAME_FORMAT_ERROR = (
-    "Playlist name can only contain ASCII letters, "
-    "numbers, spaces, underscores, and hyphens"
-)
 _INSTANCE_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]+$")
 
 # Shared string constants to avoid duplication
-_CODE_VALIDATION = "validation_error"
-_MSG_INVALID_TIME_FORMAT = "Invalid start/end time format"
-_MSG_SAME_TIME = "Start time and End time cannot be the same"
+_CODE_VALIDATION = CODE_VALIDATION
 _MSG_TIME_OVERLAP = "Playlist time range overlaps with existing playlist"
 _MSG_INVALID_PLAYLIST_REQUEST = "Invalid playlist request"
 _MSG_PLAYLIST_NOT_FOUND = "Playlist not found"
@@ -65,6 +67,15 @@ DEFAULT_PLAYLIST_NAME = "Default"
 _MSG_CANNOT_DELETE_DEFAULT = "Cannot delete the default playlist"
 
 
+def _request_model_error_response(error: RequestModelError) -> Any:
+    return json_error(
+        error.message,
+        status=error.status,
+        code=error.code,
+        details=error.details or None,
+    )
+
+
 def _validate_playlist_name(
     name: Any, field: str = "playlist_name"
 ) -> tuple[str | None, Any]:
@@ -73,29 +84,10 @@ def _validate_playlist_name(
     ``field`` is the form field name echoed back in ``details.field`` so the
     frontend can highlight the offending input.
     """
-    if not name or not name.strip():
-        return None, json_error(
-            PLAYLIST_NAME_REQUIRED_ERROR,
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": field},
-        )
-    name = name.strip()
-    if len(name) > _PLAYLIST_NAME_MAX_LEN:
-        return None, json_error(
-            f"Playlist name must be {_PLAYLIST_NAME_MAX_LEN} characters or fewer",
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": field},
-        )
-    if not _PLAYLIST_NAME_RE.match(name):
-        return None, json_error(
-            _PLAYLIST_NAME_FORMAT_ERROR,
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": field},
-        )
-    return name, None
+    normalized, error = validate_playlist_name_request(name, field=field)
+    if error is not None:
+        return None, _request_model_error_response(error)
+    return normalized, None
 
 
 # Simple in-memory cache for ETA computations (per playlist, per-minute)
@@ -588,70 +580,6 @@ def _parse_playlist_request_data() -> tuple[dict[str, Any] | None, Any]:
     return data, None
 
 
-def _validate_playlist_times(
-    start_time: Any, end_time: Any
-) -> tuple[int | None, int | None, Any]:
-    """Validate and convert time strings to minutes.
-
-    Returns (start_min, end_min, error_response).
-    """
-    if not start_time:
-        missing_field = "start_time"
-    elif not end_time:
-        missing_field = "end_time"
-    else:
-        missing_field = None
-    if missing_field is not None:
-        return (
-            None,
-            None,
-            json_error(
-                "Start time and End time are required",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": missing_field},
-            ),
-        )
-    try:
-        start_min = _to_minutes(start_time)
-    except Exception:
-        return (
-            None,
-            None,
-            json_error(
-                _MSG_INVALID_TIME_FORMAT,
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "start_time"},
-            ),
-        )
-    try:
-        end_min = _to_minutes(end_time)
-    except Exception:
-        return (
-            None,
-            None,
-            json_error(
-                _MSG_INVALID_TIME_FORMAT,
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "end_time"},
-            ),
-        )
-    if start_min == end_min:
-        return (
-            None,
-            None,
-            json_error(
-                _MSG_SAME_TIME,
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "end_time"},
-            ),
-        )
-    return start_min, end_min, None
-
-
 @playlist_bp.route("/create_playlist", methods=["POST"])  # type: ignore[untyped-decorator]
 def create_playlist() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
@@ -663,23 +591,18 @@ def create_playlist() -> Any:
     if data is None:
         return json_error("Invalid playlist request", status=400)
 
-    playlist_name, name_err = _validate_playlist_name(data.get("playlist_name"))
-    if name_err:
-        return name_err
-    start_min, end_min, time_err = _validate_playlist_times(
-        data.get("start_time"), data.get("end_time")
-    )
-    if time_err:
-        return time_err
-    if start_min is None or end_min is None:
-        return json_error("Invalid playlist times", status=400)
+    parsed, parse_err = parse_playlist_create_request(data)
+    if parse_err is not None:
+        return _request_model_error_response(parse_err)
+    if parsed is None:
+        return json_error("Invalid playlist request", status=400)
 
     with route_error_boundary(
         "create playlist",
         logger=logger,
         hint="Ensure the playlist name is unique and the config is writable.",
     ):
-        playlist = playlist_manager.get_playlist(playlist_name)
+        playlist = playlist_manager.get_playlist(parsed.playlist_name)
         if playlist:
             raise ClientInputError(
                 "A playlist with that name already exists",
@@ -691,7 +614,7 @@ def create_playlist() -> Any:
         # Prevent overlapping time windows
         try:
             overlap_err = _check_playlist_overlap(
-                start_min, end_min, playlist_manager.playlists
+                parsed.start_min, parsed.end_min, playlist_manager.playlists
             )
             if overlap_err:
                 return overlap_err
@@ -704,7 +627,7 @@ def create_playlist() -> Any:
         def _do_add_playlist(cfg: Any) -> None:
             add_pl_result.append(
                 playlist_manager.add_playlist(
-                    playlist_name, data.get("start_time"), data.get("end_time")
+                    parsed.playlist_name, parsed.start_time, parsed.end_time
                 )
             )
 
@@ -713,45 +636,14 @@ def create_playlist() -> Any:
             raise OperationFailedError("Failed to create playlist")
 
         warning = None
-        if playlist_name != "Default":
+        if parsed.playlist_name != "Default":
             warning = _default_overlap_warning(
-                start_min, end_min, playlist_manager.playlists
+                parsed.start_min, parsed.end_min, playlist_manager.playlists
             )
 
     if warning:
         return json_success("Created new Playlist!", warning=warning)
     return json_success("Created new Playlist!")
-
-
-_CYCLE_MINUTES_MIN = 1
-_CYCLE_MINUTES_MAX = 1440
-
-
-def _validate_cycle_minutes(cycle_minutes: Any) -> tuple[int | None, Any]:
-    """Validate cycle_minutes value.
-
-    Returns ``(int_value, error_response)``.  If cycle_minutes is None/absent,
-    returns ``(None, None)`` to indicate "use device default".
-    """
-    if cycle_minutes is None:
-        return None, None
-    try:
-        cm = int(cycle_minutes)
-    except (ValueError, TypeError):
-        return None, json_error(
-            "cycle_minutes must be an integer",
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": "cycle_minutes"},
-        )
-    if cm < _CYCLE_MINUTES_MIN or cm > _CYCLE_MINUTES_MAX:
-        return None, json_error(
-            f"cycle_minutes must be between {_CYCLE_MINUTES_MIN} and {_CYCLE_MINUTES_MAX}",
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": "cycle_minutes"},
-        )
-    return cm, None
 
 
 def _apply_cycle_override(
@@ -777,32 +669,18 @@ def _validate_update_playlist_payload(
     is a dict with ``new_name``, ``start_time``, ``end_time``, ``start_min``,
     ``end_min``, ``cycle_minutes_int``.
     """
-    new_name, name_err = _validate_playlist_name(data.get("new_name"), field="new_name")
-    if name_err:
-        return None, name_err
-    start_time = data.get("start_time")
-    end_time = data.get("end_time")
-    if not start_time or not end_time:
-        missing_field = "start_time" if not start_time else "end_time"
-        return None, json_error(
-            "Missing required fields",
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": missing_field},
-        )
-    start_min, end_min, time_err = _validate_playlist_times(start_time, end_time)
-    if time_err:
-        return None, time_err
-    cycle_minutes_int, cycle_err = _validate_cycle_minutes(data.get("cycle_minutes"))
-    if cycle_err:
-        return None, cycle_err
+    parsed, error = parse_playlist_update_request(dict(data))
+    if error is not None:
+        return None, _request_model_error_response(error)
+    if parsed is None:
+        return None, json_error("Invalid playlist payload", status=400)
     return {
-        "new_name": new_name,
-        "start_time": start_time,
-        "end_time": end_time,
-        "start_min": start_min,
-        "end_min": end_min,
-        "cycle_minutes_int": cycle_minutes_int,
+        "new_name": parsed.new_name,
+        "start_time": parsed.start_time,
+        "end_time": parsed.end_time,
+        "start_min": parsed.start_min,
+        "end_min": parsed.end_min,
+        "cycle_minutes_int": parsed.cycle_minutes_int,
     }, None
 
 
@@ -923,30 +801,20 @@ def delete_playlist(playlist_name: str) -> Any:
 def update_device_cycle() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     refresh_task = current_app.config["REFRESH_TASK"]
-    data = request.get_json(silent=True) or {}
-    minutes = data.get("minutes") or 0
-    try:
-        m = int(minutes)
-        if m < 1 or m > 1440:
-            return json_error(
-                "Minutes must be between 1 and 1440",
-                status=400,
-                code=_CODE_VALIDATION,
-                details={"field": "minutes"},
-            )
-    except Exception:
-        return json_error(
-            "Invalid minutes",
-            status=400,
-            code=_CODE_VALIDATION,
-            details={"field": "minutes"},
-        )
+    parsed, parse_error = parse_device_cycle_request(request.get_json(silent=True))
+    if parse_error is not None:
+        return _request_model_error_response(parse_error)
+    if parsed is None:
+        return json_error("Invalid minutes", status=400)
+
     with route_error_boundary(
         "update_device_cycle",
         logger=logger,
         hint="Check config write permissions.",
     ):
-        device_config.update_value("plugin_cycle_interval_seconds", m * 60, write=True)
+        device_config.update_value(
+            "plugin_cycle_interval_seconds", parsed.minutes * 60, write=True
+        )
         try:
             refresh_task.signal_config_change()
         except Exception:
@@ -964,27 +832,20 @@ def reorder_plugins() -> Any:
         logger=logger,
         hint="Validate payload shape and ensure the playlist exists.",
     ):
-        data = request.get_json(silent=True)
-        if not isinstance(data, dict):
+        parsed, parse_error = parse_playlist_reorder_request(
+            request.get_json(silent=True)
+        )
+        if parse_error is not None:
+            raise ClientInputError(
+                parse_error.message,
+                status=parse_error.status,
+                code=parse_error.code,
+                field=parse_error.field,
+            )
+        if parsed is None:
             raise ClientInputError("Invalid or missing JSON payload", status=400)
-        playlist_name = data.get("playlist_name")
-        ordered = data.get("ordered")  # list of {plugin_id, name}
-        if not playlist_name:
-            raise ClientInputError(
-                "playlist_name and ordered list are required",
-                status=400,
-                code=_CODE_VALIDATION,
-                field="playlist_name",
-            )
-        if not isinstance(ordered, list):
-            raise ClientInputError(
-                "playlist_name and ordered list are required",
-                status=400,
-                code=_CODE_VALIDATION,
-                field="ordered",
-            )
 
-        playlist = playlist_manager.get_playlist(playlist_name)
+        playlist = playlist_manager.get_playlist(parsed.playlist_name)
         if not playlist:
             raise ResourceLookupError(
                 _MSG_PLAYLIST_NOT_FOUND,
@@ -994,9 +855,10 @@ def reorder_plugins() -> Any:
             )
 
         reorder_result: list[bool] = []
+        ordered_payload = parsed.ordered_payload()
 
         def _do_reorder(cfg: Any) -> None:
-            reorder_result.append(playlist.reorder_plugins(ordered))
+            reorder_result.append(playlist.reorder_plugins(ordered_payload))
 
         device_config.update_atomic(_do_reorder)
         if not reorder_result or not reorder_result[0]:
@@ -1017,19 +879,21 @@ def display_next_in_playlist() -> Any:
         logger=logger,
         hint="Ensure the playlist exists and has an eligible instance to render.",
     ):
-        data = request.get_json(silent=True)
-        if not isinstance(data, dict):
-            raise ClientInputError("Invalid or missing JSON payload", status=400)
-        playlist_name = data.get("playlist_name")
-        if not playlist_name:
+        parsed, parse_error = parse_playlist_name_request(
+            request.get_json(silent=True),
+            missing_message="playlist_name required",
+        )
+        if parse_error is not None:
             raise ClientInputError(
-                "playlist_name required",
-                status=400,
-                code=_CODE_VALIDATION,
-                field="playlist_name",
+                parse_error.message,
+                status=parse_error.status,
+                code=parse_error.code,
+                field=parse_error.field,
             )
+        if parsed is None:
+            raise ClientInputError("Invalid or missing JSON payload", status=400)
 
-        playlist = playlist_manager.get_playlist(playlist_name)
+        playlist = playlist_manager.get_playlist(parsed.playlist_name)
         if not playlist:
             raise ResourceLookupError(
                 _MSG_PLAYLIST_NOT_FOUND,

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -201,6 +201,50 @@ def plugin_page(plugin_id: str) -> Any:
     )
 
 
+@plugin_bp.route("/plugin/ai_image/random_prompt", methods=["POST"])  # type: ignore[untyped-decorator]
+def ai_image_random_prompt() -> Any:
+    """Generate a prompt suggestion for the AI Image plugin."""
+    device_config = current_app.config[_CONFIG_KEY]
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return json_error("Invalid JSON payload", status=400)
+
+    provider = str(data.get("provider") or "openai").strip().lower()
+    seed_prompt = str(data.get("prompt") or "")
+
+    with route_error_boundary(
+        "generate AI image prompt",
+        logger=logger,
+        hint="Ensure the selected provider API key is configured.",
+    ):
+        if provider == "google":
+            api_key = device_config.load_env_key("GOOGLE_AI_SECRET")
+            if not api_key:
+                raise ClientInputError("Google AI API Key not configured.", status=400)
+            from google import genai
+
+            from plugins.ai_image.ai_image import AIImage
+
+            client = genai.Client(api_key=api_key)
+            prompt = AIImage.fetch_image_prompt_google(client, seed_prompt)
+        else:
+            api_key = device_config.load_env_key("OPEN_AI_SECRET")
+            if not api_key:
+                raise ClientInputError("OpenAI API Key not configured.", status=400)
+            from openai import OpenAI
+
+            from plugins.ai_image.ai_image import AIImage
+
+            client = OpenAI(api_key=api_key)
+            prompt = AIImage.fetch_image_prompt(client, seed_prompt)
+
+        if not prompt:
+            raise ClientInputError(
+                "Prompt generator returned an empty prompt.", status=502
+            )
+        return json_success("Generated prompt.", prompt=prompt)
+
+
 @plugin_bp.route("/plugins", methods=["GET"])  # type: ignore[untyped-decorator]
 def plugins_page() -> Any:
     device_config = current_app.config[_CONFIG_KEY]

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -210,6 +210,13 @@ def ai_image_random_prompt() -> Any:
         return json_error("Invalid JSON payload", status=400)
 
     provider = str(data.get("provider") or "openai").strip().lower()
+    if provider not in ("openai", "google"):
+        raise ClientInputError(
+            f"Unsupported provider: {provider!r}",
+            status=400,
+            code="validation_error",
+            field="provider",
+        )
     seed_prompt = str(data.get("prompt") or "")
 
     with route_error_boundary(

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -34,7 +34,6 @@ from utils.form_utils import (
     validate_plugin_required_fields,
 )
 from utils.http_utils import json_error, json_success
-from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 from utils.plugin_errors import (
     MANUAL_UPDATE_TIMEOUT_MSG,
     SCREENSHOT_BACKEND_UNAVAILABLE_MSG,
@@ -42,6 +41,7 @@ from utils.plugin_errors import (
 )
 from utils.plugin_history import record_change as _record_plugin_change
 from utils.progress import track_progress
+from utils.request_models import parse_plugin_instance_action_request
 from utils.security_utils import URLValidationError, validate_file_path
 
 logger = logging.getLogger(__name__)
@@ -384,42 +384,46 @@ def delete_plugin_instance() -> Any:
 
     if not request.is_json:
         raise UnsupportedMediaTypeRouteError
-    data = request.json or {}
-
-    playlist_name = data.get("playlist_name")
-    plugin_id = data.get(_PLUGIN_ID)
-    plugin_instance = data.get("plugin_instance")
-
-    if (
-        not playlist_name
-        or not isinstance(playlist_name, str)
-        or not playlist_name.strip()
-    ):
-        raise ClientInputError(PLAYLIST_NAME_REQUIRED_ERROR, status=400)
-    playlist_name = playlist_name.strip()
+    parsed, parse_error = parse_plugin_instance_action_request(
+        request.get_json(silent=True)
+    )
+    if parse_error is not None:
+        raise ClientInputError(
+            parse_error.message,
+            status=parse_error.status,
+            code=parse_error.code,
+            field=parse_error.field,
+        )
+    if parsed is None:
+        raise ClientInputError("Invalid or missing JSON payload", status=400)
 
     with route_error_boundary(
         "delete plugin instance",
         logger=logger,
         hint="Ensure the playlist and plugin instance exist before deleting.",
     ):
-        playlist = playlist_manager.get_playlist(playlist_name)
+        playlist = playlist_manager.get_playlist(parsed.playlist_name)
         if not playlist:
             raise ResourceLookupError("Playlist not found", status=400)
 
-        existing = playlist.find_plugin(plugin_id, plugin_instance)
+        existing = playlist.find_plugin(parsed.plugin_id, parsed.plugin_instance)
         plugin_settings = dict(existing.settings) if existing else {}
 
         del_result: list[bool] = []
 
         def _do_delete(cfg: Any) -> None:
-            del_result.append(playlist.delete_plugin(plugin_id, plugin_instance))
+            del_result.append(
+                playlist.delete_plugin(parsed.plugin_id, parsed.plugin_instance)
+            )
 
         device_config.update_atomic(_do_delete)
         if not del_result or not del_result[0]:
             raise ResourceLookupError("Plugin instance not found", status=400)
         _cleanup_plugin_resources(
-            device_config, plugin_id, plugin_instance, plugin_settings
+            device_config,
+            parsed.plugin_id,
+            parsed.plugin_instance,
+            plugin_settings,
         )
 
     return json_success(message="Deleted plugin instance.")
@@ -570,33 +574,40 @@ def display_plugin_instance() -> Any:
 
     if not request.is_json:
         raise UnsupportedMediaTypeRouteError
-    data = request.json or {}
-
-    playlist_name = data.get("playlist_name")
-    plugin_id = data.get(_PLUGIN_ID)
-    plugin_instance_name = data.get("plugin_instance")
+    parsed, parse_error = parse_plugin_instance_action_request(
+        request.get_json(silent=True)
+    )
+    if parse_error is not None:
+        raise ClientInputError(
+            parse_error.message,
+            status=parse_error.status,
+            code=parse_error.code,
+            field=parse_error.field,
+        )
+    if parsed is None:
+        raise ClientInputError("Invalid or missing JSON payload", status=400)
 
     with route_error_boundary(
         "display plugin instance",
         logger=logger,
         hint="Ensure the playlist exists and the refresh task can run the instance.",
     ):
-        playlist = playlist_manager.get_playlist(playlist_name)
+        playlist = playlist_manager.get_playlist(parsed.playlist_name)
         if not playlist:
             logger.warning(
                 "display_plugin_instance: playlist not found name=%s",
-                sanitize_log_field(playlist_name),
+                sanitize_log_field(parsed.playlist_name),
             )
             raise ResourceLookupError(_ERR_PLAYLIST_NOT_FOUND, status=400)
 
-        plugin_instance = playlist.find_plugin(plugin_id, plugin_instance_name)
+        plugin_instance = playlist.find_plugin(parsed.plugin_id, parsed.plugin_instance)
         if not plugin_instance:
             logger.warning(
                 "display_plugin_instance: plugin instance not found "
                 "playlist=%s plugin_id=%s instance=%s",
-                sanitize_log_field(playlist_name),
-                sanitize_log_field(plugin_id),
-                sanitize_log_field(plugin_instance_name),
+                sanitize_log_field(parsed.playlist_name),
+                sanitize_log_field(parsed.plugin_id),
+                sanitize_log_field(parsed.plugin_instance),
             )
             raise ResourceLookupError(
                 _ERR_PLUGIN_INSTANCE_NOT_FOUND,

--- a/src/config.py
+++ b/src/config.py
@@ -375,46 +375,49 @@ class Config:
 
     def read_plugins_list(self) -> list[dict[str, Any]]:
         """Reads the plugin-info.json config JSON from each plugin folder. Excludes the base plugin."""
-        plugins_root = os.path.join(self.BASE_DIR, "plugins")
-        if not os.path.isdir(plugins_root):
-            self._plugins_list_cache_fingerprint = None
-            self._plugins_list_cache_data = None
-            return []
+        with self._config_lock:
+            plugins_root = os.path.join(self.BASE_DIR, "plugins")
+            if not os.path.isdir(plugins_root):
+                self._plugins_list_cache_fingerprint = None
+                self._plugins_list_cache_data = None
+                return []
 
-        plugin_info_files: list[str] = []
-        with os.scandir(plugins_root) as entries:
-            for entry in entries:
-                if entry.name == "__pycache__" or not entry.is_dir():
+            plugin_info_files: list[str] = []
+            with os.scandir(plugins_root) as entries:
+                for entry in entries:
+                    if entry.name == "__pycache__" or not entry.is_dir():
+                        continue
+                    plugin_info_file = os.path.join(entry.path, "plugin-info.json")
+                    if os.path.isfile(plugin_info_file):
+                        plugin_info_files.append(plugin_info_file)
+
+            fingerprint_parts: list[tuple[str, int, int]] = []
+            for plugin_info_file in sorted(plugin_info_files):
+                try:
+                    stat = os.stat(plugin_info_file)
+                except OSError:
                     continue
-                plugin_info_file = os.path.join(entry.path, "plugin-info.json")
-                if os.path.isfile(plugin_info_file):
-                    plugin_info_files.append(plugin_info_file)
+                fingerprint_parts.append(
+                    (plugin_info_file, stat.st_mtime_ns, stat.st_size)
+                )
 
-        fingerprint_parts: list[tuple[str, int, int]] = []
-        for plugin_info_file in sorted(plugin_info_files):
-            try:
-                stat = os.stat(plugin_info_file)
-            except OSError:
-                continue
-            fingerprint_parts.append((plugin_info_file, stat.st_mtime_ns, stat.st_size))
+            fingerprint = tuple(fingerprint_parts)
+            if (
+                fingerprint == self._plugins_list_cache_fingerprint
+                and self._plugins_list_cache_data is not None
+            ):
+                return [plugin.copy() for plugin in self._plugins_list_cache_data]
 
-        fingerprint = tuple(fingerprint_parts)
-        if (
-            fingerprint == self._plugins_list_cache_fingerprint
-            and self._plugins_list_cache_data is not None
-        ):
-            return [plugin.copy() for plugin in self._plugins_list_cache_data]
+            plugins_list: list[dict[str, Any]] = []
+            for plugin_info_file, _mtime_ns, _size in fingerprint:
+                logger.debug(f"Reading plugin info from {plugin_info_file}")
+                with open(plugin_info_file) as f:
+                    plugin_info = cast(dict[str, Any], json.load(f))
+                plugins_list.append(plugin_info)
 
-        plugins_list: list[dict[str, Any]] = []
-        for plugin_info_file, _mtime_ns, _size in fingerprint:
-            logger.debug(f"Reading plugin info from {plugin_info_file}")
-            with open(plugin_info_file) as f:
-                plugin_info = cast(dict[str, Any], json.load(f))
-            plugins_list.append(plugin_info)
-
-        self._plugins_list_cache_fingerprint = fingerprint
-        self._plugins_list_cache_data = [plugin.copy() for plugin in plugins_list]
-        return plugins_list
+            self._plugins_list_cache_fingerprint = fingerprint
+            self._plugins_list_cache_data = [plugin.copy() for plugin in plugins_list]
+            return plugins_list
 
     def write_config(self) -> None:
         """Updates the cached config from the model objects and writes to the config file.

--- a/src/config.py
+++ b/src/config.py
@@ -160,6 +160,10 @@ class Config:
         # file has not changed.  Stored as (mtime_ns: int, data: dict).
         self._config_cache_mtime: int | None = None
         self._config_cache_data: dict[str, Any] | None = None
+        self._plugins_list_cache_fingerprint: (
+            tuple[tuple[str, int, int], ...] | None
+        ) = None
+        self._plugins_list_cache_data: list[dict[str, Any]] | None = None
         self._resolve_runtime_paths()
         # Resolve which config file to use (env/CLI overrides with safe fallbacks)
         self.config_file = self._determine_config_path()
@@ -371,22 +375,45 @@ class Config:
 
     def read_plugins_list(self) -> list[dict[str, Any]]:
         """Reads the plugin-info.json config JSON from each plugin folder. Excludes the base plugin."""
-        # Iterate over all plugin folders
-        plugins_list: list[dict[str, Any]] = []
         plugins_root = os.path.join(self.BASE_DIR, "plugins")
         if not os.path.isdir(plugins_root):
-            return plugins_list
-        for plugin in sorted(os.listdir(plugins_root)):
-            plugin_path = os.path.join(plugins_root, plugin)
-            if os.path.isdir(plugin_path) and plugin != "__pycache__":
-                # Check if the plugin-info.json file exists
-                plugin_info_file = os.path.join(plugin_path, "plugin-info.json")
-                if os.path.isfile(plugin_info_file):
-                    logger.debug(f"Reading plugin info from {plugin_info_file}")
-                    with open(plugin_info_file) as f:
-                        plugin_info = cast(dict[str, Any], json.load(f))
-                    plugins_list.append(plugin_info)
+            self._plugins_list_cache_fingerprint = None
+            self._plugins_list_cache_data = None
+            return []
 
+        plugin_info_files: list[str] = []
+        with os.scandir(plugins_root) as entries:
+            for entry in entries:
+                if entry.name == "__pycache__" or not entry.is_dir():
+                    continue
+                plugin_info_file = os.path.join(entry.path, "plugin-info.json")
+                if os.path.isfile(plugin_info_file):
+                    plugin_info_files.append(plugin_info_file)
+
+        fingerprint_parts: list[tuple[str, int, int]] = []
+        for plugin_info_file in sorted(plugin_info_files):
+            try:
+                stat = os.stat(plugin_info_file)
+            except OSError:
+                continue
+            fingerprint_parts.append((plugin_info_file, stat.st_mtime_ns, stat.st_size))
+
+        fingerprint = tuple(fingerprint_parts)
+        if (
+            fingerprint == self._plugins_list_cache_fingerprint
+            and self._plugins_list_cache_data is not None
+        ):
+            return [plugin.copy() for plugin in self._plugins_list_cache_data]
+
+        plugins_list: list[dict[str, Any]] = []
+        for plugin_info_file, _mtime_ns, _size in fingerprint:
+            logger.debug(f"Reading plugin info from {plugin_info_file}")
+            with open(plugin_info_file) as f:
+                plugin_info = cast(dict[str, Any], json.load(f))
+            plugins_list.append(plugin_info)
+
+        self._plugins_list_cache_fingerprint = fingerprint
+        self._plugins_list_cache_data = [plugin.copy() for plugin in plugins_list]
         return plugins_list
 
     def write_config(self) -> None:

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -11,7 +11,7 @@ from time import perf_counter
 
 from flask import Flask, g, url_for as flask_url_for
 from jinja2 import ChoiceLoader, FileSystemLoader
-from waitress import serve  # type: ignore[import-untyped]
+from waitress import serve
 from werkzeug.serving import is_running_from_reloader
 
 from app_setup.asset_helpers import setup_asset_helpers

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -39,6 +39,7 @@ IMAGE_MODELS = [
 ]
 DEFAULT_IMAGE_MODEL = OPENAI_IMAGE_MODEL_2
 DEFAULT_IMAGE_QUALITY = "medium"
+FALLBACK_IMAGE_PROMPT = "A vivid imaginative scene, high detail."
 
 
 class AIImage(BasePlugin):
@@ -233,6 +234,13 @@ class AIImage(BasePlugin):
         logger.info(f"Remixed prompt: '{randomized}'")
         return randomized
 
+    def _ensure_image_prompt(self, text_prompt: str) -> str:
+        prompt = text_prompt.strip()
+        if prompt:
+            return prompt
+        logger.warning("Prompt remix returned no usable prompt; using fallback prompt.")
+        return FALLBACK_IMAGE_PROMPT
+
     def _generate_google_image(
         self, device_config: Any, text_prompt: str, image_model: str, randomize: bool
     ) -> ImageType:
@@ -247,6 +255,7 @@ class AIImage(BasePlugin):
         prompt = self._maybe_randomize_google_prompt(
             google_client, text_prompt, randomize
         )
+        prompt = self._ensure_image_prompt(prompt)
         logger.info(f"Generating image with {image_model}...")
         return self.fetch_image_google(google_client, prompt, image_model)
 
@@ -266,6 +275,7 @@ class AIImage(BasePlugin):
 
         ai_client = OpenAI(api_key=api_key)
         prompt = self._maybe_randomize_openai_prompt(ai_client, text_prompt, randomize)
+        prompt = self._ensure_image_prompt(prompt)
         logger.info(f"Generating image with {image_model}...")
         return self.fetch_image(
             ai_client,

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -19,6 +19,7 @@ from plugins.base_plugin.settings_schema import (
     row,
     schema,
     section,
+    widget,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,10 +43,12 @@ DEFAULT_IMAGE_QUALITY = "medium"
 
 class AIImage(BasePlugin):
     def validate_settings(self, settings: Mapping[str, object]) -> str | None:
-        """Reject empty prompts at save time so bad input does not persist."""
-        err: str | None = validate_required_text(settings, "textPrompt", "Prompt")
-        if err:
-            return err
+        """Validate provider/model choices and prompt requirements."""
+        randomize_prompt = settings.get("randomizePrompt") == "true"
+        if not randomize_prompt:
+            err: str | None = validate_required_text(settings, "textPrompt", "Prompt")
+            if err:
+                return err
 
         err = validate_provider(settings)
         if err:
@@ -70,15 +73,18 @@ class AIImage(BasePlugin):
                     "textarea",
                     label="Prompt",
                     placeholder="A surreal breakfast floating through a neon sky.",
-                    hint="Describe the scene you want the model to render. Bold, simple compositions read best on e-ink.",
-                    required=True,
+                    hint="Describe the scene you want, or use Surprise me to draft one automatically. Bold, simple compositions read best on e-ink.",
                     rows=4,
+                ),
+                widget(
+                    "ai-image-prompt-tools",
+                    template="widgets/ai_image_prompt_tools.html",
                 ),
                 field(
                     "randomizePrompt",
                     "checkbox",
-                    label="Remix prompt before generating",
-                    hint="Pass your prompt through a writing model first to add vivid detail and unexpected styling.",
+                    label="Vivid remix",
+                    hint="Before image generation, let the selected provider turn your prompt into a more vivid version. If the prompt is blank, it will invent one.",
                     submit_unchecked=True,
                     checked_value="true",
                     unchecked_value="false",
@@ -283,6 +289,8 @@ class AIImage(BasePlugin):
             text_prompt = ""
         image_model, image_quality = self._validate_generate_inputs(settings, provider)
         randomize_prompt = settings.get("randomizePrompt") == "true"
+        if not text_prompt.strip() and not randomize_prompt:
+            raise RuntimeError("Prompt is required unless Vivid remix is enabled.")
         orientation = device_config.get_config("orientation")
         if not isinstance(orientation, str):
             orientation = "horizontal"

--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -184,7 +184,7 @@ class Apod(BasePlugin):
                 image_url,
                 dimensions=dimensions,
                 timeout_ms=timeout_ms,
-                resize=False,
+                resize=True,
             )
             if image is not None:
                 selected_image_url = image_url

--- a/src/plugins/clock/clock.py
+++ b/src/plugins/clock/clock.py
@@ -3,7 +3,6 @@ import math
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, cast
-from zoneinfo import ZoneInfo
 
 import numpy as np
 from PIL import Image, ImageColor, ImageDraw
@@ -11,6 +10,7 @@ from PIL import Image, ImageColor, ImageDraw
 from plugins.base_plugin.base_plugin import BasePlugin, DeviceConfigLike
 from plugins.base_plugin.settings_schema import field, row, schema, section, widget
 from utils.app_utils import get_font
+from utils.time_utils import get_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -58,22 +58,24 @@ class Clock(BasePlugin):
                     field(
                         "primaryColor",
                         "color",
-                        label="Primary Color",
+                        label="Face accent color",
                         default=CLOCK_FACES[0]["primary_color"],
                     ),
                     field(
                         "secondaryColor",
                         "color",
-                        label="Secondary Color",
+                        label="Face background color",
                         default=CLOCK_FACES[0]["secondary_color"],
                     ),
                 ),
+                description="These colors are used by the clock face itself.",
             ),
         )
 
     def generate_settings_template(self) -> dict[str, object]:
         template_params = super().generate_settings_template()
         template_params["clock_faces"] = CLOCK_FACES
+        template_params["style_settings"] = False
         return template_params
 
     def generate_image(
@@ -105,7 +107,7 @@ class Clock(BasePlugin):
 
         timezone_name = device_config.get_config("timezone") or DEFAULT_TIMEZONE
         tz_name = timezone_name if isinstance(timezone_name, str) else DEFAULT_TIMEZONE
-        tz = ZoneInfo(tz_name)
+        tz = get_timezone(tz_name)
         current_time = datetime.now(tz)
 
         img = None

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -921,24 +921,35 @@ class RefreshTask:
         return "".join(ch if ch.isalnum() else "_" for ch in plugin_id).upper()
 
     @classmethod
-    def _plugin_timeout_seconds(cls, plugin_id: str) -> float:
+    def _env_seconds_with_precedence(
+        cls,
+        plugin_id: str,
+        env_key: str,
+        defaults: Mapping[str, float],
+    ) -> float:
         suffix = cls._plugin_env_suffix(plugin_id)
-        specific_key = f"INKYPI_PLUGIN_TIMEOUT_S_{suffix}"
+        specific_key = f"{env_key}_{suffix}"
         if specific_key in os.environ:
-            return float(os.getenv(specific_key, "60") or "60")
-        if "INKYPI_PLUGIN_TIMEOUT_S" in os.environ:
-            return float(os.getenv("INKYPI_PLUGIN_TIMEOUT_S", "60") or "60")
-        return _PLUGIN_TIMEOUT_DEFAULTS_S.get(plugin_id, 60.0)
+            return float(os.getenv(specific_key) or "60")
+        if env_key in os.environ:
+            return float(os.getenv(env_key) or "60")
+        return defaults.get(plugin_id, 60.0)
+
+    @classmethod
+    def _plugin_timeout_seconds(cls, plugin_id: str) -> float:
+        return cls._env_seconds_with_precedence(
+            plugin_id,
+            "INKYPI_PLUGIN_TIMEOUT_S",
+            _PLUGIN_TIMEOUT_DEFAULTS_S,
+        )
 
     @classmethod
     def _manual_update_wait_seconds(cls, plugin_id: str) -> float:
-        suffix = cls._plugin_env_suffix(plugin_id)
-        specific_key = f"INKYPI_MANUAL_UPDATE_WAIT_S_{suffix}"
-        if specific_key in os.environ:
-            return float(os.getenv(specific_key, "60") or "60")
-        if "INKYPI_MANUAL_UPDATE_WAIT_S" in os.environ:
-            return float(os.getenv("INKYPI_MANUAL_UPDATE_WAIT_S", "60") or "60")
-        return _MANUAL_WAIT_DEFAULTS_S.get(plugin_id, 60.0)
+        return cls._env_seconds_with_precedence(
+            plugin_id,
+            "INKYPI_MANUAL_UPDATE_WAIT_S",
+            _MANUAL_WAIT_DEFAULTS_S,
+        )
 
     def manual_update(self, refresh_action: RefreshAction) -> dict[str, Any] | None:
         """Manually triggers an update for the specified plugin id and plugin settings by notifying the background process."""

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -64,6 +64,18 @@ except Exception:
 
 logger = logging.getLogger(__name__)
 
+_PLUGIN_TIMEOUT_DEFAULTS_S = {
+    # OpenAI/Google image generation routinely takes longer than the generic
+    # 60s guard, especially when a prompt remix runs first.
+    "ai_image": 180.0,
+}
+_MANUAL_WAIT_DEFAULTS_S = {
+    # Wait for the generated image to be saved, not the slow e-paper write.
+    # Keep this slightly above the plugin timeout so the caller sees the
+    # plugin's real result instead of a queue wait timeout.
+    "ai_image": 210.0,
+}
+
 
 class RefreshTask:
     """Handles the logic for refreshing the display using a background thread."""
@@ -904,6 +916,30 @@ class RefreshTask:
             raise exc
         raise RuntimeError(str(exc))
 
+    @staticmethod
+    def _plugin_env_suffix(plugin_id: str) -> str:
+        return "".join(ch if ch.isalnum() else "_" for ch in plugin_id).upper()
+
+    @classmethod
+    def _plugin_timeout_seconds(cls, plugin_id: str) -> float:
+        suffix = cls._plugin_env_suffix(plugin_id)
+        specific_key = f"INKYPI_PLUGIN_TIMEOUT_S_{suffix}"
+        if specific_key in os.environ:
+            return float(os.getenv(specific_key, "60") or "60")
+        if "INKYPI_PLUGIN_TIMEOUT_S" in os.environ:
+            return float(os.getenv("INKYPI_PLUGIN_TIMEOUT_S", "60") or "60")
+        return _PLUGIN_TIMEOUT_DEFAULTS_S.get(plugin_id, 60.0)
+
+    @classmethod
+    def _manual_update_wait_seconds(cls, plugin_id: str) -> float:
+        suffix = cls._plugin_env_suffix(plugin_id)
+        specific_key = f"INKYPI_MANUAL_UPDATE_WAIT_S_{suffix}"
+        if specific_key in os.environ:
+            return float(os.getenv(specific_key, "60") or "60")
+        if "INKYPI_MANUAL_UPDATE_WAIT_S" in os.environ:
+            return float(os.getenv("INKYPI_MANUAL_UPDATE_WAIT_S", "60") or "60")
+        return _MANUAL_WAIT_DEFAULTS_S.get(plugin_id, 60.0)
+
     def manual_update(self, refresh_action: RefreshAction) -> dict[str, Any] | None:
         """Manually triggers an update for the specified plugin id and plugin settings by notifying the background process."""
         if not self.running:
@@ -914,7 +950,7 @@ class RefreshTask:
 
         request = self._enqueue_manual_request(refresh_action)
 
-        wait_s = float(os.getenv("INKYPI_MANUAL_UPDATE_WAIT_S", "60") or "60")
+        wait_s = self._manual_update_wait_seconds(refresh_action.get_plugin_id())
         # JTN-786: wait for the image to hit disk rather than for the full
         # refresh (including the slow e-paper SPI write) to finish.
         # ``image_saved`` is also set by ``_complete_manual_request`` on any
@@ -1145,7 +1181,7 @@ class RefreshTask:
         plugin_id = refresh_action.get_plugin_id()
         retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
         backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
-        timeout_s = float(os.getenv("INKYPI_PLUGIN_TIMEOUT_S", "60") or "60")
+        timeout_s = self._plugin_timeout_seconds(plugin_id)
         attempts = max(1, retries + 1)
 
         # When isolation is disabled (e.g. in tests or on constrained devices),
@@ -1305,7 +1341,7 @@ class RefreshTask:
         plugin_id = refresh_action.get_plugin_id()
         retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
         backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
-        timeout_s = float(os.getenv("INKYPI_PLUGIN_TIMEOUT_S", "60") or "60")
+        timeout_s = self._plugin_timeout_seconds(plugin_id)
         attempts = max(1, retries + 1)
 
         last_exc: BaseException | None = None

--- a/src/static/scripts/playlist/form.js
+++ b/src/static/scripts/playlist/form.js
@@ -180,7 +180,13 @@
     if (!newName) return;
     if (!validateCycleMinutes()) return;
     const startTime = document.getElementById("start_time").value;
-    const endTime = document.getElementById("end_time").value;
+    const endInput = document.getElementById("end_time");
+    const originalEndTime =
+      document.getElementById("playlistModal")?.dataset.originalEndTime || "";
+    const endTime =
+      originalEndTime === "24:00" && endInput.value === "23:59"
+        ? "24:00"
+        : endInput.value;
     const cycleMinutes = document.getElementById("cycle_minutes").value;
 
     const submit = async () => {

--- a/src/static/scripts/playlist/modals.js
+++ b/src/static/scripts/playlist/modals.js
@@ -206,7 +206,10 @@
     document.getElementById("end_time").value = "17:00";
     const cycleInput = document.getElementById("cycle_minutes");
     if (cycleInput) cycleInput.value = "";
-    if (modal) modal.dataset.mode = "create";
+    if (modal) {
+      modal.dataset.mode = "create";
+      delete modal.dataset.originalEndTime;
+    }
     document.getElementById("deleteButton").classList.add("hidden");
     setModalOpen("playlistModal", true, triggerEl);
   }
@@ -228,7 +231,10 @@
     document.getElementById("end_time").value = ns.normaliseTimeForInput(endTime);
     const cycleInput = document.getElementById("cycle_minutes");
     if (cycleInput) cycleInput.value = cycleMinutes || "";
-    if (modal) modal.dataset.mode = "edit";
+    if (modal) {
+      modal.dataset.mode = "edit";
+      modal.dataset.originalEndTime = endTime || "";
+    }
     document.getElementById("deleteButton").classList.remove("hidden");
     setModalOpen("playlistModal", true, triggerEl);
   }

--- a/src/static/scripts/plugin_page.js
+++ b/src/static/scripts/plugin_page.js
@@ -161,10 +161,12 @@
       const active = btn.dataset.pluginSubtab === id;
       btn.classList.toggle("active", active);
       btn.setAttribute("aria-selected", active ? "true" : "false");
+      btn.setAttribute("tabindex", active ? "0" : "-1");
     });
     document.querySelectorAll("[data-plugin-subpanel]").forEach((panel) => {
       const active = panel.dataset.pluginSubpanel === id;
       panel.hidden = !active;
+      panel.setAttribute("aria-hidden", active ? "false" : "true");
     });
   }
 
@@ -564,7 +566,9 @@
     }
 
     function selectedFrame(element) {
-      const previous = document.querySelector(".image-option.selected");
+      const previous = document.querySelector(
+        "#frame-selection .image-option.selected"
+      );
       if (previous) previous.classList.remove("selected");
       element.classList.add("selected");
       document.getElementById("selected-frame").value =
@@ -606,6 +610,20 @@
       if (!config.styleSettings || !config.loadPluginSettings) return;
       const settings = config.pluginSettings || {};
       Object.entries(settings).forEach(([key, value]) => {
+        if (key === "selectedFrame") {
+          const frameOption = document.querySelector(
+            `#frame-selection .image-option[data-face-name="${CSS.escape(String(value))}"]`
+          );
+          if (frameOption) selectedFrame(frameOption);
+          return;
+        }
+        if (key === "backgroundOption") {
+          const radio = document.querySelector(
+            `[name="backgroundOption"][value="${CSS.escape(String(value))}"]`
+          );
+          if (radio) radio.checked = true;
+          return;
+        }
         const input = document.getElementById(key);
         if (!input || value == null || value === "") return;
         if (input.type === "checkbox") {
@@ -908,10 +926,37 @@
       setPluginSubtab(event.currentTarget.dataset.pluginSubtab);
     }
 
+    function onSubtabButtonKeydown(event) {
+      if (
+        event.key !== "ArrowRight" &&
+        event.key !== "ArrowLeft" &&
+        event.key !== "Home" &&
+        event.key !== "End"
+      ) {
+        return;
+      }
+      const buttons = Array.from(document.querySelectorAll("[data-plugin-subtab]"));
+      const currentIndex = buttons.indexOf(event.currentTarget);
+      if (currentIndex < 0) return;
+      event.preventDefault();
+      let nextIndex = currentIndex;
+      if (event.key === "ArrowRight") nextIndex = (currentIndex + 1) % buttons.length;
+      if (event.key === "ArrowLeft")
+        nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+      if (event.key === "Home") nextIndex = 0;
+      if (event.key === "End") nextIndex = buttons.length - 1;
+      const nextButton = buttons[nextIndex];
+      setPluginSubtab(nextButton.dataset.pluginSubtab);
+      nextButton.focus();
+    }
+
     function bindPluginSubtabs() {
       const buttons = document.querySelectorAll("[data-plugin-subtab]");
       if (!buttons.length) return;
       buttons.forEach((btn) => btn.addEventListener("click", onSubtabButtonClick));
+      buttons.forEach((btn) =>
+        btn.addEventListener("keydown", onSubtabButtonKeydown)
+      );
       setPluginSubtab("configure");
     }
 

--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -154,7 +154,11 @@
     };
 
     const selectOption = (option) => {
-      options.forEach((item) => item.classList.toggle("selected", item === option));
+      options.forEach((item) => {
+        const selected = item === option;
+        item.classList.toggle("selected", selected);
+        item.setAttribute("aria-pressed", selected ? "true" : "false");
+      });
       hidden.value = option.dataset.faceName || "";
       setColor(primary, option.dataset.primaryColor);
       setColor(secondary, option.dataset.secondaryColor);
@@ -170,6 +174,52 @@
 
     if (config.primaryColor) setColor(primary, config.primaryColor);
     if (config.secondaryColor) setColor(secondary, config.secondaryColor);
+  }
+
+  function initAIImagePromptTools(widget) {
+    const button = widget.querySelector("[data-ai-image-random-prompt]");
+    const promptInput = document.querySelector("[name='textPrompt']");
+    if (!button || !promptInput) return;
+
+    button.addEventListener("click", async () => {
+      const provider = document.querySelector("[name='provider']")?.value || "openai";
+      const originalText = button.textContent;
+      button.disabled = true;
+      button.textContent = "Thinking...";
+      try {
+        const response = await fetch(
+          window.__INKYPI_PLUGIN_BOOT__?.urls?.random_prompt ||
+            "/plugin/ai_image/random_prompt",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              provider,
+              prompt: promptInput.value || "",
+            }),
+          }
+        );
+        const result = await response.json();
+        if (!response.ok || !result?.success || !result.prompt) {
+          throw new Error(result?.error || "Failed to generate a prompt");
+        }
+        promptInput.value = result.prompt;
+        promptInput.dispatchEvent(new Event("input", { bubbles: true }));
+        promptInput.dispatchEvent(new Event("change", { bubbles: true }));
+        promptInput.focus();
+      } catch (error) {
+        console.debug("AI image random prompt failed:", error);
+        if (window.showResponseModal) {
+          window.showResponseModal(
+            "failure",
+            error.message || "Failed to generate a prompt"
+          );
+        }
+      } finally {
+        button.disabled = false;
+        button.textContent = originalText;
+      }
+    });
   }
 
   function initNewspaperSearch(widget, config) {
@@ -548,6 +598,7 @@
 
   const widgetInitializers = {
     "clock-face-picker": initClockFacePicker,
+    "ai-image-prompt-tools": initAIImagePromptTools,
     "newspaper-search": initNewspaperSearch,
     "calendar-repeater": initCalendarRepeater,
     "todo-repeater": initTodoRepeater,

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -105,14 +105,14 @@
         <div class="workflow-layout" data-workflow-layout>
         <section class="workflow-main-panel" data-workflow-panel="configure">
         <div class="plugin-subtab-bar" role="tablist" aria-label="Plugin configuration sections">
-            <button type="button" class="plugin-subtab active" role="tab" aria-selected="true" data-plugin-subtab="configure">Configure</button>
+            <button type="button" id="pluginConfigureTab" class="plugin-subtab active" role="tab" aria-selected="true" aria-controls="pluginConfigurePanel" data-plugin-subtab="configure">Configure</button>
             {% if style_settings %}
-            <button type="button" class="plugin-subtab" role="tab" aria-selected="false" data-plugin-subtab="style">Style</button>
+            <button type="button" id="pluginStyleTab" class="plugin-subtab" role="tab" aria-selected="false" aria-controls="pluginStylePanel" tabindex="-1" data-plugin-subtab="style">Style</button>
             {% endif %}
-            <button type="button" class="plugin-subtab" role="tab" aria-selected="false" data-plugin-subtab="schedule">Schedule</button>
+            <button type="button" id="pluginScheduleTab" class="plugin-subtab" role="tab" aria-selected="false" aria-controls="pluginSchedulePanel" tabindex="-1" data-plugin-subtab="schedule">Schedule</button>
         </div>
         <form id="settingsForm" class="settings-form workflow-settings-form" action="{{ url_for('plugin.save_plugin_settings') }}" method="post" aria-label="Plugin settings for {{ plugin.display_name }}" novalidate>
-            <div class="settings-container plugin-subpanel" data-plugin-subpanel="configure">
+            <div id="pluginConfigurePanel" class="settings-container plugin-subpanel" role="tabpanel" aria-labelledby="pluginConfigureTab" data-plugin-subpanel="configure">
                 <div class="workflow-section-header">
                     <h2>Configuration</h2>
                     <p>Adjust content and presentation settings before generating a new preview.</p>
@@ -205,7 +205,7 @@
             </div>
 
             {% if style_settings %}
-            <div class="settings-container plugin-subpanel" data-plugin-subpanel="style" hidden>
+            <div id="pluginStylePanel" class="settings-container plugin-subpanel" role="tabpanel" aria-labelledby="pluginStyleTab" data-plugin-subpanel="style" hidden aria-hidden="true">
                 <div class="workflow-section-header">
                     <h2>Style</h2>
                     <p>Frame, margins, and colors applied to the rendered image.</p>
@@ -286,7 +286,7 @@
             <input type="hidden" name="instance_name" value="{{ plugin_instance }}">
             {% endif %}
         </form>
-        <div id="pluginSchedulePanel" class="settings-container plugin-subpanel plugin-schedule-panel" data-plugin-subpanel="schedule" hidden>
+        <div id="pluginSchedulePanel" class="settings-container plugin-subpanel plugin-schedule-panel" role="tabpanel" aria-labelledby="pluginScheduleTab" data-plugin-subpanel="schedule" hidden aria-hidden="true">
             <div class="workflow-section-header">
                 <h2>Schedule</h2>
                 {% if plugin_instance %}
@@ -501,6 +501,7 @@
             styleSettings: {{ style_settings | default(false) | tojson }},
             urls: {
                 add_to_playlist: {{ url_for('playlist.add_plugin') | tojson }},
+                random_prompt: {{ url_for("plugin.ai_image_random_prompt") | tojson }},
                 save_settings: {{ url_for("plugin.save_plugin_settings") | tojson }},
                 update_instance: {{ url_for('plugin.update_plugin_instance', instance_name=(plugin_instance or '')) | tojson }},
                 update_now: {{ url_for("plugin.update_now") | tojson }},

--- a/src/templates/widgets/ai_image_prompt_tools.html
+++ b/src/templates/widgets/ai_image_prompt_tools.html
@@ -1,0 +1,13 @@
+<div class="ai-image-prompt-tools" data-ai-image-prompt-tools>
+    <button
+        type="button"
+        class="action-button is-secondary compact"
+        data-ai-image-random-prompt
+        aria-describedby="ai-image-random-prompt-help"
+    >
+        Surprise me
+    </button>
+    <small id="ai-image-random-prompt-help" class="field-note">
+        Draft a fresh prompt from the selected provider. Add a few words first to steer it.
+    </small>
+</div>

--- a/src/templates/widgets/clock_face_picker.html
+++ b/src/templates/widgets/clock_face_picker.html
@@ -8,6 +8,7 @@
             data-face-name="{{ face.name }}"
             data-primary-color="{{ face.primary_color }}"
             data-secondary-color="{{ face.secondary_color }}"
+            aria-pressed="false"
             aria-label="Select {{ face.name }}"
         >
             <img src="{{ url_for('plugin.image', plugin_id='clock', filename=face.icon) }}" alt="{{ face.name }}">

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -47,6 +47,7 @@ class PlaylistCreateRequest:
     end_time: str
     start_min: int
     end_min: int
+    cycle_minutes_int: int | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -270,6 +271,10 @@ def parse_playlist_create_request(
     if time_err is not None or start_min is None or end_min is None:
         return None, time_err
 
+    cycle_minutes_int, cycle_err = validate_cycle_minutes(data.get("cycle_minutes"))
+    if cycle_err is not None:
+        return None, cycle_err
+
     return (
         PlaylistCreateRequest(
             playlist_name=playlist_name,
@@ -277,6 +282,7 @@ def parse_playlist_create_request(
             end_time=str(end_time),
             start_min=start_min,
             end_min=end_min,
+            cycle_minutes_int=cycle_minutes_int,
         ),
         None,
     )

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -1,0 +1,404 @@
+"""Typed request models for high-churn mutating routes."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from model import Playlist
+from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
+
+CODE_VALIDATION = "validation_error"
+PLAYLIST_NAME_MAX_LEN = 64
+PLAYLIST_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]+$", re.ASCII)
+PLAYLIST_NAME_FORMAT_ERROR = (
+    "Playlist name can only contain ASCII letters, "
+    "numbers, spaces, underscores, and hyphens"
+)
+INVALID_TIME_FORMAT_MESSAGE = "Invalid start/end time format"
+SAME_TIME_MESSAGE = "Start time and End time cannot be the same"
+CYCLE_MINUTES_MIN = 1
+CYCLE_MINUTES_MAX = 1440
+
+
+@dataclass(frozen=True, slots=True)
+class RequestModelError:
+    """Structured validation error for request model parsing."""
+
+    message: str
+    status: int = 400
+    code: str = CODE_VALIDATION
+    field: str | None = None
+
+    @property
+    def details(self) -> dict[str, str]:
+        if self.field is None:
+            return {}
+        return {"field": self.field}
+
+
+@dataclass(frozen=True, slots=True)
+class PlaylistCreateRequest:
+    """Validated payload for creating a playlist."""
+
+    playlist_name: str
+    start_time: str
+    end_time: str
+    start_min: int
+    end_min: int
+
+
+@dataclass(frozen=True, slots=True)
+class PlaylistUpdateRequest:
+    """Validated payload for updating a playlist."""
+
+    new_name: str
+    start_time: str
+    end_time: str
+    start_min: int
+    end_min: int
+    cycle_minutes_int: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeysSaveRequest:
+    """Validated payload for saving API key entries."""
+
+    entries: list[Any]
+
+
+@dataclass(frozen=True, slots=True)
+class PluginOrderRequest:
+    """Validated dashboard plugin order payload."""
+
+    order: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceCycleRequest:
+    """Validated device refresh cadence payload."""
+
+    minutes: int
+
+
+@dataclass(frozen=True, slots=True)
+class PlaylistPluginOrderItem:
+    """A plugin instance position in a playlist reorder request."""
+
+    plugin_id: str
+    name: str
+
+    def as_payload(self) -> dict[str, str]:
+        return {"plugin_id": self.plugin_id, "name": self.name}
+
+
+@dataclass(frozen=True, slots=True)
+class PlaylistReorderRequest:
+    """Validated payload for playlist plugin reordering."""
+
+    playlist_name: str
+    ordered: list[PlaylistPluginOrderItem]
+
+    def ordered_payload(self) -> list[dict[str, str]]:
+        return [item.as_payload() for item in self.ordered]
+
+
+@dataclass(frozen=True, slots=True)
+class PlaylistNameRequest:
+    """Validated payload for playlist actions that only need a name."""
+
+    playlist_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class PluginInstanceActionRequest:
+    """Validated payload for actions against one plugin instance."""
+
+    playlist_name: str
+    plugin_id: str | None
+    plugin_instance: str | None
+
+
+def validate_playlist_name(
+    name: Any, *, field: str = "playlist_name"
+) -> tuple[str | None, RequestModelError | None]:
+    """Validate a playlist name and return its stripped value."""
+    if not isinstance(name, str) or not name.strip():
+        return None, RequestModelError(PLAYLIST_NAME_REQUIRED_ERROR, field=field)
+
+    normalized = name.strip()
+    if len(normalized) > PLAYLIST_NAME_MAX_LEN:
+        return None, RequestModelError(
+            f"Playlist name must be {PLAYLIST_NAME_MAX_LEN} characters or fewer",
+            field=field,
+        )
+    if not PLAYLIST_NAME_RE.match(normalized):
+        return None, RequestModelError(PLAYLIST_NAME_FORMAT_ERROR, field=field)
+    return normalized, None
+
+
+def _to_minutes(time_str: str) -> int:
+    return int(Playlist._to_minutes(time_str))
+
+
+def validate_playlist_times(
+    start_time: Any, end_time: Any
+) -> tuple[int | None, int | None, RequestModelError | None]:
+    """Validate start/end playlist times and return minute offsets."""
+    if not start_time:
+        missing_field = "start_time"
+    elif not end_time:
+        missing_field = "end_time"
+    else:
+        missing_field = None
+
+    if missing_field is not None:
+        return (
+            None,
+            None,
+            RequestModelError(
+                "Start time and End time are required",
+                field=missing_field,
+            ),
+        )
+
+    try:
+        start_min = _to_minutes(str(start_time))
+    except Exception:
+        return (
+            None,
+            None,
+            RequestModelError(
+                INVALID_TIME_FORMAT_MESSAGE,
+                field="start_time",
+            ),
+        )
+    try:
+        end_min = _to_minutes(str(end_time))
+    except Exception:
+        return (
+            None,
+            None,
+            RequestModelError(
+                INVALID_TIME_FORMAT_MESSAGE,
+                field="end_time",
+            ),
+        )
+    if start_min == end_min:
+        return None, None, RequestModelError(SAME_TIME_MESSAGE, field="end_time")
+    return start_min, end_min, None
+
+
+def validate_cycle_minutes(
+    cycle_minutes: Any,
+) -> tuple[int | None, RequestModelError | None]:
+    """Validate an optional playlist cycle override in minutes."""
+    if cycle_minutes is None:
+        return None, None
+    try:
+        cycle_minutes_int = int(cycle_minutes)
+    except (ValueError, TypeError):
+        return None, RequestModelError(
+            "cycle_minutes must be an integer",
+            field="cycle_minutes",
+        )
+    if cycle_minutes_int < CYCLE_MINUTES_MIN or cycle_minutes_int > CYCLE_MINUTES_MAX:
+        return None, RequestModelError(
+            f"cycle_minutes must be between {CYCLE_MINUTES_MIN} and {CYCLE_MINUTES_MAX}",
+            field="cycle_minutes",
+        )
+    return cycle_minutes_int, None
+
+
+def parse_api_keys_save_request(
+    data: Any,
+) -> tuple[ApiKeysSaveRequest | None, RequestModelError | None]:
+    """Parse and validate the API-key save payload envelope."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid JSON payload")
+    entries = data.get("entries", [])
+    if not isinstance(entries, list):
+        return None, RequestModelError("Invalid entries format", field="entries")
+    return ApiKeysSaveRequest(entries=entries), None
+
+
+def parse_plugin_order_request(
+    data: Any,
+) -> tuple[PluginOrderRequest | None, RequestModelError | None]:
+    """Parse and validate the dashboard plugin order payload envelope."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid JSON payload")
+    order = data.get("order", [])
+    if not isinstance(order, list):
+        return None, RequestModelError("Order must be a list", field="order")
+    if any(not isinstance(item, str) for item in order):
+        return None, RequestModelError("Order entries must be strings", field="order")
+    return PluginOrderRequest(order=order), None
+
+
+def parse_device_cycle_request(
+    data: Any,
+) -> tuple[DeviceCycleRequest | None, RequestModelError | None]:
+    """Parse and validate a device refresh cadence payload."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid minutes", field="minutes")
+    minutes = data.get("minutes") or 0
+    try:
+        minutes_int = int(minutes)
+    except (ValueError, TypeError):
+        return None, RequestModelError("Invalid minutes", field="minutes")
+    if minutes_int < CYCLE_MINUTES_MIN or minutes_int > CYCLE_MINUTES_MAX:
+        return None, RequestModelError(
+            f"Minutes must be between {CYCLE_MINUTES_MIN} and {CYCLE_MINUTES_MAX}",
+            field="minutes",
+        )
+    return DeviceCycleRequest(minutes=minutes_int), None
+
+
+def parse_playlist_create_request(
+    data: dict[str, Any],
+) -> tuple[PlaylistCreateRequest | None, RequestModelError | None]:
+    """Parse and validate a create-playlist payload."""
+    playlist_name, name_err = validate_playlist_name(data.get("playlist_name"))
+    if name_err is not None or playlist_name is None:
+        return None, name_err
+
+    start_time = data.get("start_time")
+    end_time = data.get("end_time")
+    start_min, end_min, time_err = validate_playlist_times(start_time, end_time)
+    if time_err is not None or start_min is None or end_min is None:
+        return None, time_err
+
+    return (
+        PlaylistCreateRequest(
+            playlist_name=playlist_name,
+            start_time=str(start_time),
+            end_time=str(end_time),
+            start_min=start_min,
+            end_min=end_min,
+        ),
+        None,
+    )
+
+
+def parse_playlist_update_request(
+    data: dict[str, Any],
+) -> tuple[PlaylistUpdateRequest | None, RequestModelError | None]:
+    """Parse and validate an update-playlist payload."""
+    new_name, name_err = validate_playlist_name(data.get("new_name"), field="new_name")
+    if name_err is not None or new_name is None:
+        return None, name_err
+
+    start_time = data.get("start_time")
+    end_time = data.get("end_time")
+    if not start_time or not end_time:
+        missing_field = "start_time" if not start_time else "end_time"
+        return None, RequestModelError("Missing required fields", field=missing_field)
+
+    start_min, end_min, time_err = validate_playlist_times(start_time, end_time)
+    if time_err is not None or start_min is None or end_min is None:
+        return None, time_err
+
+    cycle_minutes_int, cycle_err = validate_cycle_minutes(data.get("cycle_minutes"))
+    if cycle_err is not None:
+        return None, cycle_err
+
+    return (
+        PlaylistUpdateRequest(
+            new_name=new_name,
+            start_time=str(start_time),
+            end_time=str(end_time),
+            start_min=start_min,
+            end_min=end_min,
+            cycle_minutes_int=cycle_minutes_int,
+        ),
+        None,
+    )
+
+
+def parse_playlist_reorder_request(
+    data: Any,
+) -> tuple[PlaylistReorderRequest | None, RequestModelError | None]:
+    """Parse and validate a playlist plugin reorder payload."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid or missing JSON payload")
+
+    playlist_name = data.get("playlist_name")
+    if not isinstance(playlist_name, str) or not playlist_name.strip():
+        return None, RequestModelError(
+            "playlist_name and ordered list are required",
+            field="playlist_name",
+        )
+
+    ordered = data.get("ordered")
+    if not isinstance(ordered, list):
+        return None, RequestModelError(
+            "playlist_name and ordered list are required",
+            field="ordered",
+        )
+
+    parsed_ordered: list[PlaylistPluginOrderItem] = []
+    for item in ordered:
+        if not isinstance(item, dict):
+            return None, RequestModelError("Invalid order payload", field="ordered")
+        plugin_id = item.get("plugin_id")
+        name = item.get("name")
+        if not isinstance(plugin_id, str) or not isinstance(name, str):
+            return None, RequestModelError("Invalid order payload", field="ordered")
+        parsed_ordered.append(PlaylistPluginOrderItem(plugin_id=plugin_id, name=name))
+
+    return (
+        PlaylistReorderRequest(
+            playlist_name=playlist_name.strip(),
+            ordered=parsed_ordered,
+        ),
+        None,
+    )
+
+
+def parse_playlist_name_request(
+    data: Any, *, missing_message: str
+) -> tuple[PlaylistNameRequest | None, RequestModelError | None]:
+    """Parse and validate a playlist action payload containing only a name."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid or missing JSON payload")
+    playlist_name = data.get("playlist_name")
+    if not isinstance(playlist_name, str) or not playlist_name.strip():
+        return None, RequestModelError(missing_message, field="playlist_name")
+    return PlaylistNameRequest(playlist_name=playlist_name.strip()), None
+
+
+def parse_plugin_instance_action_request(
+    data: Any,
+    *,
+    missing_playlist_message: str = PLAYLIST_NAME_REQUIRED_ERROR,
+) -> tuple[PluginInstanceActionRequest | None, RequestModelError | None]:
+    """Parse and validate a plugin-instance action payload.
+
+    ``plugin_id`` and ``plugin_instance`` stay optional here because existing
+    routes report missing or unknown instances through their lookup path. The
+    model still centralizes JSON/object and playlist-name validation.
+    """
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid or missing JSON payload")
+
+    playlist_name = data.get("playlist_name")
+    if not isinstance(playlist_name, str) or not playlist_name.strip():
+        return None, RequestModelError(
+            missing_playlist_message,
+            field="playlist_name",
+        )
+
+    plugin_id = data.get("plugin_id")
+    plugin_instance = data.get("plugin_instance")
+    return (
+        PluginInstanceActionRequest(
+            playlist_name=playlist_name.strip(),
+            plugin_id=plugin_id if isinstance(plugin_id, str) else None,
+            plugin_instance=(
+                plugin_instance if isinstance(plugin_instance, str) else None
+            ),
+        ),
+        None,
+    )

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from model import Playlist
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 
 CODE_VALIDATION = "validation_error"
@@ -140,7 +139,12 @@ def validate_playlist_name(
 
 
 def _to_minutes(time_str: str) -> int:
-    return int(Playlist._to_minutes(time_str))
+    if time_str == "24:00":
+        return 24 * 60
+    hour, minute = map(int, time_str.split(":"))
+    if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+        raise ValueError("Invalid time")
+    return hour * 60 + minute
 
 
 def validate_playlist_times(
@@ -244,7 +248,9 @@ def parse_device_cycle_request(
     """Parse and validate a device refresh cadence payload."""
     if not isinstance(data, dict):
         return None, RequestModelError("Invalid minutes", field="minutes")
-    minutes = data.get("minutes") or 0
+    if "minutes" not in data or data.get("minutes") is None:
+        return None, RequestModelError("Minutes is required", field="minutes")
+    minutes = data["minutes"]
     try:
         minutes_int = int(minutes)
     except (ValueError, TypeError):
@@ -298,10 +304,6 @@ def parse_playlist_update_request(
 
     start_time = data.get("start_time")
     end_time = data.get("end_time")
-    if not start_time or not end_time:
-        missing_field = "start_time" if not start_time else "end_time"
-        return None, RequestModelError("Missing required fields", field=missing_field)
-
     start_min, end_min, time_err = validate_playlist_times(start_time, end_time)
     if time_err is not None or start_min is None or end_min is None:
         return None, time_err

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -342,7 +342,7 @@ def parse_playlist_reorder_request(
     ordered = data.get("ordered")
     if not isinstance(ordered, list):
         return None, RequestModelError(
-            "playlist_name and ordered list are required",
+            "ordered list is required",
             field="ordered",
         )
 

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -1,4 +1,5 @@
 # pyright: reportMissingImports=false
+from typing import Any
 
 
 def test_playlist_page_renders(client):
@@ -30,7 +31,9 @@ def test_create_update_delete_playlist_flow(client):
     assert resp.status_code == 200
 
 
-def test_create_playlist_persists_cycle_override(client, device_config_dev):
+def test_create_playlist_persists_cycle_override(
+    client: Any, device_config_dev: Any
+) -> None:
     payload = {
         "playlist_name": "FastLoop",
         "start_time": "06:00",

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -30,6 +30,21 @@ def test_create_update_delete_playlist_flow(client):
     assert resp.status_code == 200
 
 
+def test_create_playlist_persists_cycle_override(client, device_config_dev):
+    payload = {
+        "playlist_name": "FastLoop",
+        "start_time": "06:00",
+        "end_time": "09:00",
+        "cycle_minutes": 12,
+    }
+
+    resp = client.post("/create_playlist", json=payload)
+
+    assert resp.status_code == 200
+    playlist = device_config_dev.get_playlist_manager().get_playlist("FastLoop")
+    assert playlist.cycle_interval_seconds == 12 * 60
+
+
 def test_delete_default_playlist_is_refused(client, device_config_dev):
     """JTN-781: DELETE /delete_playlist/Default must return 400 and keep the playlist."""
     pm = device_config_dev.get_playlist_manager()

--- a/tests/integration/test_plugin_pages.py
+++ b/tests/integration/test_plugin_pages.py
@@ -1,4 +1,5 @@
 # pyright: reportMissingImports=false
+from typing import Any
 
 
 def test_plugin_page_ai_text(client):
@@ -10,7 +11,7 @@ def test_plugin_page_ai_text(client):
     assert b"/preview" in resp.data
 
 
-def test_plugin_page_ai_image(client):
+def test_plugin_page_ai_image(client: Any) -> None:
     resp = client.get("/plugin/ai_image")
     assert resp.status_code == 200
     assert b"AI Image" in resp.data or b"Image Model" in resp.data
@@ -19,7 +20,9 @@ def test_plugin_page_ai_image(client):
     assert b"data-ai-image-random-prompt" in resp.data
 
 
-def test_clock_page_hides_generic_style_tab_and_labels_face_colors(client):
+def test_clock_page_hides_generic_style_tab_and_labels_face_colors(
+    client: Any,
+) -> None:
     resp = client.get("/plugin/clock")
     assert resp.status_code == 200
     body = resp.data.decode("utf-8")
@@ -31,7 +34,7 @@ def test_clock_page_hides_generic_style_tab_and_labels_face_colors(client):
     assert 'aria-pressed="false"' in body
 
 
-def test_plugin_tabs_have_tabpanel_wiring(client):
+def test_plugin_tabs_have_tabpanel_wiring(client: Any) -> None:
     resp = client.get("/plugin/ai_text")
     assert resp.status_code == 200
     body = resp.data.decode("utf-8")

--- a/tests/integration/test_plugin_pages.py
+++ b/tests/integration/test_plugin_pages.py
@@ -15,6 +15,32 @@ def test_plugin_page_ai_image(client):
     assert resp.status_code == 200
     assert b"AI Image" in resp.data or b"Image Model" in resp.data
     assert b"/preview" in resp.data
+    assert b"Surprise me" in resp.data
+    assert b"data-ai-image-random-prompt" in resp.data
+
+
+def test_clock_page_hides_generic_style_tab_and_labels_face_colors(client):
+    resp = client.get("/plugin/clock")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    assert 'data-plugin-subtab="style"' not in body
+    assert "Face accent color" in body
+    assert "Face background color" in body
+    assert "These colors are used by the clock face itself." in body
+    assert 'aria-pressed="false"' in body
+
+
+def test_plugin_tabs_have_tabpanel_wiring(client):
+    resp = client.get("/plugin/ai_text")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+
+    assert 'id="pluginConfigureTab"' in body
+    assert 'aria-controls="pluginConfigurePanel"' in body
+    assert 'id="pluginConfigurePanel"' in body
+    assert 'role="tabpanel"' in body
+    assert 'aria-labelledby="pluginConfigureTab"' in body
 
 
 def test_plugin_page_apod(client):

--- a/tests/mutmut_suppressions.md
+++ b/tests/mutmut_suppressions.md
@@ -9,7 +9,7 @@ headings below for the specific sections.
 See `docs/mutation_testing.md` for the mutation-testing setup, CI schedule,
 and triage workflow. The source tracking issue is **JTN-595**.
 
-## Status of the nightly artifact (JTN-595, 2026-04-19)
+## Status of the nightly artifact (JTN-595, 2026-04-19 through 2026-04-25)
 
 The `mutation-nightly` job in `.github/workflows/ci.yml` has **never produced
 a usable `mutmut-cache` artifact** since the JTN-508 `paths_to_mutate`
@@ -32,9 +32,10 @@ artifact. That bug is fixed in the same PR that landed this file — see
   files in the expanded scope (`src/utils/`, `src/blueprints/`), targeting
   patterns that a surface-level mutmut run would obviously surface.
 
-Once the nightly workflow is sharded so it fits in budget, a follow-up
-triage pass can replace the entries here with real mutant IDs drawn from
-the artifact.
+The nightly workflow is now sharded by package (`app-setup`, `blueprints`,
+`utils`, `refresh-task`) so future scheduled runs can produce package-scoped
+artifacts instead of timing out as one monolithic pass. A follow-up triage pass
+can replace the entries here with real mutant IDs drawn from those artifacts.
 
 ## Killed in JTN-595 (2026-04-19)
 
@@ -66,13 +67,12 @@ to `"CSP violation %s"`. We deliberately do not assert on log-line
 punctuation because doing so would couple tests to cosmetic details and
 add noise without catching real regressions.
 
-### Deferred — full nightly triage pending workflow fix
+### Deferred — sharded nightly triage pending artifact review
 
-The substantive deferred work is running a full, budgeted nightly pass
-once the mutation-nightly job is sharded and its artifact is published.
-At that point, a follow-up issue should:
+The substantive deferred work is reviewing the first successful sharded
+nightly artifacts. At that point, a follow-up issue should:
 
-1. Download the `mutmut-cache` artifact from the nightly run.
+1. Download the `mutmut-cache-<shard>` artifacts from the nightly run.
 2. Iterate `mutmut results` → `mutmut show <id>` for each survivor.
 3. Append each survivor here under a **Deferred** heading, or kill it.
 

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -1,6 +1,7 @@
 # pyright: reportMissingImports=false
 import base64
 from io import BytesIO
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -96,7 +97,7 @@ def test_ai_image_validate_settings_rejects_provider_model_mismatch():
     assert "google" in error
 
 
-def test_ai_image_validate_settings_uses_default_model_for_openai():
+def test_ai_image_validate_settings_uses_default_model_for_openai() -> None:
     from plugins.ai_image.ai_image import AIImage
 
     plugin = AIImage({"id": "ai_image"})
@@ -105,7 +106,9 @@ def test_ai_image_validate_settings_uses_default_model_for_openai():
     )
 
 
-def test_ai_image_validate_settings_allows_blank_prompt_when_vivid_remix_enabled():
+def test_ai_image_validate_settings_allows_blank_prompt_when_vivid_remix_enabled() -> (
+    None
+):
     from plugins.ai_image.ai_image import AIImage
 
     plugin = AIImage({"id": "ai_image"})
@@ -122,7 +125,7 @@ def test_ai_image_validate_settings_allows_blank_prompt_when_vivid_remix_enabled
     )
 
 
-def test_ai_image_validate_settings_rejects_blank_prompt_without_vivid_remix():
+def test_ai_image_validate_settings_rejects_blank_prompt_without_vivid_remix() -> None:
     from plugins.ai_image.ai_image import AIImage
 
     plugin = AIImage({"id": "ai_image"})
@@ -368,7 +371,9 @@ def test_ai_image_randomize_prompt_blank_input(device_config_dev, monkeypatch):
         assert result is not None
 
 
-def test_ai_image_blank_prompt_without_randomize_raises(device_config_dev, monkeypatch):
+def test_ai_image_blank_prompt_without_randomize_raises(
+    device_config_dev: Any, monkeypatch: Any
+) -> None:
     from plugins.ai_image.ai_image import AIImage
 
     p = AIImage({"id": "ai_image"})
@@ -576,7 +581,7 @@ def test_ai_image_prompt_field_is_textarea():
     assert prompt_field.get("required") is not True
 
 
-def test_ai_image_schema_includes_random_prompt_widget():
+def test_ai_image_schema_includes_random_prompt_widget() -> None:
     from plugins.ai_image.ai_image import AIImage
 
     p = AIImage({"id": "ai_image"})
@@ -592,7 +597,7 @@ def test_ai_image_schema_includes_random_prompt_widget():
     assert any(item.get("widget_type") == "ai-image-prompt-tools" for item in widgets)
 
 
-def test_ai_image_prompt_renders_as_textarea(client):
+def test_ai_image_prompt_renders_as_textarea(client: Any) -> None:
     """Settings page should render the prompt as a <textarea> (JTN-377)."""
     resp = client.get("/plugin/ai_image")
     assert resp.status_code == 200
@@ -603,7 +608,7 @@ def test_ai_image_prompt_renders_as_textarea(client):
     assert "data-ai-image-random-prompt" in body
 
 
-def test_ai_image_random_prompt_endpoint_openai(client, monkeypatch):
+def test_ai_image_random_prompt_endpoint_openai(client: Any, monkeypatch: Any) -> None:
     from plugins.ai_image.ai_image import AIImage
 
     monkeypatch.setenv("OPEN_AI_SECRET", "test")
@@ -620,7 +625,9 @@ def test_ai_image_random_prompt_endpoint_openai(client, monkeypatch):
     assert body["prompt"] == "a glass city"
 
 
-def test_ai_image_random_prompt_endpoint_missing_key(client, monkeypatch):
+def test_ai_image_random_prompt_endpoint_missing_key(
+    client: Any, monkeypatch: Any
+) -> None:
     monkeypatch.delenv("OPEN_AI_SECRET", raising=False)
 
     resp = client.post(

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -639,6 +639,18 @@ def test_ai_image_random_prompt_endpoint_missing_key(
     assert "OpenAI API Key" in resp.get_json()["error"]
 
 
+def test_ai_image_random_prompt_endpoint_rejects_unknown_provider(client: Any) -> None:
+    resp = client.post(
+        "/plugin/ai_image/random_prompt",
+        json={"provider": "opneai", "prompt": ""},
+    )
+
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "Unsupported provider" in body["error"]
+    assert body["details"]["field"] == "provider"
+
+
 def test_fetch_image_prompt_api_error_handling():
     """Empty/malformed API responses should return ``""`` so callers fall back."""
     from plugins.ai_image.ai_image import AIImage
@@ -840,6 +852,35 @@ def test_maybe_randomize_openai_prompt_uses_original_when_empty(monkeypatch):
             plugin._maybe_randomize_openai_prompt(MagicMock(), "keep me", True)
             == "keep me"
         )
+
+
+def test_openai_blank_random_prompt_uses_fallback_before_image_call(
+    device_config_dev: Any, monkeypatch: Any
+) -> None:
+    from plugins.ai_image.ai_image import FALLBACK_IMAGE_PROMPT, AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    with (
+        patch(
+            "plugins.ai_image.ai_image.AIImage.fetch_image_prompt",
+            return_value="",
+        ),
+        patch.object(plugin, "fetch_image", return_value=MagicMock()) as mock_fetch,
+    ):
+        plugin.generate_image(
+            {
+                "textPrompt": "",
+                "provider": "openai",
+                "imageModel": "gpt-image-2",
+                "quality": "medium",
+                "randomizePrompt": "true",
+            },
+            device_config_dev,
+        )
+
+    assert mock_fetch.call_args.args[1] == FALLBACK_IMAGE_PROMPT
 
 
 def test_maybe_randomize_google_prompt_success(monkeypatch):

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -105,6 +105,39 @@ def test_ai_image_validate_settings_uses_default_model_for_openai():
     )
 
 
+def test_ai_image_validate_settings_allows_blank_prompt_when_vivid_remix_enabled():
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+
+    assert (
+        plugin.validate_settings(
+            {
+                "textPrompt": "",
+                "randomizePrompt": "true",
+                "provider": "openai",
+            }
+        )
+        is None
+    )
+
+
+def test_ai_image_validate_settings_rejects_blank_prompt_without_vivid_remix():
+    from plugins.ai_image.ai_image import AIImage
+
+    plugin = AIImage({"id": "ai_image"})
+
+    error = plugin.validate_settings(
+        {
+            "textPrompt": " ",
+            "randomizePrompt": "false",
+            "provider": "openai",
+        }
+    )
+
+    assert error == "Prompt is required."
+
+
 def test_ai_image_generate_image_success(client, monkeypatch, mock_openai):
     monkeypatch.setenv("OPEN_AI_SECRET", "test")
 
@@ -335,6 +368,24 @@ def test_ai_image_randomize_prompt_blank_input(device_config_dev, monkeypatch):
         assert result is not None
 
 
+def test_ai_image_blank_prompt_without_randomize_raises(device_config_dev, monkeypatch):
+    from plugins.ai_image.ai_image import AIImage
+
+    p = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    with pytest.raises(RuntimeError, match="Prompt is required"):
+        p.generate_image(
+            {
+                "textPrompt": "",
+                "imageModel": "gpt-image-2",
+                "quality": "medium",
+                "randomizePrompt": "false",
+            },
+            device_config_dev,
+        )
+
+
 def test_fetch_image_prompt_basic(monkeypatch):
     """Test fetch_image_prompt with basic functionality."""
     from plugins.ai_image.ai_image import AIImage
@@ -522,7 +573,23 @@ def test_ai_image_prompt_field_is_textarea():
     assert prompt_field is not None, "textPrompt field missing from schema"
     assert prompt_field["type"] == "textarea"
     assert prompt_field.get("rows") == 4
-    assert prompt_field.get("required") is True
+    assert prompt_field.get("required") is not True
+
+
+def test_ai_image_schema_includes_random_prompt_widget():
+    from plugins.ai_image.ai_image import AIImage
+
+    p = AIImage({"id": "ai_image"})
+    schema = p.build_settings_schema()
+
+    widgets = [
+        item
+        for section in schema["sections"]
+        for item in section["items"]
+        if item.get("kind") == "widget"
+    ]
+
+    assert any(item.get("widget_type") == "ai-image-prompt-tools" for item in widgets)
 
 
 def test_ai_image_prompt_renders_as_textarea(client):
@@ -532,6 +599,37 @@ def test_ai_image_prompt_renders_as_textarea(client):
     body = resp.data.decode("utf-8")
     assert "<textarea" in body
     assert 'name="textPrompt"' in body
+    assert "Surprise me" in body
+    assert "data-ai-image-random-prompt" in body
+
+
+def test_ai_image_random_prompt_endpoint_openai(client, monkeypatch):
+    from plugins.ai_image.ai_image import AIImage
+
+    monkeypatch.setenv("OPEN_AI_SECRET", "test")
+
+    with patch.object(AIImage, "fetch_image_prompt", return_value="a glass city"):
+        resp = client.post(
+            "/plugin/ai_image/random_prompt",
+            json={"provider": "openai", "prompt": ""},
+        )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["success"] is True
+    assert body["prompt"] == "a glass city"
+
+
+def test_ai_image_random_prompt_endpoint_missing_key(client, monkeypatch):
+    monkeypatch.delenv("OPEN_AI_SECRET", raising=False)
+
+    resp = client.post(
+        "/plugin/ai_image/random_prompt",
+        json={"provider": "openai", "prompt": ""},
+    )
+
+    assert resp.status_code == 400
+    assert "OpenAI API Key" in resp.get_json()["error"]
 
 
 def test_fetch_image_prompt_api_error_handling():

--- a/tests/plugins/test_apod.py
+++ b/tests/plugins/test_apod.py
@@ -215,6 +215,7 @@ def test_apod_hdurl_preference_on_non_low_resource(device_config_dev, monkeypatc
             result = p.generate_image({}, device_config_dev)
 
         assert mock_from_url.call_args.args[0] == "http://example.com/high_res.png"
+        assert mock_from_url.call_args.kwargs["resize"] is True
         assert result is not None
 
 

--- a/tests/plugins/test_clock.py
+++ b/tests/plugins/test_clock.py
@@ -63,7 +63,7 @@ def test_generate_settings_template():
     assert template["style_settings"] is False
 
 
-def test_clock_color_schema_labels_explain_face_colors():
+def test_clock_color_schema_labels_explain_face_colors() -> None:
     from plugins.clock.clock import Clock
 
     schema = Clock({"id": "clock"}).build_settings_schema()
@@ -186,7 +186,7 @@ def test_timezone_handling():
     assert img is not None
 
 
-def test_invalid_timezone_falls_back_in_generate_image():
+def test_invalid_timezone_falls_back_in_generate_image() -> None:
     """Imported or migrated bad timezone values should not crash rendering."""
     from unittest.mock import MagicMock
 

--- a/tests/plugins/test_clock.py
+++ b/tests/plugins/test_clock.py
@@ -60,6 +60,25 @@ def test_generate_settings_template():
     assert template["clock_faces"] == CLOCK_FACES
     assert len(template["clock_faces"]) == 4
     assert template["clock_faces"][0]["name"] == "Gradient Clock"
+    assert template["style_settings"] is False
+
+
+def test_clock_color_schema_labels_explain_face_colors():
+    from plugins.clock.clock import Clock
+
+    schema = Clock({"id": "clock"}).build_settings_schema()
+    colors = next(
+        section for section in schema["sections"] if section["title"] == "Colors"
+    )
+
+    assert colors["description"] == "These colors are used by the clock face itself."
+    labels = [
+        field["label"]
+        for row in colors["items"]
+        for field in row["items"]
+        if field["type"] == "color"
+    ]
+    assert labels == ["Face accent color", "Face background color"]
 
 
 def test_generate_image_exception_handling():
@@ -160,6 +179,29 @@ def test_timezone_handling():
     device_config.get_resolution.return_value = (400, 300)
     device_config.get_config.side_effect = lambda key: {
         "timezone": "UTC",
+        "orientation": "horizontal",
+    }.get(key)
+
+    img = clock.generate_image(settings, device_config)
+    assert img is not None
+
+
+def test_invalid_timezone_falls_back_in_generate_image():
+    """Imported or migrated bad timezone values should not crash rendering."""
+    from unittest.mock import MagicMock
+
+    from plugins.clock.clock import Clock
+
+    clock = Clock({"id": "clock"})
+    settings = {
+        "selectedClockFace": "Digital Clock",
+        "primaryColor": "#ffffff",
+        "secondaryColor": "#000000",
+    }
+    device_config = MagicMock()
+    device_config.get_resolution.return_value = (400, 300)
+    device_config.get_config.side_effect = lambda key: {
+        "timezone": "Not/A_Real_Zone",
         "orientation": "horizontal",
     }.get(key)
 

--- a/tests/unit/test_config_fallbacks_extra.py
+++ b/tests/unit/test_config_fallbacks_extra.py
@@ -1,8 +1,10 @@
 import json
 import os
+from pathlib import Path
+from typing import Any
 
 
-def _write_min_config(path, name="Cfg"):
+def _write_min_config(path: str, name: str = "Cfg") -> None:
     cfg = {
         "name": name,
         "display_type": "mock",
@@ -21,7 +23,7 @@ def _write_min_config(path, name="Cfg"):
         json.dump(cfg, f)
 
 
-def test_get_plugin_image_path(monkeypatch, tmp_path):
+def test_get_plugin_image_path(monkeypatch: Any, tmp_path: Path) -> None:
     import config as config_mod
 
     # Use temp device.json
@@ -35,7 +37,9 @@ def test_get_plugin_image_path(monkeypatch, tmp_path):
     assert path.endswith("weather_My_Instance.png")
 
 
-def test_read_plugins_list_handles_missing_dir(monkeypatch, tmp_path):
+def test_read_plugins_list_handles_missing_dir(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
     import config as config_mod
 
     # Point BASE_DIR to temp that lacks plugins dir
@@ -50,8 +54,8 @@ def test_read_plugins_list_handles_missing_dir(monkeypatch, tmp_path):
 
 
 def test_read_plugins_list_uses_cache_when_plugin_files_unchanged(
-    monkeypatch, tmp_path
-):
+    monkeypatch: Any, tmp_path: Path
+) -> None:
     import config as config_mod
 
     cfg_path = tmp_path / "config" / "device.json"
@@ -68,7 +72,7 @@ def test_read_plugins_list_uses_cache_when_plugin_files_unchanged(
     original_json_load = config_mod.json.load
     parse_count = {"n": 0}
 
-    def counting_load(fp):
+    def counting_load(fp: Any) -> Any:
         parse_count["n"] += 1
         return original_json_load(fp)
 
@@ -79,8 +83,8 @@ def test_read_plugins_list_uses_cache_when_plugin_files_unchanged(
 
 
 def test_read_plugins_list_refreshes_cache_when_plugin_file_changes(
-    monkeypatch, tmp_path
-):
+    monkeypatch: Any, tmp_path: Path
+) -> None:
     import config as config_mod
 
     cfg_path = tmp_path / "config" / "device.json"
@@ -102,7 +106,9 @@ def test_read_plugins_list_refreshes_cache_when_plugin_file_changes(
     assert cfg.read_plugins_list() == [{"id": "demo", "name": "Updated Demo"}]
 
 
-def test_determine_config_path_bootstrap_failure(monkeypatch, tmp_path):
+def test_determine_config_path_bootstrap_failure(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
     import config as config_mod
 
     # Point BASE_DIR to isolated tmp src
@@ -115,7 +121,7 @@ def test_determine_config_path_bootstrap_failure(monkeypatch, tmp_path):
     # Simulate missing install template so bootstrap fails
     # Also ensure config dir not creatable by mocking shutil.copyfile to raise
 
-    def _boom(*_a, **_kw):
+    def _boom(*_a: Any, **_kw: Any) -> None:
         raise OSError("copy failed")
 
     monkeypatch.setattr(config_mod.shutil, "copyfile", _boom)

--- a/tests/unit/test_config_fallbacks_extra.py
+++ b/tests/unit/test_config_fallbacks_extra.py
@@ -49,6 +49,59 @@ def test_read_plugins_list_handles_missing_dir(monkeypatch, tmp_path):
     assert cfg.get_plugins() == []
 
 
+def test_read_plugins_list_uses_cache_when_plugin_files_unchanged(
+    monkeypatch, tmp_path
+):
+    import config as config_mod
+
+    cfg_path = tmp_path / "config" / "device.json"
+    _write_min_config(str(cfg_path))
+    plugin_dir = tmp_path / "plugins" / "demo"
+    plugin_dir.mkdir(parents=True)
+    plugin_info = plugin_dir / "plugin-info.json"
+    plugin_info.write_text('{"id": "demo", "name": "Demo"}', encoding="utf-8")
+
+    monkeypatch.setattr(config_mod.Config, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(config_mod.Config, "config_file", str(cfg_path))
+
+    cfg = config_mod.Config()
+    original_json_load = config_mod.json.load
+    parse_count = {"n": 0}
+
+    def counting_load(fp):
+        parse_count["n"] += 1
+        return original_json_load(fp)
+
+    monkeypatch.setattr(config_mod.json, "load", counting_load)
+
+    assert cfg.read_plugins_list() == [{"id": "demo", "name": "Demo"}]
+    assert parse_count["n"] == 0
+
+
+def test_read_plugins_list_refreshes_cache_when_plugin_file_changes(
+    monkeypatch, tmp_path
+):
+    import config as config_mod
+
+    cfg_path = tmp_path / "config" / "device.json"
+    _write_min_config(str(cfg_path))
+    plugin_dir = tmp_path / "plugins" / "demo"
+    plugin_dir.mkdir(parents=True)
+    plugin_info = plugin_dir / "plugin-info.json"
+    plugin_info.write_text('{"id": "demo", "name": "Demo"}', encoding="utf-8")
+
+    monkeypatch.setattr(config_mod.Config, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(config_mod.Config, "config_file", str(cfg_path))
+
+    cfg = config_mod.Config()
+    plugin_info.write_text(
+        '{"id": "demo", "name": "Updated Demo"}',
+        encoding="utf-8",
+    )
+
+    assert cfg.read_plugins_list() == [{"id": "demo", "name": "Updated Demo"}]
+
+
 def test_determine_config_path_bootstrap_failure(monkeypatch, tmp_path):
     import config as config_mod
 

--- a/tests/unit/test_output_validator.py
+++ b/tests/unit/test_output_validator.py
@@ -1,8 +1,11 @@
 # pyright: reportMissingImports=false
 """Tests for utils.output_validator — dimension validation of plugin images."""
 
+from typing import Any
+
 import pytest
 from PIL import Image
+from pytest import MonkeyPatch
 
 from utils.output_validator import OutputDimensionMismatch, validate_image_dimensions
 
@@ -16,12 +19,12 @@ def _img(w: int, h: int) -> Image.Image:
 
 
 class TestValidateImageDimensions:
-    def test_matching_dims_returns_same_image(self):
+    def test_matching_dims_returns_same_image(self) -> None:
         img = _img(800, 480)
         result = validate_image_dimensions(img, 800, 480, plugin_id="test_plugin")
         assert result is img
 
-    def test_wrong_width_raises(self):
+    def test_wrong_width_raises(self) -> None:
         img = _img(640, 480)
         with pytest.raises(OutputDimensionMismatch) as exc_info:
             validate_image_dimensions(img, 800, 480, plugin_id="bad_plugin")
@@ -33,7 +36,7 @@ class TestValidateImageDimensions:
         assert "800x480" in str(err)
         assert "640x480" in str(err)
 
-    def test_wrong_height_raises(self):
+    def test_wrong_height_raises(self) -> None:
         img = _img(800, 600)
         with pytest.raises(OutputDimensionMismatch) as exc_info:
             validate_image_dimensions(img, 800, 480, plugin_id="tall_plugin")
@@ -41,25 +44,25 @@ class TestValidateImageDimensions:
         assert err.expected == (800, 480)
         assert err.actual == (800, 600)
 
-    def test_both_dims_wrong_raises(self):
+    def test_both_dims_wrong_raises(self) -> None:
         img = _img(100, 100)
         with pytest.raises(OutputDimensionMismatch):
             validate_image_dimensions(img, 800, 480, plugin_id="tiny_plugin")
 
-    def test_auto_rotate_transposed_dims(self):
+    def test_auto_rotate_transposed_dims(self) -> None:
         # Image is 480x800 but display expects 800x480 — should auto-rotate.
         img = _img(480, 800)
         result = validate_image_dimensions(img, 800, 480, plugin_id="rotated_plugin")
         assert result.size == (800, 480)
 
-    def test_auto_rotate_disabled_raises_on_transposed(self):
+    def test_auto_rotate_disabled_raises_on_transposed(self) -> None:
         img = _img(480, 800)
         with pytest.raises(OutputDimensionMismatch):
             validate_image_dimensions(
                 img, 800, 480, plugin_id="rotated_plugin", auto_rotate=False
             )
 
-    def test_default_plugin_id_in_error_message(self):
+    def test_default_plugin_id_in_error_message(self) -> None:
         img = _img(100, 100)
         with pytest.raises(OutputDimensionMismatch) as exc_info:
             validate_image_dimensions(img, 800, 480)
@@ -67,13 +70,13 @@ class TestValidateImageDimensions:
 
 
 class TestOutputDimensionMismatch:
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         err = OutputDimensionMismatch("my_plugin", (800, 480), (640, 400))
         assert err.plugin_id == "my_plugin"
         assert err.expected == (800, 480)
         assert err.actual == (640, 400)
 
-    def test_is_exception(self):
+    def test_is_exception(self) -> None:
         err = OutputDimensionMismatch("p", (1, 2), (3, 4))
         assert isinstance(err, Exception)
 
@@ -84,8 +87,8 @@ class TestOutputDimensionMismatch:
 
 
 def test_refresh_task_skips_display_on_dimension_mismatch(
-    device_config_dev, monkeypatch
-):
+    device_config_dev: Any, monkeypatch: MonkeyPatch
+) -> None:
     """When a plugin returns an image with wrong dimensions the display should
     NOT be updated and plugin health should be marked as failure."""
     from display.display_manager import DisplayManager
@@ -98,14 +101,17 @@ def test_refresh_task_skips_display_on_dimension_mismatch(
     # Build a wrong-sized image (neither matching nor auto-rotatable).
     bad_image = Image.new("RGB", (expected_w + 10, expected_h + 10), "red")
 
-    display_called = []
+    display_called: list[Image.Image] = []
 
     def _fake_execute_with_policy(
-        refresh_action, plugin_config, current_dt, request_id=None
-    ):
+        refresh_action: Any,
+        plugin_config: Any,
+        current_dt: Any,
+        request_id: Any = None,
+    ) -> tuple[Image.Image, None]:
         return bad_image, None
 
-    def _fake_display_image(image, **kwargs):
+    def _fake_display_image(image: Image.Image, **kwargs: Any) -> dict[str, Any]:
         display_called.append(image)
         return {}
 

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -2,16 +2,17 @@
 """Tests for the utils.paths module."""
 
 import os
+from pathlib import Path
 
 
-def test_base_dir_points_to_src():
+def test_base_dir_points_to_src() -> None:
     from utils.paths import BASE_DIR
 
     assert os.path.isdir(BASE_DIR)
     assert os.path.basename(BASE_DIR) == "src"
 
 
-def test_default_constants_exist():
+def test_default_constants_exist() -> None:
     from utils.paths import (
         CURRENT_IMAGE_FILE,
         DEFAULT_PREVIEW_IMAGE,
@@ -32,7 +33,7 @@ def test_default_constants_exist():
         assert "static" in p or "images" in p
 
 
-def test_resolve_runtime_paths_no_override():
+def test_resolve_runtime_paths_no_override() -> None:
     from utils.paths import (
         CURRENT_IMAGE_FILE,
         HISTORY_IMAGE_DIR,
@@ -48,14 +49,14 @@ def test_resolve_runtime_paths_no_override():
     assert result["history_image_dir"] == HISTORY_IMAGE_DIR
 
 
-def test_resolve_runtime_paths_empty_string():
+def test_resolve_runtime_paths_empty_string() -> None:
     from utils.paths import CURRENT_IMAGE_FILE, resolve_runtime_paths
 
     result = resolve_runtime_paths("")
     assert result["current_image_file"] == CURRENT_IMAGE_FILE
 
 
-def test_resolve_runtime_paths_with_override(tmp_path):
+def test_resolve_runtime_paths_with_override(tmp_path: Path) -> None:
     from utils.paths import resolve_runtime_paths
 
     result = resolve_runtime_paths(str(tmp_path))

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -4,6 +4,7 @@
 import json
 import threading
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 # ---------------------------------------------------------------------------
@@ -245,7 +246,7 @@ class TestUpdatePlaylist:
         pl = pm.get_playlist("Cycled")
         assert pl.cycle_interval_seconds == 15 * 60
 
-    def test_duplicate_rename_rejected(self, client):
+    def test_duplicate_rename_rejected(self, client: Any) -> None:
         _create_playlist(client, "First", "06:00", "08:00")
         _create_playlist(client, "Second", "10:00", "12:00")
 

--- a/tests/unit/test_playlist_blueprint.py
+++ b/tests/unit/test_playlist_blueprint.py
@@ -245,6 +245,22 @@ class TestUpdatePlaylist:
         pl = pm.get_playlist("Cycled")
         assert pl.cycle_interval_seconds == 15 * 60
 
+    def test_duplicate_rename_rejected(self, client):
+        _create_playlist(client, "First", "06:00", "08:00")
+        _create_playlist(client, "Second", "10:00", "12:00")
+
+        resp = client.put(
+            "/update_playlist/Second",
+            json={
+                "new_name": "First",
+                "start_time": "10:00",
+                "end_time": "12:00",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert "already exists" in resp.get_json()["error"]
+
 
 # ---------------------------------------------------------------------------
 # /delete_playlist/<name> (DELETE)

--- a/tests/unit/test_redact_secrets.py
+++ b/tests/unit/test_redact_secrets.py
@@ -9,31 +9,31 @@ exercise the direct function entry point.
 from utils.logging_utils import redact_secrets
 
 
-def test_redact_secrets_masks_api_key_assignment():
+def test_redact_secrets_masks_api_key_assignment() -> None:
     out = redact_secrets("api_key=supersecret123")
     assert "supersecret123" not in out
     assert "***REDACTED***" in out
 
 
-def test_redact_secrets_masks_bearer_token():
+def test_redact_secrets_masks_bearer_token() -> None:
     out = redact_secrets("Authorization: Bearer abc.def-XYZ_123=")
     assert "abc.def-XYZ_123=" not in out
     assert "***REDACTED***" in out
 
 
-def test_redact_secrets_masks_long_hex_string():
+def test_redact_secrets_masks_long_hex_string() -> None:
     token = "a" * 40
     out = redact_secrets(f"token value {token} trailing")
     assert token not in out
     assert "***REDACTED***" in out
 
 
-def test_redact_secrets_leaves_benign_string_unchanged():
+def test_redact_secrets_leaves_benign_string_unchanged() -> None:
     text = "/opt/inkypi/plugins/foo/render/style.css"
     assert redact_secrets(text) == text
 
 
-def test_redact_secrets_coerces_non_string_input():
+def test_redact_secrets_coerces_non_string_input() -> None:
     err = FileNotFoundError("missing: /tmp/style.css")
     out = redact_secrets(err)
     assert isinstance(out, str)

--- a/tests/unit/test_refresh_info_repo.py
+++ b/tests/unit/test_refresh_info_repo.py
@@ -6,7 +6,7 @@ from utils.refresh_info import RefreshInfoRepository
 
 
 class TestRefreshInfoRepository:
-    def test_load_valid_data(self):
+    def test_load_valid_data(self) -> None:
         data = {
             "refresh_type": "Manual Update",
             "plugin_id": "clock",
@@ -21,7 +21,7 @@ class TestRefreshInfoRepository:
         assert ri.refresh_time == "2025-01-01T00:00:00"
         assert ri.image_hash == "abc123"
 
-    def test_load_none_falls_back_to_defaults(self):
+    def test_load_none_falls_back_to_defaults(self) -> None:
         repo = RefreshInfoRepository(None)
         ri = repo.get()
         assert ri.refresh_type == "Manual Update"
@@ -29,24 +29,24 @@ class TestRefreshInfoRepository:
         assert ri.refresh_time is None
         assert ri.image_hash is None
 
-    def test_load_empty_dict_falls_back_to_defaults(self):
+    def test_load_empty_dict_falls_back_to_defaults(self) -> None:
         repo = RefreshInfoRepository({})
         ri = repo.get()
         assert ri.refresh_type == "Manual Update"
         assert ri.plugin_id == ""
 
-    def test_load_missing_keys_falls_back(self):
+    def test_load_missing_keys_falls_back(self) -> None:
         repo = RefreshInfoRepository({"refresh_type": "Playlist"})
         ri = repo.get()
         assert ri.refresh_type == "Manual Update"  # fell back to default
 
-    def test_set_replaces_refresh_info(self):
+    def test_set_replaces_refresh_info(self) -> None:
         repo = RefreshInfoRepository(None)
         new_ri = RefreshInfo("Playlist", "weather", "2025-06-01T12:00:00", "xyz")
         repo.set(new_ri)
         assert repo.get() is new_ri
 
-    def test_to_dict_round_trip(self):
+    def test_to_dict_round_trip(self) -> None:
         data = {
             "refresh_type": "Playlist",
             "plugin_id": "weather",

--- a/tests/unit/test_refresh_task_unit.py
+++ b/tests/unit/test_refresh_task_unit.py
@@ -150,6 +150,34 @@ def test_timeout_msg_truncates_float():
     assert "10s" in msg
 
 
+def test_ai_image_timeout_defaults_are_longer(monkeypatch):
+    from refresh_task import RefreshTask
+
+    monkeypatch.delenv("INKYPI_PLUGIN_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("INKYPI_PLUGIN_TIMEOUT_S_AI_IMAGE", raising=False)
+    monkeypatch.delenv("INKYPI_MANUAL_UPDATE_WAIT_S", raising=False)
+    monkeypatch.delenv("INKYPI_MANUAL_UPDATE_WAIT_S_AI_IMAGE", raising=False)
+
+    assert RefreshTask._plugin_timeout_seconds("ai_image") == 180.0
+    assert RefreshTask._manual_update_wait_seconds("ai_image") == 210.0
+    assert RefreshTask._plugin_timeout_seconds("clock") == 60.0
+    assert RefreshTask._manual_update_wait_seconds("clock") == 60.0
+
+
+def test_plugin_specific_timeout_env_overrides_global(monkeypatch):
+    from refresh_task import RefreshTask
+
+    monkeypatch.setenv("INKYPI_PLUGIN_TIMEOUT_S", "70")
+    monkeypatch.setenv("INKYPI_PLUGIN_TIMEOUT_S_AI_IMAGE", "240")
+    monkeypatch.setenv("INKYPI_MANUAL_UPDATE_WAIT_S", "75")
+    monkeypatch.setenv("INKYPI_MANUAL_UPDATE_WAIT_S_AI_IMAGE", "260")
+
+    assert RefreshTask._plugin_timeout_seconds("ai_image") == 240.0
+    assert RefreshTask._manual_update_wait_seconds("ai_image") == 260.0
+    assert RefreshTask._plugin_timeout_seconds("clock") == 70.0
+    assert RefreshTask._manual_update_wait_seconds("clock") == 75.0
+
+
 def test_cleanup_subprocess_terminates(monkeypatch):
     from refresh_task import RefreshTask
 

--- a/tests/unit/test_refresh_task_unit.py
+++ b/tests/unit/test_refresh_task_unit.py
@@ -179,6 +179,18 @@ def test_plugin_specific_timeout_env_overrides_global(monkeypatch: Any) -> None:
     assert RefreshTask._manual_update_wait_seconds("clock") == 75.0
 
 
+def test_global_timeout_env_overrides_plugin_default(monkeypatch: Any) -> None:
+    from refresh_task import RefreshTask
+
+    monkeypatch.delenv("INKYPI_PLUGIN_TIMEOUT_S_AI_IMAGE", raising=False)
+    monkeypatch.delenv("INKYPI_MANUAL_UPDATE_WAIT_S_AI_IMAGE", raising=False)
+    monkeypatch.setenv("INKYPI_PLUGIN_TIMEOUT_S", "70")
+    monkeypatch.setenv("INKYPI_MANUAL_UPDATE_WAIT_S", "75")
+
+    assert RefreshTask._plugin_timeout_seconds("ai_image") == 70.0
+    assert RefreshTask._manual_update_wait_seconds("ai_image") == 75.0
+
+
 def test_cleanup_subprocess_terminates(monkeypatch):
     from refresh_task import RefreshTask
 

--- a/tests/unit/test_refresh_task_unit.py
+++ b/tests/unit/test_refresh_task_unit.py
@@ -1,5 +1,6 @@
 # pyright: reportMissingImports=false
 
+from typing import Any
 
 from PIL import Image
 
@@ -150,7 +151,7 @@ def test_timeout_msg_truncates_float():
     assert "10s" in msg
 
 
-def test_ai_image_timeout_defaults_are_longer(monkeypatch):
+def test_ai_image_timeout_defaults_are_longer(monkeypatch: Any) -> None:
     from refresh_task import RefreshTask
 
     monkeypatch.delenv("INKYPI_PLUGIN_TIMEOUT_S", raising=False)
@@ -164,7 +165,7 @@ def test_ai_image_timeout_defaults_are_longer(monkeypatch):
     assert RefreshTask._manual_update_wait_seconds("clock") == 60.0
 
 
-def test_plugin_specific_timeout_env_overrides_global(monkeypatch):
+def test_plugin_specific_timeout_env_overrides_global(monkeypatch: Any) -> None:
     from refresh_task import RefreshTask
 
     monkeypatch.setenv("INKYPI_PLUGIN_TIMEOUT_S", "70")

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -40,6 +40,22 @@ def test_parse_playlist_create_request_returns_typed_minutes() -> None:
     assert parsed.playlist_name == "Night"
     assert parsed.start_min == 22 * 60
     assert parsed.end_min == 5 * 60
+    assert parsed.cycle_minutes_int is None
+
+
+def test_parse_playlist_create_request_accepts_cycle_override() -> None:
+    parsed, error = parse_playlist_create_request(
+        {
+            "playlist_name": "Night",
+            "start_time": "22:00",
+            "end_time": "05:00",
+            "cycle_minutes": "15",
+        }
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.cycle_minutes_int == 15
 
 
 def test_parse_playlist_create_request_rejects_matching_times() -> None:

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from utils.request_models import (
+    parse_api_keys_save_request,
+    parse_device_cycle_request,
+    parse_playlist_create_request,
+    parse_playlist_name_request,
+    parse_playlist_reorder_request,
+    parse_playlist_update_request,
+    parse_plugin_instance_action_request,
+    parse_plugin_order_request,
+    validate_cycle_minutes,
+    validate_playlist_name,
+)
+
+
+def test_validate_playlist_name_strips_and_accepts_safe_ascii() -> None:
+    name, error = validate_playlist_name("  Morning List  ")
+
+    assert error is None
+    assert name == "Morning List"
+
+
+def test_validate_playlist_name_rejects_non_ascii_with_field() -> None:
+    name, error = validate_playlist_name("Café", field="new_name")
+
+    assert name is None
+    assert error is not None
+    assert error.field == "new_name"
+    assert error.code == "validation_error"
+
+
+def test_parse_playlist_create_request_returns_typed_minutes() -> None:
+    parsed, error = parse_playlist_create_request(
+        {"playlist_name": "Night", "start_time": "22:00", "end_time": "05:00"}
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.playlist_name == "Night"
+    assert parsed.start_min == 22 * 60
+    assert parsed.end_min == 5 * 60
+
+
+def test_parse_playlist_create_request_rejects_matching_times() -> None:
+    parsed, error = parse_playlist_create_request(
+        {"playlist_name": "Same", "start_time": "10:00", "end_time": "10:00"}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "end_time"
+
+
+def test_validate_cycle_minutes_accepts_optional_and_range() -> None:
+    missing_value, missing_error = validate_cycle_minutes(None)
+    value, error = validate_cycle_minutes("15")
+
+    assert missing_value is None
+    assert missing_error is None
+    assert value == 15
+    assert error is None
+
+
+def test_validate_cycle_minutes_rejects_out_of_range() -> None:
+    value, error = validate_cycle_minutes(1441)
+
+    assert value is None
+    assert error is not None
+    assert error.field == "cycle_minutes"
+
+
+def test_parse_playlist_update_request_returns_typed_model() -> None:
+    parsed, error = parse_playlist_update_request(
+        {
+            "new_name": "Focus",
+            "start_time": "08:00",
+            "end_time": "12:00",
+            "cycle_minutes": "30",
+        }
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.new_name == "Focus"
+    assert parsed.start_min == 8 * 60
+    assert parsed.end_min == 12 * 60
+    assert parsed.cycle_minutes_int == 30
+
+
+def test_parse_api_keys_save_request_accepts_entries_list() -> None:
+    parsed, error = parse_api_keys_save_request(
+        {"entries": [{"key": "MY_KEY", "value": "secret"}]}
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.entries == [{"key": "MY_KEY", "value": "secret"}]
+
+
+def test_parse_api_keys_save_request_rejects_non_list_entries() -> None:
+    parsed, error = parse_api_keys_save_request({"entries": "bad"})
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "entries"
+
+
+def test_parse_plugin_order_request_returns_string_order() -> None:
+    parsed, error = parse_plugin_order_request({"order": ["clock", "weather"]})
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.order == ["clock", "weather"]
+
+
+def test_parse_plugin_order_request_rejects_non_string_items() -> None:
+    parsed, error = parse_plugin_order_request({"order": ["clock", 3]})
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "order"
+
+
+def test_parse_device_cycle_request_returns_int_minutes() -> None:
+    parsed, error = parse_device_cycle_request({"minutes": "30"})
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.minutes == 30
+
+
+def test_parse_device_cycle_request_rejects_out_of_range() -> None:
+    parsed, error = parse_device_cycle_request({"minutes": 0})
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "minutes"
+
+
+def test_parse_playlist_reorder_request_returns_ordered_payload() -> None:
+    parsed, error = parse_playlist_reorder_request(
+        {
+            "playlist_name": "Default",
+            "ordered": [{"plugin_id": "clock", "name": "Clock"}],
+        }
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.playlist_name == "Default"
+    assert parsed.ordered_payload() == [{"plugin_id": "clock", "name": "Clock"}]
+
+
+def test_parse_playlist_reorder_request_rejects_wrong_item_shape() -> None:
+    parsed, error = parse_playlist_reorder_request(
+        {"playlist_name": "Default", "ordered": [{"pid": "clock"}]}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "ordered"
+
+
+def test_parse_playlist_name_request_strips_name() -> None:
+    parsed, error = parse_playlist_name_request(
+        {"playlist_name": " Default "}, missing_message="playlist_name required"
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.playlist_name == "Default"
+
+
+def test_parse_plugin_instance_action_request_returns_typed_payload() -> None:
+    parsed, error = parse_plugin_instance_action_request(
+        {
+            "playlist_name": " Default ",
+            "plugin_id": "clock",
+            "plugin_instance": "Clock A",
+        }
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.playlist_name == "Default"
+    assert parsed.plugin_id == "clock"
+    assert parsed.plugin_instance == "Clock A"
+
+
+def test_parse_plugin_instance_action_request_requires_playlist_name() -> None:
+    parsed, error = parse_plugin_instance_action_request(
+        {"plugin_id": "clock", "plugin_instance": "Clock A"}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "playlist_name"

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -199,6 +199,15 @@ def test_parse_playlist_reorder_request_rejects_wrong_item_shape() -> None:
     assert error.field == "ordered"
 
 
+def test_parse_playlist_reorder_request_labels_missing_ordered() -> None:
+    parsed, error = parse_playlist_reorder_request({"playlist_name": "Default"})
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "ordered"
+    assert error.message == "ordered list is required"
+
+
 def test_parse_playlist_name_request_strips_name() -> None:
     parsed, error = parse_playlist_name_request(
         {"playlist_name": " Default "}, missing_message="playlist_name required"

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -152,6 +152,27 @@ def test_parse_device_cycle_request_rejects_out_of_range() -> None:
     assert parsed is None
     assert error is not None
     assert error.field == "minutes"
+    assert "between" in error.message
+
+
+def test_parse_device_cycle_request_requires_minutes() -> None:
+    parsed, error = parse_device_cycle_request({})
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "minutes"
+    assert error.message == "Minutes is required"
+
+
+def test_parse_playlist_update_request_uses_shared_missing_time_error() -> None:
+    parsed, error = parse_playlist_update_request(
+        {"new_name": "Focus", "end_time": "12:00"}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "start_time"
+    assert error.message == "Start time and End time are required"
 
 
 def test_parse_playlist_reorder_request_returns_ordered_payload() -> None:

--- a/tests/unit/test_requirements_lockfile.py
+++ b/tests/unit/test_requirements_lockfile.py
@@ -46,19 +46,19 @@ def _parse_lockfile(path: Path) -> dict[str, list[str]]:
 class TestRequirementsLockfile:
     """Verify that both lockfiles contain pip-compile-style hash annotations."""
 
-    def test_requirements_txt_exists(self):
+    def test_requirements_txt_exists(self) -> None:
         assert REQUIREMENTS_TXT.exists(), (
             f"{REQUIREMENTS_TXT} does not exist. "
             "Run: pip-compile --generate-hashes install/requirements.in -o install/requirements.txt"
         )
 
-    def test_requirements_dev_txt_exists(self):
+    def test_requirements_dev_txt_exists(self) -> None:
         assert REQUIREMENTS_DEV_TXT.exists(), (
             f"{REQUIREMENTS_DEV_TXT} does not exist. "
             "Run: pip-compile --generate-hashes install/requirements-dev.in -o install/requirements-dev.txt"
         )
 
-    def test_requirements_txt_has_hashes(self):
+    def test_requirements_txt_has_hashes(self) -> None:
         """Every pinned package in requirements.txt must have at least one hash."""
         packages = _parse_lockfile(REQUIREMENTS_TXT)
         assert packages, f"{REQUIREMENTS_TXT} contains no pinned packages."
@@ -69,7 +69,7 @@ class TestRequirementsLockfile:
             + "\nRegenerate with: pip-compile --generate-hashes install/requirements.in -o install/requirements.txt"
         )
 
-    def test_requirements_dev_txt_has_hashes(self):
+    def test_requirements_dev_txt_has_hashes(self) -> None:
         """Every pinned package in requirements-dev.txt must have at least one hash."""
         packages = _parse_lockfile(REQUIREMENTS_DEV_TXT)
         assert packages, f"{REQUIREMENTS_DEV_TXT} contains no pinned packages."
@@ -80,7 +80,7 @@ class TestRequirementsLockfile:
             + "\nRegenerate with: pip-compile --generate-hashes install/requirements-dev.in -o install/requirements-dev.txt"
         )
 
-    def test_requirements_txt_hash_count(self):
+    def test_requirements_txt_hash_count(self) -> None:
         """Sanity check: there should be many hashes (not a trivially empty file)."""
         content = REQUIREMENTS_TXT.read_text()
         count = content.count("--hash=sha256:")
@@ -89,7 +89,7 @@ class TestRequirementsLockfile:
             "The file may not be a pip-compile lockfile."
         )
 
-    def test_requirements_dev_txt_hash_count(self):
+    def test_requirements_dev_txt_hash_count(self) -> None:
         """Sanity check: dev lockfile should have many more hashes than prod."""
         content = REQUIREMENTS_DEV_TXT.read_text()
         count = content.count("--hash=sha256:")
@@ -98,7 +98,7 @@ class TestRequirementsLockfile:
             "The file may not be a pip-compile lockfile."
         )
 
-    def test_types_requests_pin_preserved(self):
+    def test_types_requests_pin_preserved(self) -> None:
         """types-requests must stay pinned at 2.32.0.20241016 (PR #301 / JTN-525)."""
         content = REQUIREMENTS_DEV_TXT.read_text()
         assert "types-requests==2.32.0.20241016" in content, (
@@ -107,14 +107,14 @@ class TestRequirementsLockfile:
             "Ensure requirements-dev.in specifies: types-requests==2.32.0.20241016"
         )
 
-    def test_requirements_in_exists(self):
+    def test_requirements_in_exists(self) -> None:
         """Source .in files must be committed alongside lockfiles."""
         assert (INSTALL_DIR / "requirements.in").exists(), (
             "install/requirements.in is missing. "
             "This is the human-maintained source file for pip-compile."
         )
 
-    def test_requirements_dev_in_exists(self):
+    def test_requirements_dev_in_exists(self) -> None:
         """Dev source .in file must be committed alongside the dev lockfile."""
         assert (INSTALL_DIR / "requirements-dev.in").exists(), (
             "install/requirements-dev.in is missing. "

--- a/tests/unit/test_settings_schema.py
+++ b/tests/unit/test_settings_schema.py
@@ -10,18 +10,18 @@ from plugins.base_plugin.settings_schema import (
 )
 
 
-def test_option_basic():
+def test_option_basic() -> None:
     result = option("dark", "Dark Mode")
     assert result["value"] == "dark"
     assert result["label"] == "Dark Mode"
 
 
-def test_option_extra_kwargs():
+def test_option_extra_kwargs() -> None:
     result = option("en", "English", selected=True)
     assert result["selected"] is True
 
 
-def test_field_defaults():
+def test_field_defaults() -> None:
     result = field("username")
     assert result["kind"] == "field"
     assert result["type"] == "text"
@@ -29,13 +29,13 @@ def test_field_defaults():
     assert result["label"] == "username"  # label falls back to name
 
 
-def test_field_custom_label_and_type():
+def test_field_custom_label_and_type() -> None:
     result = field("refresh_rate", field_type="number", label="Refresh Rate (s)")
     assert result["type"] == "number"
     assert result["label"] == "Refresh Rate (s)"
 
 
-def test_row_wraps_items():
+def test_row_wraps_items() -> None:
     f1 = field("a")
     f2 = field("b")
     result = row(f1, f2)
@@ -43,7 +43,7 @@ def test_row_wraps_items():
     assert result["items"] == [f1, f2]
 
 
-def test_callout_defaults_and_title():
+def test_callout_defaults_and_title() -> None:
     result = callout("Watch out!", title="Warning")
     assert result["kind"] == "callout"
     assert result["tone"] == "info"
@@ -52,19 +52,19 @@ def test_callout_defaults_and_title():
     assert result["text"] == "Watch out!"
 
 
-def test_callout_without_title_omits_key():
+def test_callout_without_title_omits_key() -> None:
     result = callout("Note")
     assert "title" not in result
 
 
-def test_widget_basic():
+def test_widget_basic() -> None:
     result = widget("color_picker", name="bg_color")
     assert result["kind"] == "widget"
     assert result["widget_type"] == "color_picker"
     assert result["name"] == "bg_color"
 
 
-def test_section_and_schema_structure():
+def test_section_and_schema_structure() -> None:
     f = field("city")
     sec = section("Location", f)
     assert sec["title"] == "Location"

--- a/tests/unit/test_weather_schema_validation.py
+++ b/tests/unit/test_weather_schema_validation.py
@@ -25,7 +25,7 @@ def _validate_openmeteo_schema(payload: dict[str, Any]) -> None:
     assert "hourly" in payload and isinstance(payload["hourly"], dict)
 
 
-def test_openweather_schema_loose_example():
+def test_openweather_schema_loose_example() -> None:
     # Example minimal valid structure
     payload = {
         "timezone": "UTC",
@@ -40,7 +40,7 @@ def test_openweather_schema_loose_example():
     _validate_openweather_schema(payload)
 
 
-def test_openmeteo_schema_loose_example():
+def test_openmeteo_schema_loose_example() -> None:
     payload = {
         "current_weather": {
             "time": "2025-01-01T12:00",


### PR DESCRIPTION
## Summary

- Restore AI Image random prompt generation with a new Surprise me control and backend prompt endpoint.
- Make OpenAI/Google image generation more reliable by extending AI Image refresh timeouts and allowing Vivid remix to invent a prompt from blank input.
- Fix playlist polish issues around all-day saves, create-time cycle overrides, and duplicate renames.
- Clean up Clock/plugin settings confusion by hiding the generic no-op Style tab for Clock, clarifying face color labels, restoring saved Style state correctly, and improving tab/clock-face accessibility.
- Resize APOD images before display validation so NASA refreshes do not fail on dimension mismatch.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not applicable: this PR does not sync from `fatihak/InkyPi`
- [x] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI: no docs needed; UI labels and tests cover the changed controls
- [x] **Frontend changes** (`src/static/**`, `src/templates/**`): targeted render tests and JS syntax checks pass locally; full browser suite left to CI

## Testing

- [x] `PYTHONPATH=src python3 -m pytest -q tests/plugins/test_ai_image.py tests/plugins/test_apod.py tests/plugins/test_clock.py tests/integration/test_plugin_pages.py tests/unit/test_request_models.py tests/unit/test_playlist_blueprint.py tests/integration/test_playlist_routes.py tests/unit/test_refresh_task_unit.py`
- [x] `python3 -m black --check src/plugins/ai_image/ai_image.py src/blueprints/plugin.py src/refresh_task/task.py src/utils/request_models.py src/blueprints/playlist.py src/plugins/clock/clock.py src/plugins/apod/apod.py tests/plugins/test_ai_image.py tests/plugins/test_apod.py tests/plugins/test_clock.py tests/integration/test_plugin_pages.py tests/unit/test_request_models.py tests/unit/test_playlist_blueprint.py tests/integration/test_playlist_routes.py tests/unit/test_refresh_task_unit.py`
- [x] `python3 -m ruff check src/plugins/ai_image/ai_image.py src/blueprints/plugin.py src/refresh_task/task.py src/utils/request_models.py src/blueprints/playlist.py src/plugins/clock/clock.py src/plugins/apod/apod.py tests/plugins/test_ai_image.py tests/plugins/test_apod.py tests/plugins/test_clock.py tests/integration/test_plugin_pages.py tests/unit/test_request_models.py tests/unit/test_playlist_blueprint.py tests/integration/test_playlist_routes.py tests/unit/test_refresh_task_unit.py`
- [x] `node --check src/static/scripts/plugin_schema.js src/static/scripts/plugin_page.js src/static/scripts/playlist/form.js src/static/scripts/playlist/modals.js`
- [x] `bash -n scripts/lint.sh`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Surprise me" random prompt generation for AI Image plugin
  * AI Image plugin now allows optional prompts when remix is enabled
  * Added cycle interval override during playlist creation

* **Bug Fixes**
  * Fixed duplicate playlist name validation
  * Fixed 24:00 time normalization in playlist updates
  * APOD images now resize properly
  * Improved Clock plugin timezone handling

* **Improvements**
  * Enhanced accessibility with keyboard navigation and ARIA labels for plugin interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->