### PR TITLE
fix(deps): bump pip to 26.2 in dev lockfile (PYSEC-2026-3721)

### DIFF
--- a/install/requirements-dev.txt
+++ b/install/requirements-dev.txt
@@ -2569,9 +2569,9 @@ x-wr-timezone==2.0.1 \
     # via recurring-ical-events
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2 \
-    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
-    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
+pip==26.2 \
+    --hash=sha256:931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad \
+    --hash=sha256:2d8542afcc84cdd8e846c2b36b2861fad1da376dd98f8e7113e9108a3c331690
     # via
     #   pip-api
     #   pip-tools


### PR DESCRIPTION
pip-audit now flags `pip==26.1.2` (PYSEC-2026-3721, fixed in 26.2), failing the **Security and SBOM** job — and therefore the CI gate — on every branch, including `main` on its next run.

Hand-edited pin + sha256 digests (wheel + sdist from PyPI). A full `pip-compile` regeneration on macOS drops the Linux-only dev packages (memray, textual…), so it was deliberately not regenerated.

Unblocks #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)