### PR TITLE
fix: cron step syntax, assert-as-control-flow, and tests that could not fail

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ omit =
 
 [report]
 show_missing = true
-fail_under = 70
+fail_under = 85
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,17 @@ scripts/test.sh tests/unit/test_inkypi.py -v
 
 # Run with coverage
 SKIP_BROWSER=1 .venv/bin/python -m pytest tests/ --cov=src --cov-report=term-missing
+
+# Fast parallel run (~6.5 min vs ~10 min serial); takes any pytest args
+scripts/test-fast.sh
+scripts/test-fast.sh tests/unit -k weather
 ```
+
+On macOS the plugin pixel-snapshot tests skip themselves: their baselines are
+rendered with ubuntu-24.04's fonts and are only reproducible on Linux, so
+comparing them here fails for reasons unrelated to your change. Set
+`REQUIRE_SNAPSHOTS=1` to force them, or `SKIP_VISUAL=1` to skip the layout
+snapshots too. CI runs on Linux and always enforces both.
 
 ### Running Browser Tests Locally
 

--- a/docs/security/pip-ghsa-58qw-9mgm-455v-tracking.md
+++ b/docs/security/pip-ghsa-58qw-9mgm-455v-tracking.md
@@ -1,6 +1,7 @@
-# Tracking: unpatched pip advisory GHSA-58qw-9mgm-455v
+# Tracking: pip advisory GHSA-58qw-9mgm-455v — CLOSED 2026-08-21
 
 Created: 2026-04-26
+Closed: 2026-08-21
 
 ## Advisory
 
@@ -37,3 +38,22 @@ Re-check monthly until closed.
 ## GitHub Issue Attempt
 
 Preferred tracking was a GitHub issue, but `gh issue create` was blocked because the `jtn0123/InkyPi` repository has issues disabled.
+
+## Resolution — 2026-08-21
+
+Closed. Every criterion above is now met:
+
+- OSV lists the advisory as **fixed in `pip` 26.1**, so the "no patched release"
+  condition that opened this item no longer holds.
+- `install/requirements-dev.txt` pins `pip==26.2`, which is past that fix. It
+  was already on `26.1.2` — i.e. non-vulnerable to this advisory — before this
+  check; the bump to `26.2` was prompted by a *different*, newer advisory
+  (`PYSEC-2026-3721`), which `26.2` also fixes.
+- `uv.lock` and the runtime export do not pin `pip` at all; it is a dev-only
+  dependency.
+- `pip-audit` reports **0 findings** against both lockfiles.
+
+The "re-check monthly" cadence was never actually run between 2026-04-26 and
+today, which is why this stayed open for roughly four months after it had in
+fact been fixed. The scheduled dependency audit proposed as item F3 in
+`.claude/grade-report.md` would have caught it.

--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -2569,9 +2569,9 @@ x-wr-timezone==2.0.1 \
     # via recurring-ical-events
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2 \
-    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
-    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
+pip==26.2 \
+    --hash=sha256:2d8542afcc84cdd8e846c2b36b2861fad1da376dd98f8e7113e9108a3c331690 \
+    --hash=sha256:931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad
     # via
     #   pip-api
     #   pip-tools

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,9 @@ addopts =
 filterwarnings =
     ignore::DeprecationWarning
 markers =
+    memory: asserts on resident set size; only meaningful when the process is not
+        competing with sibling xdist workers, so scripts/test-fast.sh runs these
+        serially after the parallel pass.
     flaky: rerun integration tests that are timing-sensitive in browser or device-adjacent flows
     integration: mark integration tests that may require browser automation or slower flows
     plugin_sweep: click-sweep parametrized over every registered plugin (JTN-698). Runs a bounded set of clicks against /plugin/<id> for each plugin to catch handler regressions. CI may route this to a dedicated job if runtime grows.

--- a/scripts/test-fast.sh
+++ b/scripts/test-fast.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fast local test loop.
+#
+# Runs the suite in parallel with pytest-xdist, then re-runs the memory-
+# sensitive tests serially. Measured on an M-series Mac: 10m13s serial ->
+# ~6m30s here.
+#
+# The split exists because `-m memory` tests assert on this process's resident
+# set size, which is only meaningful when it is not competing with sibling
+# workers — under `-n auto` they fail on load, not on a real leak.
+#
+# CI stays serial on purpose (see .github/workflows/ci.yml — "Keep CI serial
+# while the local pytest-xdist path soaks"), which is why this lives in a
+# script rather than in pytest.ini addopts, where it would leak into CI.
+#
+# Usage:
+#   scripts/test-fast.sh                 # whole suite, parallel
+#   scripts/test-fast.sh tests/unit      # just one directory
+#   scripts/test-fast.sh -k weather      # pass any pytest args through
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.." || exit 1
+
+if [[ -z "${VIRTUAL_ENV:-}" && -f .venv/bin/activate ]]; then
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+fi
+
+# `container` tests boot systemd as PID 1 and are excluded from the normal run.
+export SKIP_BROWSER="${SKIP_BROWSER:-1}"
+export PYTHONPATH="src:.${PYTHONPATH:+:${PYTHONPATH}}"
+
+TARGET=("${@:-tests/}")
+
+# pytest exits 5 when a selection matches nothing, which is expected when the
+# caller narrows to a single file that is entirely in (or out of) one pass.
+run_pass() {
+    local rc=0
+    python -m pytest "$@" || rc=$?
+    if [[ $rc -eq 5 ]]; then
+        echo "    (no tests selected for this pass)"
+        return 0
+    fi
+    return $rc
+}
+
+echo "==> parallel pass (excluding memory-sensitive tests)"
+run_pass "${TARGET[@]}" -q -m "not container and not memory" -n auto
+
+echo "==> serial pass (memory-sensitive tests)"
+run_pass "${TARGET[@]}" -q -m "not container and memory"

--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -494,7 +494,8 @@ def history_redisplay() -> tuple[dict[str, Any], int] | Any:
         if err_code is not None:
             return _filename_error_response(err_code)
 
-        assert filename is not None
+        if filename is None:
+            return _filename_error_response(_ERRCODE_FILENAME_REQUIRED)
         _safe_path, err_code = _validate_and_resolve_history_file(history_dir, filename)
         if err_code is not None:
             return _filename_error_response(err_code)
@@ -519,7 +520,8 @@ def history_delete() -> tuple[dict[str, Any], int] | Any:
         if err_code is not None:
             return _filename_error_response(err_code)
 
-        assert filename is not None
+        if filename is None:
+            return _filename_error_response(_ERRCODE_FILENAME_REQUIRED)
         safe_path, err_code = _validate_and_resolve_history_file(history_dir, filename)
         if err_code is not None:
             return _filename_error_response(err_code)

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -154,7 +154,9 @@ def _get_or_set_request_id() -> str | None:
             # JSON envelope, and that policy applied to every such value except
             # this one. After the charset check above the escape is a no-op, so
             # this is consistency and defence in depth rather than the guard.
-            rid_safe = sanitize_response_value(rid_hdr)
+            # Annotated because this module is in the mypy strict subset and
+            # `follow_imports = skip` hides form_utils' `-> str` declaration.
+            rid_safe: str = sanitize_response_value(rid_hdr)
             g.request_id = rid_safe
             return rid_safe
         # Generate

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -149,8 +149,14 @@ def _get_or_set_request_id() -> str | None:
         # bounded, so a multi-megabyte header cannot ride along on every reply.
         rid_hdr: str | None = request.headers.get("X-Request-Id")
         if rid_hdr and _REQUEST_ID_RE.fullmatch(rid_hdr):
-            g.request_id = rid_hdr
-            return rid_hdr
+            # Escaped on the way out for the same reason `_sanitize_details`
+            # escapes the details dict: it is a user-derived string reaching the
+            # JSON envelope, and that policy applied to every such value except
+            # this one. After the charset check above the escape is a no-op, so
+            # this is consistency and defence in depth rather than the guard.
+            rid_safe = sanitize_response_value(rid_hdr)
+            g.request_id = rid_safe
+            return rid_safe
         # Generate
         import uuid
 

--- a/src/utils/http_utils.py
+++ b/src/utils/http_utils.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 import os
+import re
 import socket
 import threading
 from collections.abc import Iterator
@@ -65,6 +66,10 @@ if TYPE_CHECKING:  # pragma: no cover — type hints only
 from utils.form_utils import sanitize_response_value
 
 logger = logging.getLogger(__name__)
+
+#: Accepted shape for an inbound ``X-Request-Id``. Covers uuids, hex ids, and
+#: the ``trace:span`` forms proxies emit, without admitting markup.
+_REQUEST_ID_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 
 
 def _sanitize_details(details: dict[str, Any]) -> dict[str, Any]:
@@ -134,9 +139,16 @@ def _get_or_set_request_id() -> str | None:
         rid_existing: str | None = getattr(g, "request_id", None)
         if rid_existing is not None and rid_existing != "":
             return rid_existing
-        # Prefer inbound X-Request-Id if provided by client/proxy
+        # Prefer inbound X-Request-Id if provided by client/proxy.
+        #
+        # The value is echoed back in every json_error/json_success body, so an
+        # unvalidated header is client-controlled data reflected in a response
+        # (CodeQL py/reflective-xss). A request id is an opaque correlation
+        # token, so anything outside a conservative charset is not one — reject
+        # it and generate our own rather than trying to clean it up. Also
+        # bounded, so a multi-megabyte header cannot ride along on every reply.
         rid_hdr: str | None = request.headers.get("X-Request-Id")
-        if rid_hdr is not None and rid_hdr != "":
+        if rid_hdr and _REQUEST_ID_RE.fullmatch(rid_hdr):
             g.request_id = rid_hdr
             return rid_hdr
         # Generate

--- a/src/utils/time_utils.py
+++ b/src/utils/time_utils.py
@@ -59,6 +59,21 @@ def parse_cron_field(field: str, min_val: int, max_val: int) -> set[int]:
         part = part.strip()
         if not part:
             continue
+        # Step syntax: "*/N" and "a-b/N". Without this, int("*/6") raises and
+        # the part is skipped, so "*/6" silently parsed to the empty set — a
+        # schedule that never fires rather than an error.
+        step = 1
+        if "/" in part:
+            part, _, step_s = part.partition("/")
+            try:
+                step = int(step_s)
+            except ValueError:
+                continue
+            if step < 1:
+                continue
+            part = part.strip()
+            if part == "*":
+                part = f"{min_val}-{max_val}"
         if "-" in part:
             start_s, end_s = part.split("-", 1)
             try:
@@ -67,7 +82,9 @@ def parse_cron_field(field: str, min_val: int, max_val: int) -> set[int]:
                 continue
             if start > end:
                 start, end = end, start
-            values.update(v for v in range(start, end + 1) if min_val <= v <= max_val)
+            values.update(
+                v for v in range(start, end + 1, step) if min_val <= v <= max_val
+            )
         else:
             try:
                 value = int(part)

--- a/tests/snapshots/snapshot_helper.py
+++ b/tests/snapshots/snapshot_helper.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+import pytest
 from PIL import Image
 
 _TRUTHY = {"1", "true", "yes"}
@@ -140,11 +142,41 @@ def _build_diff_overlay(
     return Image.alpha_composite(base, overlay).convert("RGB")
 
 
+def _pixel_comparison_skip_reason() -> str | None:
+    """Why pixel comparison cannot be trusted in this environment, if so.
+
+    These baselines are rendered on ubuntu-24.04 with its font set and are only
+    reproducible there (see tests/snapshots/README.md). On macOS the same code
+    renders text differently, so the comparison fails for reasons unrelated to
+    the change under test — which leaves every local run permanently red and
+    trains developers to ignore failures.
+
+    ``SKIP_VISUAL=1`` mirrors the flag tests/integration/test_visual_regression.py
+    already honours; non-Linux hosts opt out by default. Set
+    ``REQUIRE_SNAPSHOTS=1`` to force the comparison anywhere (CI does).
+    """
+    if os.getenv("REQUIRE_SNAPSHOTS", "").strip().lower() in {"1", "true", "yes"}:
+        return None
+    if os.getenv("SKIP_VISUAL", "").strip().lower() in {"1", "true", "yes"}:
+        return "SKIP_VISUAL is set"
+    if sys.platform != "linux":
+        return (
+            f"pixel baselines are Linux-rendered; {sys.platform} font rendering "
+            "differs. Set REQUIRE_SNAPSHOTS=1 to force, or regenerate baselines "
+            "from a CI run (see tests/snapshots/README.md)."
+        )
+    return None
+
+
 def assert_image_snapshot(
     image: Image.Image,
     plugin_name: str,
     case_name: str,
 ) -> None:
+    skip_reason = _pixel_comparison_skip_reason()
+    if skip_reason is not None:
+        pytest.skip(f"snapshot comparison skipped: {skip_reason}")
+
     png_path, _digest_path = _snapshot_paths(plugin_name, case_name)
     actual_png, diff_png, stats_json = _artifact_paths(plugin_name, case_name)
 

--- a/tests/test_sri.py
+++ b/tests/test_sri.py
@@ -68,8 +68,13 @@ class TestComputeSri:
         expected = (
             "sha384-tiuF6jOlT2JxytQTL/sE7cTofDIQh6DQIjzjPiit7uJxegLt3kQ/A2yC84C2mT+P"
         )
-        assert compute_sri(f) == expected
-        assert compute_sri(f) == compute_sri(f), "must also be stable across calls"
+        # Both calls are checked against the constant. Comparing the two calls
+        # to each other would be another self-comparison — it holds for any
+        # implementation, which is the bug this test used to have.
+        first = compute_sri(f)
+        second = compute_sri(f)
+        assert first == expected
+        assert second == expected, "repeated calls must agree with the digest"
 
     def test_different_content_different_hash(self, tmp_path: Path) -> None:
         f1 = tmp_path / "a.js"

--- a/tests/test_sri.py
+++ b/tests/test_sri.py
@@ -15,10 +15,13 @@ import base64
 import hashlib
 import json
 import sys
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+from flask import Flask
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC_ROOT = REPO_ROOT / "src"
@@ -59,7 +62,14 @@ class TestComputeSri:
         f.write_bytes(b"const x = 1;")
         from utils.sri import compute_sri
 
-        assert compute_sri(f) == compute_sri(f)
+        # Assert against a known-good digest rather than comparing the
+        # function to itself: `compute_sri(f) == compute_sri(f)` holds for any
+        # implementation, including one that returns a constant or None.
+        expected = (
+            "sha384-tiuF6jOlT2JxytQTL/sE7cTofDIQh6DQIjzjPiit7uJxegLt3kQ/A2yC84C2mT+P"
+        )
+        assert compute_sri(f) == expected
+        assert compute_sri(f) == compute_sri(f), "must also be stable across calls"
 
     def test_different_content_different_hash(self, tmp_path: Path) -> None:
         f1 = tmp_path / "a.js"
@@ -93,7 +103,7 @@ class TestComputeSri:
 
 class TestSriFor:
     @pytest.fixture(autouse=True)
-    def reset_cache(self):
+    def reset_cache(self) -> Iterator[Any]:
         from utils import sri as sri_mod
 
         sri_mod._reset_cache_for_tests()
@@ -177,7 +187,7 @@ class TestSriFor:
 
 class TestCdnSri:
     @pytest.fixture(autouse=True)
-    def reset_cdn_cache(self):
+    def reset_cdn_cache(self) -> Iterator[Any]:
         from utils import sri as sri_mod
 
         sri_mod._reset_cache_for_tests()
@@ -236,7 +246,7 @@ class TestCdnSri:
 
 
 class TestInitSri:
-    def test_jinja_globals_registered(self, flask_app) -> None:
+    def test_jinja_globals_registered(self, flask_app: Flask) -> None:
         from utils.sri import init_sri
 
         init_sri(flask_app)
@@ -245,7 +255,9 @@ class TestInitSri:
         assert callable(flask_app.jinja_env.globals["sri_for"])
         assert callable(flask_app.jinja_env.globals["cdn_sri"])
 
-    def test_sri_for_renders_in_template(self, tmp_path: Path, flask_app) -> None:
+    def test_sri_for_renders_in_template(
+        self, tmp_path: Path, flask_app: Flask
+    ) -> None:
         """sri_for should render a valid sha384- string in a Jinja template."""
         from utils import sri as sri_mod
         from utils.sri import init_sri
@@ -265,7 +277,9 @@ class TestInitSri:
 
         assert rendered == expected
 
-    def test_cdn_sri_renders_in_template(self, tmp_path: Path, flask_app) -> None:
+    def test_cdn_sri_renders_in_template(
+        self, tmp_path: Path, flask_app: Flask
+    ) -> None:
         from utils import sri as sri_mod
         from utils.sri import init_sri
 
@@ -325,7 +339,7 @@ class TestCdnManifest:
 
 class TestUpdateCdnSriScript:
     @pytest.fixture(autouse=True)
-    def patch_sys_path(self):
+    def patch_sys_path(self) -> Iterator[Any]:
         if str(SCRIPTS_ROOT) not in sys.path:
             sys.path.insert(0, str(SCRIPTS_ROOT))
         yield

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -611,3 +611,12 @@ class TestRequestIdIsNotReflectedUnvalidated:
 
     def test_absent_header_still_yields_an_id(self, flask_app: Any) -> None:
         assert self._request_id(flask_app, None)
+
+    def test_a_valid_id_is_unchanged_by_the_escape(self, flask_app: Any) -> None:
+        """The charset check runs first, so escaping must be a no-op here.
+
+        If this ever fails, the accepted charset and the escape disagree and one
+        of them is wrong.
+        """
+        for rid in ("abc-123_XY.z:9", "3f2504e0-4f89-11d3-9a0c-0305e82c3301"):
+            assert self._request_id(flask_app, rid) == rid

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+import pytest
 import requests
 
 
@@ -111,7 +114,6 @@ def test_shared_session_thread_isolation():
 
 from unittest.mock import Mock, patch  # noqa: E402
 
-import pytest  # noqa: E402
 from flask import Flask  # noqa: E402
 
 from src.utils.http_utils import (  # noqa: E402
@@ -561,3 +563,51 @@ class TestWantsJson:
 
         with patch("src.utils.http_utils.request", mock_request):
             assert wants_json() is False
+
+
+class TestRequestIdIsNotReflectedUnvalidated:
+    """The inbound X-Request-Id is echoed into every json_* response body.
+
+    An unvalidated header is client-controlled data reflected in a response —
+    CodeQL py/reflective-xss, 95 pre-existing alerts across the codebase all
+    tracing back to this one line.
+    """
+
+    def _request_id(self, flask_app: Any, header: str | None) -> Any:
+        from utils.http_utils import json_success
+
+        headers = {"X-Request-Id": header} if header is not None else {}
+        with flask_app.test_request_context("/", headers=headers):
+            body, _status = json_success("ok")
+            return body.get_json().get("request_id")
+
+    def test_a_well_formed_id_is_preserved(self, flask_app: Any) -> None:
+        assert self._request_id(flask_app, "abc-123_XY.z:9") == "abc-123_XY.z:9"
+
+    def test_a_uuid_is_preserved(self, flask_app: Any) -> None:
+        rid = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+        assert self._request_id(flask_app, rid) == rid
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "<script>alert(1)</script>",
+            "abc<img src=x onerror=alert(1)>",
+            # A CRLF value is not tested here: werkzeug refuses to build such a
+            # header at all, so header injection is already blocked upstream of
+            # this code and the case cannot be represented.
+            "a" * 129,
+            "spaces are not ids",
+        ],
+    )
+    def test_markup_and_oversized_values_are_replaced(
+        self, flask_app: Any, header: str
+    ) -> None:
+        got = self._request_id(flask_app, header)
+        assert got != header, "the header must not be echoed back verbatim"
+        assert "<" not in got and ">" not in got and "\n" not in got
+        # Replaced with a generated uuid rather than a cleaned-up version.
+        assert len(got) == 36
+
+    def test_absent_header_still_yields_an_id(self, flask_app: Any) -> None:
+        assert self._request_id(flask_app, None)

--- a/tests/unit/test_memory_leaks.py
+++ b/tests/unit/test_memory_leaks.py
@@ -8,7 +8,9 @@ import gc
 import os
 import time
 import tracemalloc
+from collections.abc import Iterator
 from io import BytesIO
+from typing import Any
 
 import psutil
 import pytest
@@ -22,8 +24,13 @@ from utils.image_utils import (
     resize_image,
 )
 
+# Resident-set-size assertions only mean something when this process is not
+# competing for memory with sibling workers, so these are excluded from the
+# parallel run (scripts/test-fast.sh) and executed serially instead.
+pytestmark = pytest.mark.memory
 
-def settle_memory(rounds=3, pause_s=0.01):
+
+def settle_memory(rounds: Any = 3, pause_s: Any = 0.01) -> None:
     """Give GC and RSS accounting a short chance to settle."""
     for _ in range(rounds):
         gc.collect()
@@ -31,7 +38,7 @@ def settle_memory(rounds=3, pause_s=0.01):
 
 
 @pytest.fixture
-def memory_baseline():
+def memory_baseline() -> Iterator[Any]:
     """Establish a memory baseline before each test."""
     # Force garbage collection
     gc.collect()
@@ -47,7 +54,7 @@ def memory_baseline():
     gc.collect()
 
 
-def test_image_resize_no_memory_leak(memory_baseline):
+def test_image_resize_no_memory_leak(memory_baseline: Any) -> None:
     """Test that repeated image resizing doesn't leak memory."""
     # Create a test image
     test_img = Image.new("RGB", (800, 600), color=(100, 150, 200))
@@ -71,7 +78,7 @@ def test_image_resize_no_memory_leak(memory_baseline):
     assert memory_growth < 10, f"Memory grew by {memory_growth:.2f}MB (potential leak)"
 
 
-def test_image_enhancement_no_memory_leak(memory_baseline):
+def test_image_enhancement_no_memory_leak(memory_baseline: Any) -> None:
     """Test that repeated image enhancement doesn't leak memory."""
     test_img = Image.new("RGB", (400, 300), color=(128, 128, 128))
 
@@ -96,7 +103,7 @@ def test_image_enhancement_no_memory_leak(memory_baseline):
     assert memory_growth < 10, f"Memory grew by {memory_growth:.2f}MB (potential leak)"
 
 
-def test_image_load_from_bytes_no_memory_leak(memory_baseline):
+def test_image_load_from_bytes_no_memory_leak(memory_baseline: Any) -> None:
     """Test that repeatedly loading images from bytes doesn't leak memory."""
     # Create test image bytes
     bio = BytesIO()
@@ -119,14 +126,14 @@ def test_image_load_from_bytes_no_memory_leak(memory_baseline):
 
 
 def test_plugin_execution_no_memory_leak(
-    device_config_dev, monkeypatch, memory_baseline
-):
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch, memory_baseline: Any
+) -> Any:
     """Test that repeated plugin execution doesn't leak memory."""
 
     class SimplePlugin:
         config = {"image_settings": []}
 
-        def generate_image(self, settings, device_config):
+        def generate_image(self, settings: Any, device_config: Any) -> Any:
             # Simulate typical plugin work: create an image, do some processing
             img = Image.new(
                 "RGB", device_config.get_resolution(), color=(255, 255, 255)
@@ -172,7 +179,9 @@ def test_plugin_execution_no_memory_leak(
         task.stop()
 
 
-def test_display_manager_no_memory_leak(device_config_dev, memory_baseline):
+def test_display_manager_no_memory_leak(
+    device_config_dev: Any, memory_baseline: Any
+) -> None:
     """Test that repeated display_image calls don't leak memory."""
     dm = DisplayManager(device_config_dev)
 
@@ -192,7 +201,7 @@ def test_display_manager_no_memory_leak(device_config_dev, memory_baseline):
     assert memory_growth < 20, f"Memory grew by {memory_growth:.2f}MB (potential leak)"
 
 
-def test_tracemalloc_image_processing():
+def test_tracemalloc_image_processing() -> None:
     """Use tracemalloc to detect memory allocation patterns in image processing."""
     tracemalloc.start()
 
@@ -229,7 +238,9 @@ def test_tracemalloc_image_processing():
     ), f"Largest memory allocation was {largest_growth_mb:.2f}MB (potential leak)"
 
 
-def test_long_running_refresh_task(device_config_dev, monkeypatch):
+def test_long_running_refresh_task(
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch
+) -> Any:
     """Test refresh task over an extended period to detect slow leaks."""
 
     class CyclingPlugin:
@@ -238,7 +249,7 @@ def test_long_running_refresh_task(device_config_dev, monkeypatch):
         config = {"image_settings": []}
         call_count = 0
 
-        def generate_image(self, settings, device_config):
+        def generate_image(self, settings: Any, device_config: Any) -> Any:
             self.call_count += 1
             # Create temporary objects
             Image.new("RGB", (100, 100), color=(self.call_count % 256, 128, 200))
@@ -289,7 +300,7 @@ def test_long_running_refresh_task(device_config_dev, monkeypatch):
         task.stop()
 
 
-def test_repeated_plugin_instantiation_no_leak(device_config_dev):
+def test_repeated_plugin_instantiation_no_leak(device_config_dev: Any) -> Any:
     """Test that creating and destroying plugin instances doesn't leak."""
     tracemalloc.start()
 
@@ -304,7 +315,7 @@ def test_repeated_plugin_instantiation_no_leak(device_config_dev):
         class TempPlugin:
             config = {"id": f"temp_{i}", "image_settings": []}
 
-            def generate_image(self, settings, device_config):
+            def generate_image(self, settings: Any, device_config: Any) -> Any:
                 return Image.new("RGB", (100, 100), color=(128, 128, 128))
 
         plugin = TempPlugin()
@@ -325,7 +336,7 @@ def test_repeated_plugin_instantiation_no_leak(device_config_dev):
     ), f"Largest memory allocation was {largest_growth_mb:.2f}MB (potential leak)"
 
 
-def test_image_history_doesnt_accumulate_in_memory(device_config_dev):
+def test_image_history_doesnt_accumulate_in_memory(device_config_dev: Any) -> None:
     """Test that saving history images doesn't accumulate in memory."""
     dm = DisplayManager(device_config_dev)
 

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -21,11 +22,11 @@ from utils.rate_limit import (
 
 
 class TestTokenBucket:
-    def test_initial_acquire_succeeds(self):
+    def test_initial_acquire_succeeds(self) -> None:
         bucket = TokenBucket(capacity=5, refill_rate=1 / 30)
         assert bucket.try_acquire("192.168.1.1") is True
 
-    def test_acquire_up_to_capacity(self):
+    def test_acquire_up_to_capacity(self) -> None:
         bucket = TokenBucket(capacity=3, refill_rate=0)
         # First acquisition uses up one token from a new bucket that starts at capacity
         assert bucket.try_acquire("ip") is True  # capacity-1 = 2 tokens remain
@@ -33,12 +34,12 @@ class TestTokenBucket:
         assert bucket.try_acquire("ip") is True  # 0 tokens remain
         assert bucket.try_acquire("ip") is False  # denied
 
-    def test_acquire_denied_when_empty(self):
+    def test_acquire_denied_when_empty(self) -> None:
         bucket = TokenBucket(capacity=1, refill_rate=0)
         assert bucket.try_acquire("ip") is True
         assert bucket.try_acquire("ip") is False
 
-    def test_refill_after_time_passes(self):
+    def test_refill_after_time_passes(self) -> None:
         bucket = TokenBucket(capacity=3, refill_rate=1)  # 1 token/second
         with patch("utils.rate_limit.time.monotonic", return_value=100.0):
             # Drain: first call creates bucket at cap-1=2, then two more
@@ -53,14 +54,14 @@ class TestTokenBucket:
             assert bucket.try_acquire("ip") is True
             assert bucket.try_acquire("ip") is False
 
-    def test_different_keys_tracked_separately(self):
+    def test_different_keys_tracked_separately(self) -> None:
         bucket = TokenBucket(capacity=1, refill_rate=0)
         assert bucket.try_acquire("ip-a") is True
         assert bucket.try_acquire("ip-a") is False
         # ip-b is unaffected
         assert bucket.try_acquire("ip-b") is True
 
-    def test_stale_buckets_evicted(self):
+    def test_stale_buckets_evicted(self) -> None:
         bucket = TokenBucket(capacity=5, refill_rate=1, ttl=10)
         with patch("utils.rate_limit.time.monotonic", return_value=100.0):
             bucket.try_acquire("stale-ip")
@@ -72,7 +73,7 @@ class TestTokenBucket:
 
         assert "stale-ip" not in bucket._buckets
 
-    def test_capacity_not_exceeded_by_refill(self):
+    def test_capacity_not_exceeded_by_refill(self) -> None:
         bucket = TokenBucket(capacity=5, refill_rate=100)  # fast refill
         with patch("utils.rate_limit.time.monotonic", return_value=100.0):
             bucket.try_acquire("ip")  # creates bucket
@@ -84,14 +85,14 @@ class TestTokenBucket:
             # 6th should fail
             assert bucket.try_acquire("ip") is False
 
-    def test_thread_safety(self):
+    def test_thread_safety(self) -> None:
         import threading
 
         bucket = TokenBucket(capacity=100, refill_rate=0)
         allowed_count = {"n": 0}
         lock = threading.Lock()
 
-        def worker():
+        def worker() -> None:
             local = sum(1 for _ in range(20) if bucket.try_acquire("shared"))
             with lock:
                 allowed_count["n"] += local
@@ -112,47 +113,61 @@ class TestTokenBucket:
 
 
 class TestParseRateEnv:
-    def test_defaults_returned_when_env_unset(self, monkeypatch):
+    def test_defaults_returned_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("INKYPI_RATE_LIMIT_AUTH", raising=False)
         cap, rate = _parse_rate_env("INKYPI_RATE_LIMIT_AUTH", 5, 1 / 30)
         assert cap == 5.0
         assert rate == pytest.approx(1 / 30)
 
-    def test_parses_valid_env(self, monkeypatch):
+    def test_parses_valid_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("INKYPI_RATE_LIMIT_AUTH", "10/60")
         cap, rate = _parse_rate_env("INKYPI_RATE_LIMIT_AUTH", 5, 1 / 30)
         assert cap == 10.0
         assert rate == pytest.approx(1 / 60)
 
-    def test_invalid_env_falls_back_to_defaults(self, monkeypatch):
+    def test_invalid_env_falls_back_to_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("INKYPI_RATE_LIMIT_AUTH", "bad/value")
         cap, rate = _parse_rate_env("INKYPI_RATE_LIMIT_AUTH", 5, 1 / 30)
         assert cap == 5.0
         assert rate == pytest.approx(1 / 30)
 
-    def test_make_auth_bucket_uses_defaults(self, monkeypatch):
+    def test_make_auth_bucket_uses_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("INKYPI_RATE_LIMIT_AUTH", raising=False)
         b = make_auth_bucket()
         assert b._capacity == 5.0
 
-    def test_make_refresh_bucket_uses_defaults(self, monkeypatch):
+    def test_make_refresh_bucket_uses_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("INKYPI_RATE_LIMIT_REFRESH", raising=False)
         b = make_refresh_bucket()
         assert b._capacity == 10.0
 
-    def test_make_auth_bucket_respects_env(self, monkeypatch):
+    def test_make_auth_bucket_respects_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("INKYPI_RATE_LIMIT_AUTH", "7/45")
         b = make_auth_bucket()
         assert b._capacity == 7.0
         assert b._refill_rate == pytest.approx(1 / 45)
 
-    def test_make_mutating_bucket_uses_defaults(self, monkeypatch):
+    def test_make_mutating_bucket_uses_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("INKYPI_RATE_LIMIT_MUTATING", raising=False)
         b = make_mutating_bucket()
         assert b._capacity == 10.0
         assert b._refill_rate == pytest.approx(10 / 60)
 
-    def test_make_mutating_bucket_respects_env(self, monkeypatch):
+    def test_make_mutating_bucket_respects_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("INKYPI_RATE_LIMIT_MUTATING", "15/30")
         b = make_mutating_bucket()
         assert b._capacity == 15.0
@@ -165,7 +180,7 @@ class TestParseRateEnv:
 
 
 @pytest.fixture()
-def rate_limit_app():
+def rate_limit_app() -> Any:
     """Minimal Flask app with per-endpoint token-bucket rate limiting."""
     from utils.rate_limit import TokenBucket
 
@@ -183,7 +198,7 @@ def rate_limit_app():
     from utils.http_utils import json_error
 
     @app.before_request
-    def _rl():
+    def _rl() -> Any:
         from flask import make_response, request
 
         if request.method in ("GET", "HEAD", "OPTIONS"):
@@ -206,50 +221,50 @@ def rate_limit_app():
         return None
 
     @app.route("/login", methods=["POST"])
-    def login():
+    def login() -> Any:
         return {"ok": True}
 
     @app.route("/display-next", methods=["POST"])
-    def display_next():
+    def display_next() -> Any:
         return {"ok": True}
 
     @app.route("/refresh", methods=["POST"])
-    def refresh_alias():
+    def refresh_alias() -> Any:
         return {"ok": True}
 
     @app.route("/api/health", methods=["GET"])
-    def health():
+    def health() -> Any:
         return {"status": "ok"}
 
     @app.route("/api/other", methods=["POST"])
-    def other():
+    def other() -> Any:
         return {"ok": True}
 
     return app
 
 
 class TestLoginEndpointRateLimit:
-    def test_five_logins_succeed(self, rate_limit_app):
+    def test_five_logins_succeed(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(5):
             resp = client.post("/login")
             assert resp.status_code == 200
 
-    def test_sixth_login_returns_429(self, rate_limit_app):
+    def test_sixth_login_returns_429(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(5):
             client.post("/login")
         resp = client.post("/login")
         assert resp.status_code == 429
 
-    def test_sixth_login_has_retry_after_header(self, rate_limit_app):
+    def test_sixth_login_has_retry_after_header(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(5):
             client.post("/login")
         resp = client.post("/login")
         assert resp.headers.get("Retry-After") == "30"
 
-    def test_sixth_login_has_json_error_body(self, rate_limit_app):
+    def test_sixth_login_has_json_error_body(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(5):
             client.post("/login")
@@ -263,27 +278,27 @@ class TestLoginEndpointRateLimit:
 
 
 class TestRefreshEndpointRateLimit:
-    def test_ten_refresh_calls_succeed(self, rate_limit_app):
+    def test_ten_refresh_calls_succeed(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(10):
             resp = client.post("/display-next")
             assert resp.status_code == 200
 
-    def test_eleventh_refresh_returns_429(self, rate_limit_app):
+    def test_eleventh_refresh_returns_429(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(10):
             client.post("/display-next")
         resp = client.post("/display-next")
         assert resp.status_code == 429
 
-    def test_eleventh_refresh_has_retry_after_header(self, rate_limit_app):
+    def test_eleventh_refresh_has_retry_after_header(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(10):
             client.post("/display-next")
         resp = client.post("/display-next")
         assert resp.headers.get("Retry-After") == "6"
 
-    def test_refresh_alias_also_rate_limited(self, rate_limit_app):
+    def test_refresh_alias_also_rate_limited(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(10):
             client.post("/refresh")
@@ -292,7 +307,7 @@ class TestRefreshEndpointRateLimit:
 
 
 class TestIpIsolation:
-    def test_different_ips_tracked_separately(self, rate_limit_app):
+    def test_different_ips_tracked_separately(self, rate_limit_app: Any) -> None:
         """Exhausting one IP's bucket should not affect another IP."""
         with rate_limit_app.test_client() as client:
             # Exhaust ip-a by overriding remote_addr via environ_base
@@ -307,13 +322,15 @@ class TestIpIsolation:
 
 
 class TestNonRateLimitedEndpoints:
-    def test_health_get_not_rate_limited(self, rate_limit_app):
+    def test_health_get_not_rate_limited(self, rate_limit_app: Any) -> None:
         client = rate_limit_app.test_client()
         for _ in range(20):
             resp = client.get("/api/health")
             assert resp.status_code == 200
 
-    def test_other_post_not_covered_by_endpoint_limiter(self, rate_limit_app):
+    def test_other_post_not_covered_by_endpoint_limiter(
+        self, rate_limit_app: Any
+    ) -> None:
         """General endpoints should not be blocked by the per-endpoint bucket."""
         client = rate_limit_app.test_client()
         # The other endpoint has no rate limit in this fixture
@@ -328,7 +345,7 @@ class TestNonRateLimitedEndpoints:
 
 
 @pytest.fixture()
-def mutating_rate_app():
+def mutating_rate_app() -> Any:
     """Minimal Flask app with mutating-endpoint token-bucket rate limiting (JTN-513)."""
     from utils.http_utils import json_error
     from utils.rate_limit import TokenBucket
@@ -349,7 +366,7 @@ def mutating_rate_app():
         return path in _MUTATING_PATHS or path.startswith(_MUTATING_PREFIX)
 
     @app.before_request
-    def _rl():
+    def _rl() -> Any:
         from flask import make_response, request
 
         if request.method in ("GET", "HEAD", "OPTIONS"):
@@ -370,27 +387,27 @@ def mutating_rate_app():
         return None
 
     @app.route("/login", methods=["POST"])
-    def login():
+    def login() -> Any:
         return {"ok": True}
 
     @app.route("/save_plugin_settings", methods=["POST"])
-    def save_plugin_settings():
+    def save_plugin_settings() -> Any:
         return {"ok": True}
 
     @app.route("/update_now", methods=["POST"])
-    def update_now():
+    def update_now() -> Any:
         return {"ok": True}
 
     @app.route("/api/refresh/<path:sub>", methods=["POST"])
-    def api_refresh(sub):
+    def api_refresh(sub: Any) -> Any:
         return {"ok": True}
 
     @app.route("/api/health", methods=["GET"])
-    def health():
+    def health() -> Any:
         return {"status": "ok"}
 
     @app.route("/api/other", methods=["POST"])
-    def other():
+    def other() -> Any:
         return {"ok": True}
 
     return app
@@ -399,27 +416,31 @@ def mutating_rate_app():
 class TestMutatingEndpointRateLimit:
     """JTN-513: /save_plugin_settings, /update_now, /api/refresh/* get strict token-bucket."""
 
-    def test_ten_update_now_calls_succeed(self, mutating_rate_app):
+    def test_ten_update_now_calls_succeed(self, mutating_rate_app: Any) -> None:
         client = mutating_rate_app.test_client()
         for _ in range(10):
             resp = client.post("/update_now")
             assert resp.status_code == 200
 
-    def test_eleventh_update_now_returns_429(self, mutating_rate_app):
+    def test_eleventh_update_now_returns_429(self, mutating_rate_app: Any) -> None:
         client = mutating_rate_app.test_client()
         for _ in range(10):
             client.post("/update_now")
         resp = client.post("/update_now")
         assert resp.status_code == 429
 
-    def test_eleventh_update_now_has_retry_after_header(self, mutating_rate_app):
+    def test_eleventh_update_now_has_retry_after_header(
+        self, mutating_rate_app: Any
+    ) -> None:
         client = mutating_rate_app.test_client()
         for _ in range(10):
             client.post("/update_now")
         resp = client.post("/update_now")
         assert resp.headers.get("Retry-After") == "6"
 
-    def test_eleventh_update_now_has_json_error_body(self, mutating_rate_app):
+    def test_eleventh_update_now_has_json_error_body(
+        self, mutating_rate_app: Any
+    ) -> None:
         client = mutating_rate_app.test_client()
         for _ in range(10):
             client.post("/update_now")
@@ -431,20 +452,24 @@ class TestMutatingEndpointRateLimit:
             or "request" in data.get("error", "").lower()
         )
 
-    def test_ten_save_plugin_settings_calls_succeed(self, mutating_rate_app):
+    def test_ten_save_plugin_settings_calls_succeed(
+        self, mutating_rate_app: Any
+    ) -> None:
         client = mutating_rate_app.test_client()
         for _ in range(10):
             resp = client.post("/save_plugin_settings")
             assert resp.status_code == 200
 
-    def test_eleventh_save_plugin_settings_returns_429(self, mutating_rate_app):
+    def test_eleventh_save_plugin_settings_returns_429(
+        self, mutating_rate_app: Any
+    ) -> None:
         client = mutating_rate_app.test_client()
         for _ in range(10):
             client.post("/save_plugin_settings")
         resp = client.post("/save_plugin_settings")
         assert resp.status_code == 429
 
-    def test_api_refresh_subpath_rate_limited(self, mutating_rate_app):
+    def test_api_refresh_subpath_rate_limited(self, mutating_rate_app: Any) -> None:
         """POST /api/refresh/* is matched by prefix and rate-limited."""
         client = mutating_rate_app.test_client()
         for _ in range(10):
@@ -452,14 +477,14 @@ class TestMutatingEndpointRateLimit:
         resp = client.post("/api/refresh/all")
         assert resp.status_code == 429
 
-    def test_get_requests_not_rate_limited(self, mutating_rate_app):
+    def test_get_requests_not_rate_limited(self, mutating_rate_app: Any) -> None:
         """GET requests to /api/health are never subject to mutating rate limits."""
         client = mutating_rate_app.test_client()
         for _ in range(20):
             resp = client.get("/api/health")
             assert resp.status_code == 200
 
-    def test_login_uses_its_own_tighter_bucket(self, mutating_rate_app):
+    def test_login_uses_its_own_tighter_bucket(self, mutating_rate_app: Any) -> None:
         """Login still uses its own auth bucket; exhausting it doesn't affect mutating paths."""
         client = mutating_rate_app.test_client()
         # Exhaust the auth bucket (capacity=5)
@@ -470,11 +495,12 @@ class TestMutatingEndpointRateLimit:
         assert resp.status_code == 429
         # But /update_now still works (has its own bucket, capacity=10)
         resp2 = client.post("/update_now")
-        assert resp2 == resp2  # just check it doesn't crash
         # The mutating bucket still has capacity
         assert resp2.status_code == 200
 
-    def test_different_ips_get_independent_mutating_buckets(self, mutating_rate_app):
+    def test_different_ips_get_independent_mutating_buckets(
+        self, mutating_rate_app: Any
+    ) -> None:
         """Exhausting one IP's mutating bucket does not affect another IP."""
         with mutating_rate_app.test_client() as client:
             for _ in range(10):
@@ -488,7 +514,9 @@ class TestMutatingEndpointRateLimit:
             )
             assert resp_b.status_code == 200
 
-    def test_non_mutating_post_not_blocked_by_mutating_bucket(self, mutating_rate_app):
+    def test_non_mutating_post_not_blocked_by_mutating_bucket(
+        self, mutating_rate_app: Any
+    ) -> None:
         """/api/other POST is not subject to the mutating token bucket."""
         client = mutating_rate_app.test_client()
         # Even after the mutating bucket is exhausted for this IP

--- a/tests/unit/test_refresh_task_stress.py
+++ b/tests/unit/test_refresh_task_stress.py
@@ -7,6 +7,8 @@ requests, and edge cases without deadlocks or race conditions.
 import os
 import threading
 import time
+from collections.abc import Iterator
+from typing import Any
 
 import psutil
 import pytest
@@ -15,8 +17,13 @@ from PIL import Image
 from display.display_manager import DisplayManager
 from refresh_task import ManualRefresh, RefreshTask
 
+# Resident-set-size assertions only mean something when this process is not
+# competing for memory with sibling workers, so these are excluded from the
+# parallel run (scripts/test-fast.sh) and executed serially instead.
+pytestmark = pytest.mark.memory
 
-def wait_until(predicate, timeout=1.0, interval=0.01):
+
+def wait_until(predicate: Any, timeout: Any = 1.0, interval: Any = 0.01) -> Any:
     """Poll until a condition becomes true."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -27,14 +34,14 @@ def wait_until(predicate, timeout=1.0, interval=0.01):
 
 
 @pytest.fixture
-def mock_plugin():
+def mock_plugin() -> Any:
     """Create a mock plugin that returns images quickly."""
 
     class FastPlugin:
         config = {"image_settings": []}
         call_count = 0
 
-        def generate_image(self, settings, device_config):
+        def generate_image(self, settings: Any, device_config: Any) -> Any:
             self.call_count += 1
             # Simulate very fast image generation
             return Image.new("RGB", device_config.get_resolution(), "white")
@@ -43,7 +50,7 @@ def mock_plugin():
 
 
 @pytest.fixture
-def refresh_task(device_config_dev):
+def refresh_task(device_config_dev: Any) -> Iterator[Any]:
     """Create a RefreshTask instance for testing."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -53,7 +60,9 @@ def refresh_task(device_config_dev):
         task.stop()
 
 
-def test_rapid_manual_updates(device_config_dev, mock_plugin, monkeypatch):
+def test_rapid_manual_updates(
+    device_config_dev: Any, mock_plugin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test handling of many manual updates in quick succession."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -83,8 +92,8 @@ def test_rapid_manual_updates(device_config_dev, mock_plugin, monkeypatch):
 
 
 def test_concurrent_manual_updates_from_multiple_threads(
-    device_config_dev, mock_plugin, monkeypatch
-):
+    device_config_dev: Any, mock_plugin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test concurrent manual update requests from multiple threads."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -102,7 +111,7 @@ def test_concurrent_manual_updates_from_multiple_threads(
         completed = []
         errors = []
 
-        def send_update(thread_id):
+        def send_update(thread_id: Any) -> None:
             try:
                 for _i in range(5):
                     refresh = ManualRefresh("test", {})
@@ -130,7 +139,7 @@ def test_concurrent_manual_updates_from_multiple_threads(
         task.stop()
 
 
-def test_start_stop_cycles(device_config_dev):
+def test_start_stop_cycles(device_config_dev: Any) -> None:
     """Test rapid start/stop cycles don't cause issues."""
     dm = DisplayManager(device_config_dev)
 
@@ -144,7 +153,9 @@ def test_start_stop_cycles(device_config_dev):
         assert not task.running
 
 
-def test_stop_while_refresh_in_progress(device_config_dev, monkeypatch):
+def test_stop_while_refresh_in_progress(
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch
+) -> Any:
     """Test stopping the task while a refresh is in progress."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -153,8 +164,12 @@ def test_stop_while_refresh_in_progress(device_config_dev, monkeypatch):
     slow_plugin_can_finish = threading.Event()
 
     def fake_perform(
-        refresh_action, latest_refresh, current_dt, request_id=None, **kwargs
-    ):
+        refresh_action: Any,
+        latest_refresh: Any,
+        current_dt: Any,
+        request_id: Any = None,
+        **kwargs: Any,
+    ) -> Any:
         slow_plugin_started.set()
         slow_plugin_can_finish.wait(timeout=2)
         return (
@@ -203,7 +218,9 @@ def test_stop_while_refresh_in_progress(device_config_dev, monkeypatch):
             task.stop()
 
 
-def test_manual_update_queue_ordering(device_config_dev, monkeypatch):
+def test_manual_update_queue_ordering(
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that manual updates are processed in order."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -245,7 +262,9 @@ def test_manual_update_queue_ordering(device_config_dev, monkeypatch):
         task.stop()
 
 
-def test_exception_during_refresh_does_not_crash_task(device_config_dev, monkeypatch):
+def test_exception_during_refresh_does_not_crash_task(
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch
+) -> Any:
     """Test that exceptions during refresh are captured and re-raised but don't crash the background thread."""
     monkeypatch.setenv("INKYPI_PLUGIN_RETRY_MAX", "0")
     dm = DisplayManager(device_config_dev)
@@ -254,8 +273,12 @@ def test_exception_during_refresh_does_not_crash_task(device_config_dev, monkeyp
     calls = {"count": 0}
 
     def fake_perform(
-        refresh_action, latest_refresh, current_dt, request_id=None, **kwargs
-    ):
+        refresh_action: Any,
+        latest_refresh: Any,
+        current_dt: Any,
+        request_id: Any = None,
+        **kwargs: Any,
+    ) -> Any:
         calls["count"] += 1
         if calls["count"] == 1:
             raise RuntimeError("Simulated plugin failure")
@@ -297,8 +320,8 @@ def test_exception_during_refresh_does_not_crash_task(device_config_dev, monkeyp
 
 
 def test_manual_update_returns_metrics_after_update(
-    device_config_dev, mock_plugin, monkeypatch
-):
+    device_config_dev: Any, mock_plugin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that manual updates return per-request metrics."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -322,8 +345,8 @@ def test_manual_update_returns_metrics_after_update(
 
 
 def test_high_frequency_updates_dont_deadlock(
-    device_config_dev, mock_plugin, monkeypatch
-):
+    device_config_dev: Any, mock_plugin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that very high frequency updates don't cause deadlocks."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)
@@ -356,8 +379,8 @@ def test_high_frequency_updates_dont_deadlock(
 
 
 def test_memory_not_growing_with_many_updates(
-    device_config_dev, mock_plugin, monkeypatch
-):
+    device_config_dev: Any, mock_plugin: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test that memory doesn't grow excessively with many updates."""
     dm = DisplayManager(device_config_dev)
     task = RefreshTask(device_config_dev, dm)

--- a/tests/unit/test_requirements_lockfile.py
+++ b/tests/unit/test_requirements_lockfile.py
@@ -49,13 +49,15 @@ class TestRequirementsLockfile:
     def test_requirements_txt_exists(self) -> None:
         assert REQUIREMENTS_TXT.exists(), (
             f"{REQUIREMENTS_TXT} does not exist. "
-            "Run: pip-compile --generate-hashes install/requirements.in -o install/requirements.txt"
+            "Run: uv lock && uv export --format requirements.txt --no-dev --no-emit-project --output-file install/requirements.txt"
         )
 
     def test_requirements_dev_txt_exists(self) -> None:
         assert REQUIREMENTS_DEV_TXT.exists(), (
             f"{REQUIREMENTS_DEV_TXT} does not exist. "
-            "Run: pip-compile --generate-hashes install/requirements-dev.in -o install/requirements-dev.txt"
+            "Run (on Linux only — pip-compile on macOS drops the "
+            "sys_platform=='linux' packages): pip-compile --generate-hashes "
+            "install/requirements-dev.in -o install/requirements-dev.txt"
         )
 
     def test_requirements_txt_has_hashes(self) -> None:
@@ -66,7 +68,7 @@ class TestRequirementsLockfile:
         assert not missing, (
             f"The following packages in {REQUIREMENTS_TXT} have no --hash=sha256: entries:\n"
             + "\n".join(f"  {p}" for p in missing)
-            + "\nRegenerate with: pip-compile --generate-hashes install/requirements.in -o install/requirements.txt"
+            + "\nRegenerate with: Run: uv lock && uv export --format requirements.txt --no-dev --no-emit-project --output-file install/requirements.txt"
         )
 
     def test_requirements_dev_txt_has_hashes(self) -> None:

--- a/tests/unit/test_utils_coverage.py
+++ b/tests/unit/test_utils_coverage.py
@@ -1,113 +1,103 @@
-"""Tests for utility modules to improve code coverage."""
+"""Behavioural tests for small utility helpers.
+
+Previously this file existed "to improve code coverage" and its assertions were
+either trivially true (``assert result is not None``) or wrapped in
+``except Exception: pass`` so they could not fail — including one that made a
+live call to httpbin.org. Rewritten to assert real values; the ``*/N`` cases
+below are the ones the old ``is not None`` check silently passed while
+:func:`parse_cron_field` returned an empty set.
+"""
+
+from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from plugins.plugin_registry import get_plugin_instance, load_plugins
+from utils.http_utils import json_error, json_success
+from utils.time_utils import get_next_occurrence, parse_cron_field
 
 
-def test_time_utils_parse_cron():
-    """Test time_utils cron parsing functions."""
-    from utils.time_utils import parse_cron_field
+class TestParseCronField:
+    def test_star_covers_the_whole_range(self) -> None:
+        assert parse_cron_field("*", 0, 23) == set(range(24))
 
-    # Test valid cron fields
-    result = parse_cron_field("*", 0, 23)
-    assert result is not None
+    def test_explicit_range(self) -> None:
+        assert parse_cron_field("0-5", 0, 23) == {0, 1, 2, 3, 4, 5}
 
-    result = parse_cron_field("0-5", 0, 23)
-    assert result is not None
+    def test_comma_list(self) -> None:
+        assert parse_cron_field("0,15,30,45", 0, 59) == {0, 15, 30, 45}
 
+    @pytest.mark.parametrize(
+        ("field", "lo", "hi", "expected"),
+        [
+            ("*/6", 0, 23, {0, 6, 12, 18}),
+            ("*/15", 0, 59, {0, 15, 30, 45}),
+            ("0-30/10", 0, 59, {0, 10, 20, 30}),
+        ],
+    )
+    def test_step_syntax(
+        self, field: str, lo: int, hi: int, expected: set[int]
+    ) -> None:
+        """``*/N`` used to parse to the empty set — a schedule that never fires."""
+        assert parse_cron_field(field, lo, hi) == expected
 
-def test_time_utils_get_next_occurrence():
-    """Test time_utils get_next_occurrence function."""
-    try:
-        from utils.time_utils import get_next_occurrence
+    @pytest.mark.parametrize("field", ["*/0", "*/-1", "*/x", "", "nonsense"])
+    def test_malformed_input_yields_no_values_rather_than_raising(
+        self, field: str
+    ) -> None:
+        assert parse_cron_field(field, 0, 23) == set()
 
-        # Test getting next occurrence for a cron expression
-        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
-        # Try a simple cron: every hour
-        next_time = get_next_occurrence("0 * * * *", now)
-        # Should return datetime or None
-        assert next_time is None or isinstance(next_time, datetime)
-    except (ImportError, AttributeError):
-        # Function may not exist
-        pass
-
-
-def test_http_utils_get_with_timeout():
-    """Test http_utils GET with timeout."""
-    from utils.http_utils import http_get
-
-    # Test with very short timeout (will likely fail)
-    try:
-        resp = http_get("http://httpbin.org/delay/10", timeout=0.001)
-        # If it doesn't timeout, should still be a response
-        assert resp is not None
-    except Exception:
-        # Timeout or connection error expected
-        pass
+    def test_values_outside_the_range_are_dropped(self) -> None:
+        assert parse_cron_field("5,99", 0, 23) == {5}
 
 
-def test_http_utils_json_error():
-    """Test http_utils json_error function."""
-    from utils.http_utils import json_error
+class TestGetNextOccurrence:
+    def test_hourly_advances_to_the_next_hour(self) -> None:
+        now = datetime(2025, 1, 1, 12, 30, tzinfo=UTC)
+        assert get_next_occurrence("0 * * * *", now) == datetime(
+            2025, 1, 1, 13, 0, tzinfo=UTC
+        )
 
-    response = json_error("Test error", status=400)
-    assert response is not None
+    def test_daily_advances_to_tomorrow_when_today_has_passed(self) -> None:
+        now = datetime(2025, 1, 1, 13, 0, tzinfo=UTC)
+        assert get_next_occurrence("0 12 * * *", now) == datetime(
+            2025, 1, 2, 12, 0, tzinfo=UTC
+        )
 
-
-def test_http_utils_json_success():
-    """Test http_utils json_success function."""
-    from utils.http_utils import json_success
-
-    response = json_success("Test success", extra_data="value")
-    assert response is not None
-
-
-def test_plugin_registry_get_plugin_instance():
-    """Test plugin_registry get_plugin_instance function."""
-    from plugins.plugin_registry import get_plugin_instance
-
-    # Test with a simple plugin config
-    config = {"plugin_id": "clock", "name": "Test Clock"}
-    try:
-        instance = get_plugin_instance(config)
-        assert instance is not None
-    except Exception:
-        # May fail without full configuration
-        pass
+    def test_unsatisfiable_expression_returns_none(self) -> None:
+        # Day-of-month 31 in a month that has none, restricted to February.
+        assert (
+            get_next_occurrence("0 0 31 2 *", datetime(2025, 1, 1, tzinfo=UTC)) is None
+        )
 
 
-def test_plugin_registry_load_plugins():
-    """Test plugin_registry load_plugins function."""
-    from plugins.plugin_registry import load_plugins
+class TestJsonHelpers:
+    """These build a Flask response, so they need an application context."""
 
-    # Test with empty plugins config
-    try:
-        plugins = load_plugins([])
-        assert isinstance(plugins, list)
-    except Exception:
-        # May fail without proper setup
-        pass
+    def test_json_error_carries_message_and_status(self, flask_app: Any) -> None:
+        with flask_app.app_context():
+            body, status = json_error("Test error", status=400)
+        assert status == 400
+        assert body.get_json()["error"] == "Test error"
+        assert body.get_json()["success"] is False
 
-
-def test_logging_utils_setup():
-    """Test logging_utils setup functions."""
-    try:
-        from utils.logging_utils import setup_logging
-
-        # Test setup_logging
-        setup_logging(level="DEBUG")
-        # Should not raise
-    except (ImportError, AttributeError):
-        pass
+    def test_json_success_includes_extra_fields(self, flask_app: Any) -> None:
+        with flask_app.app_context():
+            body, status = json_success("Test success", extra_data="value")
+        payload = body.get_json()
+        assert status == 200
+        assert payload["success"] is True
+        assert payload["extra_data"] == "value"
 
 
-def test_logging_utils_get_logger():
-    """Test logging_utils get_logger function."""
-    try:
-        from utils.logging_utils import get_logger
+class TestPluginRegistry:
+    def test_load_plugins_registers_lazily_and_returns_none(self) -> None:
+        """Documents the actual contract: registration is a side effect."""
+        assert load_plugins([]) is None
 
-        logger = get_logger("test")
-        assert logger is not None
-        # Try logging something
-        logger.info("Test log message")
-    except (ImportError, AttributeError):
-        pass
+    def test_get_plugin_instance_rejects_an_unknown_id(self) -> None:
+        with pytest.raises(Exception):
+            get_plugin_instance({"plugin_id": "definitely-not-a-plugin"})


### PR DESCRIPTION
## Why this is separate

Split out of #634. That PR bundled ~410 files of mechanical type annotations
with ~13 files of real logic change, which made it unreviewable — CodeRabbit
declined it outright (425 files vs its 100 limit), and a human would have had
the same problem. **This PR is the part that needs judgement.** #634 will be
rebased to hold only the annotation churn.

## Real bugs

**`*/N` cron syntax parsed to the empty set.** `parse_cron_field` had no step
support, so `int("*/6")` raised, the part was skipped, and you got an empty set
— a schedule that never fires rather than an error. Found by writing a real
assertion where the old one was `assert result is not None`, which passes for
an empty set. The existing tests had been working around it by spelling out
`0,5,10,15,…` by hand. No production caller today.

**`assert` used for control flow in a request handler.** `history.py` had
`assert filename is not None` inside `except Exception`. Under `python -O` the
guard vanishes entirely; and because the except catches `AssertionError`, a
failed invariant surfaced as a 500 instead of a 400.

## Tests that could not fail

`test_utils_coverage.py` described itself as existing *"to improve code
coverage"* and made a **live call to httpbin.org** inside
`except Exception: pass` — it passed when offline, when the assertion failed,
and when httpbin was down. Rewritten as 19 real tests.

Two of my first-draft assertions failed immediately, because the swallowed
versions had been hiding the actual contracts: `load_plugins([])` returns
`None`, not a list, and the json helpers need an app context.

Also replaced `assert compute_sri(f) == compute_sri(f)` with a known-good
digest, and deleted `assert resp2 == resp2` whose next line already asserted
the real thing.

## Developer experience

- **A green local run is now possible.** The two clock snapshot tests failed on
  every macOS run (ubuntu-24.04 font baselines). They now honour the same
  `SKIP_VISUAL` flag the layout tests already had. CI is Linux and sets neither
  flag, so it still enforces them.
- **`scripts/test-fast.sh`** — ~6m30s vs 10m13s serial. RSS-measuring modules
  carry a `memory` marker and run in a serial second pass, since asserting on
  this process's memory growth is meaningless when it competes with workers.
- **Corrected lockfile instructions.** `test_requirements_lockfile.py` told you
  to regenerate the runtime lock with pip-compile; that moved to uv, and
  pip-compile on macOS silently drops the `sys_platform == "linux"` packages —
  following the test's own error message on a Mac would have broken the Pi
  install.
- Coverage floor 70% → 85% (actual 90.4%).

## Verification

5324 passed / 0 failed; `scripts/lint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cron schedules now support stepped expressions such as `*/5` and `1-10/2`.
  * Added a faster test command that runs suitable tests in parallel while isolating memory-sensitive checks.
* **Bug Fixes**
  * Improved handling of missing filenames in history actions with clear validation errors.
* **Documentation**
  * Expanded testing guidance, including snapshot behavior across platforms and updated lockfile instructions.
* **Tests**
  * Increased the required test coverage threshold to 85%.
  * Added more deterministic validation for scheduling, responses, and plugin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->