### PR TITLE
feat: add native composite screen support for multi-region layouts

### DIFF
--- a/src/blueprints/playlist.py
+++ b/src/blueprints/playlist.py
@@ -16,9 +16,13 @@ from flask import (
     url_for,
 )
 
-from model import Playlist
+from model import COMPOSITE_PLUGIN_ID, Playlist
 from refresh_task import PlaylistRefresh
-from services.playlist_workflows import prepare_add_plugin_workflow
+from services.playlist_workflows import (
+    prepare_add_composite_screen_workflow,
+    prepare_add_plugin_workflow,
+    prepare_update_composite_screen_workflow,
+)
 from utils.app_utils import handle_request_files, parse_form
 from utils.backend_errors import (
     ClientInputError,
@@ -436,6 +440,202 @@ def add_plugin() -> Any:
     return json_success("Scheduled refresh configured.")
 
 
+def _parse_add_composite_screen_form(
+    form: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any] | None, Any]:
+    """Parse and validate the add_composite_screen form data.
+
+    Returns ``(regions, refresh_settings, error_response)``. On success
+    ``error_response`` is None; on failure the first two are None.
+    """
+    raw_refresh = form.get("refresh_settings")
+    refresh_settings, err = _parse_refresh_settings_json(raw_refresh)
+    if err:
+        _p1, _p2, _p3, error_response = err
+        return None, None, error_response
+    raw_regions = form.get("regionsJson")
+    if not raw_regions or not isinstance(raw_regions, str):
+        _p1, _p2, _p3, error_response = _form_parse_error(
+            "regionsJson is required", status=422, field="regionsJson"
+        )
+        return None, None, error_response
+    try:
+        regions = json.loads(raw_regions)
+    except (json.JSONDecodeError, ValueError):
+        _p1, _p2, _p3, error_response = _form_parse_error(
+            "Invalid JSON in regionsJson", status=422, field="regionsJson"
+        )
+        return None, None, error_response
+    if not isinstance(regions, list):
+        _p1, _p2, _p3, error_response = _form_parse_error(
+            "regionsJson must be a JSON array", status=422, field="regionsJson"
+        )
+        return None, None, error_response
+    return regions, refresh_settings, None
+
+
+@playlist_bp.route("/add_composite_screen", methods=["POST"])
+def add_composite_screen() -> Any:
+    """Add a native composite ("multi-region") screen to a playlist.
+
+    Parallel to add_plugin() above, but for a screen that renders several
+    other plugins into named regions on one canvas instead of a single
+    plugin's own settings form — see model.COMPOSITE_PLUGIN_ID and
+    refresh_task/composite_render.py.
+    """
+    device_config = current_app.config["DEVICE_CONFIG"]
+    playlist_manager = device_config.get_playlist_manager()
+
+    with route_error_boundary(
+        "add composite screen to playlist",
+        logger=logger,
+        hint="Validate region JSON; ensure playlist exists and instance name is not duplicated.",
+    ):
+        regions, refresh_settings, parse_err = _parse_add_composite_screen_form(
+            request.form
+        )
+        if parse_err:
+            return parse_err
+        assert regions is not None
+        assert refresh_settings is not None
+
+        result = prepare_add_composite_screen_workflow(
+            regions,
+            refresh_settings,
+            playlist_manager=playlist_manager,
+            device_config=device_config,
+        )
+        if not result.ok:
+            error = result.error
+            if error is None:
+                raise OperationFailedError("Failed to add to playlist")
+            return json_error(error.message, **error.as_json_kwargs())
+    return json_success("Scheduled refresh configured.")
+
+
+def _render_composite_screen_editor(
+    *,
+    edit_instance_name: str | None,
+    initial_regions: list[dict[str, Any]] | None,
+    default_playlist: str,
+) -> Any:
+    from plugins.base_plugin.base_plugin import BasePlugin
+
+    device_config = current_app.config["DEVICE_CONFIG"]
+    playlist_manager = device_config.get_playlist_manager()
+
+    available_plugins = sorted(
+        (
+            {"id": p["id"], "display_name": p.get("display_name") or p["id"]}
+            for p in device_config.get_plugins()
+            if isinstance(p.get("id"), str)
+        ),
+        key=lambda p: p["display_name"].lower(),
+    )
+    canvas_w, canvas_h = BasePlugin.get_oriented_dimensions(device_config)
+
+    return render_template(
+        "composite_screen.html",
+        available_plugins=available_plugins,
+        playlist_names=playlist_manager.get_playlist_names(),
+        default_playlist=default_playlist,
+        canvas_w=canvas_w,
+        canvas_h=canvas_h,
+        edit_instance_name=edit_instance_name,
+        initial_regions_json=json.dumps(initial_regions or []),
+        active_nav="playlists",
+    )
+
+
+@playlist_bp.route("/composite_screen/new", methods=["GET"])
+def new_composite_screen() -> Any:
+    """Region editor for creating a new composite screen.
+
+    Reached from a playlist card's "Add composite screen" link — see
+    playlist.html. Unlike a real plugin, there is no /plugin/<id> settings
+    page for this: the playlist target, instance name, refresh schedule, and
+    region list are all collected on this one page and posted together to
+    add_composite_screen() above.
+    """
+    return _render_composite_screen_editor(
+        edit_instance_name=None,
+        initial_regions=None,
+        default_playlist=request.args.get("playlist") or "",
+    )
+
+
+@playlist_bp.route("/composite_screen/edit/<string:instance_name>", methods=["GET"])
+def edit_composite_screen(instance_name: str) -> Any:
+    """Region editor for an existing composite screen's regions.
+
+    Refresh cadence isn't edited here — that's the same generic "Edit
+    refresh settings" modal every plugin instance uses (playlist.html's
+    edit-refresh action, PUT /update_plugin_instance/<name>), which works
+    unmodified for a composite instance since it doesn't touch settings when
+    the request carries none. This page only round-trips settings["regions"]
+    via update_composite_screen() below.
+    """
+    device_config = current_app.config["DEVICE_CONFIG"]
+    playlist_manager = device_config.get_playlist_manager()
+    plugin_instance = playlist_manager.find_plugin(COMPOSITE_PLUGIN_ID, instance_name)
+    if plugin_instance is None:
+        raise ResourceLookupError(
+            f"Composite screen '{instance_name}' was not found", status=404
+        )
+
+    regions = plugin_instance.settings.get("regions")
+    return _render_composite_screen_editor(
+        edit_instance_name=instance_name,
+        initial_regions=regions if isinstance(regions, list) else [],
+        default_playlist="",
+    )
+
+
+@playlist_bp.route("/update_composite_screen/<string:instance_name>", methods=["PUT"])
+def update_composite_screen(instance_name: str) -> Any:
+    """Persist an edited region list for an existing composite screen."""
+    device_config = current_app.config["DEVICE_CONFIG"]
+    playlist_manager = device_config.get_playlist_manager()
+
+    with route_error_boundary(
+        "update composite screen",
+        logger=logger,
+        hint="Validate region JSON; ensure the composite screen instance exists.",
+    ):
+        raw_regions = request.form.get("regionsJson")
+        if not raw_regions or not isinstance(raw_regions, str):
+            return json_error(
+                "regionsJson is required", status=422, details={"field": "regionsJson"}
+            )
+        try:
+            regions = json.loads(raw_regions)
+        except (json.JSONDecodeError, ValueError):
+            return json_error(
+                "Invalid JSON in regionsJson",
+                status=422,
+                details={"field": "regionsJson"},
+            )
+        if not isinstance(regions, list):
+            return json_error(
+                "regionsJson must be a JSON array",
+                status=422,
+                details={"field": "regionsJson"},
+            )
+
+        result = prepare_update_composite_screen_workflow(
+            instance_name,
+            regions,
+            playlist_manager=playlist_manager,
+            device_config=device_config,
+        )
+        if not result.ok:
+            error = result.error
+            if error is None:
+                raise OperationFailedError("Failed to update composite screen")
+            return json_error(error.message, **error.as_json_kwargs())
+    return json_success("Composite screen updated.")
+
+
 @playlist_bp.route("/playlists", methods=["GET"])
 def playlists_redirect() -> Any:
     return redirect(url_for("playlist.playlists"))
@@ -544,6 +744,7 @@ def playlists() -> Any:
         device_cycle_minutes=device_cycle_minutes,
         playlist_timing=playlist_timing,
         rotation_eta=rotation_eta,
+        composite_plugin_id=COMPOSITE_PLUGIN_ID,
         active_nav="playlists",
     )
 

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -604,16 +604,25 @@ def update_plugin_instance(instance_name: str) -> Any:
                         raise ClientInputError(settings_error, status=400)
 
         before_settings = dict(plugin_instance.settings or {})
+        # The playlist page's "Edit refresh settings" modal (actions.js
+        # saveRefreshSettings) intentionally posts only plugin_id +
+        # refresh_settings — no plugin-specific fields — so plugin_settings
+        # parses to {} for that request. Overwriting settings with an empty
+        # dict on every schedule-only edit silently deleted the instance's
+        # real settings (confirmed for a plain plugin like clock, and would
+        # equally wipe a composite screen's settings["regions"]). Only
+        # replace settings when this request actually carried some.
+        applied_settings = plugin_settings if plugin_settings else before_settings
 
         def _do_update_instance(cfg: Any) -> None:
-            plugin_instance.settings = plugin_settings
+            plugin_instance.settings = applied_settings
             if new_refresh_config is not None:
                 plugin_instance.refresh = new_refresh_config
 
         device_config.update_atomic(_do_update_instance)
         config_dir = os.path.dirname(device_config.config_file)
         _record_plugin_change(
-            config_dir, instance_name, before_settings, plugin_settings
+            config_dir, instance_name, before_settings, applied_settings
         )
 
     return json_success(message=f"Updated plugin instance {instance_name}.")

--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -17,8 +17,10 @@ from flask import (
     send_from_directory,
 )
 
+from model import COMPOSITE_PLUGIN_ID
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task import ManualRefresh, PlaylistRefresh
+from refresh_task.composite_render import CompositeScreenRenderer
 from refresh_task.job_queue import get_job_queue
 from services.plugin_workflows import save_plugin_settings_workflow
 from utils.app_utils import handle_request_files, parse_form, resolve_path
@@ -1457,10 +1459,19 @@ def instance_image(plugin_id: str, instance_name: str) -> Any:
         plugin_inst = playlist_manager.find_plugin(plugin_id, instance_name)
         if not plugin_inst:
             return (_ERR_NOT_FOUND, 404)
-        plugin_config = device_config.get_plugin(plugin_id)
-        if not plugin_config:
-            return (_ERR_NOT_FOUND, 404)
-        plugin = get_plugin_instance(plugin_config)
+        if plugin_id == COMPOSITE_PLUGIN_ID:
+            # A composite screen has no plugins/<id>/ entry to resolve via
+            # get_plugin_instance — render it the same way the refresh path
+            # does (see refresh_task.composite_render).
+            regions = plugin_inst.settings.get("regions")
+            plugin: Any = CompositeScreenRenderer(
+                list(regions) if isinstance(regions, list) else []
+            )
+        else:
+            plugin_config = device_config.get_plugin(plugin_id)
+            if not plugin_config:
+                return (_ERR_NOT_FOUND, 404)
+            plugin = get_plugin_instance(plugin_config)
         image = plugin.generate_image(plugin_inst.settings, device_config)
         image.save(path)
         return _cacheable_send_file(path)

--- a/src/model.py
+++ b/src/model.py
@@ -6,6 +6,22 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+#: Reserved ``plugin_id`` for a composite ("multi-region") screen — a
+#: PluginInstance that renders several *other* plugins into named regions on
+#: one canvas instead of a single plugin's own generate_image(). Never
+#: resolved via plugins.plugin_registry (there is no plugins/<id>/ directory
+#: for it); its region list lives in the instance's own settings["regions"].
+#: Kept here rather than in refresh_task/composite_render.py so model.py has
+#: no import-time dependency on the render module, avoiding a cycle.
+COMPOSITE_PLUGIN_ID = "__composite__"
+
+
+def is_composite_instance(plugin_instance: PluginInstance | None) -> bool:
+    """Return whether *plugin_instance* is a composite (multi-region) screen."""
+    return (
+        plugin_instance is not None and plugin_instance.plugin_id == COMPOSITE_PLUGIN_ID
+    )
+
 
 def _sanitize_log_value(value: object) -> str:
     """Sanitize a value for safe inclusion in log messages."""

--- a/src/refresh_task/composite_render.py
+++ b/src/refresh_task/composite_render.py
@@ -1,0 +1,461 @@
+"""Renders a composite ("multi-region") screen: several plugins, one canvas.
+
+Ported from the InkyPi-Layout prototype (github.com/cartagena/InkyPi-Layout),
+which built this as a third-party plugin. Here it is a native rendering path
+dispatched from refresh_task/executor.py and worker.py whenever a
+PluginInstance's plugin_id is model.COMPOSITE_PLUGIN_ID — see
+model.is_composite_instance and the ADR-0001 subprocess-isolation notes for
+why this still runs as a single opaque unit rather than one subprocess per
+region.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from PIL import Image
+
+from plugins.plugin_registry import get_plugin_instance
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_REGION_KEYS = ("plugin_id", "x", "y", "w", "h")
+
+#: Orphaned region cache files (left behind when a region is moved, resized,
+#: reconfigured, or deleted) are swept once their mtime passes this age. Age
+#: rather than "not in the current region set" because several composite
+#: screens share one cache directory — set-based pruning would have each
+#: screen delete the others' still-live entries on every refresh.
+CACHE_MAX_AGE_DAYS = 14
+
+#: Subdirectory of plugin_image_dir holding per-region cached renders.
+CACHE_DIR_NAME = "composite"
+
+
+class _RegionDeviceConfig:
+    """DeviceConfigLike proxy that reports a region's (w, h) as the resolution.
+
+    Wraps the real device_config so a child plugin's own internal layout logic
+    (font sizes, wrapping, spacing) adapts to the region's actual pixel size
+    instead of rendering full-screen and getting cropped down. Orientation is
+    pinned to "horizontal" so BasePlugin.get_oriented_dimensions() — which
+    some plugins call instead of get_resolution() directly — doesn't swap
+    width/height based on the *device's* orientation setting; the region's
+    w/h is already the exact size the child should render at. Everything
+    else (timezone, API keys via load_env_key, plugin_image_dir, etc.)
+    delegates straight through to the real device_config.
+    """
+
+    def __init__(self, device_config: Any, width: int, height: int) -> None:
+        self._device_config = device_config
+        self._width = width
+        self._height = height
+
+    def get_resolution(self) -> tuple[int, int]:
+        return (self._width, self._height)
+
+    def get_config(self, key: str | None = None, default: Any = None) -> Any:
+        if key == "orientation":
+            return "horizontal"
+        return self._device_config.get_config(key, default)
+
+    def load_env_key(self, key: str) -> str | None:
+        return cast("str | None", self._device_config.load_env_key(key))
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._device_config, name)
+
+
+class CompositeScreenRenderer:
+    """Renders a composite screen's regions onto one canvas.
+
+    Constructed with the region list from a composite PluginInstance's
+    settings["regions"]. Implements the same generate_image(settings,
+    device_config) shape as a plugin's BasePlugin.generate_image so it can be
+    handed to RefreshAction.execute() (actions.PluginLike) in place of a
+    plugin resolved via plugins.plugin_registry — see the dispatch branches
+    in executor.py/worker.py. `settings` is accepted but unused: region data
+    already came from the PluginInstance that constructed this renderer.
+    """
+
+    def __init__(self, regions: list[dict[str, Any]]) -> None:
+        self._raw_regions = regions
+
+    def generate_image(self, settings: Any, device_config: Any) -> Image.Image:
+        # BasePlugin and ImageDraw are only needed once a composite screen is
+        # actually rendered, not at import time — executor.py/worker.py
+        # import this module unconditionally at InkyPi startup, and
+        # BasePlugin's own import chain (jinja2, screenshot/image-loader
+        # tooling) is exactly the "heavy module at startup" cost
+        # test_lazy_imports.py guards against. Mirrors the same lazy-import
+        # pattern utils/fallback_image.py already uses for ImageDraw.
+        from PIL import ImageDraw
+
+        from plugins.base_plugin.base_plugin import BasePlugin
+
+        regions = self._parse_regions(self._raw_regions)
+        if not regions:
+            raise RuntimeError("At least one region must be configured.")
+
+        canvas_w, canvas_h = BasePlugin.get_oriented_dimensions(device_config)
+
+        for region in regions:
+            error = self._validate_region(region, canvas_w, canvas_h)
+            if error:
+                raise RuntimeError(error)
+            if not device_config.get_plugin(region["plugin_id"]):
+                raise RuntimeError(
+                    f"Plugin '{region['plugin_id']}' is not installed/registered."
+                )
+
+        canvas = Image.new("RGB", (canvas_w, canvas_h), "white")
+        draw = ImageDraw.Draw(canvas)
+        now = datetime.now(UTC)
+        self._prune_cache_dir(device_config, now)
+
+        for index, region in enumerate(regions):
+            region_image = self._render_region(region, index, device_config, now)
+            canvas.paste(region_image, (region["x"], region["y"]))
+            draw.rectangle(
+                [
+                    region["x"],
+                    region["y"],
+                    region["x"] + region["w"] - 1,
+                    region["y"] + region["h"] - 1,
+                ],
+                outline="black",
+                width=1,
+            )
+
+        return canvas
+
+    # ---- region rendering / per-region caching ----
+    #
+    # This cache only protects *child plugins* from being invoked (and thus
+    # hitting their upstream APIs) more often than refresh_minutes calls for.
+    # It does NOT reduce how often the physical e-paper panel itself
+    # refreshes — that cadence is controlled entirely by this composite
+    # instance's own playlist refresh interval. generate_image() always
+    # recomposites and returns a full canvas on every call; only the
+    # expensive child generate_image() call is what gets skipped when a
+    # region's cache is still fresh.
+    #
+    # The cache is *entirely* on-disk: a PNG per region under
+    # <plugin_image_dir>/composite/, with the file's own mtime as the "cached
+    # at" timestamp. Nothing about it is kept in `settings`. That's not a
+    # style preference — InkyPi runs generate_image() in a subprocess by
+    # default (INKYPI_PLUGIN_ISOLATION), so `settings` arrives as a pickled
+    # copy and anything written back into it is discarded when the child
+    # exits.
+
+    def _render_region(
+        self,
+        region: dict[str, Any],
+        index: int,
+        device_config: Any,
+        now: datetime,
+    ) -> Image.Image:
+        w, h = region["w"], region["h"]
+        cache_path = self._region_cache_path(region, index, device_config)
+        refresh_minutes = region.get("refresh_minutes")
+
+        if refresh_minutes and cache_path:
+            cached_at = self._cache_timestamp(cache_path)
+            if cached_at and now - cached_at < timedelta(minutes=refresh_minutes):
+                cached_image = self._load_cached_image(cache_path, w, h)
+                if cached_image is not None:
+                    return cached_image
+
+        try:
+            image = self._call_child_plugin(region, device_config)
+        except Exception as e:
+            logger.error(
+                "Composite region %d ('%s') failed to render: %s",
+                index,
+                region["plugin_id"],
+                e,
+            )
+            # Prefer a stale cached image over a blank error box — the rest
+            # of the composite is still useful even if one region's data
+            # source is temporarily unavailable.
+            fallback = self._load_cached_image(cache_path, w, h)
+            if fallback is not None:
+                logger.warning(
+                    "Composite region %d ('%s') reusing stale cached image "
+                    "after render failure.",
+                    index,
+                    region["plugin_id"],
+                )
+                return fallback
+            return self._render_error_placeholder(region, str(e))
+
+        if image.size != (w, h):
+            logger.warning(
+                "Plugin '%s' returned image %s, expected %s; resizing.",
+                region["plugin_id"],
+                image.size,
+                (w, h),
+            )
+            image = image.resize((w, h))
+
+        self._store_cache(cache_path, image)
+        return image
+
+    def _call_child_plugin(
+        self, region: dict[str, Any], device_config: Any
+    ) -> Image.Image:
+        plugin_id = region["plugin_id"]
+        plugin_config = device_config.get_plugin(plugin_id)
+        if not plugin_config:
+            raise RuntimeError(f"Plugin '{plugin_id}' is not installed/registered.")
+
+        child = get_plugin_instance(plugin_config)
+        scoped_device_config = _RegionDeviceConfig(
+            device_config, region["w"], region["h"]
+        )
+        region_settings = region.get("settings") or {}
+        image: Image.Image = child.generate_image(region_settings, scoped_device_config)
+        return image.convert("RGB")
+
+    def _region_cache_key(self, region: dict[str, Any], index: int) -> str:
+        payload = json.dumps(
+            {
+                "plugin_id": region["plugin_id"],
+                "x": region["x"],
+                "y": region["y"],
+                "w": region["w"],
+                "h": region["h"],
+                "settings": region.get("settings") or {},
+            },
+            sort_keys=True,
+            default=str,
+        )
+        digest = hashlib.sha1(
+            payload.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()[:10]
+        # The digest alone identifies the region; plugin_id is in the filename
+        # purely so the cache directory is readable. Strip it to the
+        # characters InkyPi's own plugin-id pattern allows anyway, so a
+        # hand-edited region config can never steer this into a path outside
+        # the cache dir.
+        safe_plugin_id = re.sub(r"[^A-Za-z0-9_]", "", region["plugin_id"])[:40]
+        return f"{index}_{safe_plugin_id}_{digest}"
+
+    def _cache_dir(self, device_config: Any) -> str | None:
+        base = getattr(device_config, "plugin_image_dir", None)
+        if not base:
+            return None
+        return os.path.join(base, CACHE_DIR_NAME)
+
+    def _region_cache_path(
+        self, region: dict[str, Any], index: int, device_config: Any
+    ) -> str | None:
+        cache_dir = self._cache_dir(device_config)
+        if cache_dir is None:
+            return None
+        return os.path.join(cache_dir, f"{self._region_cache_key(region, index)}.png")
+
+    @staticmethod
+    def _store_cache(cache_path: str | None, image: Image.Image) -> None:
+        if cache_path is None:
+            return
+        try:
+            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+            image.save(cache_path, format="PNG")
+        except OSError as e:
+            logger.warning("Composite: failed to write region cache file: %s", e)
+
+    @staticmethod
+    def _cache_timestamp(cache_path: str) -> datetime | None:
+        """Return when *cache_path* was last written, as an aware UTC datetime."""
+        try:
+            return datetime.fromtimestamp(os.path.getmtime(cache_path), UTC)
+        except OSError:
+            return None
+
+    @staticmethod
+    def _load_cached_image(
+        cache_path: str | None, width: int, height: int
+    ) -> Image.Image | None:
+        if not cache_path or not os.path.isfile(cache_path):
+            return None
+        try:
+            with Image.open(cache_path) as cached:
+                cached.load()
+                if cached.size != (width, height):
+                    return None
+                return cached.convert("RGB")
+        except Exception:
+            return None
+
+    def _prune_cache_dir(self, device_config: Any, now: datetime) -> None:
+        """Delete region cache files older than CACHE_MAX_AGE_DAYS.
+
+        Every edit to a region's geometry or settings changes its cache key
+        and so orphans the previous file; without this the cache directory
+        grows for the life of the install. Pruning by age rather than by "not
+        referenced by the regions I just rendered" is deliberate — multiple
+        composite screens share this one directory, and a set-difference
+        sweep would have each screen delete the others' still-live entries on
+        every refresh.
+        """
+        cache_dir = self._cache_dir(device_config)
+        if cache_dir is None or not os.path.isdir(cache_dir):
+            return
+        cutoff = now - timedelta(days=CACHE_MAX_AGE_DAYS)
+        try:
+            with os.scandir(cache_dir) as entries:
+                for entry in entries:
+                    if not entry.is_file() or not entry.name.endswith(".png"):
+                        continue
+                    cached_at = self._cache_timestamp(entry.path)
+                    if cached_at is None or cached_at >= cutoff:
+                        continue
+                    try:
+                        os.remove(entry.path)
+                    except OSError as e:
+                        logger.warning(
+                            "Composite: failed to prune stale cache file %s: %s",
+                            entry.path,
+                            e,
+                        )
+        except OSError as e:
+            logger.warning("Composite: failed to scan region cache directory: %s", e)
+
+    @staticmethod
+    def _render_error_placeholder(region: dict[str, Any], message: str) -> Image.Image:
+        from PIL import ImageDraw
+
+        w, h = region["w"], region["h"]
+        image = Image.new("RGB", (w, h), "#f0f0f0")
+        draw = ImageDraw.Draw(image)
+        # The reason goes on the panel as well as in the log: this box is
+        # often the only symptom an operator sees, and "unavailable" alone
+        # doesn't distinguish a missing API key from an upstream outage.
+        draw.text(
+            (6, 6),
+            f"{region['plugin_id']}\nunavailable\n{message[:120]}",
+            fill="black",
+        )
+        return image
+
+    # ---- region config parsing / validation ----
+
+    @staticmethod
+    def _parse_regions(raw_regions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        parsed: list[dict[str, Any]] = []
+        for i, region in enumerate(raw_regions):
+            if not isinstance(region, dict):
+                raise RuntimeError(f"Region {i} must be a JSON object.")
+
+            missing = [k for k in REQUIRED_REGION_KEYS if k not in region]
+            if missing:
+                raise RuntimeError(
+                    f"Region {i} is missing required field(s): {', '.join(missing)}."
+                )
+
+            plugin_id = region["plugin_id"]
+            if not isinstance(plugin_id, str) or not plugin_id:
+                raise RuntimeError(f"Region {i} has an invalid plugin_id.")
+
+            try:
+                x, y, w, h = (
+                    int(region["x"]),
+                    int(region["y"]),
+                    int(region["w"]),
+                    int(region["h"]),
+                )
+            except (TypeError, ValueError) as e:
+                raise RuntimeError(f"Region {i} has non-integer x/y/w/h.") from e
+
+            refresh_minutes = region.get("refresh_minutes")
+            if refresh_minutes is not None:
+                try:
+                    refresh_minutes = int(refresh_minutes)
+                except (TypeError, ValueError) as e:
+                    raise RuntimeError(
+                        f"Region {i} has a non-integer refresh_minutes."
+                    ) from e
+                if refresh_minutes < 0:
+                    raise RuntimeError(f"Region {i} has a negative refresh_minutes.")
+
+            region_settings = region.get("settings")
+            if region_settings is None:
+                region_settings = {}
+            if not isinstance(region_settings, dict):
+                raise RuntimeError(f"Region {i}'s settings must be a JSON object.")
+
+            parsed.append(
+                {
+                    "plugin_id": plugin_id,
+                    "x": x,
+                    "y": y,
+                    "w": w,
+                    "h": h,
+                    "settings": region_settings,
+                    "refresh_minutes": refresh_minutes,
+                }
+            )
+
+        return parsed
+
+    @staticmethod
+    def validate_region_shape(region: Mapping[str, Any]) -> str | None:
+        """Checks that hold at any resolution — usable at save time, before a
+        real device_config/canvas size is available."""
+        x, y, w, h = region["x"], region["y"], region["w"], region["h"]
+        plugin_id = region["plugin_id"]
+        if w <= 0 or h <= 0:
+            return f"Region for '{plugin_id}' must have positive width and height."
+        if x < 0 or y < 0:
+            return f"Region for '{plugin_id}' has a negative x or y."
+        return None
+
+    @classmethod
+    def _validate_region(
+        cls, region: dict[str, Any], canvas_width: int, canvas_height: int
+    ) -> str | None:
+        shape_error = cls.validate_region_shape(region)
+        if shape_error:
+            return shape_error
+        x, y, w, h = region["x"], region["y"], region["w"], region["h"]
+        plugin_id = region["plugin_id"]
+        if x + w > canvas_width or y + h > canvas_height:
+            return (
+                f"Region for '{plugin_id}' at x={x}, y={y}, w={w}, h={h} exceeds the "
+                f"{canvas_width}x{canvas_height} canvas."
+            )
+        return None
+
+
+def resolve_composite_renderer(refresh_action: Any) -> CompositeScreenRenderer:
+    """Build a renderer for a composite PlaylistRefresh action.
+
+    Called from executor.py/worker.py's plugin-resolution step in place of
+    plugins.plugin_registry.get_plugin_instance whenever the refresh
+    action's plugin id is model.COMPOSITE_PLUGIN_ID. Regions live in the
+    PluginInstance's own settings["regions"] (see model.COMPOSITE_PLUGIN_ID's
+    docstring for why no PluginInstance field was added for this).
+    """
+    plugin_instance = getattr(refresh_action, "plugin_instance", None)
+    settings = getattr(plugin_instance, "settings", None)
+    regions = settings.get("regions") if isinstance(settings, Mapping) else None
+    return CompositeScreenRenderer(list(regions) if isinstance(regions, list) else [])
+
+
+def parse_regions(raw_regions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Parse and structurally validate a raw regions list.
+
+    Public entry point for callers outside this module (the
+    add_composite_screen route) that need the same required-field/type
+    checks CompositeScreenRenderer.generate_image runs, before a
+    PluginInstance is even saved. Raises RuntimeError with a user-facing
+    message on the first invalid region — same contract as the private
+    method it wraps.
+    """
+    return CompositeScreenRenderer._parse_regions(raw_regions)

--- a/src/refresh_task/executor.py
+++ b/src/refresh_task/executor.py
@@ -14,7 +14,9 @@ from typing import Any, Protocol, cast
 
 from PIL import Image
 
+from model import COMPOSITE_PLUGIN_ID
 from refresh_task.actions import RefreshAction
+from refresh_task.composite_render import resolve_composite_renderer
 from refresh_task.context import RefreshContext
 from refresh_task.recorder import RefreshRecorder
 from refresh_task.worker import (
@@ -289,7 +291,10 @@ class RefreshExecutor:
             _cancel: threading.Event = cancel_event,
         ) -> None:
             try:
-                plugin = get_plugin_instance(dict(plugin_config))
+                if plugin_config.get("id") == COMPOSITE_PLUGIN_ID:
+                    plugin: Any = resolve_composite_renderer(refresh_action)
+                else:
+                    plugin = get_plugin_instance(dict(plugin_config))
                 image = refresh_action.execute(plugin, device_config, current_dt)
                 meta = None
                 if hasattr(plugin, "get_latest_metadata"):

--- a/src/refresh_task/task.py
+++ b/src/refresh_task/task.py
@@ -10,7 +10,7 @@ from time import monotonic, perf_counter
 from typing import Any, ClassVar, NoReturn, cast
 from uuid import uuid4
 
-from model import PlaylistManager, RefreshInfo
+from model import COMPOSITE_PLUGIN_ID, PlaylistManager, RefreshInfo
 from plugins.plugin_registry import get_plugin_instance
 from refresh_task import recorder as refresh_recorder
 from refresh_task.actions import ManualUpdateRequest, PlaylistRefresh, RefreshAction
@@ -75,6 +75,11 @@ def _plugin_requires_api_key(plugin_config: Mapping[str, Any]) -> bool:
     """Return whether plugin metadata declares API-key configuration."""
     plugin_id = plugin_config.get("id")
     if not isinstance(plugin_id, str):
+        return False
+    # A composite screen isn't a registered plugin — its own API-key needs
+    # are whatever its child regions' plugins declare, which this pre-flight
+    # check has no way to evaluate up front. Never block scheduling on it.
+    if plugin_id == COMPOSITE_PLUGIN_ID:
         return False
 
     try:
@@ -490,6 +495,11 @@ class RefreshTask:
             return None
         if not isinstance(refresh_action, PlaylistRefresh):
             return None
+        # A composite screen has no skip_display_condition of its own to ask
+        # — it isn't resolved via plugins.plugin_registry at all (see
+        # _perform_refresh's composite branch below).
+        if plugin_config.get("id") == COMPOSITE_PLUGIN_ID:
+            return None
 
         settings = getattr(refresh_action.plugin_instance, "settings", None)
         if not isinstance(settings, Mapping):
@@ -537,7 +547,16 @@ class RefreshTask:
         Threading:
             Must be called without holding ``self.condition``.
         """
-        plugin_config = self.device_config.get_plugin(refresh_action.get_plugin_id())
+        if refresh_action.get_plugin_id() == COMPOSITE_PLUGIN_ID:
+            # A composite screen has no plugins/<id>/plugin-info.json entry —
+            # its own "plugin config" is just its id; the regions it renders
+            # each resolve their own real plugin config independently inside
+            # CompositeScreenRenderer.
+            plugin_config: dict[str, Any] | None = {"id": COMPOSITE_PLUGIN_ID}
+        else:
+            plugin_config = self.device_config.get_plugin(
+                refresh_action.get_plugin_id()
+            )
         if plugin_config is None:
             logger.error(
                 f"Plugin config not found for '{refresh_action.get_plugin_id()}'."

--- a/src/refresh_task/worker.py
+++ b/src/refresh_task/worker.py
@@ -12,8 +12,10 @@ from collections.abc import Callable, Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
+from model import COMPOSITE_PLUGIN_ID
 from plugins.plugin_registry import get_plugin_instance, load_plugins
 from refresh_task.actions import PluginLike, RefreshAction
+from refresh_task.composite_render import resolve_composite_renderer
 from refresh_task.context import RefreshContext, SupportsRefreshConfig
 from utils.plugin_errors import (
     PermanentPluginError,
@@ -275,11 +277,18 @@ def _execute_refresh_attempt_worker(
         get_plugins = getattr(child_config, "get_plugins", None)
         if callable(get_plugins):
             load_plugins(get_plugins())
-        plugin_loader = cast(
-            Callable[[Mapping[str, object]], PluginLike],
-            get_plugin_instance,
-        )
-        plugin = plugin_loader(plugin_config)
+        if plugin_config.get("id") == COMPOSITE_PLUGIN_ID:
+            # A composite screen has no plugins/<id>/ directory to register —
+            # it's rendered natively rather than resolved through the plugin
+            # registry. See model.COMPOSITE_PLUGIN_ID and
+            # composite_render.resolve_composite_renderer.
+            plugin: PluginLike = resolve_composite_renderer(refresh_action)
+        else:
+            plugin_loader = cast(
+                Callable[[Mapping[str, object]], PluginLike],
+                get_plugin_instance,
+            )
+            plugin = plugin_loader(plugin_config)
         image = refresh_action.execute(plugin, child_config, current_dt)
         plugin_meta = None
         if hasattr(plugin, "get_latest_metadata"):

--- a/src/services/playlist_workflows.py
+++ b/src/services/playlist_workflows.py
@@ -335,3 +335,213 @@ def prepare_add_plugin_workflow(
         refresh_config=refresh_config or {},
         plugin_dict=plugin_dict,
     )
+
+
+def _validate_composite_regions(
+    raw_regions: list[dict[str, Any]], device_config: Any
+) -> tuple[list[dict[str, Any]] | None, WorkflowError | None]:
+    """Structurally validate a composite screen's regions, shape, and bounds.
+
+    Mirrors CompositeScreenRenderer.generate_image's own validation (shape +
+    bounds + "is this plugin actually installed") so a bad region is
+    rejected at save time rather than surfacing only on the next refresh.
+    Unlike a real plugin's validate_settings(settings) — which never
+    receives device_config, so BasePlugin subclasses can only check
+    resolution-independent shape at save time — this workflow function does
+    receive device_config, so it can check real canvas bounds too instead
+    of waiting for the next refresh to reject an out-of-bounds region.
+    """
+    from plugins.base_plugin.base_plugin import BasePlugin
+    from refresh_task.composite_render import CompositeScreenRenderer, parse_regions
+
+    if not raw_regions:
+        return None, WorkflowError(
+            "At least one region must be configured", status=422, field="regionsJson"
+        )
+    try:
+        regions = parse_regions(raw_regions)
+    except RuntimeError as e:
+        return None, WorkflowError(str(e), status=422, field="regionsJson")
+
+    canvas_w, canvas_h = BasePlugin.get_oriented_dimensions(device_config)
+    for region in regions:
+        shape_error = CompositeScreenRenderer._validate_region(
+            region, canvas_w, canvas_h
+        )
+        if shape_error:
+            return None, WorkflowError(shape_error, status=422, field="regionsJson")
+        try:
+            plugin_config = device_config.get_plugin(region["plugin_id"])
+        except Exception:
+            logger.debug(
+                "Could not look up plugin config for composite region %s",
+                sanitize_log_field(region["plugin_id"]),
+                exc_info=True,
+            )
+            plugin_config = None
+        if not plugin_config:
+            return None, WorkflowError(
+                f"Plugin '{region['plugin_id']}' is not installed/registered.",
+                status=422,
+                field="regionsJson",
+            )
+
+    return regions, None
+
+
+def prepare_add_composite_screen_workflow(
+    raw_regions: list[dict[str, Any]],
+    refresh_settings: dict[str, Any],
+    *,
+    playlist_manager: Any,
+    device_config: Any,
+) -> AddPluginWorkflowResult:
+    """Validate and execute the add-composite-screen workflow.
+
+    Parallel to prepare_add_plugin_workflow, reusing its playlist/instance-
+    name/refresh-settings validation and add_plugin_to_playlist plumbing —
+    a composite screen is a normal PluginInstance (model.COMPOSITE_PLUGIN_ID)
+    whose settings["regions"] this function validates before saving.
+    """
+    from model import COMPOSITE_PLUGIN_ID
+
+    playlist = refresh_settings.get("playlist")
+    if not playlist:
+        return _failure(
+            PLAYLIST_NAME_REQUIRED_ERROR,
+            status=422,
+            field="playlist",
+        )
+
+    instance_name, name_err = normalize_instance_name(
+        refresh_settings.get("instance_name")
+    )
+    if name_err:
+        return _failure(
+            name_err.message,
+            status=name_err.status,
+            code=name_err.code,
+            field=name_err.field,
+        )
+
+    existing = playlist_manager.find_plugin(COMPOSITE_PLUGIN_ID, instance_name)
+    if existing:
+        return _failure(
+            f"Plugin instance '{instance_name}' already exists",
+            status=400,
+            field="instance_name",
+        )
+
+    refresh_config, refresh_err = validate_plugin_refresh_settings(refresh_settings)
+    if refresh_err:
+        return _failure(
+            refresh_err.message,
+            status=refresh_err.status,
+            field=refresh_err.field,
+        )
+
+    regions, regions_err = _validate_composite_regions(raw_regions, device_config)
+    if regions_err:
+        return _failure(
+            regions_err.message,
+            status=regions_err.status,
+            field=regions_err.field,
+        )
+
+    assert instance_name is not None
+    assert regions is not None
+    plugin_dict = build_playlist_plugin_dict(
+        COMPOSITE_PLUGIN_ID, {"regions": regions}, refresh_config or {}, instance_name
+    )
+
+    try:
+        add_result: list[bool] = []
+
+        def _do_add(cfg: dict[str, Any]) -> None:
+            add_result.append(
+                playlist_manager.add_plugin_to_playlist(playlist, plugin_dict)
+            )
+            cfg["playlist_config"] = playlist_manager.to_dict()
+
+        device_config.update_atomic(_do_add)
+        if not add_result or not add_result[0]:
+            return _failure("Failed to add to playlist", status=500)
+    except Exception:
+        logger.exception("Add-composite-screen workflow failed")
+        return _failure(
+            _MSG_INVALID_PLAYLIST_REQUEST,
+            status=500,
+            code="internal_error",
+        )
+
+    return AddPluginWorkflowResult(
+        ok=True,
+        message="Scheduled refresh configured.",
+        playlist_name=playlist,
+        instance_name=instance_name,
+        refresh_config=refresh_config or {},
+        plugin_dict=plugin_dict,
+    )
+
+
+def prepare_update_composite_screen_workflow(
+    instance_name: str,
+    raw_regions: list[dict[str, Any]],
+    *,
+    playlist_manager: Any,
+    device_config: Any,
+) -> AddPluginWorkflowResult:
+    """Validate and apply a region-list update to an existing composite screen.
+
+    Only settings["regions"] changes here — refresh cadence is edited through
+    the same generic "Edit refresh settings" modal every other plugin
+    instance uses (PUT /update_plugin_instance/<name>), and a composite
+    screen can't be moved between playlists any more than a real plugin
+    instance can via that same route.
+    """
+    from model import COMPOSITE_PLUGIN_ID
+
+    instance_name = (instance_name or "").strip()
+    if not instance_name:
+        return _failure("Instance name is required", status=422, field="instance_name")
+
+    plugin_instance = playlist_manager.find_plugin(COMPOSITE_PLUGIN_ID, instance_name)
+    if plugin_instance is None:
+        return _failure(
+            f"Composite screen '{instance_name}' was not found",
+            status=404,
+            code="not_found",
+        )
+
+    regions, regions_err = _validate_composite_regions(raw_regions, device_config)
+    if regions_err:
+        return _failure(
+            regions_err.message,
+            status=regions_err.status,
+            field=regions_err.field,
+        )
+    assert regions is not None
+
+    try:
+
+        def _do_update(cfg: dict[str, Any]) -> None:
+            plugin_instance.settings = {"regions": regions}
+
+        device_config.update_atomic(_do_update)
+    except Exception:
+        logger.exception(
+            "Update-composite-screen workflow failed for %s",
+            sanitize_log_field(instance_name),
+        )
+        return _failure(
+            _MSG_INVALID_PLAYLIST_REQUEST,
+            status=500,
+            code="internal_error",
+        )
+
+    return AddPluginWorkflowResult(
+        ok=True,
+        message="Composite screen updated.",
+        instance_name=instance_name,
+        plugin_dict={"regions": regions},
+    )

--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -160,6 +160,10 @@
         item.setAttribute("aria-pressed", selected ? "true" : "false");
       });
       hidden.value = option.dataset.faceName || "";
+      // Match setColor's pattern: dispatch so anything listening for
+      // input/change on this field (e.g. a settings-save handler) observes
+      // the new selection, not just the two color fields it also updates.
+      hidden.dispatchEvent(new Event("change", { bubbles: true }));
       setColor(primary, option.dataset.primaryColor);
       setColor(secondary, option.dataset.secondaryColor);
     };
@@ -574,10 +578,21 @@
     latInput.value = config.latitude || latInput.value || "40.7128";
     lonInput.value = config.longitude || lonInput.value || "-74.0060";
 
-    const mapState = { map: null, marker: null };
+    const mapState = { map: null, marker: null, leafletWaitAttempts: 0 };
 
     const initLeafletMap = () => {
-      if (!globalThis.L || mapState.map) return;
+      if (mapState.map) return;
+      if (!globalThis.L) {
+        // Leaflet is normally already loaded by the time this page's own
+        // script tag has parsed, but a consumer that loads/embeds this
+        // widget's markup dynamically (fetching it separately from a
+        // freshly created <script>, since a cloned/parsed <script> tag
+        // never executes on its own) may still have it in flight when the
+        // modal opens. Retry briefly rather than silently no-op — bounded
+        // so a genuine load failure doesn't poll forever.
+        if (mapState.leafletWaitAttempts++ < 20) setTimeout(initLeafletMap, 150);
+        return;
+      }
       const lat = Number.parseFloat(latInput.value) || 40.7128;
       const lon = Number.parseFloat(lonInput.value) || -74.006;
       mapState.map = globalThis.L.map(mapRoot).setView([lat, lon], 4.5);
@@ -602,6 +617,12 @@
         const position = mapState.marker.getLatLng().wrap();
         latInput.value = position.lat;
         lonInput.value = position.lng;
+        // These are the two fields this whole widget exists to set — dispatch
+        // so anything listening for input/change (e.g. a settings-save
+        // handler) actually observes the picked location, matching the
+        // pattern the color-picker widget already uses for its own fields.
+        latInput.dispatchEvent(new Event("change", { bubbles: true }));
+        lonInput.dispatchEvent(new Event("change", { bubbles: true }));
       }
       modal.hidden = true;
       modal.style.display = "none";

--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -624,9 +624,16 @@
     "weather-map": initWeatherMap,
   };
 
-  function initializeWidgets(root, config) {
+  // `allowedTypes`, when given, restricts initialization to just those
+  // widget types (e.g. a caller embedding a schema fragment scoped to a
+  // single root element, where only some widget types are known-safe to
+  // re-invoke outside the one-copy-per-page assumption most of these were
+  // written under). Omitted (undefined) means "all" — the normal page-load
+  // path below always passes undefined, so its behavior is unchanged.
+  function initializeWidgets(root, config, allowedTypes) {
     root.querySelectorAll("[data-hybrid-widget]").forEach((widget) => {
       const widgetType = widget.dataset.hybridWidget;
+      if (allowedTypes && !allowedTypes.includes(widgetType)) return;
       const widgetConfig = parseJson(widget.dataset.widgetConfig || "{}", {});
       const initializer = widgetInitializers[widgetType];
       if (initializer) initializer(widget, { ...config, ...widgetConfig });
@@ -644,6 +651,16 @@
     bindStandardEvents(root);
   }
 
-  globalThis.InkyPiPluginSchema = { init };
+  // Public, externally-callable entry point for initializing widgets inside
+  // an arbitrary root/config/allowlist — e.g. a fragment scraped and cloned
+  // by another page embedding one plugin's schema inside another's, where
+  // `init()`'s own hardcoded document-wide `[data-settings-schema]` lookup
+  // isn't usable. Thin wrapper so the internal `initializeWidgets` signature
+  // stays free to evolve without also being a public API surface.
+  function initWidgetsIn(root, config, allowedTypes) {
+    initializeWidgets(root, config || {}, allowedTypes);
+  }
+
+  globalThis.InkyPiPluginSchema = { init, initWidgetsIn };
   document.addEventListener("DOMContentLoaded", init);
 })();

--- a/src/static/scripts/plugin_schema.js
+++ b/src/static/scripts/plugin_schema.js
@@ -403,11 +403,18 @@
     const addButton = widget.querySelector("[data-repeater-add]");
     if (!list || !addButton) return;
     bindRemoveButtons(list);
-    if (!list.children.length) {
-      const urls = config["calendarURLs[]"] || [""];
+    const configUrls = config["calendarURLs[]"];
+    // The template always server-renders at least one (possibly blank) row,
+    // so `!list.children.length` never fires for a caller (e.g. Layout)
+    // re-invoking this on a fragment seeded from a saved instance's config.
+    // `list.children.length <= 1` also covers that single-default-row case;
+    // when the page's own server-rendered rows already match config (the
+    // normal, non-Layout path), reseeding here is a no-op in effect.
+    if (Array.isArray(configUrls) && configUrls.length && list.children.length <= 1) {
       const colors = config["calendarColors[]"] || ["#007BFF"];
-      urls.forEach((url, index) => list.appendChild(createCalendarEntry(url, colors[index] || "#007BFF")));
-      if (!urls.length) list.appendChild(createCalendarEntry("", "#007BFF"));
+      list.innerHTML = "";
+      configUrls.forEach((url, index) => list.appendChild(createCalendarEntry(url, colors[index] || "#007BFF")));
+      bindRemoveButtons(list);
     }
     updateRepeaterEmptyState(list);
     syncRemoveButtonStates(list);
@@ -487,12 +494,19 @@
     const maxItems = Number(list?.dataset.maxItems || widget.dataset.maxItems || "3");
     if (!list || !addButton) return;
     bindRemoveButtons(list);
-    if (!list.children.length) {
-      const titles = config["list-title[]"] || [];
-      const items = config["list[]"] || [];
-      const seedCount = Math.min(Math.max(titles.length, items.length, 1), maxItems);
-      for (let index = 0; index < seedCount; index += 1) {
-        list.appendChild(createTodoEntry(titles[index] || "", items[index] || ""));
+    const configTitles = config["list-title[]"];
+    const configItems = config["list[]"];
+    // Same server-always-renders-one-row situation as initCalendarRepeater.
+    if ((Array.isArray(configTitles) && configTitles.length) || (Array.isArray(configItems) && configItems.length)) {
+      if (list.children.length <= 1) {
+        const titles = configTitles || [];
+        const items = configItems || [];
+        const seedCount = Math.min(Math.max(titles.length, items.length, 1), maxItems);
+        list.innerHTML = "";
+        for (let index = 0; index < seedCount; index += 1) {
+          list.appendChild(createTodoEntry(titles[index] || "", items[index] || ""));
+        }
+        bindRemoveButtons(list);
       }
     }
     syncRemoveButtonStates(list);

--- a/src/templates/composite_screen.html
+++ b/src/templates/composite_screen.html
@@ -1,0 +1,910 @@
+{% extends "base.html" %}
+{% block title %}InkyPi - {{ 'Edit' if edit_instance_name else 'New' }} composite screen{% endblock %}
+{% block body_attrs %} data-page="composite-screen"{% endblock %}
+{% block body %}
+    {% from 'macros/icons.html' import icon, breadcrumb %}
+    {% from 'macros/pageheader.html' import pageheader %}
+    <main id="main-content" role="main" tabindex="-1" class="page-shell page-shell-dashboard" data-page-shell="dashboard">
+    <div class="frame playlist-frame">
+        {{ breadcrumb([{'label': 'Home', 'url': url_for('main.main_page')}, {'label': 'Playlists', 'url': url_for('playlist.playlists')}, {'label': 'Edit regions' if edit_instance_name else 'New composite screen'}]) }}
+        {% call pageheader(
+            title=('Edit regions — ' + edit_instance_name) if edit_instance_name else 'New composite screen',
+            eyebrow='Composite screen',
+            description='Compose several existing plugins into named regions on one canvas, rendered as a single playlist entry.'
+        ) %}{% endcall %}
+
+        <form id="compositeForm" class="settings-form schedule-form-card" data-form-state aria-busy="false" aria-label="{{ 'Edit' if edit_instance_name else 'New' }} composite screen">
+            {% if edit_instance_name %}
+            <div class="settings-callout">
+                {{ icon('info', 'icon-image') | safe }}
+                <div>
+                    <p>Editing regions for <strong>{{ edit_instance_name }}</strong>. Its playlist and refresh
+                    schedule are unchanged here — use the clock icon on the
+                    <a href="{{ url_for('playlist.playlists') }}">Playlists</a> page to edit those.</p>
+                </div>
+            </div>
+            {% else %}
+            <div class="schedule-form-grid">
+                <section class="schedule-fieldset" aria-labelledby="compositeDestinationHeading">
+                    <div class="schedule-fieldset-title" id="compositeDestinationHeading">Destination</div>
+                    <div class="form-group">
+                        <label for="playlist" class="form-label">Playlist</label>
+                        <select id="playlist" name="playlist" class="form-input">
+                            {% for playlist_name in playlist_names %}
+                            <option value="{{ playlist_name }}"{% if playlist_name == default_playlist %} selected{% endif %}>{{ playlist_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="instance" class="form-label">Instance Name</label>
+                        <input type="text" id="instance" name="instance_name" placeholder="Enter instance name" required pattern="[A-Za-z0-9 _-]+" title="Letters, numbers, spaces, underscores, and hyphens only" class="form-input" aria-required="true">
+                    </div>
+                </section>
+                <section class="schedule-fieldset" aria-labelledby="compositeCadenceHeading">
+                    <div class="schedule-fieldset-title" id="compositeCadenceHeading">Cadence</div>
+                    <div class="form-group schedule-inline-group">
+                        <input type="radio" id="refreshTypeInterval" name="refreshType" value="interval" checked>
+                        <label for="refreshTypeInterval">Every</label>
+                        <input type="number" id="scheduleInterval" name="interval" class="form-input" required min="1" placeholder="Enter interval" aria-label="Interval value">
+                        <select id="scheduleUnit" name="unit" class="form-input" required aria-label="Time unit">
+                            <option value="minute">Minute</option>
+                            <option value="hour">Hour</option>
+                            <option value="day">Day</option>
+                        </select>
+                    </div>
+                    <div class="form-group schedule-inline-group">
+                        <input type="radio" id="refreshTypeScheduled" name="refreshType" value="scheduled">
+                        <label for="refreshTypeScheduled">Daily at</label>
+                        <input id="scheduleTime" class="time-input" type="time" name="refreshTime" step="900" aria-label="Scheduled time" disabled>
+                    </div>
+                </section>
+            </div>
+            {% endif %}
+
+            <div class="settings-card" style="margin-top: 16px;">
+                <div class="settings-card-title">Regions</div>
+                <p class="field-note">
+                    Each region assigns an installed plugin to a rectangular area of the
+                    {{ canvas_w }}&times;{{ canvas_h }} canvas, using that plugin's own settings form. Drag a
+                    region to move it, or drag its bottom-right corner to resize. Regions can't overlap, and
+                    edges snap to the canvas border or a neighboring region so you can tile the screen with
+                    no gaps.
+                </p>
+
+                <div class="form-group schedule-inline-group" role="radiogroup" aria-label="Region size display">
+                    <span class="form-label" style="margin-right:8px;">Show size as</span>
+                    <input type="radio" id="sizeUnitPercent" name="sizeUnit" value="percent" checked>
+                    <label for="sizeUnitPercent">Percentage</label>
+                    <input type="radio" id="sizeUnitPixels" name="sizeUnit" value="pixels">
+                    <label for="sizeUnitPixels">Pixels</label>
+                </div>
+
+                <div id="compositePreview" style="position:relative; width:100%; max-width:{{ canvas_w }}px; aspect-ratio:{{ canvas_w }}/{{ canvas_h }}; background:var(--surface); border:1px solid var(--surface-border); overflow:hidden; margin-bottom:16px; touch-action:none;"></div>
+
+                <div class="form-group" style="position:sticky; top:0; background:var(--surface); border-bottom:1px solid var(--surface-border); padding:10px 0; z-index:5;">
+                    <button type="button" id="addRegionBtn" class="action-button is-secondary">{{ icon('plus', 'btn-leading-icon') | safe }}Add region</button>
+                </div>
+
+                <div id="regionList"></div>
+            </div>
+
+            <div class="form-group">
+                <span id="compositeError" class="validation-message" role="alert"></span>
+            </div>
+
+            <div class="schedule-form-actions">
+                <button type="submit" id="compositeSubmitBtn" class="action-button">{{ 'Save regions' if edit_instance_name else 'Add to Playlist' }}</button>
+                <a href="{{ url_for('playlist.playlists') }}" class="action-button is-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+    </main>
+
+    <template id="regionRowTemplate">
+        <div class="settings-card region-row" style="margin-bottom:12px;">
+            <div class="form-group">
+                <label class="form-label">Plugin</label>
+                <select class="form-input region-plugin-id">
+                    {% for p in available_plugins %}
+                    <option value="{{ p.id }}">{{ p.display_name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="schema-row">
+                <div class="form-group">
+                    <label class="form-label">X</label>
+                    <input type="number" class="form-input region-x" value="0" min="0" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Y</label>
+                    <input type="number" class="form-input region-y" value="0" min="0" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Width</label>
+                    <input type="number" class="form-input region-w" value="{{ canvas_w }}" min="1" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Height</label>
+                    <input type="number" class="form-input region-h" value="{{ canvas_h }}" min="1" required>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="form-label">Settings</label>
+                <div class="region-settings-container"></div>
+            </div>
+            <div class="form-group">
+                <label class="form-label">Cache this region's render for (minutes, optional)</label>
+                <input type="number" class="form-input region-refresh-minutes" min="0" placeholder="Always re-render">
+            </div>
+            <button type="button" class="action-button is-secondary ghost-danger remove-region-btn">{{ icon('trash', 'btn-leading-icon') | safe }}Remove region</button>
+        </div>
+    </template>
+
+    <script nonce="{{ csp_nonce }}">
+    document.addEventListener('DOMContentLoaded', () => {
+        const CANVAS_W = {{ canvas_w | tojson }};
+        const CANVAS_H = {{ canvas_h | tojson }};
+        const EDIT_INSTANCE_NAME = {{ edit_instance_name | tojson }};
+        const INITIAL_REGIONS = {{ initial_regions_json | safe }};
+        const ADD_COMPOSITE_SCREEN_URL = {{ url_for('playlist.add_composite_screen') | tojson }};
+        const UPDATE_COMPOSITE_SCREEN_BASE_URL = {{ url_for('playlist.update_composite_screen', instance_name='') | tojson }};
+        const PLUGIN_PAGE_BASE_URL = {{ url_for('plugin.plugin_page', plugin_id='__PID__') | tojson }};
+        const PLAYLISTS_URL = {{ url_for('playlist.playlists') | tojson }};
+        const REGION_COLORS = ['#1976D2', '#D32F2F', '#388E3C', '#F57C00', '#7B1FA2', '#00838F'];
+
+        const regionList = document.getElementById('regionList');
+        const preview = document.getElementById('compositePreview');
+        const rowTemplate = document.getElementById('regionRowTemplate');
+        const errorEl = document.getElementById('compositeError');
+        const form = document.getElementById('compositeForm');
+
+        // ---------------------------------------------------------------
+        // Per-region "use the target plugin's real settings form" editor
+        // ---------------------------------------------------------------
+        // Fetches /plugin/<id>, pulls out the same [data-settings-schema]
+        // markup that plugin's own settings page renders, and embeds it
+        // here — namespaced so N regions on the same plugin don't collide,
+        // and with existing region settings applied so re-opening this page
+        // shows the region's real saved values instead of blanks. Plugins
+        // with no schema-driven settings (e.g. a bespoke settings.html) fall
+        // back to a raw JSON textarea, same as before.
+
+        const pluginSchemaCache = new Map();
+        let regionUidCounter = 0;
+
+        function fetchPluginSchema(pluginId) {
+            if (pluginSchemaCache.has(pluginId)) return pluginSchemaCache.get(pluginId);
+            const promise = fetch(PLUGIN_PAGE_BASE_URL.replace('__PID__', encodeURIComponent(pluginId)))
+                .then((response) => (response.ok ? response.text() : ''))
+                .then((html) => {
+                    if (!html) return null;
+                    const doc = new DOMParser().parseFromString(html, 'text/html');
+                    return doc.querySelector('[data-settings-schema]');
+                })
+                .catch(() => null);
+            pluginSchemaCache.set(pluginId, promise);
+            return promise;
+        }
+
+        function namespaceFragment(root, uid) {
+            const prefix = 'region-' + uid + '-';
+            root.querySelectorAll('[id]').forEach((el) => {
+                const oldId = el.id;
+                const newId = prefix + oldId;
+                el.id = newId;
+                root.querySelectorAll('label[for]').forEach((label) => {
+                    if (label.getAttribute('for') === oldId) label.setAttribute('for', newId);
+                });
+                root.querySelectorAll('[list]').forEach((el2) => {
+                    if (el2.getAttribute('list') === oldId) el2.setAttribute('list', newId);
+                });
+                root.querySelectorAll('[aria-describedby]').forEach((el2) => {
+                    const value = el2
+                        .getAttribute('aria-describedby')
+                        .split(/\s+/)
+                        .map((token) => (token === oldId ? newId : token))
+                        .join(' ');
+                    el2.setAttribute('aria-describedby', value);
+                });
+            });
+            root.querySelectorAll('[name]').forEach((el) => {
+                el.name = prefix + el.name;
+            });
+        }
+
+        function collectFieldsByName(root) {
+            const groups = {};
+            root.querySelectorAll('[data-field-name]').forEach((el) => {
+                const name = el.dataset.fieldName;
+                (groups[name] = groups[name] || []).push(el);
+            });
+            return groups;
+        }
+
+        function getFieldGroupValue(elements) {
+            const first = elements[0];
+            if (first.type === 'checkbox') {
+                const checked = elements.find((el) => el.type === 'checkbox' && el.checked);
+                if (checked) return checked.dataset.checkedValue || checked.value || 'true';
+                const uncheckedSource = elements.find((el) => el.dataset.uncheckedValue !== undefined);
+                return uncheckedSource ? uncheckedSource.dataset.uncheckedValue : undefined;
+            }
+            if (first.type === 'radio') {
+                const checked = elements.find((el) => el.checked);
+                return checked ? checked.value : undefined;
+            }
+            return first.value;
+        }
+
+        function setFieldGroupValue(elements, value) {
+            if (value === undefined || value === null) return;
+            const first = elements[0];
+            if (first.type === 'checkbox') {
+                elements
+                    .filter((el) => el.type === 'checkbox')
+                    .forEach((el) => {
+                        el.checked = String(value) === String(el.dataset.checkedValue || 'true');
+                    });
+                return;
+            }
+            if (first.type === 'radio') {
+                elements.forEach((el) => {
+                    el.checked = String(el.value) === String(value);
+                });
+                return;
+            }
+            elements.forEach((el) => {
+                el.value = value;
+            });
+        }
+
+        function readSchemaSettings(container) {
+            const settings = {};
+            const groups = collectFieldsByName(container);
+            Object.keys(groups).forEach((name) => {
+                const value = getFieldGroupValue(groups[name]);
+                if (value !== undefined) settings[name] = value;
+            });
+            return settings;
+        }
+
+        function applySchemaSettings(container, settings) {
+            const groups = collectFieldsByName(container);
+            Object.keys(groups).forEach((name) => {
+                if (!(name in settings)) return;
+                // Widget-owned fields (e.g. clock-face-picker's hidden face
+                // field, weather-map's lat/lon) were already seeded by
+                // InkyPiPluginSchema.initWidgetsIn's own config-driven init
+                // before this runs — re-setting them here would just repeat
+                // the same value, so skip fields living inside a widget.
+                if (groups[name][0].closest('[data-hybrid-widget]')) return;
+                setFieldGroupValue(groups[name], settings[name]);
+            });
+        }
+
+        async function refreshRegionSettingsEditor(row) {
+            const pluginId = row.querySelector('.region-plugin-id').value;
+            const container = row.querySelector('.region-settings-container');
+            const existingSettings = row._compositeSettings || {};
+
+            container.innerHTML = '<p class="field-note">Loading settings…</p>';
+            const schemaEl = await fetchPluginSchema(pluginId).catch(() => null);
+            container.innerHTML = '';
+
+            if (!schemaEl) {
+                const textarea = document.createElement('textarea');
+                textarea.className = 'form-input region-settings-json';
+                textarea.rows = 3;
+                textarea.spellcheck = false;
+                textarea.value = JSON.stringify(existingSettings, null, 2);
+                container.appendChild(textarea);
+                row.dataset.settingsMode = 'json';
+                return;
+            }
+
+            const fragment = schemaEl.cloneNode(true);
+            fragment.querySelectorAll('[name]').forEach((el) => {
+                if (!el.dataset.fieldName) el.dataset.fieldName = el.name;
+            });
+            container.appendChild(fragment);
+
+            // Widgets need real, un-namespaced ids to find their own
+            // elements (e.g. widget.querySelector('#literalId')) at init
+            // time; JS listeners bind to element references, not id
+            // strings, so namespacing immediately afterward is safe.
+            if (window.InkyPiPluginSchema && typeof window.InkyPiPluginSchema.initWidgetsIn === 'function') {
+                try {
+                    window.InkyPiPluginSchema.initWidgetsIn(container, existingSettings);
+                } catch (error) {
+                    console.debug('Composite screen: widget init failed for', pluginId, error);
+                }
+            }
+
+            namespaceFragment(container, regionUidFor(row));
+            applySchemaSettings(container, existingSettings);
+            row.dataset.settingsMode = 'schema';
+        }
+
+        function regionUidFor(row) {
+            if (!row.dataset.regionUid) {
+                regionUidCounter += 1;
+                row.dataset.regionUid = String(regionUidCounter);
+            }
+            return row.dataset.regionUid;
+        }
+
+        function readRegionSettings(row) {
+            if (row.dataset.settingsMode === 'schema') {
+                return readSchemaSettings(row.querySelector('.region-settings-container'));
+            }
+            const textarea = row.querySelector('.region-settings-json');
+            if (!textarea) return {};
+            const raw = textarea.value.trim();
+            if (!raw) return {};
+            try {
+                return JSON.parse(raw);
+            } catch {
+                return null;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Region rows
+        // ---------------------------------------------------------------
+
+        function addRegionRow(initial) {
+            const fragment = rowTemplate.content.cloneNode(true);
+            const row = fragment.querySelector('.region-row');
+            regionList.appendChild(fragment);
+            const appendedRow = regionList.lastElementChild;
+
+            if (initial) {
+                appendedRow.querySelector('.region-plugin-id').value = initial.plugin_id || '';
+                appendedRow.querySelector('.region-x').value = initial.x ?? 0;
+                appendedRow.querySelector('.region-y').value = initial.y ?? 0;
+                appendedRow.querySelector('.region-w').value = initial.w ?? CANVAS_W;
+                appendedRow.querySelector('.region-h').value = initial.h ?? CANVAS_H;
+                if (initial.refresh_minutes !== null && initial.refresh_minutes !== undefined) {
+                    appendedRow.querySelector('.region-refresh-minutes').value = initial.refresh_minutes;
+                }
+                appendedRow._compositeSettings = initial.settings || {};
+            } else {
+                // A freshly-added blank region defaults to the largest free
+                // rectangle instead of the full canvas — with other regions
+                // already placed, defaulting to 100% would just overlap
+                // them, forcing every "Add region" click into an immediate
+                // manual resize. When the free space left by existing
+                // regions isn't itself a rectangle (an L-shaped remainder,
+                // say), this picks the single largest rectangle that fits
+                // inside it.
+                const freeRect = computeLargestFreeRect(getOtherRegionRects(appendedRow));
+                appendedRow.querySelector('.region-x').value = freeRect.x;
+                appendedRow.querySelector('.region-y').value = freeRect.y;
+                appendedRow.querySelector('.region-w').value = freeRect.w;
+                appendedRow.querySelector('.region-h').value = freeRect.h;
+            }
+
+            appendedRow.querySelector('.region-plugin-id').addEventListener('change', () => {
+                appendedRow._compositeSettings = {};
+                refreshRegionSettingsEditor(appendedRow).then(renderPreview);
+            });
+
+            refreshRegionSettingsEditor(appendedRow).then(renderPreview);
+            return appendedRow;
+        }
+
+        function removeRegionRow(row) {
+            row.remove();
+            renderPreview();
+        }
+
+        function collectRegions() {
+            let sawInvalidJson = false;
+            const regions = Array.from(regionList.querySelectorAll('.region-row')).map((row) => {
+                const refreshMinutesRaw = row.querySelector('.region-refresh-minutes').value.trim();
+                const settings = readRegionSettings(row);
+                if (settings === null) sawInvalidJson = true;
+                return {
+                    plugin_id: row.querySelector('.region-plugin-id').value,
+                    x: Number.parseInt(row.querySelector('.region-x').value, 10),
+                    y: Number.parseInt(row.querySelector('.region-y').value, 10),
+                    w: Number.parseInt(row.querySelector('.region-w').value, 10),
+                    h: Number.parseInt(row.querySelector('.region-h').value, 10),
+                    settings: settings || {},
+                    refresh_minutes: refreshMinutesRaw ? Number.parseInt(refreshMinutesRaw, 10) : null,
+                };
+            });
+            regions._hasInvalidJson = sawInvalidJson;
+            return regions;
+        }
+
+        // ---------------------------------------------------------------
+        // Visual preview: render + drag-to-move + drag-to-resize, with
+        // overlap friction and edge snapping.
+        // ---------------------------------------------------------------
+
+        let activeDrag = null;
+        // ~1.5% of the canvas's smaller dimension — close enough for a
+        // free-hand pointer drag to reliably land on "flush," since fast
+        // mouse movement routinely jumps past the exact touching value
+        // between two pointermove events.
+        const SNAP_THRESHOLD = 0.015 * Math.min(CANVAS_W, CANVAS_H);
+
+        function clamp(value, min, max) {
+            return Math.min(Math.max(value, min), max);
+        }
+
+        function sizeUnit() {
+            return document.getElementById('sizeUnitPixels').checked ? 'pixels' : 'percent';
+        }
+
+        function formatSize(w, h) {
+            if (sizeUnit() === 'pixels') {
+                return w + '×' + h + 'px';
+            }
+            const pctW = Math.round((100 * w) / CANVAS_W);
+            const pctH = Math.round((100 * h) / CANVAS_H);
+            return pctW + '%×' + pctH + '%';
+        }
+
+        function getOtherRegionRects(excludeRow) {
+            return Array.from(regionList.querySelectorAll('.region-row'))
+                .filter((row) => row !== excludeRow)
+                .map((row) => ({
+                    x: Number.parseInt(row.querySelector('.region-x').value, 10) || 0,
+                    y: Number.parseInt(row.querySelector('.region-y').value, 10) || 0,
+                    w: Number.parseInt(row.querySelector('.region-w').value, 10) || 0,
+                    h: Number.parseInt(row.querySelector('.region-h').value, 10) || 0,
+                }));
+        }
+
+        function rangesOverlap(aLo, aHi, bLo, bHi) {
+            return aLo < bHi && aHi > bLo;
+        }
+
+        function rectsOverlap(a, b) {
+            return (
+                rangesOverlap(a.x, a.x + a.w, b.x, b.x + b.w) &&
+                rangesOverlap(a.y, a.y + a.h, b.y, b.y + b.h)
+            );
+        }
+
+        // Largest axis-aligned empty rectangle among existingRects on the
+        // canvas — the default geometry for a newly-added region. Uses
+        // coordinate compression (every existing rect's edges, plus the
+        // canvas edges, become grid lines) rather than a per-pixel grid, so
+        // this stays fast regardless of canvas resolution: the compressed
+        // grid has at most 2*existingRects.length+1 rows/columns. Each cell
+        // is fully inside or fully outside any given rect (cells are cut
+        // exactly on rect boundaries), so testing one point per cell —
+        // its center — correctly classifies the whole cell. Finding the
+        // largest all-empty rectangle in that cell grid is the classic
+        // "maximal rectangle in a binary matrix" problem, solved here with
+        // the standard histogram method (Θ(rows·cols), negligible at this
+        // grid size). The result's edges always land on one of the
+        // existing rects' edges or the canvas border — true for any
+        // maximal empty rectangle among axis-aligned rects — so mapping
+        // the winning cell-range back through the same coordinate arrays
+        // recovers exact canvas units, not an approximation.
+        function computeLargestFreeRect(existingRects) {
+            const fullCanvas = { x: 0, y: 0, w: CANVAS_W, h: CANVAS_H };
+            if (!existingRects.length) return fullCanvas;
+
+            const xsSet = new Set([0, CANVAS_W]);
+            const ysSet = new Set([0, CANVAS_H]);
+            existingRects.forEach((r) => {
+                xsSet.add(clamp(r.x, 0, CANVAS_W));
+                xsSet.add(clamp(r.x + r.w, 0, CANVAS_W));
+                ysSet.add(clamp(r.y, 0, CANVAS_H));
+                ysSet.add(clamp(r.y + r.h, 0, CANVAS_H));
+            });
+            const xs = Array.from(xsSet).sort((a, b) => a - b);
+            const ys = Array.from(ysSet).sort((a, b) => a - b);
+            const numCols = xs.length - 1;
+            const numRows = ys.length - 1;
+            if (numCols <= 0 || numRows <= 0) return fullCanvas;
+
+            const isEmpty = [];
+            for (let row = 0; row < numRows; row++) {
+                const cy = (ys[row] + ys[row + 1]) / 2;
+                const rowCells = [];
+                for (let col = 0; col < numCols; col++) {
+                    const cx = (xs[col] + xs[col + 1]) / 2;
+                    const occupied = existingRects.some(
+                        (r) => cx > r.x && cx < r.x + r.w && cy > r.y && cy < r.y + r.h
+                    );
+                    rowCells.push(!occupied);
+                }
+                isEmpty.push(rowCells);
+            }
+
+            const heights = new Array(numCols).fill(0);
+            let best = { area: 0, top: 0, left: 0, bottom: -1, right: -1 };
+            for (let row = 0; row < numRows; row++) {
+                for (let col = 0; col < numCols; col++) {
+                    heights[col] = isEmpty[row][col] ? heights[col] + 1 : 0;
+                }
+                const stack = [];
+                for (let col = 0; col <= numCols; col++) {
+                    const h = col === numCols ? 0 : heights[col];
+                    while (stack.length && heights[stack[stack.length - 1]] >= h) {
+                        const height = heights[stack.pop()];
+                        const left = stack.length ? stack[stack.length - 1] + 1 : 0;
+                        const width = col - left;
+                        const area = height * width;
+                        if (area > best.area) {
+                            best = { area, top: row - height + 1, left, bottom: row, right: col - 1 };
+                        }
+                    }
+                    stack.push(col);
+                }
+            }
+
+            if (best.area <= 0) return fullCanvas;
+            return {
+                x: xs[best.left],
+                y: ys[best.top],
+                w: xs[best.right + 1] - xs[best.left],
+                h: ys[best.bottom + 1] - ys[best.top],
+            };
+        }
+
+        // Regions the dragged one already overlapped *before the gesture
+        // started* are exempt from blocking for the rest of the gesture —
+        // otherwise a region that starts out overlapping something (e.g. a
+        // saved config predating this constraint) could never be dragged
+        // again at all, not even away from the overlap.
+        function preExistingOverlaps(startRect, others) {
+            const exempt = new Set();
+            others.forEach((o, i) => {
+                if (rectsOverlap(startRect, o)) exempt.add(i);
+            });
+            return exempt;
+        }
+
+        function resolveMove(startX, startY, w, h, dx, dy, others, exempt) {
+            // X axis first (Y held at start), then Y using the resolved X —
+            // this is what makes a diagonal drag slide along whichever axis
+            // isn't blocked, instead of freezing both at first contact.
+            let newX = clamp(startX + dx, 0, Math.max(0, CANVAS_W - w));
+            others.forEach((o, i) => {
+                if (exempt.has(i)) return;
+                if (!rangesOverlap(startY, startY + h, o.y, o.y + o.h)) return;
+                if (dx > 0 && o.x >= startX) newX = Math.min(newX, o.x - w);
+                if (dx < 0 && o.x + o.w <= startX + w) newX = Math.max(newX, o.x + o.w);
+            });
+            newX = clamp(newX, 0, Math.max(0, CANVAS_W - w));
+
+            let newY = clamp(startY + dy, 0, Math.max(0, CANVAS_H - h));
+            others.forEach((o, i) => {
+                if (exempt.has(i)) return;
+                if (!rangesOverlap(newX, newX + w, o.x, o.x + o.w)) return;
+                if (dy > 0 && o.y >= startY) newY = Math.min(newY, o.y - h);
+                if (dy < 0 && o.y + o.h <= startY + h) newY = Math.max(newY, o.y + o.h);
+            });
+            newY = clamp(newY, 0, Math.max(0, CANVAS_H - h));
+
+            return { x: newX, y: newY };
+        }
+
+        function resolveResize(startX, startY, startW, startH, dx, dy, others, exempt) {
+            let newW = clamp(startW + dx, 1, Math.max(1, CANVAS_W - startX));
+            if (dx > 0) {
+                others.forEach((o, i) => {
+                    if (exempt.has(i)) return;
+                    if (!rangesOverlap(startY, startY + startH, o.y, o.y + o.h)) return;
+                    if (o.x >= startX) newW = Math.min(newW, o.x - startX);
+                });
+            }
+            newW = Math.max(1, newW);
+
+            let newH = clamp(startH + dy, 1, Math.max(1, CANVAS_H - startY));
+            if (dy > 0) {
+                others.forEach((o, i) => {
+                    if (exempt.has(i)) return;
+                    if (!rangesOverlap(startX, startX + newW, o.x, o.x + o.w)) return;
+                    if (o.y >= startY) newH = Math.min(newH, o.y - startY);
+                });
+            }
+            newH = Math.max(1, newH);
+
+            return { w: newW, h: newH };
+        }
+
+        function snapToNearest(value, candidates) {
+            let best = value;
+            let bestDist = SNAP_THRESHOLD;
+            candidates.forEach((candidate) => {
+                const dist = Math.abs(value - candidate);
+                if (dist <= bestDist) {
+                    bestDist = dist;
+                    best = candidate;
+                }
+            });
+            return best;
+        }
+
+        function snapMove(x, y, w, h, others) {
+            const xCandidates = [0, CANVAS_W - w];
+            const yCandidates = [0, CANVAS_H - h];
+            others.forEach((o) => {
+                xCandidates.push(o.x - w, o.x + o.w);
+                yCandidates.push(o.y - h, o.y + o.h);
+            });
+            return {
+                x: clamp(snapToNearest(x, xCandidates), 0, Math.max(0, CANVAS_W - w)),
+                y: clamp(snapToNearest(y, yCandidates), 0, Math.max(0, CANVAS_H - h)),
+            };
+        }
+
+        function snapResize(startX, startY, w, h, others) {
+            const rightCandidates = [CANVAS_W];
+            const bottomCandidates = [CANVAS_H];
+            others.forEach((o) => {
+                rightCandidates.push(o.x, o.x + o.w);
+                bottomCandidates.push(o.y, o.y + o.h);
+            });
+            const snappedRight = snapToNearest(startX + w, rightCandidates);
+            const snappedBottom = snapToNearest(startY + h, bottomCandidates);
+            return {
+                w: Math.max(1, Math.min(snappedRight, CANVAS_W) - startX),
+                h: Math.max(1, Math.min(snappedBottom, CANVAS_H) - startY),
+            };
+        }
+
+        function renderPreview() {
+            preview.innerHTML = '';
+            const rows = Array.from(regionList.querySelectorAll('.region-row'));
+            const regions = collectRegions();
+
+            rows.forEach((row, index) => {
+                const region = regions[index];
+                if (
+                    !Number.isFinite(region.x) || !Number.isFinite(region.y) ||
+                    !Number.isFinite(region.w) || !Number.isFinite(region.h)
+                ) {
+                    return;
+                }
+                const color = REGION_COLORS[index % REGION_COLORS.length];
+                const box = document.createElement('div');
+                box.className = 'composite-region-box';
+                box.style.position = 'absolute';
+                box.style.left = (100 * region.x / CANVAS_W) + '%';
+                box.style.top = (100 * region.y / CANVAS_H) + '%';
+                box.style.width = (100 * region.w / CANVAS_W) + '%';
+                box.style.height = (100 * region.h / CANVAS_H) + '%';
+                box.style.border = '2px solid ' + color;
+                box.style.boxSizing = 'border-box';
+                box.style.overflow = 'hidden';
+                box.style.fontSize = '11px';
+                box.style.color = color;
+                box.style.padding = '2px 4px';
+                box.style.cursor = 'move';
+                box.style.userSelect = 'none';
+                box.style.display = 'flex';
+                box.style.flexDirection = 'column';
+                box.style.gap = '2px';
+                box.style.lineHeight = '1.2';
+
+                const label = document.createElement('div');
+                label.textContent = region.plugin_id || ('Region ' + (index + 1));
+                const sizeLabel = document.createElement('div');
+                sizeLabel.className = 'composite-region-size-label';
+                sizeLabel.style.opacity = '0.85';
+                sizeLabel.textContent = formatSize(region.w, region.h);
+                box.appendChild(label);
+                box.appendChild(sizeLabel);
+
+                const handle = document.createElement('div');
+                handle.className = 'composite-region-handle';
+                handle.style.position = 'absolute';
+                handle.style.right = '0';
+                handle.style.bottom = '0';
+                handle.style.width = '14px';
+                handle.style.height = '14px';
+                handle.style.cursor = 'nwse-resize';
+                handle.style.background = color;
+                handle.style.opacity = '0.6';
+                box.appendChild(handle);
+
+                box.addEventListener('pointerdown', (event) => startDrag(event, row, 'move'));
+                handle.addEventListener('pointerdown', (event) => startDrag(event, row, 'resize'));
+
+                preview.appendChild(box);
+            });
+        }
+
+        document.getElementById('sizeUnitPercent').addEventListener('change', renderPreview);
+        document.getElementById('sizeUnitPixels').addEventListener('change', renderPreview);
+
+        function startDrag(event, row, mode) {
+            event.preventDefault();
+            event.stopPropagation();
+            const previewRect = preview.getBoundingClientRect();
+            const unitsPerPxX = CANVAS_W / previewRect.width;
+            const unitsPerPxY = CANVAS_H / previewRect.height;
+            const startX = Number.parseInt(row.querySelector('.region-x').value, 10) || 0;
+            const startY = Number.parseInt(row.querySelector('.region-y').value, 10) || 0;
+            const startW = Number.parseInt(row.querySelector('.region-w').value, 10) || 1;
+            const startH = Number.parseInt(row.querySelector('.region-h').value, 10) || 1;
+            const others = getOtherRegionRects(row);
+            activeDrag = {
+                row,
+                mode,
+                startClientX: event.clientX,
+                startClientY: event.clientY,
+                unitsPerPxX,
+                unitsPerPxY,
+                startX,
+                startY,
+                startW,
+                startH,
+                others,
+                exempt: preExistingOverlaps({ x: startX, y: startY, w: startW, h: startH }, others),
+            };
+            window.addEventListener('pointermove', onDragMove);
+            window.addEventListener('pointerup', onDragEnd, { once: true });
+        }
+
+        function onDragMove(event) {
+            if (!activeDrag) return;
+            const dx = Math.round((event.clientX - activeDrag.startClientX) * activeDrag.unitsPerPxX);
+            const dy = Math.round((event.clientY - activeDrag.startClientY) * activeDrag.unitsPerPxY);
+            const { row, mode, startX, startY, startW, startH, others, exempt } = activeDrag;
+
+            if (mode === 'move') {
+                const resolved = resolveMove(startX, startY, startW, startH, dx, dy, others, exempt);
+                const snapped = snapMove(resolved.x, resolved.y, startW, startH, others);
+                row.querySelector('.region-x').value = snapped.x;
+                row.querySelector('.region-y').value = snapped.y;
+            } else {
+                const resolved = resolveResize(startX, startY, startW, startH, dx, dy, others, exempt);
+                const snapped = snapResize(startX, startY, resolved.w, resolved.h, others);
+                row.querySelector('.region-w').value = snapped.w;
+                row.querySelector('.region-h').value = snapped.h;
+            }
+            renderPreview();
+        }
+
+        function onDragEnd() {
+            activeDrag = null;
+            window.removeEventListener('pointermove', onDragMove);
+        }
+
+        document.getElementById('addRegionBtn').addEventListener('click', () => addRegionRow());
+
+        regionList.addEventListener('click', (event) => {
+            const removeBtn = event.target.closest('.remove-region-btn');
+            if (removeBtn) {
+                removeRegionRow(removeBtn.closest('.region-row'));
+            }
+        });
+        regionList.addEventListener('input', (event) => {
+            // Settings-container edits (schema fields, JSON textarea) don't
+            // change geometry and would just churn the preview/dropdowns —
+            // only re-render for the geometry inputs themselves.
+            if (event.target.closest('.region-settings-container')) return;
+            renderPreview();
+        });
+        regionList.addEventListener('change', (event) => {
+            if (event.target.closest('.region-settings-container')) return;
+            renderPreview();
+        });
+
+        {% if not edit_instance_name %}
+        // Radio-toggle between interval and scheduled cadence, mirroring
+        // the plugin settings page's own schedule form behavior.
+        const intervalRadio = document.getElementById('refreshTypeInterval');
+        const scheduledRadio = document.getElementById('refreshTypeScheduled');
+        const intervalInput = document.getElementById('scheduleInterval');
+        const unitInput = document.getElementById('scheduleUnit');
+        const timeInput = document.getElementById('scheduleTime');
+
+        function syncCadenceInputs() {
+            const useInterval = intervalRadio.checked;
+            intervalInput.disabled = !useInterval;
+            unitInput.disabled = !useInterval;
+            timeInput.disabled = useInterval;
+        }
+        intervalRadio.addEventListener('change', syncCadenceInputs);
+        scheduledRadio.addEventListener('change', syncCadenceInputs);
+        syncCadenceInputs();
+        {% endif %}
+
+        if (EDIT_INSTANCE_NAME && INITIAL_REGIONS.length) {
+            INITIAL_REGIONS.forEach((region) => addRegionRow(region));
+        } else {
+            addRegionRow();
+        }
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            errorEl.textContent = '';
+
+            const regions = collectRegions();
+            if (regions._hasInvalidJson) {
+                errorEl.textContent = "A region's Settings field is not valid JSON.";
+                return;
+            }
+            if (!regions.length) {
+                errorEl.textContent = 'At least one region must be configured.';
+                return;
+            }
+            for (const region of regions) {
+                if (!region.plugin_id) {
+                    errorEl.textContent = 'Every region needs a plugin selected.';
+                    return;
+                }
+                if (!(region.w > 0) || !(region.h > 0)) {
+                    errorEl.textContent = "Region for '" + region.plugin_id + "' must have positive width and height.";
+                    return;
+                }
+                if (region.x < 0 || region.y < 0) {
+                    errorEl.textContent = "Region for '" + region.plugin_id + "' has a negative x or y.";
+                    return;
+                }
+                if (region.x + region.w > CANVAS_W || region.y + region.h > CANVAS_H) {
+                    errorEl.textContent = "Region for '" + region.plugin_id + "' exceeds the " + CANVAS_W + 'x' + CANVAS_H + ' canvas.';
+                    return;
+                }
+            }
+
+            const body = new URLSearchParams();
+            body.set('regionsJson', JSON.stringify(regions));
+
+            const submitBtn = document.getElementById('compositeSubmitBtn');
+            submitBtn.disabled = true;
+
+            let requestUrl;
+            let method;
+            if (EDIT_INSTANCE_NAME) {
+                requestUrl = UPDATE_COMPOSITE_SCREEN_BASE_URL + encodeURIComponent(EDIT_INSTANCE_NAME);
+                method = 'PUT';
+            } else {
+                const refreshType = intervalRadio.checked ? 'interval' : 'scheduled';
+                const refreshSettings = {
+                    playlist: document.getElementById('playlist').value,
+                    instance_name: document.getElementById('instance').value.trim(),
+                    refreshType,
+                };
+                if (refreshType === 'interval') {
+                    refreshSettings.interval = intervalInput.value;
+                    refreshSettings.unit = unitInput.value;
+                } else {
+                    refreshSettings.refreshTime = timeInput.value;
+                }
+                if (!refreshSettings.playlist) {
+                    errorEl.textContent = 'A playlist is required.';
+                    submitBtn.disabled = false;
+                    return;
+                }
+                if (!refreshSettings.instance_name) {
+                    errorEl.textContent = 'Instance name is required.';
+                    submitBtn.disabled = false;
+                    return;
+                }
+                body.set('refresh_settings', JSON.stringify(refreshSettings));
+                requestUrl = ADD_COMPOSITE_SCREEN_URL;
+                method = 'POST';
+            }
+
+            fetch(requestUrl, {
+                method,
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString(),
+            })
+                .then((response) => response.json().then((data) => ({ ok: response.ok, data })))
+                .then(({ ok, data }) => {
+                    if (!ok) {
+                        throw new Error((data && data.message) || 'Failed to save composite screen.');
+                    }
+                    window.location.href = PLAYLISTS_URL;
+                })
+                .catch((error) => {
+                    errorEl.textContent = error.message || 'Failed to save composite screen.';
+                    submitBtn.disabled = false;
+                });
+        });
+    });
+    </script>
+{% endblock %}

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -98,10 +98,15 @@
                         {% set pi_label = plugin_instance.name | friendly_instance_label(plugin_instance.plugin_id) %}
                         {% set pi_suffix = plugin_instance.name | instance_suffix_label(plugin_instance.plugin_id) %}
                         {% set is_playing = playlist.name == refresh_info.playlist and plugin_instance.name == refresh_info.plugin_instance %}
+                        {% set is_composite = plugin_instance.plugin_id == composite_plugin_id %}
                         <div class="plugin-item pl-item{% if is_playing %} is-playing{% endif %}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance-name="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}">
                             <span class="drag-handle" aria-hidden="true">{{ icon('dots-six-vertical', 'drag-handle-icon') | safe }}</span>
                             <span class="pl-item-icon" aria-hidden="true">
+                                {% if is_composite %}
+                                {{ icon('squares-four', 'plugin-icon') | safe }}
+                                {% else %}
                                 <img src="{{ url_for('plugin.image', plugin_id=plugin_instance.plugin_id, filename='icon.png') }}" alt="" class="plugin-icon">
+                                {% endif %}
                             </span>
                             <div class="pl-item-main plugin-info" id="{{plugin_instance.name}}">
                                 <div class="pl-item-name"><span class="plugin-instance">{{ pi_label }}{% if pi_suffix and pi_suffix != pi_label %} <span class="plugin-instance-suffix">({{ pi_suffix }})</span>{% endif %}</span>{% if is_playing %}<span class="displayed-now">Playing</span>{% endif %}</div>
@@ -128,7 +133,7 @@
                                 <div class="plugin-thumbnail-container lightboxable"
                                      data-thumbnail-playlist="{{ playlist.name }}"
                                      data-thumbnail-plugin="{{ plugin_instance.plugin_id }}"
-                                     data-thumbnail-display-name="{{ (plugins.get(plugin_instance.plugin_id, {}).display_name or plugin_instance.plugin_id) }}"
+                                     data-thumbnail-display-name="{{ 'Composite Screen' if is_composite else (plugins.get(plugin_instance.plugin_id, {}).display_name or plugin_instance.plugin_id) }}"
                                      data-thumbnail-instance="{{ plugin_instance.name }}"
                                      data-thumbnail-instance-label="{{ pi_label }}">
                                     <div class="img-skeleton" aria-hidden="true"></div>
@@ -160,10 +165,17 @@
                                     {{ icon('clock', 'action-icon') | safe }}
                                     <span class="sr-only">Edit schedule for {{ pi_label }}</span>
                                 </button>
+                                {% if is_composite %}
+                                <a href="{{ url_for('playlist.edit_composite_screen', instance_name=plugin_instance.name) }}" class="header-button is-secondary edit-button playlist-row-icon-btn edit-plugin-link" title="Edit regions for {{ pi_label }}">
+                                    {{ icon('pencil-simple', 'action-icon') | safe }}
+                                    <span class="sr-only">Edit regions for {{ pi_label }}</span>
+                                </a>
+                                {% else %}
                                 <a href="{{ url_for('plugin.plugin_page', plugin_id=plugin_instance.plugin_id) }}?instance={{ plugin_instance.name }}" class="header-button is-secondary edit-button playlist-row-icon-btn edit-plugin-link" title="Edit plugin {{ pi_label }}">
                                     {{ icon('pencil-simple', 'action-icon') | safe }}
                                     <span class="sr-only">Edit plugin {{ pi_label }}</span>
                                 </a>
+                                {% endif %}
                                 {# data-test-skip-click: removes a plugin instance from the playlist #}
                                 <button class="header-button is-secondary ghost-danger delete-button delete-instance-btn playlist-row-icon-btn" type="button" title="Delete plugin instance {{ pi_label }}" data-playlist-action="delete-instance" data-playlist="{{ playlist.name }}" data-plugin-id="{{ plugin_instance.plugin_id }}" data-instance="{{ plugin_instance.name }}" data-instance-label="{{ pi_label }}" data-test-skip-click="true">
                                     {{ icon('trash', 'action-icon') | safe }}
@@ -178,6 +190,9 @@
                     {% endif %}
                     <a href="{{ url_for('plugin.plugins_page') }}" class="pl-add-row" title="Add plugin instance to {{ playlist.name }}">
                         {{ icon('plus', 'icon-xs') | safe }}<span>Add plugin instance</span><span class="sr-only"> to {{ playlist.name }}</span>
+                    </a>
+                    <a href="{{ url_for('playlist.new_composite_screen', playlist=playlist.name) }}" class="pl-add-row" title="Add composite screen to {{ playlist.name }}">
+                        {{ icon('squares-four', 'icon-xs') | safe }}<span>Add composite screen</span><span class="sr-only"> to {{ playlist.name }}</span>
                     </a>
                     </div>
             </div>

--- a/tests/integration/test_composite_screen_routes.py
+++ b/tests/integration/test_composite_screen_routes.py
@@ -1,0 +1,198 @@
+"""Routes for creating and editing native composite screens: GET
+/composite_screen/new, POST /add_composite_screen, GET
+/composite_screen/edit/<name>, PUT /update_composite_screen/<name>.
+"""
+
+import json
+from typing import Any
+
+from flask.testing import FlaskClient
+
+REGIONS = [
+    {"plugin_id": "clock", "x": 0, "y": 0, "w": 400, "h": 480, "settings": {}},
+    {
+        "plugin_id": "countdown",
+        "x": 400,
+        "y": 0,
+        "w": 400,
+        "h": 480,
+        "settings": {"title": "New Year"},
+    },
+]
+
+
+def _ensure_default_playlist(device_config_dev: Any) -> None:
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default", "00:00", "24:00")
+        device_config_dev.write_config()
+
+
+def _add_composite(
+    client: FlaskClient, instance_name: str, regions: list[dict[str, Any]] = REGIONS
+) -> Any:
+    return client.post(
+        "/add_composite_screen",
+        data={
+            "regionsJson": json.dumps(regions),
+            "refresh_settings": json.dumps(
+                {
+                    "playlist": "Default",
+                    "instance_name": instance_name,
+                    "refreshType": "interval",
+                    "interval": "10",
+                    "unit": "minute",
+                }
+            ),
+        },
+    )
+
+
+def test_new_composite_screen_page_renders(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    resp = client.get("/composite_screen/new")
+    assert resp.status_code == 200
+    assert b"compositeForm" in resp.data
+    assert b"Add to Playlist" in resp.data
+
+
+def test_add_composite_screen_creates_instance_with_regions(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    resp = _add_composite(client, "My Composite")
+    assert resp.status_code == 200, resp.get_json()
+
+    pm = device_config_dev.get_playlist_manager()
+    from model import COMPOSITE_PLUGIN_ID
+
+    instance = pm.find_plugin(COMPOSITE_PLUGIN_ID, "My Composite")
+    assert instance is not None
+    assert instance.settings["regions"][0]["plugin_id"] == "clock"
+    assert instance.settings["regions"][1]["settings"]["title"] == "New Year"
+    assert instance.refresh == {"interval": 600}
+
+
+def test_add_composite_screen_rejects_empty_regions(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    resp = _add_composite(client, "Empty Composite", regions=[])
+    assert resp.status_code == 422
+    body = resp.get_json() or {}
+    assert body.get("success") is False
+
+
+def test_add_composite_screen_rejects_out_of_bounds_region(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    bad_regions = [
+        {"plugin_id": "clock", "x": 700, "y": 0, "w": 200, "h": 60, "settings": {}}
+    ]
+    resp = _add_composite(client, "OOB Composite", regions=bad_regions)
+    assert resp.status_code == 422
+    body = resp.get_json() or {}
+    assert "exceeds" in (body.get("message") or body.get("error") or "")
+
+
+def test_add_composite_screen_rejects_unregistered_plugin(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    bad_regions = [
+        {
+            "plugin_id": "does_not_exist",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 60,
+            "settings": {},
+        }
+    ]
+    resp = _add_composite(client, "Bad Plugin Composite", regions=bad_regions)
+    assert resp.status_code == 422
+    body = resp.get_json() or {}
+    assert "not installed" in (body.get("message") or body.get("error") or "")
+
+
+def test_edit_composite_screen_page_prefills_regions(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    assert _add_composite(client, "Edit Me").status_code == 200
+
+    resp = client.get("/composite_screen/edit/Edit Me")
+    assert resp.status_code == 200
+    assert b"Save regions" in resp.data
+    assert b'"plugin_id": "clock"' in resp.data or b'"plugin_id":"clock"' in resp.data
+
+
+def test_edit_composite_screen_page_404s_for_unknown_instance(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    resp = client.get("/composite_screen/edit/Does Not Exist")
+    assert resp.status_code == 404
+
+
+def test_update_composite_screen_persists_new_regions(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    assert _add_composite(client, "Update Me").status_code == 200
+
+    new_regions = [
+        {"plugin_id": "clock", "x": 0, "y": 0, "w": 800, "h": 480, "settings": {}}
+    ]
+    resp = client.put(
+        "/update_composite_screen/Update Me",
+        data={"regionsJson": json.dumps(new_regions)},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    pm = device_config_dev.get_playlist_manager()
+    from model import COMPOSITE_PLUGIN_ID
+
+    instance = pm.find_plugin(COMPOSITE_PLUGIN_ID, "Update Me")
+    assert len(instance.settings["regions"]) == 1
+    assert instance.settings["regions"][0]["w"] == 800
+    # Refresh cadence is untouched by this route -- it's edited through the
+    # same generic modal every plugin instance uses.
+    assert instance.refresh == {"interval": 600}
+
+
+def test_update_composite_screen_404s_for_unknown_instance(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    resp = client.put(
+        "/update_composite_screen/Does Not Exist",
+        data={"regionsJson": json.dumps(REGIONS)},
+    )
+    assert resp.status_code == 404
+
+
+def test_update_composite_screen_rejects_invalid_region_shape(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    _ensure_default_playlist(device_config_dev)
+    assert _add_composite(client, "Shape Guard").status_code == 200
+
+    bad_regions = [
+        {"plugin_id": "clock", "x": -5, "y": 0, "w": 100, "h": 60, "settings": {}}
+    ]
+    resp = client.put(
+        "/update_composite_screen/Shape Guard",
+        data={"regionsJson": json.dumps(bad_regions)},
+    )
+    assert resp.status_code == 422
+
+    pm = device_config_dev.get_playlist_manager()
+    from model import COMPOSITE_PLUGIN_ID
+
+    # Original regions must be untouched after a rejected update.
+    instance = pm.find_plugin(COMPOSITE_PLUGIN_ID, "Shape Guard")
+    assert len(instance.settings["regions"]) == 2

--- a/tests/integration/test_jtn_381_refresh_settings_validation.py
+++ b/tests/integration/test_jtn_381_refresh_settings_validation.py
@@ -174,3 +174,45 @@ def test_update_plugin_instance_without_refresh_settings_still_works(
     assert resp.status_code == 200
     pm = device_config_dev.get_playlist_manager()
     assert pm.find_plugin("ai_text", "Inst One").refresh == {"interval": 300}
+
+
+def test_refresh_only_edit_does_not_wipe_plugin_settings(
+    client: FlaskClient, device_config_dev: Any
+) -> None:
+    """The playlist page's "Edit refresh settings" modal (actions.js
+    saveRefreshSettings) posts only plugin_id + refresh_settings — no
+    plugin-specific fields — so plugin_settings parses to {} for that
+    request alone. update_plugin_instance previously overwrote
+    plugin_instance.settings with that empty dict unconditionally, silently
+    deleting the instance's real settings on every schedule-only edit.
+    """
+    pm = device_config_dev.get_playlist_manager()
+    if not pm.get_playlist("Default"):
+        pm.add_playlist("Default", "00:00", "24:00")
+    pl = pm.get_playlist("Default")
+    pl.add_plugin(
+        {
+            "plugin_id": "clock",
+            "name": "Clock Inst",
+            "plugin_settings": {"selectedClockFace": "digital"},
+            "refresh": {"interval": 300},
+        }
+    )
+    device_config_dev.write_config()
+
+    # Mirrors saveRefreshSettings' actual payload: plugin_id + refresh_settings
+    # only, nothing else.
+    resp = client.put(
+        "/update_plugin_instance/Clock Inst",
+        data={
+            "plugin_id": "clock",
+            "refresh_settings": json.dumps(
+                {"refreshType": "interval", "interval": "20", "unit": "minute"}
+            ),
+        },
+    )
+    assert resp.status_code == 200
+
+    instance = pm.find_plugin("clock", "Clock Inst")
+    assert instance.refresh == {"interval": 1200}
+    assert instance.settings == {"selectedClockFace": "digital"}

--- a/tests/unit/test_composite_render.py
+++ b/tests/unit/test_composite_render.py
@@ -1,0 +1,449 @@
+"""Tests for the native composite-screen renderer (refresh_task/composite_render.py).
+
+Child plugins are always faked here — never call a real plugin's upstream API
+from this file.
+"""
+
+import copy
+import os
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from refresh_task.composite_render import CACHE_MAX_AGE_DAYS, CompositeScreenRenderer
+
+
+class FakeDeviceConfig:
+    """Minimal DeviceConfigLike + get_plugin()/plugin_image_dir double."""
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        plugins: dict[str, dict[str, str]],
+        resolution: tuple[int, int] = (800, 480),
+        orientation: str = "horizontal",
+    ) -> None:
+        self._resolution = resolution
+        self._orientation = orientation
+        self._plugins = plugins
+        self.plugin_image_dir = str(tmp_path / "plugin_images")
+
+    def get_resolution(self) -> tuple[int, int]:
+        return self._resolution
+
+    def get_config(self, key: str | None = None, default: Any = None) -> Any:
+        if key == "orientation":
+            return self._orientation
+        return default
+
+    def load_env_key(self, key: str) -> str | None:
+        return None
+
+    def get_plugin(self, plugin_id: str) -> dict[str, str] | None:
+        return self._plugins.get(plugin_id)
+
+
+class FakeColorPlugin:
+    """Fake child plugin: fills its assigned region with a solid color.
+
+    Tracks call count (class-level, keyed by plugin id) so tests can assert
+    on caching/reuse behavior without touching a real plugin's API.
+    """
+
+    call_counts: dict[str, int] = {}
+    fail_ids: set[str] = set()
+
+    def __init__(self, config: dict[str, str]) -> None:
+        self.config = config
+
+    def generate_image(
+        self, settings: dict[str, Any], device_config: Any
+    ) -> Image.Image:
+        plugin_id = self.config["id"]
+        FakeColorPlugin.call_counts[plugin_id] = (
+            FakeColorPlugin.call_counts.get(plugin_id, 0) + 1
+        )
+        if plugin_id in FakeColorPlugin.fail_ids:
+            raise RuntimeError(f"fake failure for {plugin_id}")
+        w, h = device_config.get_resolution()
+        color = settings.get("color", "red")
+        return Image.new("RGB", (w, h), color)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_plugin_state() -> Iterator[None]:
+    FakeColorPlugin.call_counts = {}
+    FakeColorPlugin.fail_ids = set()
+    yield
+
+
+def _patch_get_plugin_instance() -> Any:
+    return patch(
+        "refresh_task.composite_render.get_plugin_instance",
+        side_effect=lambda config: FakeColorPlugin(config),
+    )
+
+
+def _plugins_map(*ids: str) -> dict[str, dict[str, str]]:
+    return {pid: {"id": pid, "class": "FakeColorPlugin"} for pid in ids}
+
+
+def _as_subprocess_would(regions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return regions as they'd arrive after crossing the subprocess boundary.
+
+    InkyPi runs generate_image() in a separate process by default
+    (INKYPI_PLUGIN_ISOLATION=process), so the renderer is handed a pickled
+    copy of the PluginInstance and anything it writes back is discarded when
+    the child exits. Tests that reuse one long-lived regions list across
+    several generate_image() calls would silently grant this renderer a
+    persistence channel production doesn't actually have — deep-copying per
+    call models the real boundary.
+    """
+    return copy.deepcopy(regions)
+
+
+# ---------------------------------------------------------------------------
+# Regions land at the correct pixel offsets
+# ---------------------------------------------------------------------------
+
+
+def test_regions_land_at_correct_pixel_offsets(tmp_path: Path) -> None:
+    regions = [
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 0,
+            "w": 400,
+            "h": 200,
+            "settings": {"color": "red"},
+        },
+        {
+            "plugin_id": "fake_b",
+            "x": 400,
+            "y": 0,
+            "w": 400,
+            "h": 200,
+            "settings": {"color": "blue"},
+        },
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 200,
+            "w": 800,
+            "h": 280,
+            "settings": {"color": "green"},
+        },
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a", "fake_b"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with _patch_get_plugin_instance():
+        image = renderer.generate_image({}, device_config)
+
+    assert image.size == (800, 480)
+    # Sample well inside each region (avoiding the 1px black border) to
+    # confirm the right child's output landed at the right offset.
+    assert image.getpixel((200, 100)) == (255, 0, 0)  # region 1 (red)
+    assert image.getpixel((600, 100)) == (0, 0, 255)  # region 2 (blue)
+    assert image.getpixel((400, 350)) == (0, 128, 0)  # region 3 (green)
+
+
+def test_region_border_is_drawn(tmp_path: Path) -> None:
+    regions = [
+        {"plugin_id": "fake_a", "x": 10, "y": 10, "w": 100, "h": 100, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with _patch_get_plugin_instance():
+        image = renderer.generate_image({}, device_config)
+
+    assert image.getpixel((10, 10)) == (0, 0, 0)
+    assert image.getpixel((109, 10)) == (0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_generate_image_rejects_out_of_bounds_region(tmp_path: Path) -> None:
+    regions = [
+        {"plugin_id": "fake_a", "x": 700, "y": 0, "w": 200, "h": 60, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with pytest.raises(RuntimeError, match="exceeds the"):
+        renderer.generate_image({}, device_config)
+
+
+def test_generate_image_rejects_negative_offset(tmp_path: Path) -> None:
+    regions = [
+        {"plugin_id": "fake_a", "x": -5, "y": 0, "w": 100, "h": 60, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with pytest.raises(RuntimeError, match="negative"):
+        renderer.generate_image({}, device_config)
+
+
+def test_generate_image_requires_at_least_one_region(tmp_path: Path) -> None:
+    device_config = FakeDeviceConfig(tmp_path, {})
+    renderer = CompositeScreenRenderer([])
+
+    with pytest.raises(RuntimeError, match="At least one region"):
+        renderer.generate_image({}, device_config)
+
+
+def test_generate_image_rejects_unknown_plugin(tmp_path: Path) -> None:
+    regions = [
+        {
+            "plugin_id": "does_not_exist",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 60,
+            "settings": {},
+        }
+    ]
+    device_config = FakeDeviceConfig(tmp_path, {})
+    renderer = CompositeScreenRenderer(regions)
+
+    with pytest.raises(RuntimeError, match="not installed"):
+        renderer.generate_image({}, device_config)
+
+
+def test_validate_region_shape_rejects_non_positive_size() -> None:
+    region = {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 0, "h": 60}
+    error = CompositeScreenRenderer.validate_region_shape(region)
+    assert error is not None
+    assert "positive" in error
+
+
+def test_validate_region_shape_rejects_negative_offset() -> None:
+    region = {"plugin_id": "fake_a", "x": -1, "y": 0, "w": 100, "h": 60}
+    error = CompositeScreenRenderer.validate_region_shape(region)
+    assert error is not None
+    assert "negative" in error
+
+
+def test_validate_region_shape_accepts_valid_region() -> None:
+    region = {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 800, "h": 60}
+    assert CompositeScreenRenderer.validate_region_shape(region) is None
+
+
+def test_validate_region_shape_does_not_assume_an_800x480_canvas() -> None:
+    """A full-screen region on a larger panel must still be savable.
+
+    Shape validation gets no device_config, so it cannot know the real
+    resolution; bounds-checking against a hardcoded default here would make
+    the feature unusable on anything bigger than 800x480.
+    """
+    region = {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 1600, "h": 1200}
+    assert CompositeScreenRenderer.validate_region_shape(region) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-region caching
+# ---------------------------------------------------------------------------
+
+
+def test_cached_region_skips_child_plugin_within_refresh_window(tmp_path: Path) -> None:
+    regions = [
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 60,
+            "settings": {},
+            "refresh_minutes": 15,
+        }
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with _patch_get_plugin_instance():
+        renderer.generate_image({}, device_config)
+        renderer.generate_image({}, device_config)
+
+    assert FakeColorPlugin.call_counts["fake_a"] == 1
+    assert list((tmp_path / "plugin_images" / "composite").glob("*.png"))
+
+
+def test_expired_cache_re_invokes_child_plugin(tmp_path: Path) -> None:
+    regions = [
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 60,
+            "settings": {},
+            "refresh_minutes": 15,
+        }
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with _patch_get_plugin_instance():
+        renderer.generate_image({}, device_config)
+        for cached in (tmp_path / "plugin_images" / "composite").glob("*.png"):
+            old = time.time() - 3600
+            os.utime(cached, (old, old))
+        renderer.generate_image({}, device_config)
+
+    assert FakeColorPlugin.call_counts["fake_a"] == 2
+
+
+def test_region_without_refresh_minutes_always_refreshes(tmp_path: Path) -> None:
+    regions = [
+        {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 100, "h": 60, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with _patch_get_plugin_instance():
+        renderer.generate_image({}, device_config)
+        renderer.generate_image({}, device_config)
+
+    assert FakeColorPlugin.call_counts["fake_a"] == 2
+
+
+def test_child_failure_falls_back_to_stale_cache_instead_of_raising(
+    tmp_path: Path,
+) -> None:
+    regions = [
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 60,
+            "settings": {"color": "red"},
+            "refresh_minutes": 0,
+        }
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with _patch_get_plugin_instance():
+        first = renderer.generate_image({}, device_config)
+        FakeColorPlugin.fail_ids.add("fake_a")
+        second = renderer.generate_image({}, device_config)
+
+    # Region content (excluding the border) should be identical: the stale
+    # cached render was reused rather than a blank error placeholder.
+    assert first.getpixel((50, 30)) == second.getpixel((50, 30)) == (255, 0, 0)
+
+
+def test_stale_cache_files_are_pruned(tmp_path: Path) -> None:
+    regions = [
+        {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 100, "h": 60, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+    cache_dir = tmp_path / "plugin_images" / "composite"
+    cache_dir.mkdir(parents=True)
+
+    # An orphan left behind by a region that was since moved or deleted.
+    orphan = cache_dir / "9_gone_deadbeef00.png"
+    Image.new("RGB", (10, 10), "white").save(orphan)
+    expired = time.time() - (CACHE_MAX_AGE_DAYS + 1) * 86400
+    os.utime(orphan, (expired, expired))
+
+    with _patch_get_plugin_instance():
+        renderer.generate_image({}, device_config)
+
+    assert not orphan.exists()
+    # The region rendered this pass keeps its own fresh cache file.
+    assert list(cache_dir.glob("*.png"))
+
+
+def test_child_failure_without_cache_renders_placeholder_not_raise(
+    tmp_path: Path,
+) -> None:
+    regions = [
+        {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 100, "h": 60, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+    FakeColorPlugin.fail_ids.add("fake_a")
+
+    with _patch_get_plugin_instance():
+        image = renderer.generate_image({}, device_config)
+
+    assert image.size == (800, 480)
+
+
+# ---------------------------------------------------------------------------
+# Resizing a mismatched child image
+# ---------------------------------------------------------------------------
+
+
+def test_mismatched_child_image_size_gets_resized(tmp_path: Path) -> None:
+    class WrongSizePlugin:
+        def __init__(self, config: dict[str, str]) -> None:
+            self.config = config
+
+        def generate_image(
+            self, settings: dict[str, Any], device_config: Any
+        ) -> Image.Image:
+            return Image.new("RGB", (10, 10), "purple")
+
+    regions = [
+        {"plugin_id": "fake_a", "x": 0, "y": 0, "w": 100, "h": 60, "settings": {}}
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+    renderer = CompositeScreenRenderer(regions)
+
+    with patch(
+        "refresh_task.composite_render.get_plugin_instance",
+        side_effect=lambda config: WrongSizePlugin(config),
+    ):
+        image = renderer.generate_image({}, device_config)
+
+    assert image.size == (800, 480)
+    assert image.getpixel((50, 30)) == (128, 0, 128)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess-boundary discipline (see _as_subprocess_would docstring)
+# ---------------------------------------------------------------------------
+
+
+def test_caching_survives_across_deep_copied_region_lists(tmp_path: Path) -> None:
+    """Regions arrive as a fresh deep copy on every refresh in production.
+
+    The cache must therefore live entirely on disk (keyed by content, not by
+    object identity) — this pins that invariant.
+    """
+    base_regions = [
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 0,
+            "w": 100,
+            "h": 60,
+            "settings": {},
+            "refresh_minutes": 15,
+        }
+    ]
+    device_config = FakeDeviceConfig(tmp_path, _plugins_map("fake_a"))
+
+    with _patch_get_plugin_instance():
+        CompositeScreenRenderer(_as_subprocess_would(base_regions)).generate_image(
+            {}, device_config
+        )
+        CompositeScreenRenderer(_as_subprocess_would(base_regions)).generate_image(
+            {}, device_config
+        )
+
+    assert FakeColorPlugin.call_counts["fake_a"] == 1

--- a/tests/unit/test_refresh_task_composite_dispatch.py
+++ b/tests/unit/test_refresh_task_composite_dispatch.py
@@ -1,0 +1,270 @@
+"""Composite-screen dispatch: task.py/executor.py/worker.py branch on
+model.COMPOSITE_PLUGIN_ID to route to CompositeScreenRenderer instead of
+plugins.plugin_registry.get_plugin_instance. See composite_render.py and the
+"Model & scheduling dispatch" section of the implementation plan.
+"""
+
+import queue
+import threading
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from model import COMPOSITE_PLUGIN_ID, PluginInstance
+from refresh_task.actions import RefreshAction
+
+if TYPE_CHECKING:
+    from refresh_task.context import RefreshContext
+    from refresh_task.recorder import RefreshRecorder
+
+
+class _Recorder:
+    def publish_step(self, **kwargs: Any) -> None:
+        pass
+
+
+def _composite_regions() -> list[dict[str, Any]]:
+    return [
+        {
+            "plugin_id": "fake_a",
+            "x": 0,
+            "y": 0,
+            "w": 800,
+            "h": 480,
+            "settings": {"color": "red"},
+        }
+    ]
+
+
+class _FakeChildPlugin:
+    def __init__(self, config: dict[str, Any]) -> None:
+        self.config = config
+
+    def generate_image(self, settings: Any, device_config: Any) -> Image.Image:
+        w, h = device_config.get_resolution()
+        return Image.new("RGB", (w, h), settings.get("color", "red"))
+
+
+class _PlaylistStub:
+    name = "Test Playlist"
+
+
+def _composite_plugin_instance() -> PluginInstance:
+    return PluginInstance(
+        plugin_id=COMPOSITE_PLUGIN_ID,
+        name="My Composite",
+        settings={"regions": _composite_regions()},
+        refresh={"interval": 3600},
+    )
+
+
+# ---------------------------------------------------------------------------
+# task.py guards
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_requires_api_key_is_false_for_composite() -> None:
+    from refresh_task.task import _plugin_requires_api_key
+
+    assert _plugin_requires_api_key({"id": COMPOSITE_PLUGIN_ID}) is False
+
+
+def test_skip_display_reason_short_circuits_for_composite(
+    device_config_dev: Any,
+) -> None:
+    from display.display_manager import DisplayManager
+    from refresh_task.actions import PlaylistRefresh
+    from refresh_task.task import RefreshTask
+
+    dm = DisplayManager(device_config_dev)
+    task = RefreshTask(device_config_dev, dm)
+    action = PlaylistRefresh(_PlaylistStub(), _composite_plugin_instance())
+
+    with patch(
+        "refresh_task.task.get_plugin_instance",
+        side_effect=AssertionError("must not resolve a plugin for a composite screen"),
+    ):
+        reason = task._skip_display_reason(
+            action, {"id": COMPOSITE_PLUGIN_ID}, datetime.now(UTC)
+        )
+
+    assert reason is None
+
+
+def test_perform_refresh_renders_composite_screen(
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_perform_refresh must not treat a composite instance as an unknown plugin.
+
+    device_config.get_plugin(COMPOSITE_PLUGIN_ID) legitimately returns None
+    (there is no plugins/__composite__/ directory) — _perform_refresh has a
+    dedicated branch for this rather than hitting its generic
+    "Plugin config not found" early return.
+    """
+    from display.display_manager import DisplayManager
+    from model import RefreshInfo
+    from refresh_task.actions import PlaylistRefresh
+    from refresh_task.task import RefreshTask
+
+    dm = DisplayManager(device_config_dev)
+    task = RefreshTask(device_config_dev, dm)
+
+    monkeypatch.setattr(
+        device_config_dev,
+        "get_plugin",
+        lambda pid: {"id": "fake_a", "class": "FakeA"} if pid == "fake_a" else None,
+    )
+    monkeypatch.setattr(
+        "refresh_task.composite_render.get_plugin_instance",
+        lambda cfg: _FakeChildPlugin(cfg),
+        raising=True,
+    )
+
+    displayed: dict[str, Any] = {}
+    monkeypatch.setattr(
+        dm,
+        "display_image",
+        lambda image, **kwargs: displayed.__setitem__("image", image),
+    )
+
+    plugin_instance = _composite_plugin_instance()
+    action = PlaylistRefresh(_PlaylistStub(), plugin_instance, force=True)
+    latest = RefreshInfo("Playlist", COMPOSITE_PLUGIN_ID, None, None)
+
+    info, used_cached, _metrics = task._perform_refresh(
+        action, latest, task._get_current_datetime()
+    )
+
+    assert info is not None
+    assert used_cached is False
+    assert "image" in displayed
+    assert displayed["image"].size == (800, 480)
+
+
+# ---------------------------------------------------------------------------
+# executor.py — in-process isolation
+# ---------------------------------------------------------------------------
+
+
+class _Action(RefreshAction):
+    def __init__(self, plugin_instance: PluginInstance) -> None:
+        self.plugin_instance = plugin_instance
+
+    def get_plugin_id(self) -> str:
+        return self.plugin_instance.plugin_id
+
+    def execute(self, plugin: Any, device_config: Any, current_dt: datetime) -> Any:
+        return plugin.generate_image(self.plugin_instance.settings, device_config)
+
+
+class _ZombieOwner:
+    _zombie_thread_count = 0
+    _zombie_thread_lock = threading.Lock()
+
+
+class _FakeExecutorDeviceConfig:
+    def __init__(self, plugin_image_dir: str) -> None:
+        self.plugin_image_dir = plugin_image_dir
+        self._plugins = {"fake_a": {"id": "fake_a", "class": "FakeA"}}
+
+    def get_resolution(self) -> tuple[int, int]:
+        return (800, 480)
+
+    def get_config(self, key: str | None = None, default: Any = None) -> Any:
+        if key == "orientation":
+            return "horizontal"
+        return default
+
+    def load_env_key(self, key: str) -> str | None:
+        return None
+
+    def get_plugin(self, plugin_id: str) -> dict[str, Any] | None:
+        return self._plugins.get(plugin_id)
+
+
+def test_executor_inprocess_dispatches_composite_without_plugin_registry(
+    tmp_path: Any,
+) -> None:
+    from refresh_task.executor import RefreshExecutor
+
+    def _must_not_be_called(_cfg: dict[str, Any]) -> Any:
+        raise AssertionError("must not resolve a plugin for a composite screen")
+
+    executor = RefreshExecutor(
+        device_config=_FakeExecutorDeviceConfig(str(tmp_path)),
+        refresh_context=cast("RefreshContext", None),
+        recorder=cast("RefreshRecorder", _Recorder()),
+        plugin_timeout_seconds=lambda _plugin_id: 5.0,
+        zombie_owner=_ZombieOwner,
+        get_plugin_instance=_must_not_be_called,
+    )
+
+    with patch(
+        "refresh_task.composite_render.get_plugin_instance",
+        lambda cfg: _FakeChildPlugin(cfg),
+    ):
+        image, _meta = executor.execute_inprocess(
+            _Action(_composite_plugin_instance()),
+            {"id": COMPOSITE_PLUGIN_ID},
+            datetime.now(UTC),
+        )
+
+    assert image.size == (800, 480)
+
+
+# ---------------------------------------------------------------------------
+# worker.py — subprocess-isolation entry point (called in-process, as the
+# existing TestExecuteRefreshAttemptWorker tests in
+# test_refresh_task_critical.py do)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_entry_point_dispatches_composite_without_plugin_registry(
+    device_config_dev: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from refresh_task.worker import _execute_refresh_attempt_worker
+
+    result_queue: queue.Queue[Any] = queue.Queue()
+
+    def _must_not_be_called(_cfg: dict[str, Any]) -> Any:
+        raise AssertionError("must not resolve a plugin for a composite screen")
+
+    monkeypatch.setattr(
+        device_config_dev,
+        "get_plugin",
+        lambda pid: {"id": "fake_a", "class": "FakeA"} if pid == "fake_a" else None,
+    )
+
+    with (
+        patch(
+            "refresh_task.worker.get_plugin_instance", side_effect=_must_not_be_called
+        ),
+        patch(
+            "refresh_task.worker._restore_child_config", return_value=device_config_dev
+        ),
+        patch(
+            "refresh_task.composite_render.get_plugin_instance",
+            lambda cfg: _FakeChildPlugin(cfg),
+        ),
+    ):
+        _execute_refresh_attempt_worker(
+            result_queue,
+            {"id": COMPOSITE_PLUGIN_ID},
+            _Action(_composite_plugin_instance()),
+            device_config_dev,
+            datetime.now(UTC),
+        )
+
+    payload = result_queue.get_nowait()
+    assert payload["ok"] is True
+    img = Image.open(payload["image_path"])
+    try:
+        assert img.size == (800, 480)
+    finally:
+        img.close()
+        import os
+
+        os.unlink(payload["image_path"])


### PR DESCRIPTION
## Summary

Composes several existing plugins into named rectangular regions on one canvas, rendered on a single playlist refresh — e.g. a comic strip + a countdown + a task list together. Implemented as a **native, built-in feature** rather than a plugin: a composite screen is a `PluginInstance` with a reserved sentinel `plugin_id` (`model.COMPOSITE_PLUGIN_ID`), storing its regions in the instance's own `settings["regions"]`, so it rides the existing playlist rotation, refresh scheduling, snooze, and circuit-breaker machinery unmodified. Rendering is dispatched, not inherited: `task.py`/`executor.py`/`worker.py` branch on the sentinel to build a `CompositeScreenRenderer` instead of resolving a real plugin — covering both in-process and subprocess plugin isolation.

Reachable from the Playlist page via a new "Add composite screen" link, with a region editor supporting:
- Drag-to-move / drag-to-resize, with overlap prevention (dragging into a neighbor stops at its edge) and edge snapping (regions tile flush against each other or the canvas border with no gaps)
- A newly-added region defaults to the largest free rectangle (not the full canvas) — correct even when the remaining free space is L-shaped, via coordinate compression + the standard maximal-rectangle-in-a-binary-matrix algorithm
- Live region size shown as a percentage or pixels (toggle)
- Each region gets the target plugin's own real settings form (fetched from `/plugin/<id>`, namespaced per region, hybrid widgets driven by `InkyPiPluginSchema.initWidgetsIn`) rather than raw JSON, with a JSON-textarea fallback for plugins with no schema-driven settings
- Editing an existing screen's regions separately from its playlist/schedule (which reuses the existing generic "Edit refresh settings" modal)

## Also fixes

While wiring composite-screen editing into the existing "Edit refresh settings" modal, found that `update_plugin_instance` silently wiped a plugin instance's settings to `{}` on any schedule-only edit — confirmed against a plain `clock` instance, not composite-specific. Included as its own commit with a regression test.

## Commits

1. `fix: preserve plugin settings when only editing refresh schedule` — the settings-wipe bug above
2. `feat: add native composite screen rendering and scheduling dispatch` — `CompositeScreenRenderer`, the sentinel-based dispatch branches, thumbnail rendering support
3. `feat: add composite screen editor UI` — routes, `playlist_workflows.py` validation, templates

## Test plan

- [x] `scripts/lint.sh` — clean (mypy `src/` and `tests/` ratchets hold; strict subset clean)
- [x] `scripts/test.sh` — full suite passes (pre-existing failures on this checkout — install-script/git-environment tests, and a couple of tests flaky only under `-n auto` parallel sharding — all individually verified passing in isolation and unrelated to this change)
- [x] `scripts/test.sh browser-smoke` — 47/47 passing
- [x] Manual end-to-end verification with a live dev server (subprocess isolation, real headless-Chromium child plugin rendering) and Playwright-driven browser sessions for the region editor's drag/resize/snap/overlap/settings-form-embedding/edit-flow behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)