### PR TITLE
fix: follow imports in mypy, and fix the two real bugs that surfaced

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -30,7 +30,12 @@ explicit_package_bases = True
 # Broad src/ typing debt is ratcheted in scripts/lint.sh via
 # scripts/mypy_src_baseline.txt. The modules below are the fully strict subset.
 ignore_missing_imports = True
-follow_imports = skip
+# `follow_imports = skip` used to be set here. It made mypy never read an
+# imported module, so every cross-module call resolved to Any and the src/
+# error count sat at a comforting zero while 214 real type mismatches went
+# unseen. Following imports is what makes the check mean anything; the cost is
+# that the counts below are now honest rather than flattering.
+follow_imports = normal
 warn_return_any = True
 disallow_untyped_defs = False
 disallow_incomplete_defs = False

--- a/scripts/mypy_src_baseline.txt
+++ b/scripts/mypy_src_baseline.txt
@@ -1,3 +1,26 @@
 # Checked-in mypy src/ advisory baseline for scripts/lint.sh.
 # Lower this number when src/ typing debt is intentionally reduced.
-0
+#
+# 0 -> 90 (2026-08-21). This is NOT a regression, and no new error was
+# introduced. The previous zero was an artefact of `follow_imports = skip` in
+# mypy.ini: mypy never read an imported module, so every cross-module call
+# resolved to Any and whole classes of mismatch were unreportable. Turning the
+# setting on surfaced 214 pre-existing errors; 115 of those were stale
+# `# type: ignore` comments that only looked necessary while the real types
+# were invisible, and removing them left 99. Fixing the 9 that fell inside the blocking
+# strict subset — see below — brought it to 90.
+#
+# Two of the 214 were real defects, both found the moment imports were
+# followed:
+#   * PlaylistRefresh.execute called image.save() on the result of
+#     generate_image without a None check, while the base class had been
+#     widened to allow None for control-only plugins. The PluginLike Protocol
+#     still declared `-> Image.Image`, so callers type-checked against a
+#     contract the implementation no longer honoured.
+#   * client_endpoint declared its error slot as Response when json_error can
+#     also return a plain dict (its no-app-context fallback).
+#
+# return-value, arg-type and attr-defined are the ones most likely to be real
+# defects rather than annotation noise; they are the intended next piece of
+# work (item I2 in .claude/grade-report.md). This number must only go down.
+90

--- a/scripts/mypy_tests_baseline.txt
+++ b/scripts/mypy_tests_baseline.txt
@@ -1,16 +1,19 @@
 # Checked-in mypy tests/ advisory baseline for scripts/lint.sh.
 # Lower this number when tests/ typing debt is intentionally reduced.
 #
-# 7506 -> 782 (2026-08-21): mechanically annotated the whole suite —
-# 6326 parameters and 5752 return types across 411 files. Fixture parameters
-# got their real types (FlaskClient, pytest.MonkeyPatch, Path, Flask, Page,
-# Iterator[...]) rather than a blanket Any; only genuinely unknowable
-# parameters are Any. Verified: all 5359 tests still collect, and the suite
-# result is unchanged.
+# 7506 -> 782 (2026-08-21): the suite was mechanically annotated — 6326
+# parameters and 5752 return types across 411 files, with real fixture types
+# (FlaskClient, pytest.MonkeyPatch, Path, Flask, Page, Iterator[...]) rather
+# than a blanket Any.
 #
-# The residual 782 is dominated by ~380 `untyped-decorator` reports, which are
-# an artefact of `follow_imports = skip` in mypy.ini: pytest's own decorators
-# resolve to Any, so every @pytest.mark.parametrize reads as untyped. Fixing
-# that means changing follow_imports, which is a separate piece of work — see
-# item I2 in .claude/grade-report.md. The rest is type-arg/var-annotated nits.
-782
+# 782 -> 641 (2026-08-21): `follow_imports` changed from skip to normal. Most
+# of the drop is `untyped-decorator`, which was never test debt — with imports
+# skipped, pytest's own decorators resolved to Any, so every parametrized test
+# read as untyped.
+#
+# 641 -> 645 (2026-08-21): +4 from making src/ contracts honest, not from new
+# test debt. Widening PluginLike.generate_image and client_endpoint's error
+# type means test doubles like DummyDeviceConfig/FakeDeviceConfig are now
+# checked against the real DeviceConfigLike protocol, which they do not fully
+# implement. Tightening those fakes is follow-up work.
+645

--- a/src/app_setup/auth.py
+++ b/src/app_setup/auth.py
@@ -155,7 +155,7 @@ def init_auth(app: Flask, device_config: Config) -> None:
     app.config["AUTH_PIN_HASH"] = pin_hash
     logger.info("PIN auth enabled")
 
-    @app.before_request  # type: ignore
+    @app.before_request
     def _require_auth() -> Response | None:
         if _should_skip_auth():
             return None

--- a/src/app_setup/error_handlers.py
+++ b/src/app_setup/error_handlers.py
@@ -15,19 +15,19 @@ logger = logging.getLogger(__name__)
 def register_error_handlers(app: Flask) -> None:
     """Register JSON-aware error handlers for common HTTP status codes."""
 
-    @app.errorhandler(APIError)  # type: ignore
+    @app.errorhandler(APIError)
     def _handle_api_error(err: APIError) -> tuple[dict[str, object], int] | Response:
         return json_error(
             err.message, status=err.status, code=err.code, details=err.details
         )
 
-    @app.errorhandler(400)  # type: ignore
+    @app.errorhandler(400)
     def _handle_bad_request(err: object) -> tuple[dict[str, object], int] | Response:
         if wants_json():
             return json_error("Bad request", status=400)
         return make_response("Bad request", 400)
 
-    @app.errorhandler(404)  # type: ignore
+    @app.errorhandler(404)
     def _handle_not_found(
         err: object,
     ) -> tuple[dict[str, object], int] | Response | tuple[str, int]:
@@ -35,7 +35,7 @@ def register_error_handlers(app: Flask) -> None:
             return json_error("Not found", status=404)
         return render_template("404.html"), 404
 
-    @app.errorhandler(415)  # type: ignore
+    @app.errorhandler(415)
     def _handle_unsupported_media_type(
         err: object,
     ) -> tuple[dict[str, object], int] | Response:
@@ -43,7 +43,7 @@ def register_error_handlers(app: Flask) -> None:
             return json_error("Unsupported media type", status=415)
         return make_response("Unsupported media type", 415)
 
-    @app.errorhandler(Exception)  # type: ignore
+    @app.errorhandler(Exception)
     def _handle_unexpected_error(
         err: Exception,
     ) -> Response | tuple[dict[str, object], int]:

--- a/src/app_setup/health.py
+++ b/src/app_setup/health.py
@@ -8,11 +8,11 @@ from flask import Flask
 def register_health_endpoints(app: Flask) -> None:
     """Register /healthz (always-OK liveness) and /readyz (refresh-task readiness)."""
 
-    @app.route("/healthz", methods=["GET"])  # type: ignore
+    @app.route("/healthz", methods=["GET"])
     def healthz() -> tuple[str, int]:
         return ("OK", 200)
 
-    @app.route("/readyz", methods=["GET"])  # type: ignore
+    @app.route("/readyz", methods=["GET"])
     def readyz() -> tuple[str, int]:
         try:
             rt = app.config.get("REFRESH_TASK")

--- a/src/app_setup/http_metrics.py
+++ b/src/app_setup/http_metrics.py
@@ -28,13 +28,13 @@ def _should_skip(path: str) -> bool:
 def setup_http_metrics(app: Flask) -> None:
     """Register before/after request hooks that record HTTP timing metrics."""
 
-    @app.before_request  # type: ignore
+    @app.before_request
     def _http_metrics_start() -> None:
         if _should_skip(request.path):
             return
         g._http_metrics_t0 = perf_counter()
 
-    @app.after_request  # type: ignore
+    @app.after_request
     def _http_metrics_finish(response: Response) -> Response:
         t0 = getattr(g, "_http_metrics_t0", None)
         if t0 is None:

--- a/src/app_setup/schema_validator.py
+++ b/src/app_setup/schema_validator.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def register(app: Flask) -> None:
     """Attach the dev-only response schema validator to *app*."""
 
-    @app.after_request  # type: ignore
+    @app.after_request
     def _validate_response_schema(response: Response) -> Response:
         try:
             if response.mimetype != "application/json":

--- a/src/app_setup/security_middleware.py
+++ b/src/app_setup/security_middleware.py
@@ -116,7 +116,7 @@ def setup_https_redirect(app: Flask, *, dev_mode: bool) -> None:
     """When INKYPI_FORCE_HTTPS=1 (and not in dev mode), redirect HTTP→HTTPS."""
     force_https = not dev_mode and _env_bool("INKYPI_FORCE_HTTPS")
 
-    @app.before_request  # type: ignore
+    @app.before_request
     def _redirect_to_https() -> Response | None:
         if not force_https:
             return None
@@ -211,11 +211,11 @@ def _extract_csrf_token_from_request() -> str | None:
 def setup_csrf_protection(app: Flask) -> None:
     """Register CSRF token generation and per-request validation."""
 
-    @app.context_processor  # type: ignore
+    @app.context_processor
     def _inject_csrf_token() -> dict[str, Any]:
         return {"csrf_token": _generate_csrf_token}
 
-    @app.before_request  # type: ignore
+    @app.before_request
     def _check_csrf_token() -> Response | None:
         if request.method in _CSRF_SAFE_METHODS:
             return None
@@ -318,7 +318,7 @@ def setup_rate_limiting(app: Flask) -> None:
     _refresh_bucket = make_refresh_bucket()
     _mutating_bucket = make_mutating_bucket()
 
-    @app.before_request  # type: ignore
+    @app.before_request
     def _rate_limit_mutations() -> Response | None:
         if request.method in _CSRF_SAFE_METHODS:
             return None
@@ -360,11 +360,11 @@ def setup_csp_nonce(app: Flask) -> None:
     intentionally NOT used.
     """
 
-    @app.before_request  # type: ignore
+    @app.before_request
     def _generate_csp_nonce() -> None:
         g.csp_nonce = secrets.token_urlsafe(16)
 
-    @app.context_processor  # type: ignore
+    @app.context_processor
     def _inject_csp_nonce() -> dict[str, Any]:
         return {"csp_nonce": getattr(g, "csp_nonce", "")}
 
@@ -505,7 +505,7 @@ def setup_security_headers(app: Flask, *, dev_mode: bool) -> None:
     cognitive complexity stays low (SonarCloud S3776).
     """
 
-    @app.after_request  # type: ignore
+    @app.after_request
     def _set_security_headers(response: Response) -> Response:
         for step in (
             _emit_request_timing_log,

--- a/src/app_setup/smoke.py
+++ b/src/app_setup/smoke.py
@@ -75,7 +75,7 @@ def register_smoke_endpoints(app: Flask) -> None:
         SMOKE_RENDER_PATH,
     )
 
-    @app.route(SMOKE_RENDER_PATH, methods=["POST"])  # type: ignore
+    @app.route(SMOKE_RENDER_PATH, methods=["POST"])
     def smoke_render() -> tuple[dict[str, Any], int] | Response | tuple[str, int]:
         """Render the named plugin in-process and return basic image metadata.
 

--- a/src/blueprints/api_docs.py
+++ b/src/blueprints/api_docs.py
@@ -20,7 +20,7 @@ _SWAGGER_CSS_URL = "https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css"
 _SWAGGER_JS_URL = "https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js"
 
 
-@api_docs_bp.route("/api/docs", methods=["GET"])  # type: ignore
+@api_docs_bp.route("/api/docs", methods=["GET"])
 def swagger_ui() -> Response:
     """Serve the Swagger UI HTML page pointing at /api/openapi.json."""
     css_integrity = cdn_sri("swagger-ui-css")
@@ -59,7 +59,7 @@ def swagger_ui() -> Response:
     return Response(html, status=200, mimetype="text/html")
 
 
-@api_docs_bp.route("/api/openapi.json", methods=["GET"])  # type: ignore
+@api_docs_bp.route("/api/openapi.json", methods=["GET"])
 def openapi_spec() -> Response:
     """Serve the OpenAPI 3.0 spec as JSON."""
     with open(_SPEC_PATH, encoding="utf-8") as f:

--- a/src/blueprints/apikeys.py
+++ b/src/blueprints/apikeys.py
@@ -161,7 +161,7 @@ def mask_value(value: str) -> str:
     return "●" * 8 + value[-4:]
 
 
-@apikeys_bp.route("/api-keys", methods=["GET"])  # type: ignore
+@apikeys_bp.route("/api-keys", methods=["GET"])
 def apikeys_page() -> Response | str:
     """Render API keys management page."""
     env_path = get_env_path()
@@ -194,7 +194,7 @@ def apikeys_page() -> Response | str:
     )
 
 
-@apikeys_bp.route("/api-keys/save", methods=["POST"])  # type: ignore
+@apikeys_bp.route("/api-keys/save", methods=["POST"])
 def save_apikeys() -> tuple[Response | dict[str, Any], int] | Response | dict[str, Any]:
     """Save API keys to .env file."""
     try:

--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -111,7 +111,7 @@ def _record_failed_attempt() -> None:
         logger.warning("PIN auth: lockout triggered after %d failed attempts", count)
 
 
-@auth_bp.route("/login", methods=["GET"])  # type: ignore
+@auth_bp.route("/login", methods=["GET"])
 def login_get() -> str | Response:
     next_url = _safe_next_url(request.args.get("next"))
     if session.get("authed") is True:
@@ -119,7 +119,7 @@ def login_get() -> str | Response:
     return render_template(_LOGIN_TEMPLATE, error=None, next=next_url)
 
 
-@auth_bp.route("/login", methods=["POST"])  # type: ignore
+@auth_bp.route("/login", methods=["POST"])
 def login_post() -> str | Response:
     """Validate submitted PIN and establish an authenticated session."""
     # CSRF token is checked by the global before_request handler in security_middleware.
@@ -150,7 +150,7 @@ def login_post() -> str | Response:
     )
 
 
-@auth_bp.route("/logout", methods=["GET"])  # type: ignore
+@auth_bp.route("/logout", methods=["GET"])
 def logout() -> Response:
     session.clear()
     return redirect(url_for("auth.login_get"))

--- a/src/blueprints/client_error.py
+++ b/src/blueprints/client_error.py
@@ -52,7 +52,7 @@ def _strip_newlines(value: str) -> str:
     return value.replace("\r", " ").replace("\n", " ")
 
 
-@client_error_bp.route("/api/client-error", methods=["POST"])  # type: ignore
+@client_error_bp.route("/api/client-error", methods=["POST"])
 def receive_client_error() -> Any:
     """Accept a browser JS error report and emit it as a WARNING log entry.
 
@@ -101,7 +101,7 @@ def receive_client_error() -> Any:
     return Response(status=204)
 
 
-@client_error_bp.route("/api/client-error", methods=["GET"])  # type: ignore
+@client_error_bp.route("/api/client-error", methods=["GET"])
 def receive_client_error_get() -> Any:
     """Explicitly reject GET to provide a clear error instead of 405 from Flask."""
     return json_error("Method not allowed", status=405)

--- a/src/blueprints/client_log.py
+++ b/src/blueprints/client_log.py
@@ -231,7 +231,7 @@ def _emit(report: dict[str, object]) -> None:
             _captured_reports.append(dict(report))
 
 
-@client_log_bp.route("/api/client-log", methods=["POST"])  # type: ignore
+@client_log_bp.route("/api/client-log", methods=["POST"])
 def receive_client_log() -> tuple[Response, int] | Response | Any:
     """Accept a single entry OR an array of entries and log each as WARNING.
 
@@ -311,7 +311,7 @@ def receive_client_log() -> tuple[Response, int] | Response | Any:
     return Response(status=204)
 
 
-@client_log_bp.route("/api/client-log", methods=["GET"])  # type: ignore
+@client_log_bp.route("/api/client-log", methods=["GET"])
 def receive_client_log_get() -> tuple[Response, int] | Response | Any:
     """Explicitly reject GET to provide a clear error instead of 405 from Flask."""
     return json_error("Method not allowed", status=405)

--- a/src/blueprints/csp_report.py
+++ b/src/blueprints/csp_report.py
@@ -114,7 +114,7 @@ def _sanitise_report(report: dict[str, Any]) -> dict[str, Any]:
     return sanitised
 
 
-@csp_report_bp.route("/api/csp-report", methods=["POST"])  # type: ignore
+@csp_report_bp.route("/api/csp-report", methods=["POST"])
 def receive_csp_report() -> Response:
     """Accept a CSP violation report and log it.
 

--- a/src/blueprints/diagnostics.py
+++ b/src/blueprints/diagnostics.py
@@ -366,7 +366,7 @@ def _recent_client_log_summary() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@diagnostics_bp.route("/api/diagnostics", methods=["GET"])  # type: ignore
+@diagnostics_bp.route("/api/diagnostics", methods=["GET"])
 def api_diagnostics() -> Any:
     """Return a consolidated system + application diagnostics payload.
 

--- a/src/blueprints/errors.py
+++ b/src/blueprints/errors.py
@@ -21,14 +21,14 @@ logger = logging.getLogger(__name__)
 errors_bp = Blueprint("errors", __name__)
 
 
-@errors_bp.route("/errors", methods=["GET"])  # type: ignore
+@errors_bp.route("/errors", methods=["GET"])
 def errors_page() -> Response | str:
     """Render the /errors page showing captured client-side error reports."""
     reports = get_captured_reports()
     return render_template("errors.html", reports=reports)
 
 
-@errors_bp.route("/errors/clear", methods=["POST"])  # type: ignore
+@errors_bp.route("/errors/clear", methods=["POST"])
 def errors_clear() -> Any:
     """Clear all captured client-side error reports.
 

--- a/src/blueprints/events.py
+++ b/src/blueprints/events.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 events_bp = Blueprint("events", __name__)
 
 
-@events_bp.route("/api/events", methods=["GET"])  # type: ignore
-@events_bp.route("/api/events", methods=["GET"])  # type: ignore
+@events_bp.route("/api/events", methods=["GET"])
+@events_bp.route("/api/events", methods=["GET"])
 def sse_events() -> Response:
     """Stream SSE events to the client.
 
@@ -38,7 +38,7 @@ def sse_events() -> Response:
         logger.warning("/api/events: subscriber cap reached, returning 503")
         return Response("Too many SSE connections", status=503, mimetype="text/plain")
 
-    @stream_with_context  # type: ignore
+    @stream_with_context
     def generate() -> Any:
         try:
             yield from bus.stream(q)

--- a/src/blueprints/history.py
+++ b/src/blueprints/history.py
@@ -418,7 +418,7 @@ def _panel_thumb_ratio(device_config: Any) -> str | None:
     return None
 
 
-@history_bp.route("/history", methods=["GET"])  # type: ignore
+@history_bp.route("/history", methods=["GET"])
 def history_page() -> Response | str:
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
@@ -470,7 +470,7 @@ def history_page() -> Response | str:
     return render_template("history.html", **template_ctx)
 
 
-@history_bp.route("/history/image/<path:filename>", methods=["GET"])  # type: ignore
+@history_bp.route("/history/image/<path:filename>", methods=["GET"])
 def history_image(filename: str) -> Response | tuple[dict[str, Any], int]:
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
@@ -483,7 +483,7 @@ def history_image(filename: str) -> Response | tuple[dict[str, Any], int]:
     return send_from_directory(history_dir, filename)
 
 
-@history_bp.route("/history/redisplay", methods=["POST"])  # type: ignore
+@history_bp.route("/history/redisplay", methods=["POST"])
 def history_redisplay() -> tuple[dict[str, Any], int] | Any:
     device_config = current_app.config[_CONFIG_KEY]
     display_manager = current_app.config["DISPLAY_MANAGER"]
@@ -511,7 +511,7 @@ def history_redisplay() -> tuple[dict[str, Any], int] | Any:
         )
 
 
-@history_bp.route("/history/delete", methods=["POST"])  # type: ignore
+@history_bp.route("/history/delete", methods=["POST"])
 def history_delete() -> tuple[dict[str, Any], int] | Any:
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
@@ -558,7 +558,7 @@ def history_delete() -> tuple[dict[str, Any], int] | Any:
         )
 
 
-@history_bp.route("/history/clear", methods=["POST"])  # type: ignore
+@history_bp.route("/history/clear", methods=["POST"])
 def history_clear() -> tuple[dict[str, Any], int] | Any:
     device_config = current_app.config[_CONFIG_KEY]
     history_dir = device_config.history_image_dir
@@ -666,7 +666,7 @@ def _iter_history_csv(history_dir: str) -> Iterator[bytes]:
         yield buf.getvalue().encode("utf-8")
 
 
-@history_bp.route("/history/export.csv", methods=["GET"])  # type: ignore
+@history_bp.route("/history/export.csv", methods=["GET"])
 def history_export_csv() -> Response:
     """Return all history entries as a downloadable CSV file.
 
@@ -690,7 +690,7 @@ def history_export_csv() -> Response:
     )
 
 
-@history_bp.route("/history/storage", methods=["GET"])  # type: ignore
+@history_bp.route("/history/storage", methods=["GET"])
 def history_storage() -> tuple[Any, int]:
     """Return storage stats for the filesystem containing the history directory.
 

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -163,7 +163,7 @@ def _is_dev_mode() -> bool:
     return env in {"dev", "development"}
 
 
-@main_bp.route("/", methods=["GET"])  # type: ignore
+@main_bp.route("/", methods=["GET"])
 def main_page() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     # Compute a non-mutating next-up preview for SSR convenience
@@ -221,7 +221,7 @@ def main_page() -> Any:
     )
 
 
-@main_bp.route("/preview", methods=["GET"])  # type: ignore
+@main_bp.route("/preview", methods=["GET"])
 def preview_image() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     # Prefer processed image; fall back to current raw image if missing
@@ -237,7 +237,7 @@ def preview_image() -> Any:
     return maybe_serve_webp(safe_root, filename, request.headers.get("Accept"))
 
 
-@main_bp.route("/dev/mock-frame", methods=["GET"])  # type: ignore
+@main_bp.route("/dev/mock-frame", methods=["GET"])
 def dev_mock_frame() -> Any:
     """Serve the latest simulated mock-display frame in dev mode only."""
     if not _is_dev_mode():
@@ -260,7 +260,7 @@ def dev_mock_frame() -> Any:
     )
 
 
-@main_bp.route("/api/screenshot", methods=["GET"])  # type: ignore
+@main_bp.route("/api/screenshot", methods=["GET"])
 def screenshot() -> Any:
     """Return the current display image as PNG or WebP (JTN-450).
 
@@ -300,7 +300,7 @@ def screenshot() -> Any:
     return response
 
 
-@main_bp.route("/api/current_image", methods=["GET"])  # type: ignore
+@main_bp.route("/api/current_image", methods=["GET"])
 def get_current_image() -> Any:
     """Serve current_image.png with conditional request support (If-Modified-Since) for polling."""
     device_config = current_app.config["DEVICE_CONFIG"]
@@ -376,7 +376,7 @@ def _annotate_instance_labels(payload: Any) -> Any:
     return payload
 
 
-@main_bp.route("/refresh-info", methods=["GET"])  # type: ignore
+@main_bp.route("/refresh-info", methods=["GET"])
 def refresh_info() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     try:
@@ -392,7 +392,7 @@ def refresh_info() -> Any:
     return jsonify(info)
 
 
-@main_bp.route("/next-up", methods=["GET"])  # type: ignore
+@main_bp.route("/next-up", methods=["GET"])
 def next_up() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -420,7 +420,7 @@ def next_up() -> Any:
         return jsonify({})
 
 
-@main_bp.route("/api/plugin_order", methods=["POST"])  # type: ignore
+@main_bp.route("/api/plugin_order", methods=["POST"])
 def save_plugin_order() -> Any:
     """Save custom plugin order from dashboard drag-and-drop."""
     device_config = current_app.config["DEVICE_CONFIG"]
@@ -447,7 +447,7 @@ def save_plugin_order() -> Any:
     return json_success()
 
 
-@main_bp.route("/sw.js", methods=["GET"])  # type: ignore
+@main_bp.route("/sw.js", methods=["GET"])
 def service_worker() -> Any:
     """Serve the service worker from the origin root.
 
@@ -466,7 +466,7 @@ def service_worker() -> Any:
 
 
 # Serve static assets from src/static for test and dev environments
-@main_bp.route("/static/<path:filename>", methods=["GET"])  # type: ignore
+@main_bp.route("/static/<path:filename>", methods=["GET"])
 def static_files(filename: str) -> Any:
     try:
         static_dir = os.path.abspath(
@@ -477,7 +477,7 @@ def static_files(filename: str) -> Any:
         return ("Not found", 404)
 
 
-@main_bp.record  # type: ignore
+@main_bp.record
 def _configure_app_static(state: Any) -> None:
     """Ensure Flask's built-in static route serves from src/static for tests/dev."""
     try:
@@ -648,7 +648,7 @@ def _persist_dev_refresh_event(
         pass
 
 
-@main_bp.route("/display-next", methods=["POST"])  # type: ignore
+@main_bp.route("/display-next", methods=["POST"])
 def display_next() -> Any:
     allowed, retry_after = _display_next_limiter.check()
     if not allowed:
@@ -722,7 +722,7 @@ def display_next() -> Any:
     )
 
 
-@main_bp.route("/refresh", methods=["POST"])  # type: ignore
+@main_bp.route("/refresh", methods=["POST"])
 def refresh_alias() -> Any:
     """Backward-compatible alias for manual display advance."""
     return display_next()
@@ -733,7 +733,7 @@ def refresh_alias() -> Any:
 # ---------------------------------------------------------------------------
 
 
-@main_bp.app_template_filter("friendly_instance_label")  # type: ignore
+@main_bp.app_template_filter("friendly_instance_label")
 def _jinja_friendly_instance_label(instance_name: Any, plugin_id: Any = None) -> Any:
     """Jinja filter: return a friendly label for a plugin instance.
 
@@ -745,14 +745,14 @@ def _jinja_friendly_instance_label(instance_name: Any, plugin_id: Any = None) ->
     return friendly_instance_label(instance_name, plugin_id, display_name)
 
 
-@main_bp.app_template_filter("instance_suffix_label")  # type: ignore
+@main_bp.app_template_filter("instance_suffix_label")
 def _jinja_instance_suffix_label(instance_name: Any, plugin_id: Any = None) -> str:
     """Jinja filter: return a parenthesised-suffix label, or empty string."""
     label = instance_suffix_label(instance_name, plugin_id)
     return label or ""
 
 
-@main_bp.app_template_filter("is_auto_instance_name")  # type: ignore
+@main_bp.app_template_filter("is_auto_instance_name")
 def _jinja_is_auto_instance_name(instance_name: Any, plugin_id: Any = None) -> bool:
     """Jinja filter: True when the instance name is the auto-generated key."""
     return bool(is_auto_instance_name(instance_name, plugin_id))

--- a/src/blueprints/metrics.py
+++ b/src/blueprints/metrics.py
@@ -23,7 +23,7 @@ metrics_bp = Blueprint("metrics", __name__)
 _CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
 
-@metrics_bp.route("/metrics", methods=["GET"])  # type: ignore
+@metrics_bp.route("/metrics", methods=["GET"])
 def prometheus_metrics() -> Response:
     """Return all InkyPi metrics in Prometheus text exposition format."""
     if generate_latest is None:

--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -402,7 +402,7 @@ def _validate_plugin_settings_security(
     return None
 
 
-@playlist_bp.route("/add_plugin", methods=["POST"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/add_plugin", methods=["POST"])
 def add_plugin() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -436,12 +436,12 @@ def add_plugin() -> Any:
     return json_success("Scheduled refresh configured.")
 
 
-@playlist_bp.route("/playlists", methods=["GET"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/playlists", methods=["GET"])
 def playlists_redirect() -> Any:
     return redirect(url_for("playlist.playlists"))
 
 
-@playlist_bp.route("/playlist", methods=["GET"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/playlist", methods=["GET"])
 def playlists() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -582,7 +582,7 @@ def _parse_playlist_update_payload(
     return parsed, None
 
 
-@playlist_bp.route("/create_playlist", methods=["POST"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/create_playlist", methods=["POST"])
 def create_playlist() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -667,7 +667,7 @@ def _apply_cycle_override(
         playlist.cycle_interval_seconds = cycle_minutes_int * 60
 
 
-@playlist_bp.route("/update_playlist/<string:playlist_name>", methods=["PUT"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/update_playlist/<string:playlist_name>", methods=["PUT"])
 def update_playlist(playlist_name: str) -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -753,7 +753,7 @@ def update_playlist(playlist_name: str) -> Any:
     return json_success("Updated playlist!")
 
 
-@playlist_bp.route("/delete_playlist/<string:playlist_name>", methods=["DELETE"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/delete_playlist/<string:playlist_name>", methods=["DELETE"])
 def delete_playlist(playlist_name: str) -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -798,7 +798,7 @@ def delete_playlist(playlist_name: str) -> Any:
     return json_success("Deleted playlist!")
 
 
-@playlist_bp.route("/update_device_cycle", methods=["PUT"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/update_device_cycle", methods=["PUT"])
 def update_device_cycle() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     refresh_task = current_app.config["REFRESH_TASK"]
@@ -823,7 +823,7 @@ def update_device_cycle() -> Any:
         return json_success("Device refresh cadence updated.")
 
 
-@playlist_bp.route("/reorder_plugins", methods=["POST"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/reorder_plugins", methods=["POST"])
 def reorder_plugins() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     playlist_manager = device_config.get_playlist_manager()
@@ -869,7 +869,7 @@ def reorder_plugins() -> Any:
 
 
 # Trigger next eligible instance in a specific playlist immediately
-@playlist_bp.route("/display_next_in_playlist", methods=["POST"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/display_next_in_playlist", methods=["POST"])
 def display_next_in_playlist() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     refresh_task = current_app.config["REFRESH_TASK"]
@@ -942,7 +942,7 @@ def display_next_in_playlist() -> Any:
         )
 
 
-@playlist_bp.route("/playlist/eta/<string:playlist_name>", methods=["GET"])  # type: ignore[untyped-decorator]
+@playlist_bp.route("/playlist/eta/<string:playlist_name>", methods=["GET"])
 def playlist_eta(playlist_name: str) -> Any:
     """Return per-instance ETA for the named playlist.
 
@@ -1026,7 +1026,7 @@ def playlist_eta(playlist_name: str) -> Any:
         return json_success("ok", eta=eta_map)
 
 
-@playlist_bp.app_template_filter("format_relative_time")  # type: ignore[untyped-decorator]
+@playlist_bp.app_template_filter("format_relative_time")
 def format_relative_time(iso_date_string: str) -> str:
     # Parse the input ISO date string
     dt = datetime.fromisoformat(iso_date_string)

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -160,7 +160,7 @@ def _resolve_api_key_presence(
         api_key_meta["present"] = device_config.load_env_key(expected_key) is not None
 
 
-@plugin_bp.route("/plugin/<plugin_id>", methods=["GET"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/plugin/<plugin_id>", methods=["GET"])
 def plugin_page(plugin_id: str) -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()
@@ -228,7 +228,7 @@ def plugin_page(plugin_id: str) -> Any:
     )
 
 
-@plugin_bp.route("/plugin/ai_image/random_prompt", methods=["POST"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/plugin/ai_image/random_prompt", methods=["POST"])
 def ai_image_random_prompt() -> Any:
     """Generate a prompt suggestion for the AI Image plugin."""
     device_config = current_app.config[_CONFIG_KEY]
@@ -279,7 +279,7 @@ def ai_image_random_prompt() -> Any:
         return json_success("Generated prompt.", prompt=prompt)
 
 
-@plugin_bp.route("/plugins", methods=["GET"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/plugins", methods=["GET"])
 def plugins_page() -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     plugins = device_config.get_plugins()
@@ -292,7 +292,7 @@ def plugins_page() -> Any:
     )
 
 
-@plugin_bp.route("/images/<plugin_id>/<path:filename>", methods=["GET"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/images/<plugin_id>/<path:filename>", methods=["GET"])
 def image(plugin_id: str, filename: str) -> Any:
     # Reject null-byte / absolute path inputs up front (defence in depth).
     if (
@@ -371,7 +371,7 @@ def image(plugin_id: str, filename: str) -> Any:
     "/plugin_latest_image/<string:plugin_id>",
     endpoint="plugin_latest_image",
     methods=["GET"],
-)  # type: ignore[untyped-decorator]
+)
 def latest_plugin_image(plugin_id: str) -> Any:
     """Serve the most recent history image for a given plugin_id.
 
@@ -455,7 +455,7 @@ def _cleanup_plugin_resources(
         )
 
 
-@plugin_bp.route("/delete_plugin_instance", methods=["POST", "DELETE"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/delete_plugin_instance", methods=["POST", "DELETE"])
 def delete_plugin_instance() -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()
@@ -504,7 +504,7 @@ def delete_plugin_instance() -> Any:
     return json_success(message="Deleted plugin instance.")
 
 
-@plugin_bp.route("/update_plugin_instance/<string:instance_name>", methods=["PUT"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/update_plugin_instance/<string:instance_name>", methods=["PUT"])
 def update_plugin_instance(instance_name: str) -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()
@@ -616,7 +616,7 @@ def update_plugin_instance(instance_name: str) -> Any:
     return json_success(message=f"Updated plugin instance {instance_name}.")
 
 
-@plugin_bp.route("/display_plugin_instance", methods=["POST"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/display_plugin_instance", methods=["POST"])
 def display_plugin_instance() -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     refresh_task = current_app.config["REFRESH_TASK"]
@@ -671,7 +671,7 @@ def display_plugin_instance() -> Any:
 @plugin_bp.route(
     "/plugin_instance/<string:plugin_id>/<string:instance_name>/force_retry",
     methods=["POST"],
-)  # type: ignore[untyped-decorator]
+)
 def force_retry_plugin_instance(plugin_id: str, instance_name: str) -> Any:
     """Clear the circuit-breaker paused state for a plugin instance.
 
@@ -987,7 +987,7 @@ def _push_update_now_fallback_from_current_exception(
     )
 
 
-@plugin_bp.route("/api/job/<job_id>", methods=["GET"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/api/job/<job_id>", methods=["GET"])
 def job_status(job_id: str) -> tuple[Any, int]:
     """Poll the status of an asynchronous render job."""
     queue = get_job_queue()
@@ -1076,7 +1076,7 @@ def _run_update_now(
             }
 
 
-@plugin_bp.route("/update_now", methods=["POST"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/update_now", methods=["POST"])
 def update_now() -> Any:
     """Render a plugin image and push it to the display.
 
@@ -1202,7 +1202,7 @@ def update_now() -> Any:
         return json_error(_ERR_INTERNAL, status=500, code="internal_error")
 
 
-@plugin_bp.route("/save_plugin_settings", methods=["POST"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/save_plugin_settings", methods=["POST"])
 def save_plugin_settings() -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()
@@ -1238,7 +1238,7 @@ def save_plugin_settings() -> Any:
         return json_error(_ERR_INTERNAL, status=500)
 
 
-@plugin_bp.route("/plugin/<string:plugin_id>/save", methods=["POST"])  # type: ignore[untyped-decorator]
+@plugin_bp.route("/plugin/<string:plugin_id>/save", methods=["POST"])
 def save_plugin_settings_alias(plugin_id: str) -> Any:
     """Backward-compatible route alias for plugin settings save."""
     device_config = current_app.config[_CONFIG_KEY]
@@ -1420,7 +1420,7 @@ def _find_latest_plugin_refresh_time(device_config: Any, plugin_id: str) -> str 
     "/instance_image/<string:plugin_id>/<string:instance_name>",
     endpoint="plugin_instance_image",
     methods=["GET"],
-)  # type: ignore[untyped-decorator]
+)
 def instance_image(plugin_id: str, instance_name: str) -> Any:
     device_config = current_app.config[_CONFIG_KEY]
     playlist_manager = device_config.get_playlist_manager()

--- a/src/blueprints/plugin_history_bp.py
+++ b/src/blueprints/plugin_history_bp.py
@@ -73,7 +73,7 @@ def _instance_exists(device_config: Any, instance_name: str) -> bool:
 
 @plugin_history_bp.route(
     "/api/plugins/instance/<string:instance_name>/history", methods=["GET"]
-)  # type: ignore
+)
 def plugin_instance_history(instance_name: str) -> Any:
     """Return recent config-change history for a plugin instance."""
     safe_name = _safe_instance_name(instance_name)
@@ -98,7 +98,7 @@ def plugin_instance_history(instance_name: str) -> Any:
 
 @plugin_history_bp.route(
     "/api/plugins/instance/<string:instance_name>/diff", methods=["GET"]
-)  # type: ignore
+)
 def plugin_instance_diff(instance_name: str) -> Any:
     """Return the diff between the two most-recent history entries."""
     safe_name = _safe_instance_name(instance_name)

--- a/src/blueprints/plugin_io.py
+++ b/src/blueprints/plugin_io.py
@@ -78,7 +78,7 @@ def _make_json_attachment(payload: dict[str, Any], filename: str) -> Response:
 # ---------------------------------------------------------------------------
 
 
-@plugin_io_bp.route("/api/plugins/export", methods=["GET"])  # type: ignore
+@plugin_io_bp.route("/api/plugins/export", methods=["GET"])
 def export_plugins() -> Response:
     """Export one or all plugin instances as a downloadable JSON file.
 
@@ -182,7 +182,7 @@ def _validate_payload(payload: object) -> tuple[str | None, list[dict[str, Any]]
     return None, instances
 
 
-@plugin_io_bp.route("/api/plugins/import", methods=["POST"])  # type: ignore
+@plugin_io_bp.route("/api/plugins/import", methods=["POST"])
 def import_plugins() -> (
     tuple[Response | dict[str, Any], int] | Response | dict[str, Any]
 ):

--- a/src/blueprints/settings/_config.py
+++ b/src/blueprints/settings/_config.py
@@ -96,7 +96,7 @@ _mod.settings_bp.add_url_rule(
 )
 
 
-@_mod.settings_bp.route("/settings/safe_reset", methods=["POST"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/safe_reset", methods=["POST"])
 def safe_reset() -> Any:
     with route_error_boundary(
         "safe reset",
@@ -124,7 +124,7 @@ def safe_reset() -> Any:
         return json_success(message="Safe reset applied.")
 
 
-@_mod.settings_bp.route("/settings", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings", methods=["GET"])
 def settings_page() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     timezones = sorted(available_timezones())
@@ -136,7 +136,7 @@ def settings_page() -> Any:
     )
 
 
-@_mod.settings_bp.route("/settings/diagnostics", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/diagnostics", methods=["GET"])
 def diagnostics_redirect() -> Any:
     """Redirect /settings/diagnostics to the Diagnostics accordion on /settings.
 
@@ -148,7 +148,7 @@ def diagnostics_redirect() -> Any:
     return redirect("/settings#diagnostics", code=302)
 
 
-@_mod.settings_bp.route("/settings/backup", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/backup", methods=["GET"])
 def backup_restore_page() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     # For now, reuse the main settings page and anchor to a section; separate template can be added later
@@ -177,8 +177,8 @@ def _include_export_keys() -> bool:
     return str(value or "").strip().lower() in ("1", "true", "yes", "on")
 
 
-@_mod.settings_bp.route("/settings/export", methods=["GET"])  # type: ignore[untyped-decorator]
-@_mod.settings_bp.route(  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/export", methods=["GET"])
+@_mod.settings_bp.route(
     "/settings/export", methods=["POST"], endpoint="export_settings_post"
 )
 def export_settings() -> Any:
@@ -235,7 +235,7 @@ def _extract_import_payload() -> dict[str, Any] | None:
     return dict(payload)
 
 
-@_mod.settings_bp.route("/settings/import", methods=["POST"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/import", methods=["POST"])
 def import_settings() -> Any:
     with route_error_boundary(
         "import settings",
@@ -289,7 +289,7 @@ def import_settings() -> Any:
         return json_success(message=f"Restored {' and '.join(parts)}")
 
 
-@_mod.settings_bp.route("/settings/api-keys", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/api-keys", methods=["GET"])
 def api_keys_page() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
 
@@ -332,7 +332,7 @@ def api_keys_page() -> Any:
     )
 
 
-@_mod.settings_bp.route("/settings/save_api_keys", methods=["POST"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/save_api_keys", methods=["POST"])
 def save_api_keys() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     with route_error_boundary(
@@ -386,7 +386,7 @@ def save_api_keys() -> Any:
         return json_success(message="API keys saved.", updated=updated)
 
 
-@_mod.settings_bp.route("/settings/delete_api_key", methods=["POST"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/settings/delete_api_key", methods=["POST"])
 def delete_api_key() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
     key = request.form.get("key")
@@ -595,7 +595,7 @@ def _build_settings_dict(
     return settings, plugin_cycle_interval_seconds
 
 
-@_mod.settings_bp.route("/save_settings", methods=["POST"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/save_settings", methods=["POST"])
 def save_settings() -> Any:
     device_config = current_app.config["DEVICE_CONFIG"]
 

--- a/src/blueprints/settings/_health.py
+++ b/src/blueprints/settings/_health.py
@@ -103,7 +103,7 @@ def _filter_health_by_window(health: dict[str, Any], window_min: int) -> dict[st
     return filtered
 
 
-@_mod.settings_bp.route("/api/health/plugins", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/api/health/plugins", methods=["GET"])
 def health_plugins() -> tuple[Any, int] | Response:
     try:
         rt = current_app.config["REFRESH_TASK"]
@@ -118,7 +118,7 @@ def health_plugins() -> tuple[Any, int] | Response:
         return json_internal_error("health plugins", details={"error": str(e)})
 
 
-@_mod.settings_bp.route("/api/health/system", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/api/health/system", methods=["GET"])
 def health_system() -> tuple[Any, int] | Response:
     try:
         data: dict[str, Any] = {}
@@ -145,7 +145,7 @@ def health_system() -> tuple[Any, int] | Response:
         return json_internal_error("health system", details={"error": str(e)})
 
 
-@_mod.settings_bp.route("/api/progress/stream", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/api/progress/stream", methods=["GET"])
 def progress_stream() -> Response | tuple[Any, int]:
     if not _progress_stream_enabled():
         return json_error("Progress SSE disabled", status=404)
@@ -167,7 +167,7 @@ def progress_stream() -> Response | tuple[Any, int]:
             released = True
         _release_progress_stream()
 
-    @stream_with_context  # type: ignore[untyped-decorator]
+    @stream_with_context
     def gen() -> Generator[str, None, None]:
         try:
             yield from _iter_progress_events(bus, last_seq)

--- a/src/blueprints/settings/_logs.py
+++ b/src/blueprints/settings/_logs.py
@@ -11,7 +11,7 @@ from utils.http_utils import json_error
 from utils.time_utils import now_device_tz
 
 
-@_mod.settings_bp.route("/download-logs", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/download-logs", methods=["GET"])
 def download_logs() -> Response:
     try:
         # Guardrail hours clamp
@@ -83,7 +83,7 @@ def _filter_log_lines(lines: list[str], contains: str, level: str) -> list[str]:
     return lines
 
 
-@_mod.settings_bp.route("/api/logs", methods=["GET"])  # type: ignore[untyped-decorator]
+@_mod.settings_bp.route("/api/logs", methods=["GET"])
 def api_logs() -> Response | tuple[Any, int]:
     """JSON logs API with server-side filter, level selection and limits."""
     try:

--- a/src/blueprints/settings/_updates.py
+++ b/src/blueprints/settings/_updates.py
@@ -318,7 +318,7 @@ def _auto_clear_stale_update_state() -> tuple[str | None, bool]:
     return failed_name, unit_failed
 
 
-@_mod.settings_bp.route("/settings/update_status", methods=["GET"])  # type: ignore
+@_mod.settings_bp.route("/settings/update_status", methods=["GET"])
 def update_status() -> Response:
     with route_error_boundary(
         "update status",
@@ -462,7 +462,7 @@ def start_rollback() -> tuple[object, int] | Response:
         raise
 
 
-@_mod.settings_bp.route("/api/version", methods=["GET"])  # type: ignore
+@_mod.settings_bp.route("/api/version", methods=["GET"])
 def api_version() -> Response:
     """Return current and latest version info.
 

--- a/src/blueprints/stats.py
+++ b/src/blueprints/stats.py
@@ -33,7 +33,7 @@ _WINDOW_24H = 86_400
 _WINDOW_7D = 604_800
 
 
-@stats_bp.route("/api/stats", methods=["GET"])  # type: ignore
+@stats_bp.route("/api/stats", methods=["GET"])
 def refresh_stats() -> Any:
     """Return aggregated refresh statistics for 1h, 24h, and 7d windows."""
     device_config = current_app.config.get("DEVICE_CONFIG")

--- a/src/blueprints/version_info.py
+++ b/src/blueprints/version_info.py
@@ -107,7 +107,7 @@ _PYTHON_VERSION: str = sys.version
 # ---------------------------------------------------------------------------
 
 
-@version_info_bp.route("/api/version/info", methods=["GET"])  # type: ignore
+@version_info_bp.route("/api/version/info", methods=["GET"])
 def api_version_info() -> Response:
     """Return build and runtime version metadata.
 
@@ -137,7 +137,7 @@ def _system_uptime_seconds() -> int | None:
         return None
 
 
-@version_info_bp.route("/api/uptime", methods=["GET"])  # type: ignore
+@version_info_bp.route("/api/uptime", methods=["GET"])
 def api_uptime() -> Response:
     """Return process and system uptime information."""
     process_uptime = time.monotonic() - _PROCESS_START_TIME

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -393,7 +393,7 @@ def _configure_upload_limits(app: Flask) -> None:
 def _register_before_request_hooks(app: Flask) -> None:
     """Attach before-request hooks for refresh task, timers, and request IDs."""
 
-    @app.before_request  # type: ignore[untyped-decorator]
+    @app.before_request
     def _ensure_refresh_task_started() -> None:
         if WEB_ONLY:
             return
@@ -403,14 +403,14 @@ def _register_before_request_hooks(app: Flask) -> None:
                 logger.info("Starting refresh task (flask dev server lazy start)")
                 rt.start()
 
-    @app.before_request  # type: ignore[untyped-decorator]
+    @app.before_request
     def _start_request_timer() -> None:
         try:
             g._t0 = perf_counter()
         except Exception:
             pass
 
-    @app.before_request  # type: ignore[untyped-decorator]
+    @app.before_request
     def _attach_request_id() -> None:
         try:
             from utils.http_utils import _get_or_set_request_id

--- a/src/refresh_task/actions.py
+++ b/src/refresh_task/actions.py
@@ -24,7 +24,15 @@ class PluginLike(Protocol):
 
     def generate_image(
         self, settings: Mapping[str, object], device_config: object
-    ) -> Image.Image: ...
+    ) -> Image.Image | None:
+        """Mirrors ``BasePlugin.generate_image``, ``None`` included.
+
+        This protocol declared a bare ``Image.Image`` after the base class was
+        widened to allow ``None`` for control-only plugins, so every caller
+        type-checked against a contract the implementation no longer honoured.
+        That is how the missing ``None`` guard below went unnoticed.
+        """
+        ...
 
 
 class DeviceConfigLike(Protocol):
@@ -77,8 +85,13 @@ class RefreshAction:
 
     def execute(
         self, plugin: PluginLike, device_config: DeviceConfigLike, current_dt: datetime
-    ) -> Image.Image:
-        """Execute the refresh operation and return the updated image."""
+    ) -> Image.Image | None:
+        """Execute the refresh operation and return the updated image.
+
+        ``None`` means the plugin produced no image on purpose — a control-only
+        plugin whose point is the side effect. Callers must treat that as a
+        completed refresh with nothing to display, not as a failure.
+        """
         raise NotImplementedError("Subclasses must implement the execute method.")
 
     def get_refresh_info(self) -> RefreshInfo:
@@ -106,7 +119,7 @@ class ManualRefresh(RefreshAction):
 
     def execute(
         self, plugin: PluginLike, device_config: DeviceConfigLike, current_dt: datetime
-    ) -> Image.Image:
+    ) -> Image.Image | None:
         """Performs a manual refresh using the stored plugin ID and settings."""
         return plugin.generate_image(self.plugin_settings, device_config)
 
@@ -152,7 +165,7 @@ class PlaylistRefresh(RefreshAction):
 
     def execute(
         self, plugin: PluginLike, device_config: DeviceConfigLike, current_dt: datetime
-    ) -> Image.Image:
+    ) -> Image.Image | None:
         """Performs a refresh for the specified plugin instance within its playlist context."""
         # Determine the file path for the plugin's image
         plugin_image_path = os.path.join(
@@ -166,6 +179,13 @@ class PlaylistRefresh(RefreshAction):
             )
             # Generate a new image
             image = plugin.generate_image(self.plugin_instance.settings, device_config)
+            if image is None:
+                # A control-only plugin produced no image on purpose. There is
+                # nothing to persist, but the refresh did happen, so the
+                # timestamp still advances — otherwise the plugin is retried
+                # every cycle. RefreshTask handles the None from here.
+                self.plugin_instance.latest_refresh_time = current_dt.isoformat()
+                return None
             image.save(plugin_image_path)
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
         else:

--- a/src/utils/client_endpoint.py
+++ b/src/utils/client_endpoint.py
@@ -16,10 +16,17 @@ from flask import Response, request
 from utils.http_utils import json_error
 from utils.rate_limit import TokenBucket
 
+#: What :func:`utils.http_utils.json_error` actually hands back. It normally
+#: returns a ``Response`` from ``jsonify``, but falls back to a plain ``dict``
+#: when there is no application context for jsonify to use. The signatures here
+#: previously admitted only ``Response``, so every error path in this module was
+#: typed as something narrower than the value it returns.
+ErrorResponse = tuple["Response | dict[str, Any]", int]
+
 
 def enforce_size_and_rate(
     rate_limiter: TokenBucket, body_max: int
-) -> tuple[bytes | None, tuple[Response, int] | None]:
+) -> tuple[bytes | None, ErrorResponse | None]:
     """Enforce body-size cap + per-IP rate-limit.
 
     Returns ``(raw_body, None)`` on success or ``(None, error_response)``.
@@ -45,7 +52,7 @@ def enforce_size_and_rate(
 
 def parse_client_report(
     rate_limiter: TokenBucket, body_max: int
-) -> tuple[dict[str, Any] | None, Response | tuple[Response, int] | None]:
+) -> tuple[dict[str, Any] | None, ErrorResponse | None]:
     """Validate body size, rate-limit, and parse JSON.
 
     Returns ``(data, None)`` on success or ``(None, error_response)`` on

--- a/tests/unit/test_skip_display_and_no_image.py
+++ b/tests/unit/test_skip_display_and_no_image.py
@@ -14,7 +14,9 @@ working plugin.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -225,3 +227,64 @@ class TestSkipAndNoImageAreDistinct:
         # The no-image path has no reason to report — it is the normal outcome
         # for a control-only plugin, every single cycle.
         assert _skip_reason(task, monkeypatch, reason=None) is None
+
+
+class TestPlaylistRefreshHandlesAControlOnlyPlugin:
+    """A plugin returning None must not crash the playlist path.
+
+    `RefreshTask` handles a None image correctly, but `PlaylistRefresh.execute`
+    called `image.save(...)` before returning, so it died first with
+    `AttributeError: 'NoneType' object has no attribute 'save'`. The same plugin
+    worked through `ManualRefresh`, which just returns the value — so this only
+    bit control-only plugins once they were added to a playlist.
+
+    Invisible to mypy because the `PluginLike` Protocol still declared
+    `-> Image.Image` after `BasePlugin` was widened to allow None, and
+    `follow_imports = skip` meant nothing checked the two against each other.
+    """
+
+    class _ControlOnlyPlugin:
+        """Its point is the side effect; it renders nothing."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def generate_image(self, _settings: Any, _device_config: Any) -> None:
+            self.calls += 1
+            return
+
+    class _DueInstance(_FakeInstance):
+        """Always due, so execute() takes the generate-and-save branch."""
+
+        latest_refresh_time: str | None = None
+
+        def should_refresh(self, _now: Any) -> bool:
+            return True
+
+    def _run(self, tmp_path: Path) -> tuple[Any, Any]:
+        from refresh_task.actions import PlaylistRefresh
+
+        instance = self._DueInstance({})
+        instance.latest_refresh_time = None
+        plugin = self._ControlOnlyPlugin()
+        # cast: _FakeInstance is a stand-in, not a full PluginInstanceLike.
+        action = PlaylistRefresh(_FakePlaylist(), cast(Any, instance))
+
+        device_config = MagicMock()
+        device_config.plugin_image_dir = str(tmp_path)
+        result = action.execute(plugin, device_config, datetime.now(UTC))
+        return result, (plugin, instance)
+
+    def test_returns_none_instead_of_raising(self, tmp_path: Path) -> None:
+        result, (plugin, _instance) = self._run(tmp_path)
+        assert result is None
+        assert plugin.calls == 1, "the plugin must still have been run"
+
+    def test_no_image_file_is_written(self, tmp_path: Path) -> None:
+        self._run(tmp_path)
+        assert list(tmp_path.glob("*")) == [], "nothing to save, so nothing written"
+
+    def test_the_refresh_timestamp_still_advances(self, tmp_path: Path) -> None:
+        """Otherwise the plugin is retried every single cycle."""
+        _result, (_plugin, instance) = self._run(tmp_path)
+        assert instance.latest_refresh_time is not None


### PR DESCRIPTION
## The setting

`follow_imports = skip` meant mypy never read an imported module, so every
cross-module call resolved to `Any`. **`src/` reported a comforting zero** while
whole classes of mismatch were unreportable. Turning it on surfaced **214
pre-existing errors** — none of them new.

| | before | after |
|---|---|---|
| `src/` | 0 | 214 → **90** |
| `tests/` | 782 | **645** |

115 of the 214 were stale `# type: ignore` comments that only looked necessary
while the real types were invisible. Removing them left 99; fixing the 9 inside
the blocking strict subset left **90**.

`tests/` went *down*, because ~380 `untyped-decorator` reports were never test
debt — just pytest's own decorators resolving to `Any`.

## Two real bugs

### A control-only plugin crashed the playlist path

`BasePlugin.generate_image` was widened to allow `None` for plugins whose point
is a side effect, and `RefreshTask` handles that correctly. But
`PlaylistRefresh.execute` called `image.save(...)` on the result **before**
returning, so it died first:

```
AttributeError: 'NoneType' object has no attribute 'save'
```

The same plugin worked through `ManualRefresh`, which just returns the value —
so this only bit control-only plugins once they were **added to a playlist**.

Why nothing caught it: the `PluginLike` Protocol in `actions.py` still declared
`-> Image.Image` after the base class was widened, so callers type-checked
against a contract the implementation no longer honoured — and with imports
skipped, nothing ever compared the two.

Protocol realigned, save guarded, and the refresh timestamp still advances on
the `None` path so the plugin isn't retried every cycle. **The regression test
fails with exactly that `AttributeError` when the guard is removed** — verified
by reverting only the guard.

### `client_endpoint`'s error type was narrower than its values

Both helpers declared the error slot as `Response`, but `json_error` also
returns a plain `dict` — its fallback when there's no application context for
`jsonify`. Given a name, `ErrorResponse`, and widened to match.

## On the raised `src/` baseline

0 → 90 is **not a regression**. Both baseline files carry the reasoning inline
so it isn't misread as one later. The +4 on `tests/` is test doubles now being
checked against the real `DeviceConfigLike` protocol, which they don't fully
implement — follow-up work.

## Verification

5335 passed / 0 failed; strict subset clean; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)