### PR TITLE
refactor: extract refresh executor policy

### DIFF
--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -2530,9 +2530,9 @@ x-wr-timezone==2.0.1 \
     # via recurring-ical-events
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1 \
-    --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
-    --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
+pip==26.1 \
+    --hash=sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1 \
+    --hash=sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3
     # via
     #   pip-api
     #   pip-tools

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -22,7 +22,6 @@ from refresh_task.worker import (
     _get_mp_context,
     _remote_exception,
 )
-from utils.plugin_errors import PermanentPluginError
 
 logger = logging.getLogger(__name__)
 
@@ -432,7 +431,8 @@ class RefreshExecutor:
     def _raise_if_permanent(
         exc: BaseException, plugin_id: str, attempt: int, attempts: int
     ) -> bool:
-        if not isinstance(exc, PermanentPluginError):
+        error_class_names = {cls.__name__ for cls in type(exc).__mro__}
+        if "PermanentPluginError" not in error_class_names:
             return False
         logger.info(
             "plugin_lifecycle: attempt_terminal | plugin_id=%s attempt=%s/%s error=%s",

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -369,10 +369,8 @@ class RefreshExecutor:
             worker_thread.join(timeout=timeout_s)
 
             if worker_thread.is_alive():
-                last_exc = self.handle_thread_timeout(
-                    plugin_id, timeout_s, cancel_event
-                )
-            elif "error" in result_holder:
+                raise self.handle_thread_timeout(plugin_id, timeout_s, cancel_event)
+            if "error" in result_holder:
                 last_exc = result_holder["error"]
             else:
                 return result_holder["image"], result_holder.get("meta")

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -232,24 +232,14 @@ class RefreshExecutor:
                 return image, exc_or_meta
 
             last_exc = self._normalize_timeout(plugin_id, timeout_s, exc_or_meta)
-            if self._raise_if_permanent(last_exc, plugin_id, attempt, attempts):
-                raise last_exc
-
-            if attempt < attempts:
-                logger.warning(
-                    "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
-                    plugin_id,
-                    attempt,
-                    attempts,
-                    backoff_ms,
-                    last_exc,
-                )
-                sleep(max(0.0, backoff_ms / 1000.0))
-                self.recorder.publish_step(
-                    plugin_id=plugin_id,
-                    request_id=request_id,
-                    step=f"retry {attempt}/{attempts - 1}",
-                )
+            self._handle_attempt_failure(
+                last_exc,
+                plugin_id=plugin_id,
+                attempt=attempt,
+                attempts=attempts,
+                backoff_ms=backoff_ms,
+                request_id=request_id,
+            )
 
         if last_exc is not None:
             raise last_exc
@@ -387,24 +377,14 @@ class RefreshExecutor:
             else:
                 return result_holder["image"], result_holder.get("meta")
 
-            if self._raise_if_permanent(last_exc, plugin_id, attempt, attempts):
-                raise last_exc
-
-            if attempt < attempts:
-                logger.warning(
-                    "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
-                    plugin_id,
-                    attempt,
-                    attempts,
-                    backoff_ms,
-                    last_exc,
-                )
-                sleep(max(0.0, backoff_ms / 1000.0))
-                self.recorder.publish_step(
-                    plugin_id=plugin_id,
-                    request_id=request_id,
-                    step=f"retry {attempt}/{attempts - 1}",
-                )
+            self._handle_attempt_failure(
+                last_exc,
+                plugin_id=plugin_id,
+                attempt=attempt,
+                attempts=attempts,
+                backoff_ms=backoff_ms,
+                request_id=request_id,
+            )
 
         if last_exc is not None:
             raise last_exc
@@ -416,6 +396,37 @@ class RefreshExecutor:
         backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
         attempts = max(1, retries + 1)
         return retries, backoff_ms, attempts
+
+    def _handle_attempt_failure(
+        self,
+        exc: BaseException,
+        *,
+        plugin_id: str,
+        attempt: int,
+        attempts: int,
+        backoff_ms: int,
+        request_id: str | None,
+    ) -> None:
+        if self._raise_if_permanent(exc, plugin_id, attempt, attempts):
+            raise exc
+
+        if attempt >= attempts:
+            return
+
+        logger.warning(
+            "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
+            plugin_id,
+            attempt,
+            attempts,
+            backoff_ms,
+            exc,
+        )
+        sleep(max(0.0, backoff_ms / 1000.0))
+        self.recorder.publish_step(
+            plugin_id=plugin_id,
+            request_id=request_id,
+            step=f"retry {attempt}/{attempts - 1}",
+        )
 
     @staticmethod
     def _normalize_timeout(

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -1,0 +1,369 @@
+"""Plugin execution policy for refresh cycles."""
+
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import threading
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from time import sleep
+from typing import Any, Protocol, cast
+
+from PIL import Image
+
+from refresh_task.actions import RefreshAction
+from refresh_task.context import RefreshContext
+from refresh_task.recorder import RefreshRecorder
+from refresh_task.worker import (
+    _execute_refresh_attempt_worker,
+    _get_mp_context,
+    _remote_exception,
+)
+from utils.plugin_errors import PermanentPluginError
+
+logger = logging.getLogger(__name__)
+
+
+class ZombieStateOwner(Protocol):
+    _zombie_thread_count: int
+    _zombie_thread_lock: threading.Lock
+
+
+GetPluginInstance = Callable[[dict[str, Any]], Any]
+TimeoutResolver = Callable[[str], float]
+MpContextFactory = Callable[[], Any]
+WorkerTarget = Callable[..., None]
+RemoteExceptionFactory = Callable[[str, str], BaseException]
+
+
+class RefreshExecutor:
+    """Runs plugin refresh actions with retry, timeout, and isolation policy."""
+
+    def __init__(
+        self,
+        *,
+        device_config: Any,
+        refresh_context: RefreshContext,
+        recorder: RefreshRecorder,
+        plugin_timeout_seconds: TimeoutResolver,
+        zombie_owner: ZombieStateOwner,
+        get_plugin_instance: GetPluginInstance,
+        mp_context_factory: MpContextFactory = _get_mp_context,
+        worker_target: WorkerTarget = _execute_refresh_attempt_worker,
+        remote_exception_factory: RemoteExceptionFactory = _remote_exception,
+    ) -> None:
+        self.device_config = device_config
+        self.refresh_context = refresh_context
+        self.recorder = recorder
+        self.plugin_timeout_seconds = plugin_timeout_seconds
+        self.zombie_owner = zombie_owner
+        self.get_plugin_instance = get_plugin_instance
+        self.mp_context_factory = mp_context_factory
+        self.worker_target = worker_target
+        self.remote_exception_factory = remote_exception_factory
+
+    @staticmethod
+    def timeout_msg(plugin_id: str, timeout_s: float) -> str:
+        """Return a canonical timeout error message string."""
+        return f"Plugin '{plugin_id}' timed out after {int(timeout_s)}s"
+
+    @staticmethod
+    def cleanup_subprocess(proc: Any, plugin_id: str) -> None:
+        """Terminate a subprocess that is still alive after its timeout."""
+        import signal as _signal
+
+        getpgid = getattr(os, "getpgid", None)
+        killpg = getattr(os, "killpg", None)
+        if callable(getpgid) and callable(killpg):
+            try:
+                pgid = getpgid(proc.pid)
+                if pgid != getpgid(0):
+                    killpg(pgid, _signal.SIGKILL)  # NOSONAR
+            except OSError:
+                pass
+
+        proc.terminate()
+        proc.join(timeout=2)
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=2)
+        if proc.is_alive():
+            logger.warning(
+                "plugin_lifecycle: zombie_process | plugin_id=%s pid=%s "
+                "- process did not exit after kill",
+                plugin_id,
+                proc.pid,
+            )
+
+    def handle_process_result(
+        self,
+        result_queue: Any,
+        proc: Any,
+        plugin_id: str,
+        attempt: int,
+    ) -> tuple[Any, Any]:
+        """Read and validate the result queue from a finished subprocess."""
+        try:
+            payload = result_queue.get_nowait()
+        except queue.Empty:
+            payload = None
+        if not payload:
+            if proc.exitcode == 0:
+                raise RuntimeError(
+                    f"Plugin '{plugin_id}' exited without returning a result"
+                )
+            raise RuntimeError(f"Plugin '{plugin_id}' exited with code {proc.exitcode}")
+        if payload.get("ok"):
+            image_path = payload["image_path"]
+            try:
+                with Image.open(image_path) as image:
+                    result_image = image.copy()
+            finally:
+                try:
+                    os.unlink(image_path)
+                except OSError:
+                    pass
+            logger.info(
+                "plugin_lifecycle: attempt_success | plugin_id=%s attempt=%s",
+                plugin_id,
+                attempt,
+            )
+            return result_image, payload.get("plugin_meta")
+        return None, self.remote_exception_factory(
+            str(payload.get("error_type") or "RuntimeError"),
+            str(payload.get("error_message") or "unknown error"),
+        )
+
+    def run_subprocess_attempt(
+        self,
+        refresh_action: RefreshAction,
+        plugin_config: Mapping[str, Any],
+        current_dt: datetime,
+        plugin_id: str,
+        timeout_s: float,
+        attempt: int,
+    ) -> tuple[Any, Any]:
+        """Spawn a subprocess for one plugin execution attempt."""
+        ctx = self.mp_context_factory()
+        result_queue = ctx.Queue(maxsize=1)
+        proc = cast(Any, ctx).Process(
+            target=self.worker_target,
+            args=(
+                result_queue,
+                plugin_config,
+                refresh_action,
+                self.refresh_context,
+                current_dt,
+            ),
+            daemon=True,
+        )
+        try:
+            proc.start()
+            proc.join(timeout=timeout_s)
+            if proc.is_alive():
+                self.cleanup_subprocess(proc, plugin_id)
+                return None, TimeoutError(self.timeout_msg(plugin_id, timeout_s))
+            return self.handle_process_result(result_queue, proc, plugin_id, attempt)
+        except TimeoutError:
+            return None, TimeoutError(self.timeout_msg(plugin_id, timeout_s))
+        except Exception as exc:
+            return None, exc
+        finally:
+            try:
+                result_queue.close()
+            except OSError:
+                pass
+            try:
+                result_queue.join_thread()
+            except OSError:
+                pass
+
+    def execute_with_policy(
+        self,
+        refresh_action: RefreshAction,
+        plugin_config: Mapping[str, Any],
+        current_dt: datetime,
+        request_id: str | None = None,
+    ) -> tuple[Any, Any]:
+        """Run a plugin with the configured retry and isolation policy."""
+        plugin_id = refresh_action.get_plugin_id()
+        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
+        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
+        timeout_s = self.plugin_timeout_seconds(plugin_id)
+        attempts = max(1, retries + 1)
+
+        isolation = (os.getenv("INKYPI_PLUGIN_ISOLATION") or "process").strip().lower()
+        if isolation == "none":
+            return self.execute_inprocess(refresh_action, plugin_config, current_dt)
+
+        last_exc: BaseException | None = None
+        for attempt in range(1, attempts + 1):
+            logger.info(
+                "plugin_lifecycle: attempt_start | plugin_id=%s attempt=%s attempts=%s timeout_s=%s",
+                plugin_id,
+                attempt,
+                attempts,
+                timeout_s,
+            )
+            image, exc_or_meta = self.run_subprocess_attempt(
+                refresh_action, plugin_config, current_dt, plugin_id, timeout_s, attempt
+            )
+            if image is not None:
+                return image, exc_or_meta
+
+            last_exc = self._normalize_timeout(plugin_id, timeout_s, exc_or_meta)
+            if self._raise_if_permanent(last_exc, plugin_id, attempt, attempts):
+                raise last_exc
+
+            if attempt < attempts:
+                logger.warning(
+                    "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
+                    plugin_id,
+                    attempt,
+                    attempts,
+                    backoff_ms,
+                    last_exc,
+                )
+                sleep(max(0.0, backoff_ms / 1000.0))
+                self.recorder.publish_step(
+                    plugin_id=plugin_id,
+                    request_id=request_id,
+                    step=f"retry {attempt}/{attempts - 1}",
+                )
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError(f"Plugin '{plugin_id}' failed with unknown error")
+
+    def make_inprocess_worker(
+        self,
+        refresh_action: RefreshAction,
+        plugin_config: Mapping[str, Any],
+        device_config: Any,
+        current_dt: datetime,
+        plugin_id: str,
+    ) -> tuple[Callable[[], None], dict[str, Any], threading.Event]:
+        """Return a worker function plus result holder and cancel event."""
+        result_holder: dict[str, Any] = {}
+        cancel_event = threading.Event()
+        result_holder["cancel_event"] = cancel_event
+
+        def _worker(
+            holder: dict[str, Any] = result_holder,
+            _cancel: threading.Event = cancel_event,
+        ) -> None:
+            try:
+                plugin = self.get_plugin_instance(dict(plugin_config))
+                image = refresh_action.execute(plugin, device_config, current_dt)
+                meta = None
+                if hasattr(plugin, "get_latest_metadata"):
+                    meta = plugin.get_latest_metadata()
+                holder["image"] = image
+                holder["meta"] = meta
+            except Exception as exc:
+                holder["error"] = exc
+            finally:
+                if _cancel.is_set():
+                    with self.zombie_owner._zombie_thread_lock:
+                        self.zombie_owner._zombie_thread_count = max(
+                            0, self.zombie_owner._zombie_thread_count - 1
+                        )
+                    logger.info(
+                        "Zombie thread for plugin '%s' has finished. "
+                        "Active zombie threads: %d",
+                        plugin_id,
+                        self.zombie_owner._zombie_thread_count,
+                    )
+
+        return _worker, result_holder, cancel_event
+
+    def handle_thread_timeout(
+        self, plugin_id: str, timeout_s: float, cancel_event: threading.Event
+    ) -> TimeoutError:
+        """Mark a timed-out worker thread as a zombie and return a TimeoutError."""
+        cancel_event.set()
+        with self.zombie_owner._zombie_thread_lock:
+            self.zombie_owner._zombie_thread_count += 1
+            zombie_count = self.zombie_owner._zombie_thread_count
+        logger.warning(
+            "Plugin '%s' timed out after %ds — cancellation event set. "
+            "Thread cannot be force-killed; it will run until completion. "
+            "Active zombie threads: %d",
+            plugin_id,
+            int(timeout_s),
+            zombie_count,
+        )
+        return TimeoutError(self.timeout_msg(plugin_id, timeout_s))
+
+    def execute_inprocess(
+        self,
+        refresh_action: RefreshAction,
+        plugin_config: Mapping[str, Any],
+        current_dt: datetime,
+    ) -> tuple[Any, Any]:
+        """Run a plugin directly in the current process with retries and timeout."""
+        plugin_id = refresh_action.get_plugin_id()
+        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
+        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
+        timeout_s = self.plugin_timeout_seconds(plugin_id)
+        attempts = max(1, retries + 1)
+
+        last_exc: BaseException | None = None
+        for attempt in range(1, attempts + 1):
+            _worker, result_holder, cancel_event = self.make_inprocess_worker(
+                refresh_action,
+                plugin_config,
+                self.device_config,
+                current_dt,
+                plugin_id,
+            )
+
+            worker_thread = threading.Thread(target=_worker, daemon=True)
+            worker_thread.start()
+            worker_thread.join(timeout=timeout_s)
+
+            if worker_thread.is_alive():
+                last_exc = self.handle_thread_timeout(
+                    plugin_id, timeout_s, cancel_event
+                )
+            elif "error" in result_holder:
+                last_exc = result_holder["error"]
+            else:
+                return result_holder["image"], result_holder.get("meta")
+
+            if self._raise_if_permanent(last_exc, plugin_id, attempt, attempts):
+                raise last_exc
+
+            if attempt < attempts:
+                sleep(max(0.0, backoff_ms / 1000.0))
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError(f"Plugin '{plugin_id}' failed with unknown error")
+
+    @staticmethod
+    def _normalize_timeout(
+        plugin_id: str, timeout_s: float, exc_or_meta: Any
+    ) -> BaseException:
+        if isinstance(exc_or_meta, TimeoutError):
+            return TimeoutError(RefreshExecutor.timeout_msg(plugin_id, timeout_s))
+        if isinstance(exc_or_meta, BaseException):
+            return exc_or_meta
+        return RuntimeError(str(exc_or_meta))
+
+    @staticmethod
+    def _raise_if_permanent(
+        exc: BaseException, plugin_id: str, attempt: int, attempts: int
+    ) -> bool:
+        if not isinstance(exc, PermanentPluginError):
+            return False
+        logger.info(
+            "plugin_lifecycle: attempt_terminal | plugin_id=%s attempt=%s/%s error=%s",
+            plugin_id,
+            attempt,
+            attempts,
+            exc,
+        )
+        return True

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import queue
+import signal
 import threading
 from collections.abc import Callable, Mapping
 from datetime import datetime
@@ -72,15 +73,13 @@ class RefreshExecutor:
     @staticmethod
     def cleanup_subprocess(proc: Any, plugin_id: str) -> None:
         """Terminate a subprocess that is still alive after its timeout."""
-        import signal as _signal
-
         getpgid = getattr(os, "getpgid", None)
         killpg = getattr(os, "killpg", None)
         if callable(getpgid) and callable(killpg):
             try:
                 pgid = getpgid(proc.pid)
                 if pgid != getpgid(0):
-                    killpg(pgid, _signal.SIGKILL)  # NOSONAR
+                    killpg(pgid, signal.SIGKILL)  # NOSONAR
             except OSError:
                 pass
 
@@ -105,11 +104,28 @@ class RefreshExecutor:
         attempt: int,
     ) -> tuple[Any, Any]:
         """Read and validate the result queue from a finished subprocess."""
+        return self.handle_process_result_payload(
+            result_queue,
+            proc,
+            plugin_id,
+            attempt,
+            remote_exception_factory=self.remote_exception_factory,
+        )
+
+    @staticmethod
+    def handle_process_result_payload(
+        result_queue: Any,
+        proc: Any,
+        plugin_id: str,
+        attempt: int,
+        remote_exception_factory: RemoteExceptionFactory = _remote_exception,
+    ) -> tuple[Any, Any]:
+        """Read and validate the result queue from a finished subprocess."""
         try:
             payload = result_queue.get_nowait()
         except queue.Empty:
             payload = None
-        if not payload:
+        if payload is None:
             if proc.exitcode == 0:
                 raise RuntimeError(
                     f"Plugin '{plugin_id}' exited without returning a result"
@@ -131,7 +147,7 @@ class RefreshExecutor:
                 attempt,
             )
             return result_image, payload.get("plugin_meta")
-        return None, self.remote_exception_factory(
+        return None, remote_exception_factory(
             str(payload.get("error_type") or "RuntimeError"),
             str(payload.get("error_message") or "unknown error"),
         )
@@ -189,14 +205,17 @@ class RefreshExecutor:
     ) -> tuple[Any, Any]:
         """Run a plugin with the configured retry and isolation policy."""
         plugin_id = refresh_action.get_plugin_id()
-        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
-        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
+        _retries, backoff_ms, attempts = self.retry_policy()
         timeout_s = self.plugin_timeout_seconds(plugin_id)
-        attempts = max(1, retries + 1)
 
         isolation = (os.getenv("INKYPI_PLUGIN_ISOLATION") or "process").strip().lower()
         if isolation == "none":
-            return self.execute_inprocess(refresh_action, plugin_config, current_dt)
+            return self.execute_inprocess(
+                refresh_action,
+                plugin_config,
+                current_dt,
+                request_id=request_id,
+            )
 
         last_exc: BaseException | None = None
         for attempt in range(1, attempts + 1):
@@ -246,16 +265,37 @@ class RefreshExecutor:
         plugin_id: str,
     ) -> tuple[Callable[[], None], dict[str, Any], threading.Event]:
         """Return a worker function plus result holder and cancel event."""
+        return self.make_inprocess_worker_for(
+            refresh_action=refresh_action,
+            plugin_config=plugin_config,
+            device_config=device_config,
+            current_dt=current_dt,
+            plugin_id=plugin_id,
+            zombie_owner=self.zombie_owner,
+            get_plugin_instance=self.get_plugin_instance,
+        )
+
+    @staticmethod
+    def make_inprocess_worker_for(
+        *,
+        refresh_action: RefreshAction,
+        plugin_config: Mapping[str, Any],
+        device_config: Any,
+        current_dt: datetime,
+        plugin_id: str,
+        zombie_owner: ZombieStateOwner,
+        get_plugin_instance: GetPluginInstance,
+    ) -> tuple[Callable[[], None], dict[str, Any], threading.Event]:
+        """Return a worker function plus result holder and cancel event."""
         result_holder: dict[str, Any] = {}
         cancel_event = threading.Event()
-        result_holder["cancel_event"] = cancel_event
 
         def _worker(
             holder: dict[str, Any] = result_holder,
             _cancel: threading.Event = cancel_event,
         ) -> None:
             try:
-                plugin = self.get_plugin_instance(dict(plugin_config))
+                plugin = get_plugin_instance(dict(plugin_config))
                 image = refresh_action.execute(plugin, device_config, current_dt)
                 meta = None
                 if hasattr(plugin, "get_latest_metadata"):
@@ -266,15 +306,15 @@ class RefreshExecutor:
                 holder["error"] = exc
             finally:
                 if _cancel.is_set():
-                    with self.zombie_owner._zombie_thread_lock:
-                        self.zombie_owner._zombie_thread_count = max(
-                            0, self.zombie_owner._zombie_thread_count - 1
+                    with zombie_owner._zombie_thread_lock:
+                        zombie_owner._zombie_thread_count = max(
+                            0, zombie_owner._zombie_thread_count - 1
                         )
                     logger.info(
                         "Zombie thread for plugin '%s' has finished. "
                         "Active zombie threads: %d",
                         plugin_id,
-                        self.zombie_owner._zombie_thread_count,
+                        zombie_owner._zombie_thread_count,
                     )
 
         return _worker, result_holder, cancel_event
@@ -283,10 +323,26 @@ class RefreshExecutor:
         self, plugin_id: str, timeout_s: float, cancel_event: threading.Event
     ) -> TimeoutError:
         """Mark a timed-out worker thread as a zombie and return a TimeoutError."""
+        return self.handle_thread_timeout_for(
+            plugin_id,
+            timeout_s,
+            cancel_event,
+            zombie_owner=self.zombie_owner,
+        )
+
+    @staticmethod
+    def handle_thread_timeout_for(
+        plugin_id: str,
+        timeout_s: float,
+        cancel_event: threading.Event,
+        *,
+        zombie_owner: ZombieStateOwner,
+    ) -> TimeoutError:
+        """Mark a timed-out worker thread as a zombie and return a TimeoutError."""
         cancel_event.set()
-        with self.zombie_owner._zombie_thread_lock:
-            self.zombie_owner._zombie_thread_count += 1
-            zombie_count = self.zombie_owner._zombie_thread_count
+        with zombie_owner._zombie_thread_lock:
+            zombie_owner._zombie_thread_count += 1
+            zombie_count = zombie_owner._zombie_thread_count
         logger.warning(
             "Plugin '%s' timed out after %ds — cancellation event set. "
             "Thread cannot be force-killed; it will run until completion. "
@@ -295,20 +351,19 @@ class RefreshExecutor:
             int(timeout_s),
             zombie_count,
         )
-        return TimeoutError(self.timeout_msg(plugin_id, timeout_s))
+        return TimeoutError(RefreshExecutor.timeout_msg(plugin_id, timeout_s))
 
     def execute_inprocess(
         self,
         refresh_action: RefreshAction,
         plugin_config: Mapping[str, Any],
         current_dt: datetime,
+        request_id: str | None = None,
     ) -> tuple[Any, Any]:
         """Run a plugin directly in the current process with retries and timeout."""
         plugin_id = refresh_action.get_plugin_id()
-        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
-        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
+        _retries, backoff_ms, attempts = self.retry_policy()
         timeout_s = self.plugin_timeout_seconds(plugin_id)
-        attempts = max(1, retries + 1)
 
         last_exc: BaseException | None = None
         for attempt in range(1, attempts + 1):
@@ -337,11 +392,31 @@ class RefreshExecutor:
                 raise last_exc
 
             if attempt < attempts:
+                logger.warning(
+                    "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
+                    plugin_id,
+                    attempt,
+                    attempts,
+                    backoff_ms,
+                    last_exc,
+                )
                 sleep(max(0.0, backoff_ms / 1000.0))
+                self.recorder.publish_step(
+                    plugin_id=plugin_id,
+                    request_id=request_id,
+                    step=f"retry {attempt}/{attempts - 1}",
+                )
 
         if last_exc is not None:
             raise last_exc
         raise RuntimeError(f"Plugin '{plugin_id}' failed with unknown error")
+
+    @staticmethod
+    def retry_policy() -> tuple[int, int, int]:
+        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
+        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
+        attempts = max(1, retries + 1)
+        return retries, backoff_ms, attempts
 
     @staticmethod
     def _normalize_timeout(

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -2,13 +2,12 @@
 
 import logging
 import os
-import queue
 import threading
 from collections import deque
 from collections.abc import Callable, Mapping
 from datetime import datetime
-from time import perf_counter, sleep
-from typing import Any, NoReturn, cast
+from time import perf_counter
+from typing import Any, ClassVar, NoReturn, cast
 from uuid import uuid4
 
 from model import PlaylistManager, RefreshInfo
@@ -17,18 +16,16 @@ from refresh_task import recorder as refresh_recorder
 from refresh_task.actions import ManualUpdateRequest, PlaylistRefresh, RefreshAction
 from refresh_task.context import RefreshContext
 from refresh_task.display_pipeline import DisplayPipeline
+from refresh_task.executor import RefreshExecutor
 from refresh_task.health import PluginHealthTracker
 from refresh_task.housekeeping import RefreshHousekeeper
 from refresh_task.scheduler import RefreshScheduler
 from refresh_task.worker import (
-    _execute_refresh_attempt_worker,
     _get_mp_context,
-    _remote_exception,
     sweep_orphan_render_tempfiles,
 )
 from utils.image_utils import compute_image_hash
 from utils.output_validator import OutputDimensionMismatch, validate_image_dimensions
-from utils.plugin_errors import PermanentPluginError
 from utils.progress import ProgressTracker, track_progress
 from utils.time_utils import now_device_tz
 from utils.webhooks import send_failure_webhook
@@ -102,6 +99,15 @@ class RefreshTask:
             housekeeper=self.housekeeper,
             recorder=self.recorder,
             update_plugin_health=self._update_plugin_health_positional,
+        )
+        self.executor = RefreshExecutor(
+            device_config=self.device_config,
+            refresh_context=self.refresh_context,
+            recorder=self.recorder,
+            plugin_timeout_seconds=self._plugin_timeout_seconds,
+            zombie_owner=type(self),
+            get_plugin_instance=lambda cfg: get_plugin_instance(cfg),
+            mp_context_factory=lambda: _get_mp_context(),
         )
         self._tick_count: int = 0
         self.watchdog_thread: threading.Thread | None = None
@@ -843,64 +849,12 @@ class RefreshTask:
     @staticmethod
     def _timeout_msg(plugin_id: str, timeout_s: float) -> str:
         """Return a canonical timeout error message string."""
-        return f"Plugin '{plugin_id}' timed out after {int(timeout_s)}s"
+        return RefreshExecutor.timeout_msg(plugin_id, timeout_s)
 
     @staticmethod
     def _cleanup_subprocess(proc: Any, plugin_id: str) -> None:
-        """Terminate a subprocess that is still alive after its timeout.
-
-        JTN-S2: ``killpg(SIGKILL)`` the worker's process group up front,
-        before any terminate/join dance.  The worker calls ``os.setsid()``
-        at startup, so it is a session leader and its pgid equals its
-        pid; the chromium screenshot subprocess plus chromium's zygote /
-        renderer / utility descendants all inherit that same pgid.  Doing
-        the killpg BEFORE checking ``proc.is_alive()`` is critical — if
-        we only killpg "when the worker survives terminate", a worker
-        that exits gracefully on SIGTERM would skip the killpg entirely
-        and leave its chromium descendants reparented to PID 1.  That
-        was the on-device leak: 9 chromium processes survived per
-        timeout because the worker's own SIGTERM handler returned cleanly.
-
-        ``getpgid(0) != pgid`` guards against signaling our own group in
-        the (impossible-in-production) case where the worker never made
-        it past setsid.
-        """
-        import signal as _signal
-
-        # 1. Take down the whole worker session up front — catches the
-        #    chromium tree before any of it can be reparented.
-        #    ``getpgid``/``killpg`` are POSIX-only; ``getattr`` guards the
-        #    Windows case so we silently fall through to the
-        #    terminate()/kill() fallback instead of raising AttributeError
-        #    (which the except below would not catch).
-        getpgid = getattr(os, "getpgid", None)
-        killpg = getattr(os, "killpg", None)
-        if callable(getpgid) and callable(killpg):
-            try:
-                pgid = getpgid(proc.pid)
-                # Signal is scoped to the worker's own session (the worker
-                # called ``setsid`` at startup) and guarded against our
-                # own pgid, so the only processes affected are the ones
-                # this refresh task spawned.  SonarCloud python:S4828.
-                if pgid != getpgid(0):
-                    killpg(pgid, _signal.SIGKILL)  # NOSONAR
-            except OSError:
-                # ProcessLookupError / PermissionError are OSError subclasses.
-                pass
-
-        # 2. Standard terminate/kill dance to reap the worker entry.
-        proc.terminate()
-        proc.join(timeout=2)
-        if proc.is_alive():
-            proc.kill()
-            proc.join(timeout=2)
-        if proc.is_alive():
-            logger.warning(
-                "plugin_lifecycle: zombie_process | plugin_id=%s pid=%s "
-                "- process did not exit after kill",
-                plugin_id,
-                proc.pid,
-            )
+        """Terminate a subprocess that is still alive after its timeout."""
+        RefreshExecutor.cleanup_subprocess(proc, plugin_id)
 
     @staticmethod
     def _handle_process_result(
@@ -909,49 +863,16 @@ class RefreshTask:
         plugin_id: str,
         attempt: int,
     ) -> tuple[Any, Any]:
-        """Read and validate the result queue from a finished subprocess.
-
-        Returns ``(image, metadata)`` on success, or ``(None, exception)``
-        on failure.  Raises ``RuntimeError`` directly for unrecoverable exit
-        conditions.
-        """
-        try:
-            payload = result_queue.get_nowait()
-        except queue.Empty:
-            payload = None
-        if not payload:
-            if proc.exitcode == 0:
-                raise RuntimeError(
-                    f"Plugin '{plugin_id}' exited without returning a result"
-                )
-            raise RuntimeError(f"Plugin '{plugin_id}' exited with code {proc.exitcode}")
-        if payload.get("ok"):
-            from PIL import Image
-
-            # Worker writes PNG to a tempfile and passes the path via the
-            # queue (see worker.py for the pipe-buffer-deadlock rationale).
-            # Load into memory with image.copy() so we can unlink the
-            # underlying file immediately; the in-memory PIL.Image does
-            # not retain a reference to it.
-            image_path = payload["image_path"]
-            try:
-                with Image.open(image_path) as image:
-                    result_image = image.copy()
-            finally:
-                try:
-                    os.unlink(image_path)
-                except OSError:
-                    pass
-            logger.info(
-                "plugin_lifecycle: attempt_success | plugin_id=%s attempt=%s",
-                plugin_id,
-                attempt,
-            )
-            return result_image, payload.get("plugin_meta")
-        return None, _remote_exception(
-            str(payload.get("error_type") or "RuntimeError"),
-            str(payload.get("error_message") or "unknown error"),
+        """Read and validate the result queue from a finished subprocess."""
+        executor = RefreshExecutor(
+            device_config=None,
+            refresh_context=cast(Any, None),
+            recorder=cast(Any, None),
+            plugin_timeout_seconds=lambda _plugin_id: 60.0,
+            zombie_owner=RefreshTask,
+            get_plugin_instance=lambda _cfg: None,
         )
+        return executor.handle_process_result(result_queue, proc, plugin_id, attempt)
 
     def _run_subprocess_attempt(
         self,
@@ -962,44 +883,15 @@ class RefreshTask:
         timeout_s: float,
         attempt: int,
     ) -> tuple[Any, Any]:
-        """Spawn a subprocess for one plugin execution attempt.
-
-        Returns ``(image, exc_or_meta)`` on success, or raises/returns an exception
-        as the second element when the attempt fails.
-        """
-        ctx = _get_mp_context()
-        result_queue = ctx.Queue(maxsize=1)
-        proc = cast(Any, ctx).Process(
-            target=_execute_refresh_attempt_worker,
-            args=(
-                result_queue,
-                plugin_config,
-                refresh_action,
-                self.refresh_context,
-                current_dt,
-            ),
-            daemon=True,
+        """Spawn a subprocess for one plugin execution attempt."""
+        return self.executor.run_subprocess_attempt(
+            refresh_action,
+            plugin_config,
+            current_dt,
+            plugin_id,
+            timeout_s,
+            attempt,
         )
-        try:
-            proc.start()
-            proc.join(timeout=timeout_s)
-            if proc.is_alive():
-                self._cleanup_subprocess(proc, plugin_id)
-                return None, TimeoutError(self._timeout_msg(plugin_id, timeout_s))
-            return self._handle_process_result(result_queue, proc, plugin_id, attempt)
-        except TimeoutError:
-            return None, TimeoutError(self._timeout_msg(plugin_id, timeout_s))
-        except Exception as exc:
-            return None, exc
-        finally:
-            try:
-                result_queue.close()
-            except OSError:
-                pass
-            try:
-                result_queue.join_thread()
-            except OSError:
-                pass
 
     def _execute_with_policy(
         self,
@@ -1008,101 +900,39 @@ class RefreshTask:
         current_dt: datetime,
         request_id: str | None = None,
     ) -> tuple[Any, Any]:
-        """Run a plugin with the configured retry and isolation policy.
-
-        Reads environment variables to determine the execution strategy:
-        - ``INKYPI_PLUGIN_ISOLATION``: ``"process"`` (default) spawns a
-          subprocess per attempt; ``"none"`` runs in-process via a worker thread.
-        - ``INKYPI_PLUGIN_RETRY_MAX``: Maximum number of retries (default 1).
-        - ``INKYPI_PLUGIN_RETRY_BACKOFF_MS``: Sleep between retries (default 500 ms).
-        - ``INKYPI_PLUGIN_TIMEOUT_S``: Per-attempt timeout in seconds (default 60).
-
-        Args:
-            refresh_action: The :class:`RefreshAction` describing what to run.
-            plugin_config: The raw plugin configuration dict from device.json.
-            current_dt: The current device-timezone datetime used by the plugin.
-            request_id: Optional correlation ID for logging and benchmarking.
-
-        Returns:
-            A ``(image, plugin_meta)`` tuple where *image* is a
-            ``PIL.Image.Image`` and *plugin_meta* is optional metadata from the
-            plugin.
-
-        Raises:
-            TimeoutError: If all attempts time out.
-            RuntimeError: If all attempts fail with an unrecoverable error.
-        """
-        plugin_id = refresh_action.get_plugin_id()
-        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
-        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
-        timeout_s = self._plugin_timeout_seconds(plugin_id)
-        attempts = max(1, retries + 1)
-
-        # When isolation is disabled (e.g. in tests or on constrained devices),
-        # run the plugin directly in the current process instead of spawning a
-        # subprocess.  This avoids pickling issues that arise with the ``spawn``
-        # and ``forkserver`` multiprocessing start methods on Linux.
-        isolation = (os.getenv("INKYPI_PLUGIN_ISOLATION") or "process").strip().lower()
-        if isolation == "none":
-            return self._execute_inprocess(refresh_action, plugin_config, current_dt)
-
-        last_exc: BaseException | None = None
-        for attempt in range(1, attempts + 1):
-            logger.info(
-                "plugin_lifecycle: attempt_start | plugin_id=%s attempt=%s attempts=%s timeout_s=%s",
-                plugin_id,
-                attempt,
-                attempts,
-                timeout_s,
+        """Run a plugin with the configured retry and isolation policy."""
+        # Preserve existing private-test hooks that monkeypatch
+        # ``task._run_subprocess_attempt`` while the real policy lives in the
+        # executor collaborator.
+        attempt_runner = self._run_subprocess_attempt
+        if (
+            getattr(attempt_runner, "__func__", None)
+            is RefreshTask._run_subprocess_attempt
+        ):
+            return self.executor.execute_with_policy(
+                refresh_action,
+                plugin_config,
+                current_dt,
+                request_id=request_id,
             )
-            image, exc_or_meta = self._run_subprocess_attempt(
-                refresh_action, plugin_config, current_dt, plugin_id, timeout_s, attempt
+
+        original_runner = self.executor.run_subprocess_attempt
+        cast(Any, self.executor).run_subprocess_attempt = attempt_runner
+        try:
+            return self.executor.execute_with_policy(
+                refresh_action,
+                plugin_config,
+                current_dt,
+                request_id=request_id,
             )
-            if image is not None:
-                return image, exc_or_meta
-
-            last_exc = exc_or_meta
-            if isinstance(last_exc, TimeoutError):
-                last_exc = TimeoutError(self._timeout_msg(plugin_id, timeout_s))
-
-            # JTN-778: permanent errors (bad URL, malformed config) will fail
-            # identically on retry — skip remaining attempts to avoid burning
-            # CPU and log lines on every scheduled playlist tick.
-            if isinstance(last_exc, PermanentPluginError):
-                logger.info(
-                    "plugin_lifecycle: attempt_terminal | plugin_id=%s attempt=%s/%s error=%s",
-                    plugin_id,
-                    attempt,
-                    attempts,
-                    last_exc,
-                )
-                raise last_exc
-
-            if attempt < attempts:
-                logger.warning(
-                    "plugin_lifecycle: attempt_retry | plugin_id=%s attempt=%s/%s backoff_ms=%s error=%s",
-                    plugin_id,
-                    attempt,
-                    attempts,
-                    backoff_ms,
-                    last_exc,
-                )
-                sleep(max(0.0, backoff_ms / 1000.0))
-                self.recorder.publish_step(
-                    plugin_id=plugin_id,
-                    request_id=request_id,
-                    step=f"retry {attempt}/{attempts - 1}",
-                )
-
-        if last_exc is not None:
-            raise last_exc
-        raise RuntimeError(f"Plugin '{plugin_id}' failed with unknown error")
+        finally:
+            cast(Any, self.executor).run_subprocess_attempt = original_runner
 
     # Class-level counter tracking threads that timed out but could not be stopped.
     # Python threads cannot be force-killed; cooperative plugins should check the
     # cancel_event passed via result_holder["cancel_event"] and exit early.
-    _zombie_thread_count: int = 0
-    _zombie_thread_lock: threading.Lock = threading.Lock()
+    _zombie_thread_count: ClassVar[int] = 0
+    _zombie_thread_lock: ClassVar[threading.Lock] = threading.Lock()
 
     @staticmethod
     def _make_inprocess_worker(
@@ -1112,61 +942,37 @@ class RefreshTask:
         current_dt: datetime,
         plugin_id: str,
     ) -> tuple[Callable[[], None], dict[str, Any], threading.Event]:
-        """Return a ``(worker_fn, result_holder, cancel_event)`` tuple.
-
-        The returned *worker_fn* is suitable for ``threading.Thread(target=...)``.
-        """
-        result_holder: dict[str, Any] = {}
-        cancel_event = threading.Event()
-        result_holder["cancel_event"] = cancel_event
-
-        def _worker(
-            holder: dict[str, Any] = result_holder,
-            _cancel: threading.Event = cancel_event,
-        ) -> None:
-            try:
-                plugin = get_plugin_instance(dict(plugin_config))
-                image = refresh_action.execute(plugin, device_config, current_dt)
-                meta = None
-                if hasattr(plugin, "get_latest_metadata"):
-                    meta = plugin.get_latest_metadata()
-                holder["image"] = image
-                holder["meta"] = meta
-            except Exception as exc:
-                holder["error"] = exc
-            finally:
-                if _cancel.is_set():
-                    with RefreshTask._zombie_thread_lock:
-                        RefreshTask._zombie_thread_count = max(
-                            0, RefreshTask._zombie_thread_count - 1
-                        )
-                    logging.getLogger(__name__).info(
-                        "Zombie thread for plugin '%s' has finished. "
-                        "Active zombie threads: %d",
-                        plugin_id,
-                        RefreshTask._zombie_thread_count,
-                    )
-
-        return _worker, result_holder, cancel_event
+        """Return a ``(worker_fn, result_holder, cancel_event)`` tuple."""
+        executor = RefreshExecutor(
+            device_config=device_config,
+            refresh_context=cast(Any, None),
+            recorder=cast(Any, None),
+            plugin_timeout_seconds=lambda _plugin_id: 60.0,
+            zombie_owner=RefreshTask,
+            get_plugin_instance=lambda cfg: get_plugin_instance(cfg),
+        )
+        return executor.make_inprocess_worker(
+            refresh_action,
+            plugin_config,
+            device_config,
+            current_dt,
+            plugin_id,
+        )
 
     @staticmethod
     def _handle_thread_timeout(
         plugin_id: str, timeout_s: float, cancel_event: threading.Event
     ) -> TimeoutError:
         """Mark a timed-out worker thread as a zombie and return a TimeoutError."""
-        cancel_event.set()
-        with RefreshTask._zombie_thread_lock:
-            RefreshTask._zombie_thread_count += 1
-            zombie_count = RefreshTask._zombie_thread_count
-        logging.getLogger(__name__).warning(
-            "Plugin '%s' timed out after %ds — cancellation event set. "
-            "Thread cannot be force-killed; it will run until completion. "
-            "Active zombie threads: %d",
-            plugin_id,
-            int(timeout_s),
-            zombie_count,
+        executor = RefreshExecutor(
+            device_config=None,
+            refresh_context=cast(Any, None),
+            recorder=cast(Any, None),
+            plugin_timeout_seconds=lambda _plugin_id: timeout_s,
+            zombie_owner=RefreshTask,
+            get_plugin_instance=lambda _cfg: None,
         )
-        return TimeoutError(f"Plugin '{plugin_id}' timed out after {int(timeout_s)}s")
+        return executor.handle_thread_timeout(plugin_id, timeout_s, cancel_event)
 
     def _execute_inprocess(
         self,
@@ -1174,67 +980,10 @@ class RefreshTask:
         plugin_config: Mapping[str, Any],
         current_dt: datetime,
     ) -> tuple[Any, Any]:
-        """Run a plugin directly in the current process (no subprocess isolation).
-
-        Used when ``INKYPI_PLUGIN_ISOLATION=none`` to avoid pickling constraints
-        imposed by the ``spawn``/``forkserver`` multiprocessing start methods.
-
-        Supports retries and timeouts via a worker thread so the behaviour
-        mirrors the subprocess path as closely as possible.
-
-        On timeout a ``threading.Event`` (``cancel_event``) is set so that
-        cooperative plugins can detect cancellation and exit early.  Because
-        Python threads cannot be force-killed, a timed-out thread becomes a
-        "zombie" daemon thread.  The class-level ``_zombie_thread_count``
-        counter is incremented for each such thread and decremented when the
-        thread eventually finishes, enabling monitoring.
-        """
-        plugin_id = refresh_action.get_plugin_id()
-        retries = int(os.getenv("INKYPI_PLUGIN_RETRY_MAX", "1") or "1")
-        backoff_ms = int(os.getenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "500") or "500")
-        timeout_s = self._plugin_timeout_seconds(plugin_id)
-        attempts = max(1, retries + 1)
-
-        last_exc: BaseException | None = None
-        for attempt in range(1, attempts + 1):
-            _worker, result_holder, cancel_event = self._make_inprocess_worker(
-                refresh_action,
-                plugin_config,
-                self.device_config,
-                current_dt,
-                plugin_id,
-            )
-
-            worker_thread = threading.Thread(target=_worker, daemon=True)
-            worker_thread.start()
-            worker_thread.join(timeout=timeout_s)
-
-            if worker_thread.is_alive():
-                last_exc = self._handle_thread_timeout(
-                    plugin_id, timeout_s, cancel_event
-                )
-            elif "error" in result_holder:
-                last_exc = result_holder["error"]
-            else:
-                return result_holder["image"], result_holder.get("meta")
-
-            # JTN-778: permanent errors are terminal — skip retries.
-            if isinstance(last_exc, PermanentPluginError):
-                logger.info(
-                    "plugin_lifecycle: attempt_terminal | plugin_id=%s attempt=%s/%s error=%s",
-                    plugin_id,
-                    attempt,
-                    attempts,
-                    last_exc,
-                )
-                raise last_exc
-
-            if attempt < attempts:
-                sleep(max(0.0, backoff_ms / 1000.0))
-
-        if last_exc is not None:
-            raise last_exc
-        raise RuntimeError(f"Plugin '{plugin_id}' failed with unknown error")
+        """Run a plugin directly in the current process."""
+        return self.executor.execute_inprocess(
+            refresh_action, plugin_config, current_dt
+        )
 
     def _update_plugin_health(
         self,
@@ -1302,6 +1051,7 @@ class RefreshTask:
         subprocess launches pick up the latest configuration values.
         """
         self.refresh_context = RefreshContext.from_config(self.device_config)
+        self.executor.refresh_context = self.refresh_context
         if self.running:
             with self.condition:
                 self.condition.notify_all()

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -109,6 +109,7 @@ class RefreshTask:
             get_plugin_instance=lambda cfg: get_plugin_instance(cfg),
             mp_context_factory=lambda: _get_mp_context(),
         )
+        self._executor_run_subprocess_attempt = self.executor.run_subprocess_attempt
         self._tick_count: int = 0
         self.watchdog_thread: threading.Thread | None = None
 
@@ -864,15 +865,12 @@ class RefreshTask:
         attempt: int,
     ) -> tuple[Any, Any]:
         """Read and validate the result queue from a finished subprocess."""
-        executor = RefreshExecutor(
-            device_config=None,
-            refresh_context=cast(Any, None),
-            recorder=cast(Any, None),
-            plugin_timeout_seconds=lambda _plugin_id: 60.0,
-            zombie_owner=RefreshTask,
-            get_plugin_instance=lambda _cfg: None,
+        return RefreshExecutor.handle_process_result_payload(
+            result_queue,
+            proc,
+            plugin_id,
+            attempt,
         )
-        return executor.handle_process_result(result_queue, proc, plugin_id, attempt)
 
     def _run_subprocess_attempt(
         self,
@@ -884,7 +882,7 @@ class RefreshTask:
         attempt: int,
     ) -> tuple[Any, Any]:
         """Spawn a subprocess for one plugin execution attempt."""
-        return self.executor.run_subprocess_attempt(
+        return self._executor_run_subprocess_attempt(
             refresh_action,
             plugin_config,
             current_dt,
@@ -901,23 +899,8 @@ class RefreshTask:
         request_id: str | None = None,
     ) -> tuple[Any, Any]:
         """Run a plugin with the configured retry and isolation policy."""
-        # Preserve existing private-test hooks that monkeypatch
-        # ``task._run_subprocess_attempt`` while the real policy lives in the
-        # executor collaborator.
-        attempt_runner = self._run_subprocess_attempt
-        if (
-            getattr(attempt_runner, "__func__", None)
-            is RefreshTask._run_subprocess_attempt
-        ):
-            return self.executor.execute_with_policy(
-                refresh_action,
-                plugin_config,
-                current_dt,
-                request_id=request_id,
-            )
-
         original_runner = self.executor.run_subprocess_attempt
-        cast(Any, self.executor).run_subprocess_attempt = attempt_runner
+        cast(Any, self.executor).run_subprocess_attempt = self._run_subprocess_attempt
         try:
             return self.executor.execute_with_policy(
                 refresh_action,
@@ -929,8 +912,8 @@ class RefreshTask:
             cast(Any, self.executor).run_subprocess_attempt = original_runner
 
     # Class-level counter tracking threads that timed out but could not be stopped.
-    # Python threads cannot be force-killed; cooperative plugins should check the
-    # cancel_event passed via result_holder["cancel_event"] and exit early.
+    # Python threads cannot be force-killed; the cancel event is internal
+    # lifecycle bookkeeping that lets the worker decrement this count on exit.
     _zombie_thread_count: ClassVar[int] = 0
     _zombie_thread_lock: ClassVar[threading.Lock] = threading.Lock()
 
@@ -943,20 +926,14 @@ class RefreshTask:
         plugin_id: str,
     ) -> tuple[Callable[[], None], dict[str, Any], threading.Event]:
         """Return a ``(worker_fn, result_holder, cancel_event)`` tuple."""
-        executor = RefreshExecutor(
+        return RefreshExecutor.make_inprocess_worker_for(
+            refresh_action=refresh_action,
+            plugin_config=plugin_config,
             device_config=device_config,
-            refresh_context=cast(Any, None),
-            recorder=cast(Any, None),
-            plugin_timeout_seconds=lambda _plugin_id: 60.0,
+            current_dt=current_dt,
+            plugin_id=plugin_id,
             zombie_owner=RefreshTask,
             get_plugin_instance=lambda cfg: get_plugin_instance(cfg),
-        )
-        return executor.make_inprocess_worker(
-            refresh_action,
-            plugin_config,
-            device_config,
-            current_dt,
-            plugin_id,
         )
 
     @staticmethod
@@ -964,15 +941,12 @@ class RefreshTask:
         plugin_id: str, timeout_s: float, cancel_event: threading.Event
     ) -> TimeoutError:
         """Mark a timed-out worker thread as a zombie and return a TimeoutError."""
-        executor = RefreshExecutor(
-            device_config=None,
-            refresh_context=cast(Any, None),
-            recorder=cast(Any, None),
-            plugin_timeout_seconds=lambda _plugin_id: timeout_s,
+        return RefreshExecutor.handle_thread_timeout_for(
+            plugin_id,
+            timeout_s,
+            cancel_event,
             zombie_owner=RefreshTask,
-            get_plugin_instance=lambda _cfg: None,
         )
-        return executor.handle_thread_timeout(plugin_id, timeout_s, cancel_event)
 
     def _execute_inprocess(
         self,

--- a/tests/unit/test_refresh_task_executor.py
+++ b/tests/unit/test_refresh_task_executor.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from refresh_task.executor import RefreshExecutor
+from utils.plugin_errors import PermanentPluginError
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.steps: list[dict[str, Any]] = []
+
+    def publish_step(self, **kwargs: Any) -> None:
+        self.steps.append(kwargs)
+
+
+class _ZombieOwner:
+    _zombie_thread_count = 0
+    _zombie_thread_lock = threading.Lock()
+
+
+class _Action:
+    def __init__(self, plugin_id: str = "clock") -> None:
+        self.plugin_id = plugin_id
+
+    def get_plugin_id(self) -> str:
+        return self.plugin_id
+
+    def execute(self, plugin: Any, device_config: Any, current_dt: datetime) -> Any:
+        return plugin.generate_image({}, device_config)
+
+
+def _make_executor(**kwargs: Any) -> tuple[RefreshExecutor, _Recorder]:
+    recorder = _Recorder()
+    executor = RefreshExecutor(
+        device_config=object(),
+        refresh_context=kwargs.get("refresh_context"),
+        recorder=recorder,
+        plugin_timeout_seconds=lambda _plugin_id: 0.01,
+        zombie_owner=_ZombieOwner,
+        get_plugin_instance=kwargs.get("get_plugin_instance", lambda _cfg: object()),
+    )
+    return executor, recorder
+
+
+def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) -> None:
+    executor, recorder = _make_executor()
+    image = Image.new("RGB", (4, 4), "blue")
+    calls = {"count": 0}
+
+    def attempt(*args: Any, **kwargs: Any) -> tuple[Any, Any]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return None, RuntimeError("temporary")
+        return image, {"ok": True}
+
+    monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "process")
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "1")
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "0")
+    executor.run_subprocess_attempt = attempt
+
+    result, meta = executor.execute_with_policy(
+        _Action(), {}, datetime.now(UTC), request_id="req-1"
+    )
+
+    assert result is image
+    assert meta == {"ok": True}
+    assert calls["count"] == 2
+    assert recorder.steps == [
+        {
+            "plugin_id": "clock",
+            "request_id": "req-1",
+            "step": "retry 1/1",
+        }
+    ]
+
+
+def test_executor_policy_skips_retry_for_permanent_error(monkeypatch: Any) -> None:
+    executor, _recorder = _make_executor()
+    calls = {"count": 0}
+
+    def attempt(*args: Any, **kwargs: Any) -> tuple[Any, Any]:
+        calls["count"] += 1
+        return None, PermanentPluginError("bad URL")
+
+    monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "process")
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "3")
+    executor.run_subprocess_attempt = attempt
+
+    with pytest.raises(PermanentPluginError, match="bad URL"):
+        executor.execute_with_policy(_Action(), {}, datetime.now(UTC))
+
+    assert calls["count"] == 1
+
+
+def test_executor_inprocess_success_returns_image_and_metadata(
+    monkeypatch: Any,
+) -> None:
+    expected = Image.new("RGB", (4, 4), "red")
+
+    class Plugin:
+        def generate_image(self, settings: Any, device_config: Any) -> Image.Image:
+            return expected
+
+        def get_latest_metadata(self) -> dict[str, str]:
+            return {"source": "test"}
+
+    executor, _recorder = _make_executor(get_plugin_instance=lambda _cfg: Plugin())
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "0")
+
+    image, meta = executor.execute_inprocess(_Action(), {}, datetime.now(UTC))
+
+    assert image is expected
+    assert meta == {"source": "test"}
+
+
+def test_executor_thread_timeout_tracks_zombie(monkeypatch: Any) -> None:
+    _ZombieOwner._zombie_thread_count = 0
+    release = threading.Event()
+
+    class Plugin:
+        def generate_image(self, settings: Any, device_config: Any) -> Image.Image:
+            release.wait(timeout=5)
+            return Image.new("RGB", (4, 4), "green")
+
+    executor, _recorder = _make_executor(get_plugin_instance=lambda _cfg: Plugin())
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "0")
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        executor.execute_inprocess(_Action("slow"), {}, datetime.now(UTC))
+
+    assert _ZombieOwner._zombie_thread_count == 1
+    release.set()

--- a/tests/unit/test_refresh_task_executor.py
+++ b/tests/unit/test_refresh_task_executor.py
@@ -9,9 +9,6 @@ from typing import Any
 import pytest
 from PIL import Image
 
-from refresh_task.executor import RefreshExecutor
-from utils.plugin_errors import PermanentPluginError
-
 
 class _Recorder:
     def __init__(self) -> None:
@@ -37,7 +34,9 @@ class _Action:
         return plugin.generate_image({}, device_config)
 
 
-def _make_executor(**kwargs: Any) -> tuple[RefreshExecutor, _Recorder]:
+def _make_executor(**kwargs: Any) -> tuple[Any, _Recorder]:
+    from refresh_task.executor import RefreshExecutor
+
     recorder = _Recorder()
     executor = RefreshExecutor(
         device_config=object(),
@@ -54,6 +53,7 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
     executor, recorder = _make_executor()
     image = Image.new("RGB", (4, 4), "blue")
     calls = {"count": 0}
+    from refresh_task.executor import RefreshExecutor
 
     def attempt(
         self: RefreshExecutor,
@@ -93,6 +93,8 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
 def test_executor_policy_skips_retry_for_permanent_error(monkeypatch: Any) -> None:
     executor, _recorder = _make_executor()
     calls = {"count": 0}
+    from refresh_task.executor import RefreshExecutor
+    from utils.plugin_errors import PermanentPluginError
 
     def attempt(
         self: RefreshExecutor,

--- a/tests/unit/test_refresh_task_executor.py
+++ b/tests/unit/test_refresh_task_executor.py
@@ -190,3 +190,33 @@ def test_executor_thread_timeout_tracks_zombie(monkeypatch: Any) -> None:
     while _ZombieOwner._zombie_thread_count > 0 and time.monotonic() < deadline:
         time.sleep(0.05)
     assert _ZombieOwner._zombie_thread_count == 0
+
+
+def test_executor_inprocess_timeout_does_not_retry(monkeypatch: Any) -> None:
+    _ZombieOwner._zombie_thread_count = 0
+    release = threading.Event()
+    calls = {"count": 0}
+
+    class Plugin:
+        def generate_image(self, settings: Any, device_config: Any) -> Image.Image:
+            calls["count"] += 1
+            release.wait(timeout=5)
+            return Image.new("RGB", (4, 4), "green")
+
+    executor, recorder = _make_executor(get_plugin_instance=lambda _cfg: Plugin())
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "1")
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "0")
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        executor.execute_inprocess(
+            _Action("slow"), {}, datetime.now(UTC), request_id="req-timeout"
+        )
+
+    assert calls["count"] == 1
+    assert recorder.steps == []
+    assert _ZombieOwner._zombie_thread_count == 1
+    release.set()
+    deadline = time.monotonic() + 5
+    while _ZombieOwner._zombie_thread_count > 0 and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert _ZombieOwner._zombie_thread_count == 0

--- a/tests/unit/test_refresh_task_executor.py
+++ b/tests/unit/test_refresh_task_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import threading
 import time
 from datetime import UTC, datetime
@@ -35,10 +36,9 @@ class _Action:
 
 
 def _make_executor(**kwargs: Any) -> tuple[Any, _Recorder]:
-    from refresh_task.executor import RefreshExecutor
-
+    refresh_executor = importlib.import_module("refresh_task.executor")
     recorder = _Recorder()
-    executor = RefreshExecutor(
+    executor = refresh_executor.RefreshExecutor(
         device_config=object(),
         refresh_context=kwargs.get("refresh_context"),
         recorder=recorder,
@@ -53,10 +53,9 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
     executor, recorder = _make_executor()
     image = Image.new("RGB", (4, 4), "blue")
     calls = {"count": 0}
-    from refresh_task.executor import RefreshExecutor
 
     def attempt(
-        self: RefreshExecutor,
+        self: Any,
         refresh_action: Any,
         plugin_config: Any,
         current_dt: datetime,
@@ -93,11 +92,11 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
 def test_executor_policy_skips_retry_for_permanent_error(monkeypatch: Any) -> None:
     executor, _recorder = _make_executor()
     calls = {"count": 0}
-    from refresh_task.executor import RefreshExecutor
-    from utils.plugin_errors import PermanentPluginError
+    plugin_errors = importlib.import_module("utils.plugin_errors")
+    permanent_error = plugin_errors.PermanentPluginError
 
     def attempt(
-        self: RefreshExecutor,
+        self: Any,
         refresh_action: Any,
         plugin_config: Any,
         current_dt: datetime,
@@ -106,13 +105,13 @@ def test_executor_policy_skips_retry_for_permanent_error(monkeypatch: Any) -> No
         attempt_number: int,
     ) -> tuple[Any, Any]:
         calls["count"] += 1
-        return None, PermanentPluginError("bad URL")
+        return None, permanent_error("bad URL")
 
     monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "process")
     monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "3")
     executor.run_subprocess_attempt = MethodType(attempt, executor)
 
-    with pytest.raises(PermanentPluginError, match="bad URL"):
+    with pytest.raises(permanent_error, match="bad URL"):
         executor.execute_with_policy(_Action(), {}, datetime.now(UTC))
 
     assert calls["count"] == 1

--- a/tests/unit/test_refresh_task_executor.py
+++ b/tests/unit/test_refresh_task_executor.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import threading
+import time
 from datetime import UTC, datetime
+from types import MethodType
 from typing import Any
 
 import pytest
@@ -53,7 +55,15 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
     image = Image.new("RGB", (4, 4), "blue")
     calls = {"count": 0}
 
-    def attempt(*args: Any, **kwargs: Any) -> tuple[Any, Any]:
+    def attempt(
+        self: RefreshExecutor,
+        refresh_action: Any,
+        plugin_config: Any,
+        current_dt: datetime,
+        plugin_id: str,
+        timeout_s: float,
+        attempt_number: int,
+    ) -> tuple[Any, Any]:
         calls["count"] += 1
         if calls["count"] == 1:
             return None, RuntimeError("temporary")
@@ -62,7 +72,7 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
     monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "process")
     monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "1")
     monkeypatch.setenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "0")
-    executor.run_subprocess_attempt = attempt
+    executor.run_subprocess_attempt = MethodType(attempt, executor)
 
     result, meta = executor.execute_with_policy(
         _Action(), {}, datetime.now(UTC), request_id="req-1"
@@ -84,13 +94,21 @@ def test_executor_policy_skips_retry_for_permanent_error(monkeypatch: Any) -> No
     executor, _recorder = _make_executor()
     calls = {"count": 0}
 
-    def attempt(*args: Any, **kwargs: Any) -> tuple[Any, Any]:
+    def attempt(
+        self: RefreshExecutor,
+        refresh_action: Any,
+        plugin_config: Any,
+        current_dt: datetime,
+        plugin_id: str,
+        timeout_s: float,
+        attempt_number: int,
+    ) -> tuple[Any, Any]:
         calls["count"] += 1
         return None, PermanentPluginError("bad URL")
 
     monkeypatch.setenv("INKYPI_PLUGIN_ISOLATION", "process")
     monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "3")
-    executor.run_subprocess_attempt = attempt
+    executor.run_subprocess_attempt = MethodType(attempt, executor)
 
     with pytest.raises(PermanentPluginError, match="bad URL"):
         executor.execute_with_policy(_Action(), {}, datetime.now(UTC))
@@ -119,6 +137,37 @@ def test_executor_inprocess_success_returns_image_and_metadata(
     assert meta == {"source": "test"}
 
 
+def test_executor_inprocess_retry_publishes_request_step(monkeypatch: Any) -> None:
+    image = Image.new("RGB", (4, 4), "purple")
+    calls = {"count": 0}
+
+    class Plugin:
+        def generate_image(self, settings: Any, device_config: Any) -> Image.Image:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RuntimeError("temporary")
+            return image
+
+    executor, recorder = _make_executor(get_plugin_instance=lambda _cfg: Plugin())
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "1")
+    monkeypatch.setenv("INKYPI_PLUGIN_RETRY_BACKOFF_MS", "0")
+
+    result, meta = executor.execute_inprocess(
+        _Action(), {}, datetime.now(UTC), request_id="req-2"
+    )
+
+    assert result is image
+    assert meta is None
+    assert calls["count"] == 2
+    assert recorder.steps == [
+        {
+            "plugin_id": "clock",
+            "request_id": "req-2",
+            "step": "retry 1/1",
+        }
+    ]
+
+
 def test_executor_thread_timeout_tracks_zombie(monkeypatch: Any) -> None:
     _ZombieOwner._zombie_thread_count = 0
     release = threading.Event()
@@ -136,3 +185,7 @@ def test_executor_thread_timeout_tracks_zombie(monkeypatch: Any) -> None:
 
     assert _ZombieOwner._zombie_thread_count == 1
     release.set()
+    deadline = time.monotonic() + 5
+    while _ZombieOwner._zombie_thread_count > 0 and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert _ZombieOwner._zombie_thread_count == 0


### PR DESCRIPTION
## Summary
- add a `RefreshExecutor` collaborator for plugin execution policy, subprocess attempts, in-process timeout handling, retry behavior, and zombie-thread tracking
- wire `RefreshTask` through the executor while preserving compatibility wrappers for existing private-helper tests
- address review feedback around retry progress correlation, timeout cleanup bookkeeping, subprocess payload handling, and compatibility shim allocation

## Validation
- `bash scripts/lint.sh`
- `PYTHONPATH=src pytest -q tests/unit/test_refresh_task_executor.py tests/unit/test_execute_inprocess.py tests/unit/test_permanent_plugin_error.py tests/unit/test_refresh_task_critical.py::TestExecuteWithPolicyErrors tests/unit/test_refresh_task_unit.py tests/integration/test_refresh_task.py tests/integration/test_error_injection.py tests/integration/test_update_now_timeout.py`
- `PYTHONPATH=src python3 -m mypy src/refresh_task`

## PR Checklist
- Base branch: `main`
- Compatibility: no external API or response-contract changes; `RefreshTask` private compatibility wrappers remain available for existing tests/callers
- Release notes: not needed, internal refactor only
- Docs: not needed, no user-facing behavior change
- Frontend: not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured plugin execution framework to enhance modularity and improve timeout handling, retry logic, and error recovery across subprocess and in-process execution modes.

* **Tests**
  * Added comprehensive unit test coverage for plugin execution scenarios, including timeout, retry, and isolation behavior.

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->