### PR TITLE
fix: treat empty ICS calendar feed as zero events instead of a fatal error

### DIFF
--- a/src/plugins/calendar/calendar.py
+++ b/src/plugins/calendar/calendar.py
@@ -454,6 +454,15 @@ class Calendar(BasePlugin):
         try:
             response = get_http_session().get(calendar_url, timeout=30)
             response.raise_for_status()
+            if not response.text.strip():
+                # A 200 with an empty body is a valid (if pointless) ICS feed,
+                # not a fetch failure — treat it as a calendar with no events
+                # rather than aborting every other calendar_url in this instance.
+                logger.warning(
+                    "Calendar url returned empty content, treating as no events: %s",
+                    calendar_url,
+                )
+                return icalendar.Calendar()
             return icalendar.Calendar.from_ical(response.text)
         except Exception as e:
             raise RuntimeError(f"Failed to fetch iCalendar url: {str(e)}") from e

--- a/tests/plugins/test_calendar_errors.py
+++ b/tests/plugins/test_calendar_errors.py
@@ -63,6 +63,29 @@ def test_calendar_malformed_ics(monkeypatch: pytest.MonkeyPatch) -> None:
         p.fetch_calendar("http://example.com/bad.ics")
 
 
+def test_calendar_empty_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 200 response with an empty body is treated as a calendar with no
+    events, not a fatal error (JTN empty-ICS regression)."""
+    p = _make_calendar_plugin()
+
+    class FakeResp:
+        text = ""
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            pass
+
+    mock_session = type(
+        "S", (), {"get": staticmethod(lambda url, **kwargs: FakeResp())}
+    )()
+    monkeypatch.setattr(
+        "plugins.calendar.calendar.get_http_session", lambda: mock_session
+    )
+
+    cal = p.fetch_calendar("http://example.com/empty.ics")
+    assert cal.subcomponents == []
+
+
 def test_calendar_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """ICS URL request times out."""
     p = _make_calendar_plugin()


### PR DESCRIPTION
## Summary

- A calendar feed that returns `200 OK` with an empty body (`Content-Length: 0`) is a valid, if pointless, ICS feed — not a fetch failure. `icalendar.Calendar.from_ical("")` raises `ValueError: Found no components where exactly one is required:`, which `Calendar.fetch_calendar` was wrapping into a fatal `RuntimeError`.
- That error aborted the *entire* plugin instance's refresh, not just the empty feed — `fetch_ics_events` loops over every configured `calendarURLs[]` entry, so one empty URL blanked out events from every other, perfectly valid calendar URL configured on the same instance, and tripped the refresh task's circuit breaker/fallback-image path.
- Fix: `fetch_calendar` now treats a blank/whitespace-only response body as a calendar with zero events (returns an empty `icalendar.Calendar()`) instead of raising, logging a warning for visibility.

## Base Branch Confirmation

- [x] This PR is based on `origin/main` (not a stale long-lived branch)
- [x] I rebased/merged latest `origin/main` before opening

## Parent-Fork Sync Checklist

_Not applicable — this is not a sync from `fatihak/InkyPi`._

- [ ] If this PR syncs from `fatihak/InkyPi`, changes were cherry-picked by feature
- [ ] Relevant upstream behavior differences were documented in PR description
- [ ] Plugin/add-to-playlist/update flows were smoke-tested after sync

## Compatibility/Release Checklist

- [x] `pytest` relevant suites pass locally (`tests/plugins/test_calendar.py`, `test_calendar_errors.py`, `test_calendar_validation.py` — 54 passed; `mypy` clean on the changed file)
- [x] No breaking API route/path changes
- [x] Error responses follow JSON contract (`success:false,error,code,details,request_id`) — n/a, no route/response changes
- [ ] Docs updated for new flags/endpoints/UI — n/a, no new flags/endpoints/UI
- [ ] **Frontend changes** (`src/static/**`, `src/templates/**`): n/a, no frontend files touched

## Testing

- Reproduced locally: `icalendar.Calendar.from_ical("")` → `ValueError: Found no components where exactly one is required:`, matching the reporter's traceback (`RuntimeError: Failed to fetch iCalendar url: Found no components...`) triggered by a real ICS server returning `200 OK` / `Content-Length: 0`.
- Added `test_calendar_empty_content` in `tests/plugins/test_calendar_errors.py`, asserting `fetch_calendar` returns an empty `icalendar.Calendar` (not a raised exception) for a blank response body.
- `PYTHONPATH=$(pwd)/src pytest tests/plugins/test_calendar.py tests/plugins/test_calendar_errors.py tests/plugins/test_calendar_validation.py -q` → 54 passed.
- `mypy src/plugins/calendar/calendar.py` → no issues found.
