### PR TITLE
refactor: add plugin request models

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -41,7 +41,13 @@ from utils.plugin_errors import (
 )
 from utils.plugin_history import record_change as _record_plugin_change
 from utils.progress import track_progress
-from utils.request_models import parse_plugin_instance_action_request
+from utils.request_models import (
+    RequestModelError,
+    parse_plugin_instance_action_request,
+    parse_plugin_settings_form_request,
+    parse_plugin_update_instance_request,
+    parse_plugin_update_now_request,
+)
 from utils.security_utils import URLValidationError, validate_file_path
 
 logger = logging.getLogger(__name__)
@@ -58,6 +64,26 @@ _ERR_PLUGIN_INSTANCE_NOT_FOUND = "Plugin instance not found"
 _ERR_PLUGIN_NOT_FOUND = "Plugin not found"
 _ERR_PLAYLIST_NOT_FOUND = "Playlist not found"
 _MSG_CIRCUIT_BREAKER_RESET = "Circuit-breaker reset for plugin instance."
+
+
+def _raise_request_model_error(error: RequestModelError) -> None:
+    raise ClientInputError(
+        error.message,
+        status=error.status,
+        code=error.code,
+        field=error.field,
+    )
+
+
+def _plugin_form_data(*, include_form_for_files: bool = False) -> dict[str, Any]:
+    form_data = cast(dict[str, Any], cast(Any, parse_form)(request.form))
+    file_args: tuple[Any, ...]
+    if include_form_for_files:
+        file_args = (request.files, request.form)
+    else:
+        file_args = (request.files,)
+    form_data.update(cast(dict[str, Any], cast(Any, handle_request_files)(*file_args)))
+    return form_data
 
 
 def _plugins_dir() -> str:
@@ -490,7 +516,6 @@ def update_plugin_instance(instance_name: str) -> Any:
         logger=logger,
         hint="Check submitted plugin settings and config persistence.",
     ):
-        form_data = cast(dict[str, Any], cast(Any, parse_form)(request.form))
         if not instance_name:
             raise ClientInputError(
                 "Instance name is required",
@@ -498,22 +523,15 @@ def update_plugin_instance(instance_name: str) -> Any:
                 code="validation_error",
                 field="instance_name",
             )
-        plugin_settings: dict[str, Any] = form_data
-        plugin_settings.update(
-            cast(
-                dict[str, Any],
-                cast(Any, handle_request_files)(request.files, request.form),
-            )
+        parsed, parse_error = parse_plugin_update_instance_request(
+            _plugin_form_data(include_form_for_files=True)
         )
-
-        plugin_id = plugin_settings.pop(_PLUGIN_ID, None)
-        if not plugin_id:
-            raise ClientInputError(
-                _ERR_PLUGIN_ID_REQUIRED,
-                status=422,
-                code="validation_error",
-                field=_PLUGIN_ID,
-            )
+        if parse_error is not None:
+            _raise_request_model_error(parse_error)
+        if parsed is None:
+            raise ClientInputError("Invalid form payload", status=400)
+        plugin_id = parsed.plugin_id
+        plugin_settings = parsed.plugin_settings
         plugin_instance = playlist_manager.find_plugin(plugin_id, instance_name)
         if not plugin_instance:
             logger.warning(
@@ -532,28 +550,11 @@ def update_plugin_instance(instance_name: str) -> Any:
         # and the new refresh config was never applied — reload silently
         # reverted the user's change while the toast said "success".
         new_refresh_config: dict[str, Any] | None = None
-        raw_refresh = plugin_settings.pop("refresh_settings", None)
-        if raw_refresh is not None:
-            try:
-                refresh_payload = json.loads(raw_refresh)
-            except (TypeError, ValueError) as exc:
-                raise ClientInputError(
-                    "Refresh settings must be valid JSON",
-                    status=400,
-                    code="validation_error",
-                    field="refresh_settings",
-                ) from exc
-            if not isinstance(refresh_payload, dict):
-                raise ClientInputError(
-                    "Refresh settings must be an object",
-                    status=400,
-                    code="validation_error",
-                    field="refresh_settings",
-                )
+        if parsed.refresh_settings is not None:
             from blueprints.playlist import validate_plugin_refresh_settings
 
             new_refresh_config, refresh_err = validate_plugin_refresh_settings(
-                refresh_payload
+                parsed.refresh_settings
             )
             if refresh_err:
                 return refresh_err
@@ -1059,24 +1060,24 @@ def update_now() -> Any:
 
     plugin_id: str | None = None
     try:
-        plugin_settings = cast(dict[str, Any], cast(Any, parse_form)(request.form))
-        plugin_settings.update(
-            cast(dict[str, Any], cast(Any, handle_request_files)(request.files))
+        parsed, parse_error = parse_plugin_update_now_request(
+            _plugin_form_data(),
+            async_header=request.headers.get("X-Async", ""),
+            async_query=request.args.get("async", ""),
         )
-        plugin_id = plugin_settings.pop(_PLUGIN_ID, None)
-        if not plugin_id:
+        if parse_error is not None:
             return json_error(
-                _ERR_PLUGIN_ID_REQUIRED,
-                status=422,
-                code="validation_error",
-                details={"field": _PLUGIN_ID},
+                parse_error.message,
+                status=parse_error.status,
+                code=parse_error.code,
+                details=parse_error.details,
             )
+        if parsed is None:
+            return json_error("Invalid form payload", status=400)
+        plugin_id = parsed.plugin_id
+        plugin_settings = parsed.plugin_settings
 
-        want_async = request.headers.get(
-            "X-Async", ""
-        ).lower() == "true" or request.args.get("async", "").lower() in ("1", "true")
-
-        if want_async:
+        if parsed.want_async:
             queue = get_job_queue()
             app = current_app._get_current_object()  # real app, not proxy
             job_id = queue.enqueue(_run_update_now, app, plugin_id, plugin_settings)
@@ -1158,25 +1159,25 @@ def save_plugin_settings() -> Any:
     htmx = _is_htmx_request()
 
     try:
-        plugin_settings = cast(dict[str, Any], cast(Any, parse_form)(request.form))
-        plugin_settings.update(
-            cast(dict[str, Any], cast(Any, handle_request_files)(request.files))
-        )
-        plugin_id = plugin_settings.pop(_PLUGIN_ID, None)
-        if not plugin_id:
+        parsed, parse_error = parse_plugin_settings_form_request(_plugin_form_data())
+        if parse_error is not None:
             if htmx:
                 return _render_plugin_form_error(
-                    _ERR_PLUGIN_ID_REQUIRED, status=422, field=_PLUGIN_ID
+                    parse_error.message,
+                    status=parse_error.status,
+                    field=parse_error.field,
                 )
             return json_error(
-                _ERR_PLUGIN_ID_REQUIRED,
-                status=422,
-                code="validation_error",
-                details={"field": _PLUGIN_ID},
+                parse_error.message,
+                status=parse_error.status,
+                code=parse_error.code,
+                details=parse_error.details,
             )
+        if parsed is None:
+            raise ClientInputError("Invalid form payload", status=400)
         return _save_plugin_settings_common(
-            plugin_id=plugin_id,
-            plugin_settings=plugin_settings,
+            plugin_id=parsed.plugin_id,
+            plugin_settings=parsed.plugin_settings,
             device_config=device_config,
             playlist_manager=playlist_manager,
         )

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -3,7 +3,7 @@ import logging
 import os
 from collections.abc import Mapping
 from time import perf_counter
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 
 from flask import (
     Blueprint,
@@ -66,7 +66,7 @@ _ERR_PLAYLIST_NOT_FOUND = "Playlist not found"
 _MSG_CIRCUIT_BREAKER_RESET = "Circuit-breaker reset for plugin instance."
 
 
-def _raise_request_model_error(error: RequestModelError) -> None:
+def _raise_request_model_error(error: RequestModelError) -> NoReturn:
     raise ClientInputError(
         error.message,
         status=error.status,
@@ -76,13 +76,13 @@ def _raise_request_model_error(error: RequestModelError) -> None:
 
 
 def _plugin_form_data(*, include_form_for_files: bool = False) -> dict[str, Any]:
-    form_data = cast(dict[str, Any], cast(Any, parse_form)(request.form))
+    form_data = parse_form(request.form)
     file_args: tuple[Any, ...]
     if include_form_for_files:
         file_args = (request.files, request.form)
     else:
         file_args = (request.files,)
-    form_data.update(cast(dict[str, Any], cast(Any, handle_request_files)(*file_args)))
+    form_data.update(handle_request_files(*file_args))
     return form_data
 
 
@@ -465,14 +465,11 @@ def delete_plugin_instance() -> Any:
         request.get_json(silent=True)
     )
     if parse_error is not None:
-        raise ClientInputError(
-            parse_error.message,
-            status=parse_error.status,
-            code=parse_error.code,
-            field=parse_error.field,
-        )
+        _raise_request_model_error(parse_error)
     if parsed is None:
-        raise ClientInputError("Invalid or missing JSON payload", status=400)
+        _raise_request_model_error(
+            RequestModelError(message="Invalid or missing JSON payload", status=400)
+        )
 
     with route_error_boundary(
         "delete plugin instance",
@@ -630,14 +627,11 @@ def display_plugin_instance() -> Any:
         request.get_json(silent=True)
     )
     if parse_error is not None:
-        raise ClientInputError(
-            parse_error.message,
-            status=parse_error.status,
-            code=parse_error.code,
-            field=parse_error.field,
-        )
+        _raise_request_model_error(parse_error)
     if parsed is None:
-        raise ClientInputError("Invalid or missing JSON payload", status=400)
+        _raise_request_model_error(
+            RequestModelError(message="Invalid or missing JSON payload", status=400)
+        )
 
     with route_error_boundary(
         "display plugin instance",
@@ -1066,14 +1060,11 @@ def update_now() -> Any:
             async_query=request.args.get("async", ""),
         )
         if parse_error is not None:
-            return json_error(
-                parse_error.message,
-                status=parse_error.status,
-                code=parse_error.code,
-                details=parse_error.details,
-            )
+            _raise_request_model_error(parse_error)
         if parsed is None:
-            return json_error("Invalid form payload", status=400)
+            _raise_request_model_error(
+                RequestModelError(message="Invalid form payload", status=400)
+            )
         plugin_id = parsed.plugin_id
         plugin_settings = parsed.plugin_settings
 
@@ -1147,6 +1138,13 @@ def update_now() -> Any:
             status=504,
             code="manual_update_timeout",
         )
+    except ClientInputError as e:
+        return json_error(
+            e.message,
+            status=e.status,
+            code=e.code,
+            details=e.details,
+        )
     except Exception as e:
         logger.exception("Error in update_now: %s", e)
         return json_error(_ERR_INTERNAL, status=500, code="internal_error")
@@ -1195,10 +1193,8 @@ def save_plugin_settings_alias(plugin_id: str) -> Any:
     playlist_manager = device_config.get_playlist_manager()
 
     try:
-        plugin_settings = cast(dict[str, Any], cast(Any, parse_form)(request.form))
-        plugin_settings.update(
-            cast(dict[str, Any], cast(Any, handle_request_files)(request.files))
-        )
+        plugin_settings = _plugin_form_data()
+        plugin_settings.pop(_PLUGIN_ID, None)
         return _save_plugin_settings_common(
             plugin_id=plugin_id,
             plugin_settings=plugin_settings,

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -257,7 +257,12 @@ class AIImage(BasePlugin):
         )
         prompt = self._ensure_image_prompt(prompt)
         logger.info(f"Generating image with {image_model}...")
-        return self.fetch_image_google(google_client, prompt, image_model)
+        return self.fetch_image_google(
+            google_client,
+            prompt,
+            image_model,
+            dimensions=self.get_oriented_dimensions(device_config),
+        )
 
     def _generate_openai_image(
         self,
@@ -283,6 +288,7 @@ class AIImage(BasePlugin):
             model=image_model,
             quality=image_quality,
             orientation=orientation,
+            dimensions=self.get_oriented_dimensions(device_config),
         )
 
     def generate_image(
@@ -352,6 +358,7 @@ class AIImage(BasePlugin):
         model: str = DEFAULT_IMAGE_MODEL,
         quality: str = "medium",
         orientation: str = "horizontal",
+        dimensions: tuple[int, int] | None = None,
     ) -> ImageType:
         """Fetch image from OpenAI API."""
         logger.info(
@@ -385,14 +392,26 @@ class AIImage(BasePlugin):
         image_base64 = response.data[0].b64_json
         image_bytes = base64.b64decode(image_base64)
         image_loader = cast(Any, self.image_loader)
+        target_dimensions = dimensions or (1536, 1536)
         image = image_loader.from_bytesio(
-            BytesIO(image_bytes), (1536, 1536), resize=False
+            BytesIO(image_bytes), target_dimensions, resize=dimensions is not None
         )
         if image is None:
             raise RuntimeError("Failed to decode generated image")
+        logger.info(
+            "OpenAI generated image prepared for display: %dx%d",
+            image.size[0],
+            image.size[1],
+        )
         return image
 
-    def fetch_image_google(self, client: Any, prompt: str, model: str) -> ImageType:
+    def fetch_image_google(
+        self,
+        client: Any,
+        prompt: str,
+        model: str,
+        dimensions: tuple[int, int] | None = None,
+    ) -> ImageType:
         """Fetch image from Google Imagen API."""
         from google.genai import types
 
@@ -416,13 +435,19 @@ class AIImage(BasePlugin):
         if not response.generated_images:
             raise RuntimeError("Google Imagen returned no images")
         image_loader = cast(Any, self.image_loader)
+        target_dimensions = dimensions or (1536, 1536)
         image = image_loader.from_bytesio(
             BytesIO(response.generated_images[0].image.image_bytes),
-            (1536, 1536),
-            resize=False,
+            target_dimensions,
+            resize=dimensions is not None,
         )
         if image is None:
             raise RuntimeError("Failed to decode generated image")
+        logger.info(
+            "Google generated image prepared for display: %dx%d",
+            image.size[0],
+            image.size[1],
+        )
         return image
 
     @staticmethod

--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -156,6 +156,13 @@ class Apod(BasePlugin):
             params["date"] = cast(str, settings["customDate"])
 
         apod_url = os.getenv("INKYPI_NASA_API_URL", "https://api.nasa.gov")
+        logger.info(
+            "APOD request: date=%s randomized=%s base_url=%s timeout_s=%.1f",
+            params.get("date", "today"),
+            settings.get("randomizeApod") == "true",
+            apod_url,
+            self._request_timeout(),
+        )
         response = get_http_session().get(
             f"{apod_url}/planetary/apod",
             params=params,
@@ -167,6 +174,12 @@ class Apod(BasePlugin):
             raise RuntimeError("Failed to retrieve NASA APOD.")
 
         data = cast(dict[str, object], response.json())
+        logger.info(
+            "APOD response: date=%s media_type=%s title=%s",
+            data.get("date"),
+            data.get("media_type"),
+            data.get("title"),
+        )
 
         if data.get("media_type") != "image":
             raise RuntimeError("APOD is not an image today.")
@@ -176,6 +189,13 @@ class Apod(BasePlugin):
         timeout_ms = int(self._request_timeout() * 1000)
         dimensions = self.get_oriented_dimensions(device_config)
         candidate_urls = self._candidate_image_urls(data)
+        logger.info(
+            "APOD image candidates: count=%d low_resource=%s target=%dx%d",
+            len(candidate_urls),
+            self.image_loader.is_low_resource,
+            dimensions[0],
+            dimensions[1],
+        )
         if not candidate_urls:
             raise RuntimeError("Failed to load APOD image.")
 
@@ -188,6 +208,13 @@ class Apod(BasePlugin):
             )
             if image is not None:
                 selected_image_url = image_url
+                logger.info(
+                    "APOD image loaded: attempt=%d/%d size=%dx%d",
+                    idx + 1,
+                    len(candidate_urls),
+                    image.size[0],
+                    image.size[1],
+                )
                 break
             logger.warning(
                 "APOD image load failed for %s (attempt %s/%s)",

--- a/src/plugins/apod/apod.py
+++ b/src/plugins/apod/apod.py
@@ -145,20 +145,23 @@ class Apod(BasePlugin):
             raise RuntimeError("NASA API Key not configured.")
 
         params = {"api_key": api_key}
+        request_date = "today"
 
         if settings.get("randomizeApod") == "true":
             start = datetime(2015, 1, 1, tzinfo=UTC)
             end = datetime.now(tz=UTC)
             delta_days = (end - start).days
             random_date = start + timedelta(days=randint(0, delta_days))
-            params["date"] = random_date.strftime("%Y-%m-%d")
+            request_date = random_date.strftime("%Y-%m-%d")
+            params["date"] = request_date
         elif isinstance(settings.get("customDate"), str):
-            params["date"] = cast(str, settings["customDate"])
+            request_date = cast(str, settings["customDate"])
+            params["date"] = request_date
 
         apod_url = os.getenv("INKYPI_NASA_API_URL", "https://api.nasa.gov")
         logger.info(
             "APOD request: date=%s randomized=%s base_url=%s timeout_s=%.1f",
-            params.get("date", "today"),
+            request_date,
             settings.get("randomizeApod") == "true",
             apod_url,
             self._request_timeout(),

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -1077,9 +1077,12 @@ class RefreshTask:
                 break
             if getattr(plugin, "paused", False):
                 logger.info(
-                    "plugin circuit_breaker: skipping paused plugin | plugin_id=%s instance=%s",
+                    "plugin circuit_breaker: skipping paused plugin | "
+                    "plugin_id=%s instance=%s failures=%s reason=%s",
                     plugin.plugin_id,
                     plugin.name,
+                    getattr(plugin, "consecutive_failure_count", "?"),
+                    getattr(plugin, "disabled_reason", None) or "not recorded",
                 )
                 attempts_left -= 1
                 continue

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -250,7 +250,11 @@ def validate_plugin_id(
     missing_message: str = "plugin_id is required",
 ) -> tuple[str | None, RequestModelError | None]:
     """Validate a required plugin identifier and return its stripped value."""
-    if not isinstance(value, str) or not value.strip():
+    if not isinstance(value, str):
+        return None, RequestModelError(
+            "plugin_id must be a string", status=422, field=field
+        )
+    if not value.strip():
         return None, RequestModelError(missing_message, status=422, field=field)
     return value.strip(), None
 
@@ -276,7 +280,7 @@ def _pop_required_plugin_id(
 def _parse_optional_refresh_settings(
     raw_refresh: Any,
 ) -> tuple[dict[str, Any] | None, RequestModelError | None]:
-    if raw_refresh is None:
+    if not raw_refresh:
         return None, None
     try:
         refresh_payload = json.loads(raw_refresh)
@@ -294,7 +298,14 @@ def _parse_optional_refresh_settings(
 
 
 def _truthy_async_flag(value: Any) -> bool:
-    return isinstance(value, str) and value.lower() in ("1", "true")
+    return isinstance(value, str) and value.strip().lower() in {
+        "1",
+        "true",
+        "t",
+        "yes",
+        "y",
+        "on",
+    }
 
 
 def parse_api_keys_save_request(

--- a/src/utils/request_models.py
+++ b/src/utils/request_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -120,6 +121,32 @@ class PluginInstanceActionRequest:
     plugin_instance: str | None
 
 
+@dataclass(frozen=True, slots=True)
+class PluginSettingsFormRequest:
+    """Validated form payload for saving plugin settings."""
+
+    plugin_id: str
+    plugin_settings: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class PluginUpdateInstanceRequest:
+    """Validated form payload for updating an existing plugin instance."""
+
+    plugin_id: str
+    plugin_settings: dict[str, Any]
+    refresh_settings: dict[str, Any] | None
+
+
+@dataclass(frozen=True, slots=True)
+class PluginUpdateNowRequest:
+    """Validated form payload for rendering a plugin immediately."""
+
+    plugin_id: str
+    plugin_settings: dict[str, Any]
+    want_async: bool
+
+
 def validate_playlist_name(
     name: Any, *, field: str = "playlist_name"
 ) -> tuple[str | None, RequestModelError | None]:
@@ -214,6 +241,60 @@ def validate_cycle_minutes(
             field="cycle_minutes",
         )
     return cycle_minutes_int, None
+
+
+def validate_plugin_id(
+    value: Any,
+    *,
+    field: str = "plugin_id",
+    missing_message: str = "plugin_id is required",
+) -> tuple[str | None, RequestModelError | None]:
+    """Validate a required plugin identifier and return its stripped value."""
+    if not isinstance(value, str) or not value.strip():
+        return None, RequestModelError(missing_message, status=422, field=field)
+    return value.strip(), None
+
+
+def _copy_mapping(data: Any) -> dict[str, Any] | None:
+    if not isinstance(data, dict):
+        return None
+    return dict(data)
+
+
+def _pop_required_plugin_id(
+    data: Any,
+) -> tuple[str | None, dict[str, Any] | None, RequestModelError | None]:
+    copied = _copy_mapping(data)
+    if copied is None:
+        return None, None, RequestModelError("Invalid form payload")
+    plugin_id, error = validate_plugin_id(copied.pop("plugin_id", None))
+    if error is not None or plugin_id is None:
+        return None, None, error
+    return plugin_id, copied, None
+
+
+def _parse_optional_refresh_settings(
+    raw_refresh: Any,
+) -> tuple[dict[str, Any] | None, RequestModelError | None]:
+    if raw_refresh is None:
+        return None, None
+    try:
+        refresh_payload = json.loads(raw_refresh)
+    except (TypeError, ValueError):
+        return None, RequestModelError(
+            "Refresh settings must be valid JSON",
+            field="refresh_settings",
+        )
+    if not isinstance(refresh_payload, dict):
+        return None, RequestModelError(
+            "Refresh settings must be an object",
+            field="refresh_settings",
+        )
+    return refresh_payload, None
+
+
+def _truthy_async_flag(value: Any) -> bool:
+    return isinstance(value, str) and value.lower() in ("1", "true")
 
 
 def parse_api_keys_save_request(
@@ -385,6 +466,68 @@ def parse_playlist_name_request(
     if not isinstance(playlist_name, str) or not playlist_name.strip():
         return None, RequestModelError(missing_message, field="playlist_name")
     return PlaylistNameRequest(playlist_name=playlist_name.strip()), None
+
+
+def parse_plugin_settings_form_request(
+    data: Any,
+) -> tuple[PluginSettingsFormRequest | None, RequestModelError | None]:
+    """Parse a plugin settings form body that must include ``plugin_id``."""
+    plugin_id, plugin_settings, error = _pop_required_plugin_id(data)
+    if error is not None or plugin_id is None or plugin_settings is None:
+        return None, error
+    return (
+        PluginSettingsFormRequest(
+            plugin_id=plugin_id,
+            plugin_settings=plugin_settings,
+        ),
+        None,
+    )
+
+
+def parse_plugin_update_instance_request(
+    data: Any,
+) -> tuple[PluginUpdateInstanceRequest | None, RequestModelError | None]:
+    """Parse an update-plugin-instance form body."""
+    plugin_id, plugin_settings, error = _pop_required_plugin_id(data)
+    if error is not None or plugin_id is None or plugin_settings is None:
+        return None, error
+
+    refresh_settings, refresh_error = _parse_optional_refresh_settings(
+        plugin_settings.pop("refresh_settings", None)
+    )
+    if refresh_error is not None:
+        return None, refresh_error
+
+    return (
+        PluginUpdateInstanceRequest(
+            plugin_id=plugin_id,
+            plugin_settings=plugin_settings,
+            refresh_settings=refresh_settings,
+        ),
+        None,
+    )
+
+
+def parse_plugin_update_now_request(
+    data: Any,
+    *,
+    async_header: Any = "",
+    async_query: Any = "",
+) -> tuple[PluginUpdateNowRequest | None, RequestModelError | None]:
+    """Parse a manual plugin render form body."""
+    plugin_id, plugin_settings, error = _pop_required_plugin_id(data)
+    if error is not None or plugin_id is None or plugin_settings is None:
+        return None, error
+
+    return (
+        PluginUpdateNowRequest(
+            plugin_id=plugin_id,
+            plugin_settings=plugin_settings,
+            want_async=_truthy_async_flag(async_header)
+            or _truthy_async_flag(async_query),
+        ),
+        None,
+    )
 
 
 def parse_plugin_instance_action_request(

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -160,6 +160,27 @@ def test_ai_image_generate_image_success(client, monkeypatch, mock_openai):
         assert resp.status_code == 200
 
 
+def test_ai_image_openai_resizes_generated_image_to_display(
+    device_config_dev, monkeypatch, mock_openai
+):
+    from plugins.ai_image.ai_image import AIImage
+
+    monkeypatch.setenv("OPEN_AI_SECRET", "test")
+
+    plugin = AIImage({"id": "ai_image"})
+    result = plugin.generate_image(
+        {
+            "textPrompt": "a cat",
+            "provider": "openai",
+            "imageModel": "gpt-image-2",
+            "quality": "medium",
+        },
+        device_config_dev,
+    )
+
+    assert result.size == tuple(device_config_dev.get_resolution())
+
+
 def test_ai_image_google_generate_success(device_config_dev, monkeypatch):
     """Test ai_image plugin with Google Imagen provider."""
     import sys
@@ -205,6 +226,7 @@ def test_ai_image_google_generate_success(device_config_dev, monkeypatch):
     result = p.generate_image(settings, device_config_dev)
     assert result is not None
     assert isinstance(result, PILImage.Image)
+    assert result.size == tuple(device_config_dev.get_resolution())
 
 
 def test_ai_image_google_empty_results_raises(device_config_dev, monkeypatch):

--- a/tests/plugins/test_apod.py
+++ b/tests/plugins/test_apod.py
@@ -1,4 +1,5 @@
 # pyright: reportMissingImports=false
+import logging
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
@@ -6,7 +7,11 @@ import pytest
 
 
 def test_apod_success(
-    monkeypatch, device_config_dev, realistic_nasa_apod_response, fake_image_response
+    monkeypatch,
+    caplog,
+    device_config_dev,
+    realistic_nasa_apod_response,
+    fake_image_response,
 ):
     from plugins.apod.apod import Apod
 
@@ -32,8 +37,12 @@ def test_apod_success(
         plugin.image_loader, "from_url", MagicMock(return_value=fake_image)
     )
 
+    caplog.set_level(logging.INFO, logger="plugins.apod.apod")
     img = plugin.generate_image({}, device_config_dev)
     assert img.size[0] > 0
+    assert "APOD request: date=today" in caplog.text
+    assert "APOD response:" in caplog.text
+    assert "APOD image candidates:" in caplog.text
 
 
 def test_apod_requires_key(monkeypatch, device_config_dev):

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -10,6 +10,7 @@ Covers:
 - /plugin_instance/<plugin_id>/<instance_name>/force_retry endpoint
 """
 
+import logging
 import os
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
@@ -321,15 +322,19 @@ class TestCircuitBreakerScheduler:
         pm.active_playlist = "CircuitTest"
         return pm
 
-    def test_paused_plugin_skipped_by_scheduler(self, device_config_dev, monkeypatch):
+    def test_paused_plugin_skipped_by_scheduler(
+        self, device_config_dev, monkeypatch, caplog
+    ):
         from model import RefreshInfo
 
         monkeypatch.setenv("PLUGIN_FAILURE_THRESHOLD", "5")
+        caplog.set_level(logging.INFO, logger="refresh_task.task")
         task = _make_task(device_config_dev)
 
         paused_pi = _make_plugin_instance("weather", "paused_weather")
         paused_pi.paused = True
         paused_pi.consecutive_failure_count = 5
+        paused_pi.disabled_reason = "last API error"
 
         good_pi = _make_plugin_instance("clock", "my_clock")
 
@@ -349,6 +354,7 @@ class TestCircuitBreakerScheduler:
         assert plugin is not None
         assert plugin.name == "my_clock"
         assert plugin.paused is False
+        assert "failures=5 reason=last API error" in caplog.text
 
     def test_all_paused_returns_none(self, device_config_dev, monkeypatch):
         from model import RefreshInfo

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -283,6 +283,16 @@ def test_validate_plugin_id_rejects_missing_with_field() -> None:
     assert error.message == "plugin_id is required"
 
 
+def test_validate_plugin_id_rejects_non_string_with_field() -> None:
+    plugin_id, error = validate_plugin_id(123)
+
+    assert plugin_id is None
+    assert error is not None
+    assert error.status == 422
+    assert error.field == "plugin_id"
+    assert error.message == "plugin_id must be a string"
+
+
 def test_parse_plugin_settings_form_request_pops_plugin_id() -> None:
     parsed, error = parse_plugin_settings_form_request(
         {"plugin_id": "  clock  ", "timezone": "UTC"}
@@ -341,6 +351,17 @@ def test_parse_plugin_update_instance_request_rejects_non_object_refresh() -> No
     assert error.field == "refresh_settings"
 
 
+def test_parse_plugin_update_instance_request_ignores_empty_refresh_settings() -> None:
+    parsed, error = parse_plugin_update_instance_request(
+        {"plugin_id": "clock", "refresh_settings": ""}
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.refresh_settings is None
+    assert parsed.plugin_settings == {}
+
+
 def test_parse_plugin_update_now_request_extracts_async_flag() -> None:
     parsed, error = parse_plugin_update_now_request(
         {"plugin_id": "clock", "timezone": "UTC"},
@@ -352,6 +373,39 @@ def test_parse_plugin_update_now_request_extracts_async_flag() -> None:
     assert parsed.plugin_id == "clock"
     assert parsed.plugin_settings == {"timezone": "UTC"}
     assert parsed.want_async is True
+
+
+def test_parse_plugin_update_now_request_extracts_header_async_flag() -> None:
+    parsed, error = parse_plugin_update_now_request(
+        {"plugin_id": "clock"},
+        async_header="true",
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.want_async is True
+
+
+def test_parse_plugin_update_now_request_accepts_html_on_async_flag() -> None:
+    parsed, error = parse_plugin_update_now_request(
+        {"plugin_id": "clock"},
+        async_query="on",
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.want_async is True
+
+
+def test_parse_plugin_update_now_request_treats_empty_async_as_false() -> None:
+    parsed, error = parse_plugin_update_now_request(
+        {"plugin_id": "clock"},
+        async_query="",
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.want_async is False
 
 
 def test_parse_plugin_instance_action_request_requires_playlist_name() -> None:

--- a/tests/unit/test_request_models.py
+++ b/tests/unit/test_request_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from utils.request_models import (
     parse_api_keys_save_request,
     parse_device_cycle_request,
@@ -9,8 +11,12 @@ from utils.request_models import (
     parse_playlist_update_request,
     parse_plugin_instance_action_request,
     parse_plugin_order_request,
+    parse_plugin_settings_form_request,
+    parse_plugin_update_instance_request,
+    parse_plugin_update_now_request,
     validate_cycle_minutes,
     validate_playlist_name,
+    validate_plugin_id,
 )
 
 
@@ -258,6 +264,94 @@ def test_parse_plugin_instance_action_request_returns_typed_payload() -> None:
     assert parsed.playlist_name == "Default"
     assert parsed.plugin_id == "clock"
     assert parsed.plugin_instance == "Clock A"
+
+
+def test_validate_plugin_id_strips_and_accepts_string() -> None:
+    plugin_id, error = validate_plugin_id("  weather  ")
+
+    assert error is None
+    assert plugin_id == "weather"
+
+
+def test_validate_plugin_id_rejects_missing_with_field() -> None:
+    plugin_id, error = validate_plugin_id(" ")
+
+    assert plugin_id is None
+    assert error is not None
+    assert error.status == 422
+    assert error.field == "plugin_id"
+    assert error.message == "plugin_id is required"
+
+
+def test_parse_plugin_settings_form_request_pops_plugin_id() -> None:
+    parsed, error = parse_plugin_settings_form_request(
+        {"plugin_id": "  clock  ", "timezone": "UTC"}
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.plugin_id == "clock"
+    assert parsed.plugin_settings == {"timezone": "UTC"}
+
+
+def test_parse_plugin_settings_form_request_rejects_missing_plugin_id() -> None:
+    parsed, error = parse_plugin_settings_form_request({"timezone": "UTC"})
+
+    assert parsed is None
+    assert error is not None
+    assert error.status == 422
+    assert error.field == "plugin_id"
+
+
+def test_parse_plugin_update_instance_request_decodes_refresh_settings() -> None:
+    parsed, error = parse_plugin_update_instance_request(
+        {
+            "plugin_id": "clock",
+            "timezone": "UTC",
+            "refresh_settings": json.dumps({"refreshType": "interval"}),
+        }
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.plugin_id == "clock"
+    assert parsed.plugin_settings == {"timezone": "UTC"}
+    assert parsed.refresh_settings == {"refreshType": "interval"}
+
+
+def test_parse_plugin_update_instance_request_rejects_bad_refresh_json() -> None:
+    parsed, error = parse_plugin_update_instance_request(
+        {"plugin_id": "clock", "refresh_settings": "not valid json"}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.message == "Refresh settings must be valid JSON"
+    assert error.field == "refresh_settings"
+
+
+def test_parse_plugin_update_instance_request_rejects_non_object_refresh() -> None:
+    parsed, error = parse_plugin_update_instance_request(
+        {"plugin_id": "clock", "refresh_settings": json.dumps(["bad"])}
+    )
+
+    assert parsed is None
+    assert error is not None
+    assert error.message == "Refresh settings must be an object"
+    assert error.field == "refresh_settings"
+
+
+def test_parse_plugin_update_now_request_extracts_async_flag() -> None:
+    parsed, error = parse_plugin_update_now_request(
+        {"plugin_id": "clock", "timezone": "UTC"},
+        async_query="1",
+    )
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.plugin_id == "clock"
+    assert parsed.plugin_settings == {"timezone": "UTC"}
+    assert parsed.want_async is True
 
 
 def test_parse_plugin_instance_action_request_requires_playlist_name() -> None:


### PR DESCRIPTION
## Summary

- Add typed plugin form request models for save, update-instance, and update-now flows.
- Move required `plugin_id`, async flag, and `refresh_settings` parsing out of `src/blueprints/plugin.py`.
- Resize AI-generated OpenAI/Google images to the configured display dimensions before refresh validation.
- Add APOD and circuit-breaker log breadcrumbs so paused NASA/APOD instances and upstream image responses are easier to debug.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [x] Not a parent-fork sync
- [x] No upstream behavior differences to document
- [x] Plugin save/update/update-now, AI image, APOD, and circuit-breaker flows covered by focused tests

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs not needed: internal request-model refactor plus plugin diagnostics/fix
- [x] No frontend changes (`src/static/**`, `src/templates/**` untouched)

## Testing

- `PYTHONPATH=src pytest -q tests/unit/test_request_models.py tests/integration/test_plugin_routes.py tests/integration/test_plugin_validation.py tests/integration/test_plugin_update_now.py tests/integration/test_jtn_381_refresh_settings_validation.py tests/integration/test_plugin_htmx.py tests/plugins/test_ai_image.py tests/plugins/test_apod.py tests/unit/test_circuit_breaker.py tests/contract tests/contracts/test_json_envelope.py`
- `PYTHONPATH=src pytest -q tests/plugins/test_ai_image.py tests/plugins/test_apod.py tests/unit/test_circuit_breaker.py`
- `PYTHONPATH=src python3 -m mypy src/utils src/blueprints/plugin.py`
- `mypy --strict src/utils/http_utils.py src/utils/plugin_errors.py src/utils/security_utils.py src/utils/client_endpoint.py src/utils/display_names.py src/utils/messages.py src/utils/output_validator.py src/utils/paths.py src/utils/refresh_info.py src/utils/refresh_stats.py src/refresh_task/actions.py src/refresh_task/context.py src/refresh_task/worker.py src/utils/sri.py src/utils/time_utils.py src/utils/http_cache.py src/utils/request_models.py src/model.py`
- `python3 -m ruff check src/utils/request_models.py src/blueprints/plugin.py src/plugins/ai_image/ai_image.py src/plugins/apod/apod.py src/refresh_task/task.py tests/unit/test_request_models.py tests/plugins/test_ai_image.py tests/plugins/test_apod.py tests/unit/test_circuit_breaker.py`
- `bash scripts/lint.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin image generation now respects device display resolution.

* **Bug Fixes**
  * Plugin settings and update operations now validate input more strictly with clearer error messages.

* **Improvements**
  * Enhanced diagnostic logging for plugin execution and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->