### PR TITLE
fix: render calendar plugin instead of blank white image

### DIFF
--- a/src/plugins/base_plugin/base_plugin.py
+++ b/src/plugins/base_plugin/base_plugin.py
@@ -29,6 +29,7 @@ PLUGIN_API_VERSION = "1.0"
 PLUGINS_DIR = resolve_path("plugins")
 BASE_PLUGIN_DIR = os.path.join(PLUGINS_DIR, "base_plugin")
 BASE_PLUGIN_RENDER_DIR = os.path.join(BASE_PLUGIN_DIR, "render")
+STATIC_DIR = resolve_path("static")
 
 FRAME_STYLES = [
     {"name": "None", "icon": "frames/blank.png"},
@@ -407,6 +408,7 @@ class BasePlugin:
             css_file, cast(Sequence[str], extra_css_files)
         )
         template_params["style_sheets"] = [self.to_file_url(path) for path in css_files]
+        template_params["static_dir"] = self.to_file_url(STATIC_DIR)
         template_params["width"] = dimensions[0]
         template_params["height"] = dimensions[1]
 

--- a/src/plugins/calendar/render/calendar.css
+++ b/src/plugins/calendar/render/calendar.css
@@ -5,6 +5,10 @@
   padding: 0;
 }
 
+html, body, .container {
+  height: 100%;
+}
+
 .calendar {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- The calendar template referenced an undefined `static_dir` Jinja variable for its FullCalendar `<script>` tag, so the vendored JS never loaded in the offline `file://` screenshot context and the plugin rendered as a blank white frame regardless of the configured ICS feed. Wiring `static_dir` into `render_image()` also fixes the weather plugin's Chart.js tag, which had the same bug.
- Separately, the calendar grid depended on a `height:100%` ancestor chain (`html`/`body`/`.container`) that was never established, so even with the script loading the day grid collapsed to zero height.

Reproduced directly against a real public ICS feed (blank output before, full rendered month grid with events after) and verified both fixes independently before combining them.

## Test plan
- [x] `ruff check` on the changed Python file
- [x] `tests/plugins/test_calendar.py`, `test_calendar_errors.py`, `test_calendar_validation.py` (53 passed)
- [x] `tests/unit/test_base_plugin.py` (27 passed)
- [x] Manual `generate_image()` run against a public ICS feed, confirmed rendered output changes from blank to a populated month grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)