### PR TITLE
feat: improve AI image failures and refresh progress

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -36,8 +36,8 @@ from utils.form_utils import (
 from utils.http_utils import json_error, json_success
 from utils.plugin_errors import (
     MANUAL_UPDATE_TIMEOUT_MSG,
-    ProviderReportedPluginError,
     SCREENSHOT_BACKEND_UNAVAILABLE_MSG,
+    ProviderReportedPluginError,
     ScreenshotBackendError,
 )
 from utils.plugin_history import record_change as _record_plugin_change
@@ -827,6 +827,7 @@ def _update_now_direct(
                 code="manual_update_timeout",
             )
         except ProviderReportedPluginError as e:
+            safe_msg = e.safe_message()
             logger.info(
                 "Plugin %s provider rejected request: %s",
                 sanitize_log_field(plugin_id),
@@ -836,7 +837,7 @@ def _update_now_direct(
                 plugin_id, plugin_config, device_config, display_manager, e
             )
             return json_error(
-                str(e),
+                safe_msg,
                 status=400,
                 code="provider_rejected",
             )
@@ -1154,13 +1155,14 @@ def update_now() -> Any:
             code="manual_update_timeout",
         )
     except ProviderReportedPluginError as e:
+        safe_msg = e.safe_message()
         logger.info(
             "update_now: provider rejected plugin %s: %s",
             sanitize_log_field(plugin_id or "?"),
             sanitize_log_field(str(e)),
         )
         return json_error(
-            str(e),
+            safe_msg,
             status=400,
             code="provider_rejected",
         )

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -36,6 +36,7 @@ from utils.form_utils import (
 from utils.http_utils import json_error, json_success
 from utils.plugin_errors import (
     MANUAL_UPDATE_TIMEOUT_MSG,
+    ProviderReportedPluginError,
     SCREENSHOT_BACKEND_UNAVAILABLE_MSG,
     ScreenshotBackendError,
 )
@@ -825,6 +826,20 @@ def _update_now_direct(
                 status=504,
                 code="manual_update_timeout",
             )
+        except ProviderReportedPluginError as e:
+            logger.info(
+                "Plugin %s provider rejected request: %s",
+                sanitize_log_field(plugin_id),
+                sanitize_log_field(str(e)),
+            )
+            _push_update_now_fallback(
+                plugin_id, plugin_config, device_config, display_manager, e
+            )
+            return json_error(
+                str(e),
+                status=400,
+                code="provider_rejected",
+            )
         except RuntimeError as e:
             # RuntimeError is raised by plugins to signal a user-actionable
             # failure (bad config, upstream API returned empty, etc.).  Do not
@@ -1137,6 +1152,17 @@ def update_now() -> Any:
             MANUAL_UPDATE_TIMEOUT_MSG,
             status=504,
             code="manual_update_timeout",
+        )
+    except ProviderReportedPluginError as e:
+        logger.info(
+            "update_now: provider rejected plugin %s: %s",
+            sanitize_log_field(plugin_id or "?"),
+            sanitize_log_field(str(e)),
+        )
+        return json_error(
+            str(e),
+            status=400,
+            code="provider_rejected",
         )
     except ClientInputError as e:
         return json_error(

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -298,11 +298,6 @@ class AIImage(BasePlugin):
         return msg
 
     @staticmethod
-    def _is_openai_moderation_block(exc: BaseException) -> bool:
-        payload = AIImage._openai_error_payload(exc)
-        return payload.get("code") == "moderation_blocked"
-
-    @staticmethod
     def _safe_rewrite_openai_prompt(
         ai_client: Any, prompt: str, reason: Mapping[str, str | None]
     ) -> str:
@@ -397,7 +392,8 @@ class AIImage(BasePlugin):
             if not any(payload.values()):
                 raise
             safe_message = self._openai_user_error_message(payload)
-            if safe_rewrite_blocked_prompt and self._is_openai_moderation_block(exc):
+            is_moderation_block = payload.get("code") == "moderation_blocked"
+            if safe_rewrite_blocked_prompt and is_moderation_block:
                 logger.warning(
                     "%s Retrying once with opt-in safe prompt rewrite.",
                     safe_message,

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import re
 from collections.abc import Mapping
 from io import BytesIO
 from typing import Any, cast
@@ -21,6 +22,7 @@ from plugins.base_plugin.settings_schema import (
     section,
     widget,
 )
+from utils.plugin_errors import ProviderReportedPluginError
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,8 @@ IMAGE_MODELS = [
 DEFAULT_IMAGE_MODEL = OPENAI_IMAGE_MODEL_2
 DEFAULT_IMAGE_QUALITY = "medium"
 FALLBACK_IMAGE_PROMPT = "A vivid imaginative scene, high detail."
+SAFE_REWRITE_SETTING = "safeRewriteBlockedPrompt"
+_OPENAI_REQUEST_ID_RE = re.compile(r"\b(req_[A-Za-z0-9]+)\b")
 
 
 class AIImage(BasePlugin):
@@ -89,6 +93,20 @@ class AIImage(BasePlugin):
                     submit_unchecked=True,
                     checked_value="true",
                     unchecked_value="false",
+                ),
+                field(
+                    SAFE_REWRITE_SETTING,
+                    "checkbox",
+                    label="Retry blocked prompts with safe rewrite",
+                    hint="If OpenAI rejects a generated image prompt, rewrite it once with generic visual language and retry. This is off by default so failures stay visible.",
+                    submit_unchecked=True,
+                    checked_value="true",
+                    unchecked_value="false",
+                    visible_if={
+                        "field": "provider",
+                        "operator": "equals",
+                        "equals": "openai",
+                    },
                 ),
             ),
             section(
@@ -241,6 +259,88 @@ class AIImage(BasePlugin):
         logger.warning("Prompt remix returned no usable prompt; using fallback prompt.")
         return FALLBACK_IMAGE_PROMPT
 
+    @staticmethod
+    def _openai_error_payload(exc: BaseException) -> dict[str, str | None]:
+        """Extract response-safe OpenAI error fields from SDK exceptions."""
+        body = getattr(exc, "body", None)
+        error_obj: object = None
+        if isinstance(body, Mapping):
+            error_obj = body.get("error")
+        code = error_type = message = request_id = None
+        if isinstance(error_obj, Mapping):
+            code = str(error_obj.get("code") or "") or None
+            error_type = str(error_obj.get("type") or "") or None
+            message = str(error_obj.get("message") or "") or None
+        request_id_attr = getattr(exc, "request_id", None)
+        if isinstance(request_id_attr, str) and request_id_attr:
+            request_id = request_id_attr
+        if request_id is None:
+            match = _OPENAI_REQUEST_ID_RE.search(str(exc))
+            if match:
+                request_id = match.group(1)
+        return {
+            "code": code,
+            "type": error_type,
+            "message": message,
+            "request_id": request_id,
+        }
+
+    @staticmethod
+    def _openai_user_error_message(payload: Mapping[str, str | None]) -> str:
+        code = payload.get("code") or payload.get("type") or "provider_error"
+        request_id = payload.get("request_id")
+        if code == "moderation_blocked":
+            msg = "OpenAI rejected the image prompt (moderation_blocked)."
+        else:
+            msg = f"OpenAI image generation failed ({code})."
+        if request_id:
+            msg = f"{msg} Request id: {request_id}."
+        return msg
+
+    @staticmethod
+    def _is_openai_moderation_block(exc: BaseException) -> bool:
+        payload = AIImage._openai_error_payload(exc)
+        return payload.get("code") == "moderation_blocked"
+
+    @staticmethod
+    def _safe_rewrite_openai_prompt(
+        ai_client: Any, prompt: str, reason: Mapping[str, str | None]
+    ) -> str:
+        logger.info(
+            "Rewriting OpenAI image prompt after provider rejection: code=%s type=%s request_id=%s",
+            reason.get("code"),
+            reason.get("type"),
+            reason.get("request_id"),
+        )
+        response = ai_client.chat.completions.create(
+            model="gpt-5-nano",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Rewrite image-generation prompts into safe, generic visual "
+                        "language. Remove named artists, living people, franchises, "
+                        "copyrighted style labels, and provocative references. Keep the "
+                        "core subject and mood. Return only one prompt under 30 words."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": f'Rewrite this prompt safely: "{prompt}"',
+                },
+            ],
+            temperature=0.4,
+        )
+        choices = getattr(response, "choices", None) or []
+        message = getattr(choices[0], "message", None) if choices else None
+        content = getattr(message, "content", None) if message else None
+        rewritten = (content or "").strip()
+        if rewritten:
+            logger.info("Safe prompt rewrite produced: %s", rewritten)
+        else:
+            logger.warning("Safe prompt rewrite returned an empty result.")
+        return rewritten
+
     def _generate_google_image(
         self, device_config: Any, text_prompt: str, image_model: str, randomize: bool
     ) -> ImageType:
@@ -272,6 +372,7 @@ class AIImage(BasePlugin):
         image_quality: str,
         orientation: str,
         randomize: bool,
+        safe_rewrite_blocked_prompt: bool,
     ) -> ImageType:
         api_key = device_config.load_env_key("OPEN_AI_SECRET")
         if not api_key:
@@ -282,14 +383,49 @@ class AIImage(BasePlugin):
         prompt = self._maybe_randomize_openai_prompt(ai_client, text_prompt, randomize)
         prompt = self._ensure_image_prompt(prompt)
         logger.info(f"Generating image with {image_model}...")
-        return self.fetch_image(
-            ai_client,
-            prompt,
-            model=image_model,
-            quality=image_quality,
-            orientation=orientation,
-            dimensions=self.get_oriented_dimensions(device_config),
-        )
+        try:
+            return self.fetch_image(
+                ai_client,
+                prompt,
+                model=image_model,
+                quality=image_quality,
+                orientation=orientation,
+                dimensions=self.get_oriented_dimensions(device_config),
+            )
+        except Exception as exc:
+            payload = self._openai_error_payload(exc)
+            if not any(payload.values()):
+                raise
+            safe_message = self._openai_user_error_message(payload)
+            if safe_rewrite_blocked_prompt and self._is_openai_moderation_block(exc):
+                logger.warning(
+                    "%s Retrying once with opt-in safe prompt rewrite.",
+                    safe_message,
+                )
+                rewritten = self._safe_rewrite_openai_prompt(ai_client, prompt, payload)
+                if rewritten:
+                    try:
+                        return self.fetch_image(
+                            ai_client,
+                            rewritten,
+                            model=image_model,
+                            quality=image_quality,
+                            orientation=orientation,
+                            dimensions=self.get_oriented_dimensions(device_config),
+                        )
+                    except Exception as retry_exc:
+                        retry_payload = self._openai_error_payload(retry_exc)
+                        if not any(retry_payload.values()):
+                            raise
+                        retry_message = self._openai_user_error_message(retry_payload)
+                        logger.error(
+                            "Safe prompt rewrite retry failed: %s",
+                            retry_message,
+                        )
+                        raise ProviderReportedPluginError(retry_message) from retry_exc
+                logger.warning("Safe rewrite was empty; reporting original rejection.")
+            logger.error("%s", safe_message)
+            raise ProviderReportedPluginError(safe_message) from exc
 
     def generate_image(
         self, settings: Mapping[str, object], device_config: Any
@@ -305,6 +441,7 @@ class AIImage(BasePlugin):
             text_prompt = ""
         image_model, image_quality = self._validate_generate_inputs(settings, provider)
         randomize_prompt = settings.get("randomizePrompt") == "true"
+        safe_rewrite_blocked_prompt = settings.get(SAFE_REWRITE_SETTING) == "true"
         if not text_prompt.strip() and not randomize_prompt:
             raise RuntimeError("Prompt is required unless Vivid remix is enabled.")
         orientation = device_config.get_config("orientation")
@@ -332,6 +469,7 @@ class AIImage(BasePlugin):
                     image_quality,
                     orientation,
                     randomize_prompt,
+                    safe_rewrite_blocked_prompt,
                 )
 
             if image:
@@ -457,10 +595,9 @@ class AIImage(BasePlugin):
         system_content = (
             "You are a creative assistant generating extremely random and unique image prompts. "
             "Avoid common themes. Focus on unexpected, unconventional, and bizarre combinations "
-            "of art style, medium, subjects, time periods, and moods. No repetition. Prompts "
-            "should be 20 words or less and specify random artist, movie, tv show or time period "
-            "for the theme. Do not provide any headers or repeat the request, just provide the "
-            "updated prompt in your response."
+            "of visual genre, medium, subjects, time periods, and moods. No repetition. Prompts "
+            "should be 20 words or less and avoid named artists, people, franchises, movies, or TV shows. "
+            "Do not provide any headers or repeat the request, just provide the updated prompt."
         )
         user_content = (
             "Give me a completely random image prompt, something unexpected and creative! "
@@ -474,11 +611,10 @@ class AIImage(BasePlugin):
                 "and descriptive version that captures the essence of the original while "
                 "making it unique and vivid. Avoid adding irrelevant details but feel free "
                 "to include creative and visual enhancements. Avoid common themes. Focus on "
-                "unexpected, unconventional, and bizarre combinations of art style, medium, "
+                "unexpected, unconventional, and bizarre combinations of visual genre, medium, "
                 "subjects, time periods, and moods. Do not provide any headers or repeat the "
                 "request, just provide your updated prompt in the response. Prompts "
-                "should be 20 words or less and specify random artist, movie, tv show or time "
-                "period for the theme."
+                "should be 20 words or less and avoid named artists, people, franchises, movies, or TV shows. "
             )
             user_content = (
                 f'Original prompt: "{from_prompt}"\n'
@@ -516,10 +652,9 @@ class AIImage(BasePlugin):
         system_content = (
             "You are a creative assistant generating extremely random and unique image prompts. "
             "Avoid common themes. Focus on unexpected, unconventional, and bizarre combinations "
-            "of art style, medium, subjects, time periods, and moods. No repetition. Prompts "
-            "should be 20 words or less and specify random artist, movie, tv show or time period "
-            "for the theme. Do not provide any headers or repeat the request, just provide the "
-            "updated prompt in your response."
+            "of visual genre, medium, subjects, time periods, and moods. No repetition. Prompts "
+            "should be 20 words or less and avoid named artists, people, franchises, movies, or TV shows. "
+            "Do not provide any headers or repeat the request, just provide the updated prompt."
         )
         user_content = (
             "Give me a completely random image prompt, something unexpected and creative! "
@@ -533,11 +668,10 @@ class AIImage(BasePlugin):
                 "and descriptive version that captures the essence of the original while "
                 "making it unique and vivid. Avoid adding irrelevant details but feel free "
                 "to include creative and visual enhancements. Avoid common themes. Focus on "
-                "unexpected, unconventional, and bizarre combinations of art style, medium, "
+                "unexpected, unconventional, and bizarre combinations of visual genre, medium, "
                 "subjects, time periods, and moods. Do not provide any headers or repeat the "
                 "request, just provide your updated prompt in the response. Prompts "
-                "should be 20 words or less and specify random artist, movie, tv show or time "
-                "period for the theme."
+                "should be 20 words or less and avoid named artists, people, franchises, movies, or TV shows. "
             )
             user_content = (
                 f'Original prompt: "{from_prompt}"\n'

--- a/src/plugins/ai_image/ai_image.py
+++ b/src/plugins/ai_image/ai_image.py
@@ -422,10 +422,17 @@ class AIImage(BasePlugin):
                             "Safe prompt rewrite retry failed: %s",
                             retry_message,
                         )
-                        raise ProviderReportedPluginError(retry_message) from retry_exc
+                        raise ProviderReportedPluginError(
+                            retry_message,
+                            reason_code=retry_payload.get("code")
+                            or retry_payload.get("type"),
+                        ) from retry_exc
                 logger.warning("Safe rewrite was empty; reporting original rejection.")
             logger.error("%s", safe_message)
-            raise ProviderReportedPluginError(safe_message) from exc
+            raise ProviderReportedPluginError(
+                safe_message,
+                reason_code=payload.get("code") or payload.get("type"),
+            ) from exc
 
     def generate_image(
         self, settings: Mapping[str, object], device_config: Any

--- a/src/refresh_task/display_pipeline.py
+++ b/src/refresh_task/display_pipeline.py
@@ -228,7 +228,7 @@ class DisplayPipeline:
         manual_request: ManualUpdateRequest | None,
         plugin_id: str,
         request_id: str | None,
-    ) -> Callable[[Mapping[str, Any]], None] | None:
+    ) -> Callable[[Mapping[str, Any]], None]:
         """Return a callback that reports disk-save progress and releases waiters."""
 
         def on_image_saved(save_metrics: Mapping[str, Any]) -> None:

--- a/src/refresh_task/display_pipeline.py
+++ b/src/refresh_task/display_pipeline.py
@@ -85,6 +85,11 @@ class DisplayPipeline:
         # already wrote it. Unblock the manual-update waiter immediately.
         if manual_request is not None:
             manual_request.image_saved.set()
+        self.recorder.publish_step(
+            plugin_id=plugin_id,
+            request_id=request_id,
+            step="Image unchanged; display skipped",
+        )
         return None, None
 
     def push_to_display(
@@ -117,7 +122,17 @@ class DisplayPipeline:
         display_duration_ms = None
         preprocess_ms = None
         display_driver = None
-        on_image_saved = self._manual_image_saved_callback(manual_request)
+        display_ok = False
+        on_image_saved = self._image_saved_callback(
+            manual_request=manual_request,
+            plugin_id=plugin_id,
+            request_id=request_id,
+        )
+        self.recorder.publish_step(
+            plugin_id=plugin_id,
+            request_id=request_id,
+            step="Saving image",
+        )
 
         try:
             display_metrics = self.display_manager.display_image(
@@ -130,6 +145,7 @@ class DisplayPipeline:
                 preprocess_ms = display_metrics.get("preprocess_ms")
                 display_duration_ms = display_metrics.get("display_ms")
                 display_driver = display_metrics.get("display_driver")
+            display_ok = True
         except Exception as exc:
             logger.error(
                 "plugin_lifecycle: display_failure | plugin_id=%s instance=%s error=%s",
@@ -168,6 +184,12 @@ class DisplayPipeline:
                     "request_id": request_id,
                 },
             )
+            if display_ok:
+                self.recorder.publish_step(
+                    plugin_id=plugin_id,
+                    request_id=request_id,
+                    step="Display complete",
+                )
             self.recorder.save_stage(
                 benchmark_id or "",
                 "display_pipeline",
@@ -200,15 +222,23 @@ class DisplayPipeline:
             refresh_action=refresh_action,
         )
 
-    @staticmethod
-    def _manual_image_saved_callback(
+    def _image_saved_callback(
+        self,
+        *,
         manual_request: ManualUpdateRequest | None,
+        plugin_id: str,
+        request_id: str | None,
     ) -> Callable[[Mapping[str, Any]], None] | None:
-        """Return a callback that releases manual-update waiters after disk save."""
-        if manual_request is None:
-            return None
+        """Return a callback that reports disk-save progress and releases waiters."""
 
         def on_image_saved(save_metrics: Mapping[str, Any]) -> None:
+            self.recorder.publish_step(
+                plugin_id=plugin_id,
+                request_id=request_id,
+                step="Image saved; writing to display",
+            )
+            if manual_request is None:
+                return
             manual_request.image_saved_metrics = {
                 "generate_ms": None,
                 "preprocess_ms": save_metrics.get("preprocess_ms"),

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -225,6 +225,11 @@ class RefreshExecutor:
                 attempts,
                 timeout_s,
             )
+            self.recorder.publish_step(
+                plugin_id=plugin_id,
+                request_id=request_id,
+                step=f"Starting render attempt {attempt}/{attempts}",
+            )
             image, exc_or_meta = self.run_subprocess_attempt(
                 refresh_action, plugin_config, current_dt, plugin_id, timeout_s, attempt
             )
@@ -356,6 +361,11 @@ class RefreshExecutor:
 
         last_exc: BaseException | None = None
         for attempt in range(1, attempts + 1):
+            self.recorder.publish_step(
+                plugin_id=plugin_id,
+                request_id=request_id,
+                step=f"Starting render attempt {attempt}/{attempts}",
+            )
             _worker, result_holder, cancel_event = self.make_inprocess_worker(
                 refresh_action,
                 plugin_config,

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -61,17 +61,38 @@ _MANUAL_WAIT_DEFAULTS_S = {
     # plugin's real result instead of a queue wait timeout.
     "ai_image": 210.0,
 }
-_API_KEY_PLUGIN_IDS = frozenset(
-    {
-        "ai_image",
-        "ai_text",
-        "apod",
-        "github",
-        "image_album",
-        "unsplash",
-        "weather",
-    }
-)
+
+
+def _plugin_requires_api_key(plugin_config: Mapping[str, Any]) -> bool:
+    """Return whether plugin metadata declares API-key configuration."""
+    plugin_id = plugin_config.get("id")
+    if not isinstance(plugin_id, str):
+        return False
+
+    try:
+        plugin = get_plugin_instance(dict(plugin_config))
+    except Exception:
+        logger.debug(
+            "Could not inspect API-key metadata for plugin %s",
+            plugin_id,
+            exc_info=True,
+        )
+        return False
+
+    if getattr(plugin, "requires_api_key", False):
+        return True
+
+    try:
+        template = plugin.generate_settings_template()
+    except Exception:
+        logger.debug(
+            "Could not inspect settings template for plugin %s",
+            plugin_id,
+            exc_info=True,
+        )
+        return False
+
+    return isinstance(template, Mapping) and "api_key" in template
 
 
 class RefreshTask:
@@ -415,7 +436,7 @@ class RefreshTask:
                 request_id=request_id,
                 step=(
                     "Checking provider credentials"
-                    if plugin_id in _API_KEY_PLUGIN_IDS
+                    if _plugin_requires_api_key(plugin_config)
                     else "Checking plugin settings"
                 ),
             )

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -61,6 +61,17 @@ _MANUAL_WAIT_DEFAULTS_S = {
     # plugin's real result instead of a queue wait timeout.
     "ai_image": 210.0,
 }
+_API_KEY_PLUGIN_IDS = frozenset(
+    {
+        "ai_image",
+        "ai_text",
+        "apod",
+        "github",
+        "image_album",
+        "unsplash",
+        "weather",
+    }
+)
 
 
 class RefreshTask:
@@ -394,6 +405,25 @@ class RefreshTask:
                 refresh_id=benchmark_id,
                 request_id=request_id,
             )
+            self.recorder.publish_step(
+                plugin_id=plugin_id,
+                request_id=request_id,
+                step="Preparing plugin",
+            )
+            self.recorder.publish_step(
+                plugin_id=plugin_id,
+                request_id=request_id,
+                step=(
+                    "Checking provider credentials"
+                    if plugin_id in _API_KEY_PLUGIN_IDS
+                    else "Checking plugin settings"
+                ),
+            )
+            self.recorder.publish_step(
+                plugin_id=plugin_id,
+                request_id=request_id,
+                step="Generating image",
+            )
             try:
                 image, plugin_meta = self._execute_with_policy(
                     refresh_action,
@@ -456,10 +486,20 @@ class RefreshTask:
                 "request_id": request_id,
             },
         )
+        self.recorder.publish_step(
+            plugin_id=plugin_id,
+            request_id=request_id,
+            step="Image generated",
+        )
         if image is None:
             raise RuntimeError("Plugin returned None image; cannot refresh display.")
 
         # Validate dimensions before doing anything expensive (hash / display push).
+        self.recorder.publish_step(
+            plugin_id=plugin_id,
+            request_id=request_id,
+            step="Checking image",
+        )
         expected_w, expected_h = self.device_config.get_resolution()
         try:
             image = validate_image_dimensions(

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -17,6 +17,7 @@ from refresh_task.actions import PluginLike, RefreshAction
 from refresh_task.context import RefreshContext, SupportsRefreshConfig
 from utils.plugin_errors import (
     PermanentPluginError,
+    ProviderReportedPluginError,
     ScreenshotBackendError,
     URLValidationError,
 )
@@ -201,6 +202,7 @@ def _remote_exception(error_type: str, error_message: str) -> BaseException:
         # would reconstruct it as a plain RuntimeError and fall through to
         # the generic 500 ``internal_error`` handler.
         "ScreenshotBackendError": ScreenshotBackendError,
+        "ProviderReportedPluginError": ProviderReportedPluginError,
     }
     exc_cls = exc_types.get(error_type, RuntimeError)
     return exc_cls(error_message)

--- a/src/static/scripts/plugin_form.js
+++ b/src/static/scripts/plugin_form.js
@@ -42,6 +42,50 @@
     return { setStep, start, stop };
   }
 
+  function attachLiveProgress(progress, pluginId){
+    if (!pluginId || typeof EventSource === 'undefined') {
+      return { close(){}, hasRecent(){ return false; } };
+    }
+    let source = null;
+    let lastLiveAt = 0;
+    const startedAt = Date.now() / 1000 - 5;
+    const labels = {
+      queued: 'Queued on device',
+      running: 'Preparing plugin',
+      done: 'Done',
+      error: 'Failed — see error above'
+    };
+    function applyEvent(payload){
+      if (!payload || payload.plugin_id !== pluginId) return;
+      if (typeof payload.ts === 'number' && payload.ts < startedAt) return;
+      let text = payload.step || labels[payload.state] || null;
+      if (payload.state === 'error' && payload.error) {
+        text = `Failed — ${payload.error}`;
+      }
+      if (!text) return;
+      lastLiveAt = Date.now();
+      const pctByState = { queued: 15, running: 25, step: 50, done: 100, error: 100 };
+      progress.setStep(text, pctByState[payload.state] || 55);
+      if (payload.state === 'done' || payload.state === 'error') {
+        try { source?.close(); } catch(e){}
+      }
+    }
+    try {
+      source = new EventSource('/api/progress/stream');
+      ['queued', 'running', 'step', 'done', 'error'].forEach((eventName) => {
+        source.addEventListener(eventName, (event) => {
+          try { applyEvent(JSON.parse(event.data || '{}')); } catch(e){}
+        });
+      });
+    } catch (e) {
+      console.warn('Live progress stream unavailable:', e);
+    }
+    return {
+      close(){ try { source?.close(); } catch(e){} },
+      hasRecent(){ return lastLiveAt > 0 && Date.now() - lastLiveAt < 3000; }
+    };
+  }
+
   function surfaceFieldError(result) {
     const message = result?.error || result?.message || "";
     const field = String(result?.field || "").toLowerCase();
@@ -98,6 +142,7 @@
     const formData = new FormData(form);
     let success = false;
     let result = null;
+    let liveProgress = null;
 
     // append uploaded files
     try { Object.keys(uploadedFiles || {}).forEach(key => { (uploadedFiles[key] || []).forEach(f => formData.append(key, f)); }); } catch(e){ console.warn('Failed to append uploaded files:', e); if (window.showResponseModal) window.showResponseModal('failure', 'Failed to attach uploaded files: ' + (e.message || e)); return { success: false, result: null }; }
@@ -128,6 +173,7 @@
       if (response.status === 202) {
         const accepted = await response.json();
         const jobId = accepted.job_id;
+        liveProgress = attachLiveProgress(progress, String(formData.get('plugin_id') || ''));
         progress.setStep('Rendering (background)…', 40);
 
         // Poll /api/job/<id> until done or error
@@ -143,7 +189,9 @@
             const pollResp = await fetch('/api/job/' + jobId, { signal: controller.signal });
             const jobInfo = await pollResp.json();
             if (jobInfo.status === 'running') {
-              progress.setStep('Rendering (background)…', 40 + Math.min(polls, 50));
+              if (!liveProgress?.hasRecent()) {
+                progress.setStep('Rendering (background)…', 40 + Math.min(polls, 50));
+              }
             } else if (jobInfo.status === 'done') {
               result = jobInfo.result || { success: true, message: 'Display updated' };
               // metrics display
@@ -210,6 +258,7 @@
       }
     } finally {
       clearTimeout(timeoutId);
+      try { liveProgress?.close(); } catch(e){}
       if (loadingIndicator) loadingIndicator.style.display = 'none';
       progress.setStep(success ? 'Done' : 'Failed \u2014 see error above', 100);
       progress.stop();

--- a/src/utils/plugin_errors.py
+++ b/src/utils/plugin_errors.py
@@ -63,6 +63,16 @@ class PermanentPluginError(RuntimeError):
     """
 
 
+class ProviderReportedPluginError(PermanentPluginError):
+    """A response-safe provider rejection that should be shown to the user.
+
+    Plugins raise this when an upstream API returns a specific, user-actionable
+    rejection such as an image-safety block. The message should already be
+    scrubbed down to provider, reason code, and request id before construction;
+    callers may return ``str(exc)`` to clients.
+    """
+
+
 class URLValidationError(PermanentPluginError):
     """Raised by plugins when a user-supplied URL fails SSRF/scheme validation.
 

--- a/src/utils/plugin_errors.py
+++ b/src/utils/plugin_errors.py
@@ -64,13 +64,34 @@ class PermanentPluginError(RuntimeError):
 
 
 class ProviderReportedPluginError(PermanentPluginError):
-    """A response-safe provider rejection that should be shown to the user.
+    """A provider rejection with a response-safe summary.
 
     Plugins raise this when an upstream API returns a specific, user-actionable
-    rejection such as an image-safety block. The message should already be
-    scrubbed down to provider, reason code, and request id before construction;
-    callers may return ``str(exc)`` to clients.
+    rejection such as an image-safety block. The exception text is for logs; API
+    handlers must use :meth:`safe_message` so provider or SDK exception details
+    cannot leak into HTTP responses.
     """
+
+    def __init__(self, message: str, *, reason_code: str | None = None) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code or _extract_provider_reason_code(message)
+
+    def safe_message(self) -> str:
+        """Return a response-safe provider rejection reason.
+
+        The returned value is selected from hardcoded module constants, matching
+        the CodeQL-safe pattern used by :class:`URLValidationError`.
+        """
+        if self.reason_code == PROVIDER_REASON_OPENAI_MODERATION_BLOCKED:
+            return OPENAI_MODERATION_BLOCKED_MSG
+        return PROVIDER_REJECTED_MSG
+
+
+PROVIDER_REASON_OPENAI_MODERATION_BLOCKED = "moderation_blocked"
+OPENAI_MODERATION_BLOCKED_MSG = (
+    "OpenAI rejected the image prompt (moderation_blocked). See logs for request id."
+)
+PROVIDER_REJECTED_MSG = "Provider rejected the request. See logs for details."
 
 
 class URLValidationError(PermanentPluginError):
@@ -170,3 +191,10 @@ def _extract_reason(message: str) -> str:
     if message.startswith(prefix):
         return message[len(prefix) :]
     return message
+
+
+def _extract_provider_reason_code(message: str) -> str | None:
+    """Extract a known provider reason code from a log-oriented message."""
+    if PROVIDER_REASON_OPENAI_MODERATION_BLOCKED in message:
+        return PROVIDER_REASON_OPENAI_MODERATION_BLOCKED
+    return None

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -382,6 +382,51 @@ def test_ai_image_openai_safe_rewrite_retries_moderation_block(
     assert "generic icy retro science fiction cathedral" in second_prompt
 
 
+def test_ai_image_openai_safe_rewrite_reports_retry_rejection(
+    device_config_dev: Any, monkeypatch: Any
+) -> None:
+    from plugins.ai_image.ai_image import AIImage
+    from utils.plugin_errors import (
+        OPENAI_MODERATION_BLOCKED_MSG,
+        ProviderReportedPluginError,
+    )
+
+    p = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    with patch("plugins.ai_image.ai_image.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_client.images.generate.side_effect = [
+            _FakeOpenAIImageError(),
+            _FakeOpenAIImageError(),
+        ]
+        rewrite_response = MagicMock()
+        rewrite_choice = MagicMock()
+        rewrite_choice.message.content = "generic icy retro science fiction cathedral"
+        rewrite_response.choices = [rewrite_choice]
+        mock_client.chat.completions.create.return_value = rewrite_response
+
+        with pytest.raises(ProviderReportedPluginError) as exc:
+            p.generate_image(
+                {
+                    "textPrompt": "icy sci-fi cathedral",
+                    "provider": "openai",
+                    "imageModel": "gpt-image-2",
+                    "quality": "medium",
+                    "safeRewriteBlockedPrompt": "true",
+                },
+                device_config_dev,
+            )
+
+    message = str(exc.value)
+    assert "moderation_blocked" in message
+    assert "req_testblocked123" in message
+    assert exc.value.safe_message() == OPENAI_MODERATION_BLOCKED_MSG
+    assert mock_client.images.generate.call_count == 2
+    assert mock_client.chat.completions.create.call_count == 1
+
+
 def test_ai_image_raises_when_provider_returns_no_image(device_config_dev, monkeypatch):
     """AI image generation should not return None on a falsy provider response."""
     from plugins.ai_image.ai_image import AIImage

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -8,6 +8,19 @@ import pytest
 from PIL import Image as PILImage
 
 
+class _FakeOpenAIImageError(Exception):
+    def __init__(self) -> None:
+        super().__init__("provider rejected request req_testblocked123")
+        self.body = {
+            "error": {
+                "message": "Your request was rejected by the safety system.",
+                "type": "image_generation_user_error",
+                "code": "moderation_blocked",
+            }
+        }
+        self.request_id = "req_testblocked123"
+
+
 @pytest.fixture(autouse=True)
 def mock_openai():
     """Mock OpenAI for all ai_image tests."""
@@ -284,6 +297,85 @@ def test_ai_image_openai_api_failure(device_config_dev, monkeypatch):
 
         with pytest.raises(RuntimeError, match="API request failure"):
             p.generate_image(settings, device_config_dev)
+
+
+def test_ai_image_openai_moderation_block_reports_provider_reason(
+    device_config_dev: Any, monkeypatch: Any
+) -> None:
+    from plugins.ai_image.ai_image import AIImage
+    from utils.plugin_errors import ProviderReportedPluginError
+
+    p = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    with patch("plugins.ai_image.ai_image.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_client.images.generate.side_effect = _FakeOpenAIImageError()
+
+        with pytest.raises(ProviderReportedPluginError) as exc:
+            p.generate_image(
+                {
+                    "textPrompt": "icy sci-fi cathedral",
+                    "provider": "openai",
+                    "imageModel": "gpt-image-2",
+                    "quality": "medium",
+                    "safeRewriteBlockedPrompt": "false",
+                },
+                device_config_dev,
+            )
+
+    message = str(exc.value)
+    assert "moderation_blocked" in message
+    assert "req_testblocked123" in message
+    assert mock_client.chat.completions.create.call_count == 0
+
+
+def test_ai_image_openai_safe_rewrite_retries_moderation_block(
+    device_config_dev: Any, monkeypatch: Any
+) -> None:
+    from plugins.ai_image.ai_image import AIImage
+
+    p = AIImage({"id": "ai_image"})
+    monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
+
+    with patch("plugins.ai_image.ai_image.OpenAI") as mock_openai:
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+
+        img = PILImage.new("RGB", (64, 64), "black")
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        img_b64 = base64.b64encode(buf.getvalue()).decode()
+        success = MagicMock()
+        success.data = [MagicMock()]
+        success.data[0].b64_json = img_b64
+
+        mock_client.images.generate.side_effect = [
+            _FakeOpenAIImageError(),
+            success,
+        ]
+        rewrite_response = MagicMock()
+        rewrite_choice = MagicMock()
+        rewrite_choice.message.content = "generic icy retro science fiction cathedral"
+        rewrite_response.choices = [rewrite_choice]
+        mock_client.chat.completions.create.return_value = rewrite_response
+
+        result = p.generate_image(
+            {
+                "textPrompt": "icy sci-fi cathedral",
+                "provider": "openai",
+                "imageModel": "gpt-image-2",
+                "quality": "medium",
+                "safeRewriteBlockedPrompt": "true",
+            },
+            device_config_dev,
+        )
+
+    assert result.size == tuple(device_config_dev.get_resolution())
+    assert mock_client.images.generate.call_count == 2
+    second_prompt = mock_client.images.generate.call_args_list[1].kwargs["prompt"]
+    assert "generic icy retro science fiction cathedral" in second_prompt
 
 
 def test_ai_image_raises_when_provider_returns_no_image(device_config_dev, monkeypatch):
@@ -617,6 +709,22 @@ def test_ai_image_schema_includes_random_prompt_widget() -> None:
     ]
 
     assert any(item.get("widget_type") == "ai-image-prompt-tools" for item in widgets)
+
+
+def test_ai_image_schema_includes_safe_rewrite_opt_in() -> None:
+    from plugins.ai_image.ai_image import SAFE_REWRITE_SETTING, AIImage
+
+    p = AIImage({"id": "ai_image"})
+    schema = p.build_settings_schema()
+
+    fields = [
+        item
+        for section in schema["sections"]
+        for item in section["items"]
+        if item.get("kind") == "field"
+    ]
+
+    assert any(item.get("name") == SAFE_REWRITE_SETTING for item in fields)
 
 
 def test_ai_image_prompt_renders_as_textarea(client: Any) -> None:

--- a/tests/plugins/test_ai_image.py
+++ b/tests/plugins/test_ai_image.py
@@ -303,7 +303,10 @@ def test_ai_image_openai_moderation_block_reports_provider_reason(
     device_config_dev: Any, monkeypatch: Any
 ) -> None:
     from plugins.ai_image.ai_image import AIImage
-    from utils.plugin_errors import ProviderReportedPluginError
+    from utils.plugin_errors import (
+        OPENAI_MODERATION_BLOCKED_MSG,
+        ProviderReportedPluginError,
+    )
 
     p = AIImage({"id": "ai_image"})
     monkeypatch.setattr(device_config_dev, "load_env_key", lambda key: "fake_key")
@@ -328,6 +331,7 @@ def test_ai_image_openai_moderation_block_reports_provider_reason(
     message = str(exc.value)
     assert "moderation_blocked" in message
     assert "req_testblocked123" in message
+    assert exc.value.safe_message() == OPENAI_MODERATION_BLOCKED_MSG
     assert mock_client.chat.completions.create.call_count == 0
 
 

--- a/tests/unit/test_refresh_task_display_pipeline.py
+++ b/tests/unit/test_refresh_task_display_pipeline.py
@@ -49,6 +49,7 @@ def _make_pipeline(device_config_dev: Any, display_manager: _DisplayManager) -> 
     list[tuple[str, str | None, bool, Mapping[str, Any] | None, str | None]],
     list[tuple[str, str, int | None, Mapping[str, Any] | None]],
     list[dict[str, Any]],
+    list[dict[str, Any]],
 ]:
     housekeeper = RefreshHousekeeper(device_config_dev, display_manager)
     recorder = RefreshRecorder(device_config_dev)
@@ -57,6 +58,7 @@ def _make_pipeline(device_config_dev: Any, display_manager: _DisplayManager) -> 
     ] = []
     stages: list[tuple[str, str, int | None, Mapping[str, Any] | None]] = []
     errors: list[dict[str, Any]] = []
+    steps: list[dict[str, Any]] = []
 
     def update_health(
         plugin_id: str,
@@ -79,22 +81,26 @@ def _make_pipeline(device_config_dev: Any, display_manager: _DisplayManager) -> 
     def publish_error(**kwargs: Any) -> None:
         errors.append(kwargs)
 
+    def publish_step(**kwargs: Any) -> None:
+        steps.append(kwargs)
+
     recorder.save_stage = save_stage
     recorder.publish_error = publish_error
+    recorder.publish_step = publish_step
     pipeline = DisplayPipeline(
         display_manager=display_manager,
         housekeeper=housekeeper,
         recorder=recorder,
         update_plugin_health=update_health,
     )
-    return pipeline, health_updates, stages, errors
+    return pipeline, health_updates, stages, errors, steps
 
 
 def test_display_pipeline_success_records_metrics_and_stage(
     device_config_dev: Any,
 ) -> None:
     display_manager = _DisplayManager()
-    pipeline, health_updates, stages, errors = _make_pipeline(
+    pipeline, health_updates, stages, errors, steps = _make_pipeline(
         device_config_dev, display_manager
     )
     action = ManualRefresh("clock", {})
@@ -119,13 +125,18 @@ def test_display_pipeline_success_records_metrics_and_stage(
     ]
     assert health_updates == []
     assert errors == []
+    assert [item["step"] for item in steps] == [
+        "Saving image",
+        "Image saved; writing to display",
+        "Display complete",
+    ]
 
 
 def test_display_pipeline_cached_path_releases_manual_waiter(
     device_config_dev: Any,
 ) -> None:
     display_manager = _DisplayManager()
-    pipeline, _health_updates, stages, _errors = _make_pipeline(
+    pipeline, _health_updates, stages, _errors, steps = _make_pipeline(
         device_config_dev, display_manager
     )
     action = ManualRefresh("clock", {})
@@ -149,13 +160,14 @@ def test_display_pipeline_cached_path_releases_manual_waiter(
     assert request.image_saved.is_set()
     assert display_manager.calls == []
     assert stages == []
+    assert steps[-1]["step"] == "Image unchanged; display skipped"
 
 
 def test_display_pipeline_manual_callback_sets_image_saved_metrics(
     device_config_dev: Any,
 ) -> None:
     display_manager = _DisplayManager()
-    pipeline, _health_updates, _stages, _errors = _make_pipeline(
+    pipeline, _health_updates, _stages, _errors, _steps = _make_pipeline(
         device_config_dev, display_manager
     )
     action = ManualRefresh("clock", {})
@@ -188,7 +200,7 @@ def test_display_pipeline_failure_records_health_and_progress_error(
 ) -> None:
     display_manager = _DisplayManager()
     display_manager.exception = RuntimeError("display offline")
-    pipeline, health_updates, _stages, errors = _make_pipeline(
+    pipeline, health_updates, _stages, errors, steps = _make_pipeline(
         device_config_dev, display_manager
     )
     action = ManualRefresh("clock", {})
@@ -227,4 +239,8 @@ def test_display_pipeline_failure_records_health_and_progress_error(
             "error": "display offline",
             "retained_display": True,
         }
+    ]
+    assert [item["step"] for item in steps] == [
+        "Saving image",
+        "Image saved; writing to display",
     ]

--- a/tests/unit/test_refresh_task_executor.py
+++ b/tests/unit/test_refresh_task_executor.py
@@ -84,8 +84,18 @@ def test_executor_policy_retries_transient_subprocess_error(monkeypatch: Any) ->
         {
             "plugin_id": "clock",
             "request_id": "req-1",
+            "step": "Starting render attempt 1/2",
+        },
+        {
+            "plugin_id": "clock",
+            "request_id": "req-1",
             "step": "retry 1/1",
-        }
+        },
+        {
+            "plugin_id": "clock",
+            "request_id": "req-1",
+            "step": "Starting render attempt 2/2",
+        },
     ]
 
 
@@ -164,8 +174,18 @@ def test_executor_inprocess_retry_publishes_request_step(monkeypatch: Any) -> No
         {
             "plugin_id": "clock",
             "request_id": "req-2",
+            "step": "Starting render attempt 1/2",
+        },
+        {
+            "plugin_id": "clock",
+            "request_id": "req-2",
             "step": "retry 1/1",
-        }
+        },
+        {
+            "plugin_id": "clock",
+            "request_id": "req-2",
+            "step": "Starting render attempt 2/2",
+        },
     ]
 
 
@@ -213,7 +233,13 @@ def test_executor_inprocess_timeout_does_not_retry(monkeypatch: Any) -> None:
         )
 
     assert calls["count"] == 1
-    assert recorder.steps == []
+    assert recorder.steps == [
+        {
+            "plugin_id": "slow",
+            "request_id": "req-timeout",
+            "step": "Starting render attempt 1/2",
+        }
+    ]
     assert _ZombieOwner._zombie_thread_count == 1
     release.set()
     deadline = time.monotonic() + 5


### PR DESCRIPTION
## Summary

- Surface OpenAI image-generation provider rejections with response-safe details like `moderation_blocked` and request ids.
- Add an opt-in AI Image safe-rewrite retry for blocked prompts, while leaving default behavior as explicit failure.
- Publish richer refresh progress stages for all plugins, with provider-credential checks for API-key plugins and live SSE updates in the plugin form.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

N/A: this is not an upstream sync PR.

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`)
- [x] Docs updated for new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): ran browser tests (`SKIP_BROWSER=0 .venv/bin/python -m pytest tests/`) and all passed

Frontend note: full browser suite was not run; `node --check src/static/scripts/plugin_form.js` and route/progress integration tests passed. The new AI Image setting is documented inline in the settings schema hint.

## Testing

- `python3 -m pytest tests/plugins/test_ai_image.py tests/unit/test_refresh_task_display_pipeline.py tests/unit/test_refresh_task_executor.py -q`
- `python3 -m pytest tests/integration/test_plugin_routes.py tests/unit/test_progress_events.py tests/integration/test_observability_api.py -q`
- `python3 -m black --check src/plugins/ai_image/ai_image.py src/utils/plugin_errors.py src/refresh_task/worker.py src/blueprints/plugin.py src/refresh_task/task.py src/refresh_task/executor.py src/refresh_task/display_pipeline.py tests/plugins/test_ai_image.py tests/unit/test_refresh_task_display_pipeline.py tests/unit/test_refresh_task_executor.py`
- `python3 -m py_compile src/plugins/ai_image/ai_image.py src/utils/plugin_errors.py src/refresh_task/worker.py src/blueprints/plugin.py src/refresh_task/task.py src/refresh_task/executor.py src/refresh_task/display_pipeline.py`
- `node --check src/static/scripts/plugin_form.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live progress streaming displays detailed step-by-step updates during image generation
  * Automatic retry mechanism for blocked image generation with prompt rewriting
  * Granular progress events throughout the render pipeline lifecycle

* **Bug Fixes**
  * Improved error handling and user-facing messages for provider rejections
  * Better exception type preservation in asynchronous plugin execution

* **Tests**
  * Added coverage for moderation block handling and retry behavior
  * Enhanced progress event tracking validation across refresh pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->