### PR TITLE
refactor: tighten playlist request models

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -29,18 +29,17 @@ from utils.backend_errors import (
 from utils.http_utils import (
     json_error,
     json_success,
-    reissue_json_error,
 )
 from utils.messages import PLAYLIST_NAME_REQUIRED_ERROR
 from utils.request_models import (
     CODE_VALIDATION,
+    PlaylistUpdateRequest,
     RequestModelError,
     parse_device_cycle_request,
     parse_playlist_create_request,
     parse_playlist_name_request,
     parse_playlist_reorder_request,
     parse_playlist_update_request,
-    validate_playlist_name as validate_playlist_name_request,
 )
 from utils.time_utils import calculate_seconds, now_device_tz
 
@@ -74,20 +73,6 @@ def _request_model_error_response(error: RequestModelError) -> Any:
         code=error.code,
         details=error.details or None,
     )
-
-
-def _validate_playlist_name(
-    name: Any, field: str = "playlist_name"
-) -> tuple[str | None, Any]:
-    """Validate playlist name format. Returns (cleaned_name, error_response) tuple.
-
-    ``field`` is the form field name echoed back in ``details.field`` so the
-    frontend can highlight the offending input.
-    """
-    normalized, error = validate_playlist_name_request(name, field=field)
-    if error is not None:
-        return None, _request_model_error_response(error)
-    return normalized, None
 
 
 # Simple in-memory cache for ETA computations (per playlist, per-minute)
@@ -563,21 +548,38 @@ def playlists() -> Any:
     )
 
 
-def _parse_playlist_request_data() -> tuple[dict[str, Any] | None, Any]:
+def _parse_playlist_request_data(
+    *,
+    form_fields: tuple[str, ...],
+    unsupported_message: str = "Unsupported media type",
+    unsupported_status: int = 415,
+) -> tuple[dict[str, Any] | None, RequestModelError | None]:
     """Parse and validate playlist create/update request data.
 
     Returns (data_dict, error_response). If error_response is not None, return it.
     """
-    data = request.get_json(silent=True)
-    if data is None:
-        form_data = request.form.to_dict()
-        if any(k in form_data for k in ("playlist_name", "start_time", "end_time")):
-            data = form_data
-        else:
-            return None, json_error("Unsupported media type", status=415)
-    if not isinstance(data, dict):
-        return None, json_error("Invalid JSON data", status=400)
-    return data, None
+    if request.is_json:
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return None, RequestModelError("Invalid JSON data")
+        return data, None
+
+    form_data = request.form.to_dict()
+    if any(k in form_data for k in form_fields):
+        return form_data, None
+    return None, RequestModelError(unsupported_message, status=unsupported_status)
+
+
+def _parse_playlist_update_payload(
+    data: Any,
+) -> tuple[PlaylistUpdateRequest | None, Any]:
+    """Validate an /update_playlist request payload."""
+    parsed, error = parse_playlist_update_request(data)
+    if error is not None:
+        return None, _request_model_error_response(error)
+    if parsed is None:
+        return None, json_error("Invalid playlist payload", status=400)
+    return parsed, None
 
 
 @playlist_bp.route("/create_playlist", methods=["POST"])  # type: ignore[untyped-decorator]
@@ -585,9 +587,11 @@ def create_playlist() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
 
-    data, err = _parse_playlist_request_data()
+    data, err = _parse_playlist_request_data(
+        form_fields=("playlist_name", "start_time", "end_time", "cycle_minutes")
+    )
     if err:
-        return reissue_json_error(err, _MSG_INVALID_PLAYLIST_REQUEST)
+        return _request_model_error_response(err)
     if data is None:
         return json_error("Invalid playlist request", status=400)
 
@@ -663,52 +667,26 @@ def _apply_cycle_override(
         playlist.cycle_interval_seconds = cycle_minutes_int * 60
 
 
-def _validate_update_playlist_payload(
-    data: Mapping[str, Any],
-) -> tuple[dict[str, Any] | None, Any]:
-    """Validate an /update_playlist request payload.
-
-    Returns ``(parsed, error_response)``; exactly one is non-None.  ``parsed``
-    is a dict with ``new_name``, ``start_time``, ``end_time``, ``start_min``,
-    ``end_min``, ``cycle_minutes_int``.
-    """
-    parsed, error = parse_playlist_update_request(dict(data))
-    if error is not None:
-        return None, _request_model_error_response(error)
-    if parsed is None:
-        return None, json_error("Invalid playlist payload", status=400)
-    return {
-        "new_name": parsed.new_name,
-        "start_time": parsed.start_time,
-        "end_time": parsed.end_time,
-        "start_min": parsed.start_min,
-        "end_min": parsed.end_min,
-        "cycle_minutes_int": parsed.cycle_minutes_int,
-    }, None
-
-
 @playlist_bp.route("/update_playlist/<string:playlist_name>", methods=["PUT"])  # type: ignore[untyped-decorator]
 def update_playlist(playlist_name: str) -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
 
-    data = request.get_json(silent=True)
-    if not isinstance(data, dict):
-        return json_error("Invalid JSON data", status=400)
+    data, body_err = _parse_playlist_request_data(
+        form_fields=("new_name", "start_time", "end_time", "cycle_minutes"),
+        unsupported_message="Invalid JSON data",
+        unsupported_status=400,
+    )
+    if body_err:
+        return _request_model_error_response(body_err)
+    if data is None:
+        return json_error("Invalid playlist request", status=400)
 
-    parsed, err = _validate_update_playlist_payload(data)
+    parsed, err = _parse_playlist_update_payload(data)
     if err:
         return err
-    if not isinstance(parsed, dict):
+    if parsed is None:
         return json_error("Invalid playlist payload", status=400)
-    new_name = parsed["new_name"]
-    start_time = parsed["start_time"]
-    end_time = parsed["end_time"]
-    start_min = parsed["start_min"]
-    end_min = parsed["end_min"]
-    cycle_minutes_int = parsed["cycle_minutes_int"]
-    if start_min is None or end_min is None:
-        return json_error("Invalid playlist times", status=400)
 
     playlist = playlist_manager.get_playlist(playlist_name)
     if not playlist:
@@ -722,7 +700,10 @@ def update_playlist(playlist_name: str) -> Any:
     # Prevent overlapping (exclude the playlist being updated)
     try:
         overlap_err = _check_playlist_overlap(
-            start_min, end_min, playlist_manager.playlists, exclude_name=playlist_name
+            parsed.start_min,
+            parsed.end_min,
+            playlist_manager.playlists,
+            exclude_name=playlist_name,
         )
         if overlap_err:
             return overlap_err
@@ -733,7 +714,7 @@ def update_playlist(playlist_name: str) -> Any:
     duplicate_name_result: list[bool] = []
 
     def _do_update_playlist(cfg: Any) -> None:
-        existing_with_new_name = playlist_manager.get_playlist(new_name)
+        existing_with_new_name = playlist_manager.get_playlist(parsed.new_name)
         if (
             existing_with_new_name is not None
             and existing_with_new_name is not playlist
@@ -742,10 +723,12 @@ def update_playlist(playlist_name: str) -> Any:
             return
         upd_result.append(
             playlist_manager.update_playlist(
-                playlist_name, new_name, start_time, end_time
+                playlist_name, parsed.new_name, parsed.start_time, parsed.end_time
             )
         )
-        _apply_cycle_override(playlist_manager, new_name, cycle_minutes_int)
+        _apply_cycle_override(
+            playlist_manager, parsed.new_name, parsed.cycle_minutes_int
+        )
 
     device_config.update_atomic(_do_update_playlist)
     if duplicate_name_result:
@@ -760,9 +743,9 @@ def update_playlist(playlist_name: str) -> Any:
 
     # Warn if the updated playlist overlaps with Default.
     warning = None
-    if playlist_name != "Default" and new_name != "Default":
+    if playlist_name != "Default" and parsed.new_name != "Default":
         warning = _default_overlap_warning(
-            start_min, end_min, playlist_manager.playlists
+            parsed.start_min, parsed.end_min, playlist_manager.playlists
         )
 
     if warning:

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -264,9 +264,12 @@ def parse_device_cycle_request(
 
 
 def parse_playlist_create_request(
-    data: dict[str, Any],
+    data: Any,
 ) -> tuple[PlaylistCreateRequest | None, RequestModelError | None]:
     """Parse and validate a create-playlist payload."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid JSON data")
+
     playlist_name, name_err = validate_playlist_name(data.get("playlist_name"))
     if name_err is not None or playlist_name is None:
         return None, name_err
@@ -295,9 +298,12 @@ def parse_playlist_create_request(
 
 
 def parse_playlist_update_request(
-    data: dict[str, Any],
+    data: Any,
 ) -> tuple[PlaylistUpdateRequest | None, RequestModelError | None]:
     """Parse and validate an update-playlist payload."""
+    if not isinstance(data, dict):
+        return None, RequestModelError("Invalid JSON data")
+
     new_name, name_err = validate_playlist_name(data.get("new_name"), field="new_name")
     if name_err is not None or new_name is None:
         return None, name_err
@@ -332,12 +338,9 @@ def parse_playlist_reorder_request(
     if not isinstance(data, dict):
         return None, RequestModelError("Invalid or missing JSON payload")
 
-    playlist_name = data.get("playlist_name")
-    if not isinstance(playlist_name, str) or not playlist_name.strip():
-        return None, RequestModelError(
-            "playlist_name and ordered list are required",
-            field="playlist_name",
-        )
+    playlist_name, name_err = validate_playlist_name(data.get("playlist_name"))
+    if name_err is not None or playlist_name is None:
+        return None, name_err
 
     ordered = data.get("ordered")
     if not isinstance(ordered, list):
@@ -352,13 +355,20 @@ def parse_playlist_reorder_request(
             return None, RequestModelError("Invalid order payload", field="ordered")
         plugin_id = item.get("plugin_id")
         name = item.get("name")
-        if not isinstance(plugin_id, str) or not isinstance(name, str):
+        if (
+            not isinstance(plugin_id, str)
+            or not plugin_id.strip()
+            or not isinstance(name, str)
+            or not name.strip()
+        ):
             return None, RequestModelError("Invalid order payload", field="ordered")
-        parsed_ordered.append(PlaylistPluginOrderItem(plugin_id=plugin_id, name=name))
+        parsed_ordered.append(
+            PlaylistPluginOrderItem(plugin_id=plugin_id.strip(), name=name.strip())
+        )
 
     return (
         PlaylistReorderRequest(
-            playlist_name=playlist_name.strip(),
+            playlist_name=playlist_name,
             ordered=parsed_ordered,
         ),
         None,

--- a/tests/integration/test_playlist_routes.py
+++ b/tests/integration/test_playlist_routes.py
@@ -31,6 +31,41 @@ def test_create_update_delete_playlist_flow(client):
     assert resp.status_code == 200
 
 
+def test_update_playlist_accepts_form_payload(client, device_config_dev):
+    pm = device_config_dev.get_playlist_manager()
+    pm.add_playlist("FormUpdate", "06:00", "09:00")
+    device_config_dev.write_config()
+
+    resp = client.put(
+        "/update_playlist/FormUpdate",
+        data={
+            "new_name": "FormUpdated",
+            "start_time": "07:00",
+            "end_time": "10:00",
+            "cycle_minutes": "12",
+        },
+    )
+
+    assert resp.status_code == 200
+    playlist = pm.get_playlist("FormUpdated")
+    assert playlist is not None
+    assert playlist.cycle_interval_seconds == 12 * 60
+
+
+def test_update_playlist_malformed_json_returns_fielded_error(client):
+    resp = client.put(
+        "/update_playlist/Default",
+        data=b"{{invalid",
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert body["error"] == "Invalid JSON data"
+    assert body["code"] == "validation_error"
+
+
 def test_create_playlist_persists_cycle_override(
     client: Any, device_config_dev: Any
 ) -> None:
@@ -135,6 +170,34 @@ def test_reorder_plugins_endpoint(client, device_config_dev):
     assert len(pl2.plugins) == 2
     assert pl2.plugins[0].plugin_id == "clock"
     assert pl2.plugins[0].name == "B"
+
+
+def test_reorder_plugins_rejects_empty_plugin_id(client, device_config_dev):
+    pm = device_config_dev.get_playlist_manager()
+    pm.add_playlist("BadReorder", "00:00", "24:00")
+    pl = pm.get_playlist("BadReorder")
+    pl.add_plugin(
+        {
+            "plugin_id": "clock",
+            "name": "A",
+            "plugin_settings": {},
+            "refresh": {"interval": 60},
+        }
+    )
+    device_config_dev.write_config()
+
+    resp = client.post(
+        "/reorder_plugins",
+        json={
+            "playlist_name": "BadReorder",
+            "ordered": [{"plugin_id": "", "name": "A"}],
+        },
+    )
+
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["success"] is False
+    assert body["details"]["field"] == "ordered"
 
 
 def test_cycle_override_zero_rejected(client, device_config_dev):

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -68,6 +68,14 @@ def test_parse_playlist_create_request_rejects_matching_times() -> None:
     assert error.field == "end_time"
 
 
+def test_parse_playlist_create_request_rejects_non_object_payload() -> None:
+    parsed, error = parse_playlist_create_request(["not", "an", "object"])
+
+    assert parsed is None
+    assert error is not None
+    assert error.message == "Invalid JSON data"
+
+
 def test_validate_cycle_minutes_accepts_optional_and_range() -> None:
     missing_value, missing_error = validate_cycle_minutes(None)
     value, error = validate_cycle_minutes("15")
@@ -102,6 +110,14 @@ def test_parse_playlist_update_request_returns_typed_model() -> None:
     assert parsed.start_min == 8 * 60
     assert parsed.end_min == 12 * 60
     assert parsed.cycle_minutes_int == 30
+
+
+def test_parse_playlist_update_request_rejects_non_object_payload() -> None:
+    parsed, error = parse_playlist_update_request("bad")
+
+    assert parsed is None
+    assert error is not None
+    assert error.message == "Invalid JSON data"
 
 
 def test_parse_api_keys_save_request_accepts_entries_list() -> None:
@@ -178,8 +194,8 @@ def test_parse_playlist_update_request_uses_shared_missing_time_error() -> None:
 def test_parse_playlist_reorder_request_returns_ordered_payload() -> None:
     parsed, error = parse_playlist_reorder_request(
         {
-            "playlist_name": "Default",
-            "ordered": [{"plugin_id": "clock", "name": "Clock"}],
+            "playlist_name": " Default ",
+            "ordered": [{"plugin_id": " clock ", "name": " Clock "}],
         }
     )
 
@@ -192,6 +208,16 @@ def test_parse_playlist_reorder_request_returns_ordered_payload() -> None:
 def test_parse_playlist_reorder_request_rejects_wrong_item_shape() -> None:
     parsed, error = parse_playlist_reorder_request(
         {"playlist_name": "Default", "ordered": [{"pid": "clock"}]}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.field == "ordered"
+
+
+def test_parse_playlist_reorder_request_rejects_empty_plugin_id() -> None:
+    parsed, error = parse_playlist_reorder_request(
+        {"playlist_name": "Default", "ordered": [{"plugin_id": " ", "name": "Clock"}]}
     )
 
     assert parsed is None


### PR DESCRIPTION
## Summary

- Complete the 5.1 playlist request-model slice by routing create/update through typed payload parsing.
- Preserve route-specific bad-body behavior while adding update form payload support.
- Tighten playlist reorder validation for malformed/empty ordered IDs before model mutation.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [x] Relevant upstream behavior differences were documented in PR description
- [x] Plugin/add-to-playlist/update flows were smoke-tested after sync

Not a parent-fork sync.

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI
- [x] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

No docs or frontend changes in this PR.

## Testing

- `python3 -m black --check src/blueprints/playlist.py src/utils/request_models.py tests/unit/test_request_models.py tests/integration/test_playlist_routes.py`
- `python3 -m ruff check src/blueprints/playlist.py src/utils/request_models.py tests/unit/test_request_models.py tests/integration/test_playlist_routes.py`
- `PYTHONPATH=src python3 -m mypy src/utils src/blueprints/playlist.py`
- `PYTHONPATH=src pytest -q tests/unit/test_request_models.py tests/integration/test_playlist_routes.py tests/integration/test_playlist_crud_e2e.py tests/contracts/test_json_envelope.py tests/integration/test_playlist_more.py tests/integration/test_playlist_coverage.py tests/unit/test_playlist_blueprint.py tests/unit/test_input_validation_hardening.py`
- `bash scripts/lint.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for playlist form submissions and JSON payloads
  * Improved structured error responses for malformed requests in playlist operations
  * Stricter validation for plugin ordering to prevent invalid configurations

* **Refactor**
  * Streamlined request parsing and error handling across playlist operations for better consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->