### PR TITLE
refactor: extract refresh display pipeline

### DIFF
--- a/src/refresh_task/display_pipeline.py
+++ b/src/refresh_task/display_pipeline.py
@@ -1,0 +1,220 @@
+"""Display update and fallback handling for refresh cycles."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from time import perf_counter
+from typing import Any, Protocol
+
+from PIL import Image
+
+from refresh_task.actions import ManualUpdateRequest
+from refresh_task.housekeeping import RefreshActionLike, RefreshHousekeeper
+from refresh_task.recorder import RefreshRecorder
+
+logger = logging.getLogger(__name__)
+
+
+class SupportsDisplayPipeline(Protocol):
+    """Display-manager surface needed for refresh display pushes."""
+
+    def display_image(
+        self,
+        image: Image.Image,
+        image_settings: object = ...,
+        history_meta: dict[str, str | None] | None = ...,
+        on_image_saved: Callable[[Mapping[str, Any]], None] | None = ...,
+    ) -> object: ...
+
+
+HealthUpdater = Callable[
+    [str, str | None, bool, Mapping[str, Any] | None, str | None],
+    None,
+]
+
+
+class DisplayPipeline:
+    """Owns display persistence, fallback rendering, and display-stage metrics."""
+
+    def __init__(
+        self,
+        *,
+        display_manager: SupportsDisplayPipeline,
+        housekeeper: RefreshHousekeeper,
+        recorder: RefreshRecorder,
+        update_plugin_health: HealthUpdater,
+    ) -> None:
+        self.display_manager = display_manager
+        self.housekeeper = housekeeper
+        self.recorder = recorder
+        self.update_plugin_health = update_plugin_health
+
+    def push_or_skip_display(
+        self,
+        *,
+        used_cached: bool,
+        image: Image.Image,
+        plugin_config: Mapping[str, Any],
+        refresh_action: RefreshActionLike,
+        refresh_info: Mapping[str, Any],
+        benchmark_id: str | None,
+        plugin_id: str,
+        instance_name: str | None,
+        request_id: str | None,
+        manual_request: ManualUpdateRequest | None,
+    ) -> tuple[int | None, int | None]:
+        """Push the image to the display, or skip when the cache is warm."""
+        if not used_cached:
+            return self.push_to_display(
+                image=image,
+                plugin_config=plugin_config,
+                refresh_action=refresh_action,
+                refresh_info=refresh_info,
+                benchmark_id=benchmark_id,
+                plugin_id=plugin_id,
+                instance_name=instance_name,
+                request_id=request_id,
+                manual_request=manual_request,
+            )
+        logger.info(
+            f"Image already displayed, skipping refresh. | refresh_info: {refresh_info}"
+        )
+        # No display push means no ``on_image_saved`` callback, but the
+        # image-on-disk invariant still holds because the previous refresh
+        # already wrote it. Unblock the manual-update waiter immediately.
+        if manual_request is not None:
+            manual_request.image_saved.set()
+        return None, None
+
+    def push_to_display(
+        self,
+        *,
+        image: Image.Image,
+        plugin_config: Mapping[str, Any],
+        refresh_action: RefreshActionLike,
+        refresh_info: Mapping[str, Any],
+        benchmark_id: str | None,
+        plugin_id: str,
+        instance_name: str | None,
+        request_id: str | None,
+        manual_request: ManualUpdateRequest | None = None,
+    ) -> tuple[int | None, int | None]:
+        """Push image to the display hardware and record display benchmark stages."""
+        logger.info(f"Updating display. | refresh_info: {refresh_info}")
+        history_meta = self.housekeeper.build_history_meta(refresh_action)
+        logger.info(
+            "plugin_lifecycle: display_start",
+            extra={
+                "stage": "display_start",
+                "plugin_id": plugin_id,
+                "instance": instance_name,
+                "refresh_id": benchmark_id,
+                "request_id": request_id,
+            },
+        )
+        stage_t1 = perf_counter()
+        display_duration_ms = None
+        preprocess_ms = None
+        display_driver = None
+        on_image_saved = self._manual_image_saved_callback(manual_request)
+
+        try:
+            display_metrics = self.display_manager.display_image(
+                image,
+                image_settings=plugin_config.get("image_settings", []),
+                history_meta=history_meta,
+                on_image_saved=on_image_saved,
+            )
+            if isinstance(display_metrics, dict):
+                preprocess_ms = display_metrics.get("preprocess_ms")
+                display_duration_ms = display_metrics.get("display_ms")
+                display_driver = display_metrics.get("display_driver")
+        except Exception as exc:
+            logger.error(
+                "plugin_lifecycle: display_failure | plugin_id=%s instance=%s error=%s",
+                plugin_id,
+                instance_name,
+                exc,
+            )
+            retained_display = bool(self.housekeeper.stale_display_path())
+            self.update_plugin_health(
+                plugin_id,
+                instance_name,
+                False,
+                {"retained_display": retained_display},
+                str(exc),
+            )
+            self.recorder.publish_error(
+                plugin_id=plugin_id,
+                instance=instance_name,
+                refresh_id=benchmark_id,
+                request_id=request_id,
+                error=str(exc),
+                retained_display=retained_display,
+            )
+            raise
+        finally:
+            if display_duration_ms is None:
+                display_duration_ms = int((perf_counter() - stage_t1) * 1000)
+            logger.info(
+                "plugin_lifecycle: display_complete",
+                extra={
+                    "stage": "display_complete",
+                    "plugin_id": plugin_id,
+                    "instance": instance_name,
+                    "duration_ms": display_duration_ms,
+                    "refresh_id": benchmark_id,
+                    "request_id": request_id,
+                },
+            )
+            self.recorder.save_stage(
+                benchmark_id or "",
+                "display_pipeline",
+                display_duration_ms,
+            )
+            if display_driver:
+                self.recorder.save_stage(
+                    benchmark_id or "",
+                    "display_driver",
+                    display_duration_ms,
+                    extra={"driver": display_driver},
+                )
+        return display_duration_ms, preprocess_ms
+
+    def push_fallback_image(
+        self,
+        *,
+        plugin_id: str,
+        instance_name: str | None,
+        exc: BaseException,
+        plugin_config: Mapping[str, Any],
+        refresh_action: RefreshActionLike,
+    ) -> None:
+        """Render and push an error-card fallback image to the display."""
+        self.housekeeper.push_fallback_image(
+            plugin_id=plugin_id,
+            instance_name=instance_name,
+            exc=exc,
+            plugin_config=plugin_config,
+            refresh_action=refresh_action,
+        )
+
+    @staticmethod
+    def _manual_image_saved_callback(
+        manual_request: ManualUpdateRequest | None,
+    ) -> Callable[[Mapping[str, Any]], None] | None:
+        """Return a callback that releases manual-update waiters after disk save."""
+        if manual_request is None:
+            return None
+
+        def on_image_saved(save_metrics: Mapping[str, Any]) -> None:
+            manual_request.image_saved_metrics = {
+                "generate_ms": None,
+                "preprocess_ms": save_metrics.get("preprocess_ms"),
+                "display_ms": None,
+                "stage": "image_saved",
+            }
+            manual_request.image_saved.set()
+
+        return on_image_saved

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -16,6 +16,7 @@ from plugins.plugin_registry import get_plugin_instance
 from refresh_task import recorder as refresh_recorder
 from refresh_task.actions import ManualUpdateRequest, PlaylistRefresh, RefreshAction
 from refresh_task.context import RefreshContext
+from refresh_task.display_pipeline import DisplayPipeline
 from refresh_task.health import PluginHealthTracker
 from refresh_task.housekeeping import RefreshHousekeeper
 from refresh_task.scheduler import RefreshScheduler
@@ -95,6 +96,12 @@ class RefreshTask:
         self.health_tracker = PluginHealthTracker(
             device_config=self.device_config,
             plugin_health=self.plugin_health,
+        )
+        self.display_pipeline = DisplayPipeline(
+            display_manager=self.display_manager,
+            housekeeper=self.housekeeper,
+            recorder=self.recorder,
+            update_plugin_health=self._update_plugin_health_positional,
         )
         self._tick_count: int = 0
         self.watchdog_thread: threading.Thread | None = None
@@ -554,25 +561,28 @@ class RefreshTask:
         """
         if not used_cached:
             return self._push_to_display(
-                image,
-                plugin_config,
-                refresh_action,
-                refresh_info,
-                benchmark_id,
-                plugin_id,
-                instance_name,
-                request_id,
+                image=image,
+                plugin_config=plugin_config,
+                refresh_action=refresh_action,
+                refresh_info=refresh_info,
+                benchmark_id=benchmark_id,
+                plugin_id=plugin_id,
+                instance_name=instance_name,
+                request_id=request_id,
                 manual_request=manual_request,
             )
-        logger.info(
-            f"Image already displayed, skipping refresh. | refresh_info: {refresh_info}"
+        return self.display_pipeline.push_or_skip_display(
+            used_cached=used_cached,
+            image=image,
+            plugin_config=plugin_config,
+            refresh_action=refresh_action,
+            refresh_info=refresh_info,
+            benchmark_id=benchmark_id,
+            plugin_id=plugin_id,
+            instance_name=instance_name,
+            request_id=request_id,
+            manual_request=manual_request,
         )
-        # JTN-786: no display push means no ``on_image_saved`` callback, but
-        # the image-on-disk invariant still holds (the previous refresh
-        # already wrote it), so unblock the manual-update waiter immediately.
-        if manual_request is not None:
-            manual_request.image_saved.set()
-        return None, None
 
     def _push_to_display(
         self,
@@ -587,101 +597,17 @@ class RefreshTask:
         manual_request: ManualUpdateRequest | None = None,
     ) -> tuple[int | None, int | None]:
         """Push image to the display hardware and record benchmark stages."""
-        logger.info(f"Updating display. | refresh_info: {refresh_info}")
-        history_meta = self.housekeeper.build_history_meta(refresh_action)
-        logger.info(
-            "plugin_lifecycle: display_start",
-            extra={
-                "stage": "display_start",
-                "plugin_id": plugin_id,
-                "instance": instance_name,
-                "refresh_id": benchmark_id,
-                "request_id": request_id,
-            },
+        return self.display_pipeline.push_to_display(
+            image=image,
+            plugin_config=plugin_config,
+            refresh_action=refresh_action,
+            refresh_info=refresh_info,
+            benchmark_id=benchmark_id,
+            plugin_id=plugin_id,
+            instance_name=instance_name,
+            request_id=request_id,
+            manual_request=manual_request,
         )
-        stage_t1 = perf_counter()
-        display_duration_ms = None
-        preprocess_ms = None
-        display_driver = None
-        # JTN-786: wire a callback so ``manual_update`` can return once the
-        # processed image is persisted to disk — the hardware write that
-        # follows can take ~27s on an Inky 7.3" Impression and was tripping
-        # the 60s manual-update cap for renders with a slow generate phase.
-        on_image_saved = None
-        if manual_request is not None:
-
-            def on_image_saved(save_metrics: Mapping[str, Any]) -> None:
-                manual_request.image_saved_metrics = {
-                    "generate_ms": None,  # filled in by the waiter if needed
-                    "preprocess_ms": save_metrics.get("preprocess_ms"),
-                    "display_ms": None,  # still running
-                    "stage": "image_saved",
-                }
-                manual_request.image_saved.set()
-
-        try:
-            display_metrics = self.display_manager.display_image(
-                image,
-                image_settings=plugin_config.get("image_settings", []),
-                history_meta=history_meta,
-                on_image_saved=on_image_saved,
-            )
-            if isinstance(display_metrics, dict):
-                preprocess_ms = display_metrics.get("preprocess_ms")
-                display_duration_ms = display_metrics.get("display_ms")
-                display_driver = display_metrics.get("display_driver")
-            else:
-                display_driver = None
-        except Exception as exc:
-            logger.error(
-                "plugin_lifecycle: display_failure | plugin_id=%s instance=%s error=%s",
-                plugin_id,
-                instance_name,
-                exc,
-            )
-            self._update_plugin_health(
-                plugin_id=plugin_id,
-                instance=instance_name,
-                ok=False,
-                metrics={"retained_display": bool(self._stale_display_path())},
-                error=str(exc),
-            )
-            self.recorder.publish_error(
-                plugin_id=plugin_id,
-                instance=instance_name,
-                refresh_id=benchmark_id,
-                request_id=request_id,
-                error=str(exc),
-                retained_display=bool(self._stale_display_path()),
-            )
-            raise
-        finally:
-            if display_duration_ms is None:
-                display_duration_ms = int((perf_counter() - stage_t1) * 1000)
-            logger.info(
-                "plugin_lifecycle: display_complete",
-                extra={
-                    "stage": "display_complete",
-                    "plugin_id": plugin_id,
-                    "instance": instance_name,
-                    "duration_ms": display_duration_ms,
-                    "refresh_id": benchmark_id,
-                    "request_id": request_id,
-                },
-            )
-            self.recorder.save_stage(
-                benchmark_id or "",
-                "display_pipeline",
-                display_duration_ms,
-            )
-            if display_driver:
-                self.recorder.save_stage(
-                    benchmark_id or "",
-                    "display_driver",
-                    display_duration_ms,
-                    extra={"driver": display_driver},
-                )
-        return display_duration_ms, preprocess_ms
 
     def _save_benchmark(
         self,
@@ -724,7 +650,7 @@ class RefreshTask:
         changed rather than stale content.  Best-effort: any error here is
         logged but never re-raised.
         """
-        self.housekeeper.push_fallback_image(
+        self.display_pipeline.push_fallback_image(
             plugin_id=plugin_id,
             instance_name=instance_name,
             exc=exc,
@@ -752,6 +678,23 @@ class RefreshTask:
             used_cached=used_cached,
         )
         self.device_config.write_config()
+
+    def _update_plugin_health_positional(
+        self,
+        plugin_id: str,
+        instance: str | None,
+        ok: bool,
+        metrics: Mapping[str, Any] | None,
+        error: str | None,
+    ) -> None:
+        """Positional adapter for collaborators that update plugin health."""
+        self._update_plugin_health(
+            plugin_id=plugin_id,
+            instance=instance,
+            ok=ok,
+            metrics=dict(metrics) if metrics is not None else None,
+            error=error,
+        )
 
     def _enqueue_manual_request(self, refresh_action: Any) -> ManualUpdateRequest:
         """Create and queue a ManualUpdateRequest; wake the background thread."""

--- a/tests/unit/test_refresh_task_display_pipeline.py
+++ b/tests/unit/test_refresh_task_display_pipeline.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from refresh_task.actions import ManualRefresh, ManualUpdateRequest
+from refresh_task.display_pipeline import DisplayPipeline
+from refresh_task.housekeeping import RefreshHousekeeper
+from refresh_task.recorder import RefreshRecorder
+
+
+class _DisplayManager:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.response: object = {
+            "display_ms": 21,
+            "preprocess_ms": 8,
+            "display_driver": "mock",
+        }
+        self.exception: BaseException | None = None
+
+    def display_image(
+        self,
+        image: Image.Image,
+        image_settings: object = None,
+        history_meta: dict[str, str | None] | None = None,
+        on_image_saved: Any = None,
+    ) -> object:
+        self.calls.append(
+            {
+                "image": image,
+                "image_settings": image_settings,
+                "history_meta": history_meta,
+                "on_image_saved": on_image_saved,
+            }
+        )
+        if on_image_saved is not None:
+            on_image_saved({"preprocess_ms": 8})
+        if self.exception is not None:
+            raise self.exception
+        return self.response
+
+
+def _make_pipeline(device_config_dev: Any, display_manager: _DisplayManager) -> tuple[
+    DisplayPipeline,
+    list[tuple[str, str | None, bool, Mapping[str, Any] | None, str | None]],
+    list[tuple[str, str, int | None, Mapping[str, Any] | None]],
+    list[dict[str, Any]],
+]:
+    housekeeper = RefreshHousekeeper(device_config_dev, display_manager)
+    recorder = RefreshRecorder(device_config_dev)
+    health_updates: list[
+        tuple[str, str | None, bool, Mapping[str, Any] | None, str | None]
+    ] = []
+    stages: list[tuple[str, str, int | None, Mapping[str, Any] | None]] = []
+    errors: list[dict[str, Any]] = []
+
+    def update_health(
+        plugin_id: str,
+        instance: str | None,
+        ok: bool,
+        metrics: Mapping[str, Any] | None,
+        error: str | None,
+    ) -> None:
+        health_updates.append((plugin_id, instance, ok, metrics, error))
+
+    def save_stage(
+        refresh_id: str,
+        stage: str,
+        duration_ms: int | None = None,
+        *,
+        extra: Mapping[str, Any] | None = None,
+    ) -> None:
+        stages.append((refresh_id, stage, duration_ms, extra))
+
+    def publish_error(**kwargs: Any) -> None:
+        errors.append(kwargs)
+
+    recorder.save_stage = save_stage
+    recorder.publish_error = publish_error
+    pipeline = DisplayPipeline(
+        display_manager=display_manager,
+        housekeeper=housekeeper,
+        recorder=recorder,
+        update_plugin_health=update_health,
+    )
+    return pipeline, health_updates, stages, errors
+
+
+def test_display_pipeline_success_records_metrics_and_stage(
+    device_config_dev: Any,
+) -> None:
+    display_manager = _DisplayManager()
+    pipeline, health_updates, stages, errors = _make_pipeline(
+        device_config_dev, display_manager
+    )
+    action = ManualRefresh("clock", {})
+    image = Image.new("RGB", device_config_dev.get_resolution(), "white")
+
+    display_ms, preprocess_ms = pipeline.push_to_display(
+        image=image,
+        plugin_config={"image_settings": [{"name": "saturation", "value": 1}]},
+        refresh_action=action,
+        refresh_info=action.get_refresh_info(),
+        benchmark_id="refresh-1",
+        plugin_id="clock",
+        instance_name=None,
+        request_id="request-1",
+    )
+
+    assert (display_ms, preprocess_ms) == (21, 8)
+    assert display_manager.calls[0]["history_meta"]["plugin_id"] == "clock"
+    assert stages == [
+        ("refresh-1", "display_pipeline", 21, None),
+        ("refresh-1", "display_driver", 21, {"driver": "mock"}),
+    ]
+    assert health_updates == []
+    assert errors == []
+
+
+def test_display_pipeline_cached_path_releases_manual_waiter(
+    device_config_dev: Any,
+) -> None:
+    display_manager = _DisplayManager()
+    pipeline, _health_updates, stages, _errors = _make_pipeline(
+        device_config_dev, display_manager
+    )
+    action = ManualRefresh("clock", {})
+    request = ManualUpdateRequest("request-2", action)
+    image = Image.new("RGB", device_config_dev.get_resolution(), "white")
+
+    result = pipeline.push_or_skip_display(
+        used_cached=True,
+        image=image,
+        plugin_config={},
+        refresh_action=action,
+        refresh_info=action.get_refresh_info(),
+        benchmark_id="refresh-2",
+        plugin_id="clock",
+        instance_name=None,
+        request_id="request-2",
+        manual_request=request,
+    )
+
+    assert result == (None, None)
+    assert request.image_saved.is_set()
+    assert display_manager.calls == []
+    assert stages == []
+
+
+def test_display_pipeline_manual_callback_sets_image_saved_metrics(
+    device_config_dev: Any,
+) -> None:
+    display_manager = _DisplayManager()
+    pipeline, _health_updates, _stages, _errors = _make_pipeline(
+        device_config_dev, display_manager
+    )
+    action = ManualRefresh("clock", {})
+    request = ManualUpdateRequest("request-3", action)
+    image = Image.new("RGB", device_config_dev.get_resolution(), "white")
+
+    pipeline.push_to_display(
+        image=image,
+        plugin_config={},
+        refresh_action=action,
+        refresh_info=action.get_refresh_info(),
+        benchmark_id="refresh-3",
+        plugin_id="clock",
+        instance_name=None,
+        request_id="request-3",
+        manual_request=request,
+    )
+
+    assert request.image_saved.is_set()
+    assert request.image_saved_metrics == {
+        "generate_ms": None,
+        "preprocess_ms": 8,
+        "display_ms": None,
+        "stage": "image_saved",
+    }
+
+
+def test_display_pipeline_failure_records_health_and_progress_error(
+    device_config_dev: Any, tmp_path: Any
+) -> None:
+    display_manager = _DisplayManager()
+    display_manager.exception = RuntimeError("display offline")
+    pipeline, health_updates, _stages, errors = _make_pipeline(
+        device_config_dev, display_manager
+    )
+    action = ManualRefresh("clock", {})
+    image = Image.new("RGB", device_config_dev.get_resolution(), "white")
+    processed = tmp_path / "processed.png"
+    processed.write_bytes(b"x")
+    device_config_dev.processed_image_file = str(processed)
+
+    with pytest.raises(RuntimeError, match="display offline"):
+        pipeline.push_to_display(
+            image=image,
+            plugin_config={},
+            refresh_action=action,
+            refresh_info=action.get_refresh_info(),
+            benchmark_id="refresh-4",
+            plugin_id="clock",
+            instance_name="Clock",
+            request_id="request-4",
+        )
+
+    assert health_updates == [
+        (
+            "clock",
+            "Clock",
+            False,
+            {"retained_display": True},
+            "display offline",
+        )
+    ]
+    assert errors == [
+        {
+            "plugin_id": "clock",
+            "instance": "Clock",
+            "refresh_id": "refresh-4",
+            "request_id": "request-4",
+            "error": "display offline",
+            "retained_display": True,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a DisplayPipeline collaborator for display pushes, cache skips, image-saved callbacks, display failure reporting, and fallback image delegation
- wire RefreshTask through the display pipeline while keeping compatibility wrappers for existing tests/callers
- add focused display pipeline coverage for success, cached manual release, manual image-saved metrics, and display failure health/progress reporting

## Validation
- bash scripts/lint.sh
- PYTHONPATH=src pytest -q tests/unit/test_refresh_task_display_pipeline.py tests/unit/test_refresh_task_helpers.py tests/unit/test_plugin_failure_fallback.py tests/integration/test_display_flows.py tests/integration/test_refresh_task.py
- PYTHONPATH=src python3 -m mypy src/refresh_task src/display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced display refresh reliability with improved error handling and recovery.
  * Strengthened plugin health monitoring during image display operations.

* **Refactor**
  * Reorganized display pipeline logic for better maintainability and consistency across cached and non-cached display paths.

* **Tests**
  * Added comprehensive test coverage for display pipeline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->