### PR TITLE
ci: point Dependabot at uv.lock instead of the generated requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/install"
+  # Source of truth is pyproject.toml + uv.lock (JTN-616); install/requirements.txt
+  # is generated from them by `uv export`. Pointing Dependabot at /install made it
+  # edit that generated file, which fails the lockfile drift check by construction
+  # and duplicated every security bump across both paths. The uv ecosystem updates
+  # pyproject.toml and uv.lock together, keeping `uv lock --check` green.
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     # Dependabot PRs cannot read repo secrets, so SONAR_TOKEN is empty and the
     # scan always fails. Skip it rather than report a misleading red check.
-    if: always() && github.actor != 'dependabot[bot]'
+    if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,9 @@ jobs:
     name: SonarCloud Scan
     needs: [tests]
     runs-on: ubuntu-latest
-    if: always()
+    # Dependabot PRs cannot read repo secrets, so SONAR_TOKEN is empty and the
+    # scan always fails. Skip it rather than report a misleading red check.
+    if: always() && github.actor != 'dependabot[bot]'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`install/requirements.txt` is autogenerated:

```
# This file was autogenerated by uv via the following command:
#    uv export --format requirements.txt --no-dev --no-emit-project --output-file install/requirements.txt
```

But Dependabot's only pip ecosystem pointed **at that generated file** (`directory: "/install"`). Two consequences:

1. Every pip bump edits a generated artifact without touching `uv.lock`, so `scripts/check_requirements_drift.sh` fails by construction. That is why *Lockfile drift check* is red on #620, #621, #622, #623 and #625.
2. Security updates separately target the root `pyproject.toml`, which is why each bump appears **twice** (#620/#621 pi-heif, #623/#625 pyasn1).

Switched to `package-ecosystem: "uv"` at the root, which updates `pyproject.toml` and `uv.lock` together and keeps `uv lock --check` green. Also skips SonarCloud for Dependabot, which cannot read `SONAR_TOKEN`.

**Still outstanding:** this does not by itself make the drift check pass, because `install/requirements.txt` must still be regenerated via `uv export` on each PR. That needs a decision about how the regenerated file gets committed back (write token vs. a manual step). The five open bump PRs will need recreating against the new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to use the repository’s current package configuration and lockfile.
  * Improved dependency update workflows to reduce duplicate updates and lockfile inconsistencies.

* **Bug Fixes**
  * Prevented code quality checks from failing on automated dependency update pull requests when required secrets are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->